### PR TITLE
Fix Quick Replies overlay clipping and delete styling

### DIFF
--- a/packages/client/src/components/chat/QuickReplyMenu.tsx
+++ b/packages/client/src/components/chat/QuickReplyMenu.tsx
@@ -1,11 +1,13 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import { MoreHorizontal } from "lucide-react";
 import { cn } from "../../lib/utils";
@@ -31,11 +33,36 @@ export function QuickReplyMenu({ actions, disabled = false }: QuickReplyMenuProp
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const pendingFocusRef = useRef<"first" | "last" | null>(null);
+  const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0, ready: false });
   const isDisabled = disabled || actions.length === 0;
   const singleAction = actions.length === 1 ? actions[0] : null;
   const visibleActions = actions.slice().reverse();
+
+  const updateMenuPosition = useCallback(() => {
+    const trigger = triggerRef.current;
+    const menu = menuRef.current;
+    if (!trigger || !menu) return;
+
+    const triggerRect = trigger.getBoundingClientRect();
+    const menuRect = menu.getBoundingClientRect();
+    const viewportPadding = 8;
+    const gap = 8;
+    const left = Math.max(
+      viewportPadding,
+      Math.min(
+        triggerRect.left + triggerRect.width / 2 - menuRect.width / 2,
+        window.innerWidth - viewportPadding - menuRect.width,
+      ),
+    );
+    const top = Math.max(viewportPadding, triggerRect.top - gap - menuRect.height);
+
+    setMenuPosition((current) =>
+      current.ready && current.top === top && current.left === left ? current : { top, left, ready: true },
+    );
+  }, []);
 
   const focusMenuItem = useCallback((target: "first" | "last" | { fromIndex: number; delta: 1 | -1 }) => {
     const focusable = itemRefs.current
@@ -61,7 +88,8 @@ export function QuickReplyMenu({ actions, disabled = false }: QuickReplyMenuProp
   useEffect(() => {
     if (!open) return;
     const handlePointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) {
+      const target = event.target as Node;
+      if (!rootRef.current?.contains(target) && !menuRef.current?.contains(target)) {
         setOpen(false);
       }
     };
@@ -75,6 +103,17 @@ export function QuickReplyMenu({ actions, disabled = false }: QuickReplyMenuProp
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [open]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    updateMenuPosition();
+    window.addEventListener("resize", updateMenuPosition);
+    window.addEventListener("scroll", updateMenuPosition, true);
+    return () => {
+      window.removeEventListener("resize", updateMenuPosition);
+      window.removeEventListener("scroll", updateMenuPosition, true);
+    };
+  }, [open, updateMenuPosition, visibleActions.length]);
 
   useEffect(() => {
     if (!open || !pendingFocusRef.current) return;
@@ -148,7 +187,10 @@ export function QuickReplyMenu({ actions, disabled = false }: QuickReplyMenuProp
         type="button"
         onClick={() => void handleSelect(singleAction)}
         disabled={singleDisabled}
-        aria-label={localizeUi("ui.chat.quickreplymenu.value1Value2", { value1: singleAction.label, value2: singleAction.description })}
+        aria-label={localizeUi("ui.chat.quickreplymenu.value1Value2", {
+          value1: singleAction.label,
+          value2: singleAction.description,
+        })}
         className={cn(
           "flex h-11 w-11 shrink-0 items-center justify-center rounded-full transition-all duration-200 focus-visible:ring-2 focus-visible:ring-foreground/20 sm:h-8 sm:w-8",
           !singleDisabled
@@ -186,81 +228,95 @@ export function QuickReplyMenu({ actions, disabled = false }: QuickReplyMenuProp
         <MoreHorizontal size="1rem" />
       </button>
 
-      <AnimatePresence>
-        {open && (
-          <div className="absolute bottom-full left-1/2 z-[60] mb-2 -translate-x-1/2">
-            <motion.div
-              key="quick-replies-rail"
-              role="menu"
-              aria-label={localizeUi("settings.quickReplies.label")}
-              aria-orientation="vertical"
-              className="flex flex-col items-center gap-1.5"
-              initial="closed"
-              animate="open"
-              exit="closed"
-              variants={{
-                open: { transition: { staggerChildren: 0.045, delayChildren: 0.02 } },
-                closed: { transition: { staggerChildren: 0.025, staggerDirection: -1 } },
+      {createPortal(
+        <AnimatePresence>
+          {open && (
+            <div
+              ref={menuRef}
+              className="fixed z-[9999]"
+              style={{
+                top: menuPosition.top,
+                left: menuPosition.left,
+                visibility: menuPosition.ready ? "visible" : "hidden",
               }}
             >
-              {visibleActions.map((action, index) => (
-                <motion.button
-                  ref={(element) => {
-                    itemRefs.current[index] = element;
-                  }}
-                  key={action.id}
-                  type="button"
-                  role="menuitem"
-                  disabled={action.disabled}
-                  onClick={() => void handleSelect(action)}
-                  onKeyDown={(event) => handleItemKeyDown(event, index)}
-                  aria-label={localizeUi("ui.chat.quickreplymenu.value1Value2", { value1: action.label, value2: action.description })}
-                  className={cn(
-                    "group relative flex h-11 w-11 items-center justify-center rounded-full border shadow-xl outline-none transition-colors focus-visible:ring-2 focus-visible:ring-foreground/20 sm:h-10 sm:w-10",
-                    action.disabled
-                      ? "cursor-not-allowed border-foreground/10 bg-[var(--card)]/75 opacity-45"
-                      : "border-foreground/20 bg-[var(--card)] text-foreground/55 hover:bg-foreground/10 hover:text-foreground/80 active:scale-95",
-                  )}
-                  title={formatActionTitle(action)}
-                  variants={{
-                    open: {
-                      opacity: 1,
-                      scale: 1,
-                      y: 0,
-                      filter: "blur(0px)",
-                      transition: {
-                        type: "spring",
-                        stiffness: 520,
-                        damping: 28,
-                        mass: 0.75,
-                        delay: index * 0.015,
-                      },
-                    },
-                    closed: {
-                      opacity: 0,
-                      scale: 0.55,
-                      y: 36 + index * 10,
-                      filter: "blur(2px)",
-                      transition: { duration: 0.12, ease: "easeOut" },
-                    },
-                  }}
-                >
-                  <span
+              <motion.div
+                key="quick-replies-rail"
+                role="menu"
+                aria-label={localizeUi("settings.quickReplies.label")}
+                aria-orientation="vertical"
+                className="flex flex-col items-center gap-1.5"
+                initial="closed"
+                animate="open"
+                exit="closed"
+                variants={{
+                  open: { transition: { staggerChildren: 0.045, delayChildren: 0.02 } },
+                  closed: { transition: { staggerChildren: 0.025, staggerDirection: -1 } },
+                }}
+              >
+                {visibleActions.map((action, index) => (
+                  <motion.button
+                    ref={(element) => {
+                      itemRefs.current[index] = element;
+                    }}
+                    key={action.id}
+                    type="button"
+                    role="menuitem"
+                    disabled={action.disabled}
+                    onClick={() => void handleSelect(action)}
+                    onKeyDown={(event) => handleItemKeyDown(event, index)}
+                    aria-label={localizeUi("ui.chat.quickreplymenu.value1Value2", {
+                      value1: action.label,
+                      value2: action.description,
+                    })}
                     className={cn(
-                      "flex h-8 w-8 shrink-0 items-center justify-center rounded-full ring-1 transition-colors",
+                      "group relative flex h-11 w-11 items-center justify-center rounded-full border shadow-xl outline-none transition-colors focus-visible:ring-2 focus-visible:ring-foreground/20 sm:h-10 sm:w-10",
                       action.disabled
-                        ? "bg-foreground/5 text-foreground/40 ring-transparent"
-                        : "bg-foreground/10 ring-foreground/15 group-hover:bg-transparent group-hover:ring-transparent",
+                        ? "cursor-not-allowed border-foreground/10 bg-[var(--card)]/75 opacity-45"
+                        : "border-foreground/20 bg-[var(--card)] text-foreground/55 hover:bg-foreground/10 hover:text-foreground/80 active:scale-95",
                     )}
+                    title={formatActionTitle(action)}
+                    variants={{
+                      open: {
+                        opacity: 1,
+                        scale: 1,
+                        y: 0,
+                        filter: "blur(0px)",
+                        transition: {
+                          type: "spring",
+                          stiffness: 520,
+                          damping: 28,
+                          mass: 0.75,
+                          delay: index * 0.015,
+                        },
+                      },
+                      closed: {
+                        opacity: 0,
+                        scale: 0.55,
+                        y: 36 + index * 10,
+                        filter: "blur(2px)",
+                        transition: { duration: 0.12, ease: "easeOut" },
+                      },
+                    }}
                   >
-                    {action.icon}
-                  </span>
-                </motion.button>
-              ))}
-            </motion.div>
-          </div>
-        )}
-      </AnimatePresence>
+                    <span
+                      className={cn(
+                        "flex h-8 w-8 shrink-0 items-center justify-center rounded-full ring-1 transition-colors",
+                        action.disabled
+                          ? "bg-foreground/5 text-foreground/40 ring-transparent"
+                          : "bg-foreground/10 ring-foreground/15 group-hover:bg-transparent group-hover:ring-transparent",
+                      )}
+                    >
+                      {action.icon}
+                    </span>
+                  </motion.button>
+                ))}
+              </motion.div>
+            </div>
+          )}
+        </AnimatePresence>,
+        document.body,
+      )}
     </div>
   );
 }

--- a/packages/client/src/components/chat/QuickReplyMenu.tsx
+++ b/packages/client/src/components/chat/QuickReplyMenu.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useRef,
   useState,
@@ -30,6 +31,7 @@ interface QuickReplyMenuProps {
 
 export function QuickReplyMenu({ actions, disabled = false }: QuickReplyMenuProps) {
   const { t: localizeUi } = useUiTranslation();
+  const menuId = useId();
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -57,7 +59,12 @@ export function QuickReplyMenu({ actions, disabled = false }: QuickReplyMenuProp
         window.innerWidth - viewportPadding - menuRect.width,
       ),
     );
-    const top = Math.max(viewportPadding, triggerRect.top - gap - menuRect.height);
+    const preferredTop = triggerRect.top - gap - menuRect.height;
+    const maxTop = window.innerHeight - viewportPadding - menuRect.height;
+    const top =
+      preferredTop >= viewportPadding
+        ? preferredTop
+        : Math.max(viewportPadding, Math.min(triggerRect.bottom + gap, maxTop));
 
     setMenuPosition((current) =>
       current.ready && current.top === top && current.left === left ? current : { top, left, ready: true },
@@ -107,11 +114,21 @@ export function QuickReplyMenu({ actions, disabled = false }: QuickReplyMenuProp
   useLayoutEffect(() => {
     if (!open) return;
     updateMenuPosition();
-    window.addEventListener("resize", updateMenuPosition);
-    window.addEventListener("scroll", updateMenuPosition, true);
+    let frame = 0;
+    const scrollListenerOptions = { capture: true, passive: true } as const;
+    const scheduleUpdate = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        updateMenuPosition();
+      });
+    };
+    window.addEventListener("resize", scheduleUpdate);
+    window.addEventListener("scroll", scheduleUpdate, scrollListenerOptions);
     return () => {
-      window.removeEventListener("resize", updateMenuPosition);
-      window.removeEventListener("scroll", updateMenuPosition, true);
+      if (frame) cancelAnimationFrame(frame);
+      window.removeEventListener("resize", scheduleUpdate);
+      window.removeEventListener("scroll", scheduleUpdate, scrollListenerOptions);
     };
   }, [open, updateMenuPosition, visibleActions.length]);
 
@@ -215,6 +232,7 @@ export function QuickReplyMenu({ actions, disabled = false }: QuickReplyMenuProp
         aria-label={localizeUi("settings.quickReplies.label")}
         aria-haspopup="menu"
         aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
         className={cn(
           "flex h-11 w-11 items-center justify-center rounded-full transition-all duration-200 sm:h-8 sm:w-8",
           open
@@ -242,6 +260,7 @@ export function QuickReplyMenu({ actions, disabled = false }: QuickReplyMenuProp
             >
               <motion.div
                 key="quick-replies-rail"
+                id={menuId}
                 role="menu"
                 aria-label={localizeUi("settings.quickReplies.label")}
                 aria-orientation="vertical"

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -2895,7 +2895,7 @@ function CustomQuickRepliesManager() {
                 <button
                   type="button"
                   onClick={() => removeCustomQuickReply(entry.id)}
-                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10 active:scale-90"
+                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-[var(--primary)] transition-colors hover:bg-[var(--primary)]/10 active:scale-90"
                   title={localize("Remove quick reply")}
                   aria-label={localize("Remove quick reply")}
                 >


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

No linked issue. This bug was reported directly by the maintainer with a screenshot.

## Why this change

- The multi-action Quick Replies rail rendered inside the chat composer's overflow and stacking contexts, so Roleplay mode clipped it at the input border instead of displaying it above the chat.
- Custom Quick Reply delete buttons used the destructive red token even though they are compact settings controls that should follow the active accent.

## What changed

- Render the opened Quick Replies rail through a `document.body` portal with fixed, viewport-clamped coordinates above its trigger.
- Reposition the rail on viewport resize and ancestor scrolling while preserving its existing animation, keyboard navigation, outside-click dismissal, and action behavior.
- Style the custom Quick Reply trash icon with the active primary accent token.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm --filter @marinara-engine/client exec eslint src/components/chat/QuickReplyMenu.tsx src/components/panels/SettingsPanel.tsx`
- `pnpm --filter @marinara-engine/client build`
- Exercised the Roleplay Quick Replies menu against the local app at 1280×800 and 390×844. Confirmed the menu is portaled under `document.body`, uses fixed positioning at `z-index: 9999`, and remains entirely above its trigger at both viewport sizes.
- Confirmed the custom Quick Reply delete control resolves to `--primary` instead of `--destructive` in the tested theme.
- The in-app browser connector failed during initialization, so the live UI verification used the repository's installed Playwright runtime against the same local development server.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Maintainer-provided screenshot captured the original clipping.
- Desktop and mobile after-fix captures were inspected locally during verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quick reply menu positioning when opening, scrolling, or resizing the page.
  * Prevented the menu from appearing in an incorrect location while positioning loads.
  * Improved outside-click behavior for the quick reply menu.

* **Style**
  * Updated the quick reply removal button to use the primary color.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->