### PR TITLE
Fix assigned Roleplay issues and add Mari docs lookup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,7 @@ COPY scripts/docker-entrypoint.mjs /usr/local/bin/marinara-docker-entrypoint.mjs
 COPY scripts/install-backgroundremover.mjs scripts/install-backgroundremover.mjs
 
 # User guides served by the in-app documentation viewer (/api/docs)
+COPY README.md README.md
 COPY docs/ docs/
 
 # Ensure /app/data exists for runtime use (file storage, uploads, generated assets)

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -123,6 +123,7 @@ COPY scripts/docker-entrypoint.mjs /usr/local/bin/marinara-docker-entrypoint.mjs
 COPY scripts/install-backgroundremover.mjs scripts/install-backgroundremover.mjs
 
 # User guides served by the in-app documentation viewer (/api/docs)
+COPY README.md README.md
 COPY docs/ docs/
 
 # Ensure data directory exists

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -598,8 +598,8 @@ const EditTextarea = memo(function EditTextarea({
           if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleSave();
           if (e.key === "Escape") onCancel();
         }}
-        className="w-full resize-none overflow-y-hidden rounded-lg bg-black/30 px-3 py-2 text-white outline-none ring-1 ring-white/20 focus:ring-blue-400/50"
-        style={{ fontSize, lineHeight: 1.5 }}
+        className="w-full resize-none overflow-y-auto overscroll-contain rounded-lg bg-black/30 px-3 py-2 text-white outline-none ring-1 ring-white/20 focus:ring-blue-400/50"
+        style={{ fontSize, lineHeight: 1.5, maxHeight: "min(60dvh, 32rem)" }}
       />
       <div className="flex items-center gap-1.5 justify-end">
         <button

--- a/packages/client/src/components/chat/SpriteOverlay.tsx
+++ b/packages/client/src/components/chat/SpriteOverlay.tsx
@@ -639,8 +639,8 @@ function CharacterSprite({
         </div>
       )}
 
-      <div style={{ opacity: resolvedSpriteOpacity }}>
-        <AnimatePresence mode="wait">
+      <div className="grid" style={{ opacity: resolvedSpriteOpacity }}>
+        <AnimatePresence mode="sync">
           <motion.img
             key={`${placementKey}-${expression}`}
             src={spriteUrl}
@@ -651,7 +651,7 @@ function CharacterSprite({
                   : localizeUi("ui.chat.charactersprite.expression"),
               value2: expression,
             })}
-            className={`${sizeClass} w-auto object-contain drop-shadow-[0_0_20px_rgba(0,0,0,0.5)] ${editing ? "cursor-grab active:cursor-grabbing" : ""}`}
+            className={`${sizeClass} col-start-1 row-start-1 w-auto object-contain drop-shadow-[0_0_20px_rgba(0,0,0,0.5)] ${editing ? "cursor-grab active:cursor-grabbing" : ""}`}
             style={spriteScaleStyle}
             draggable={false}
             initial={variant.initial}

--- a/packages/server/src/services/professor-mari/documentation-tools.ts
+++ b/packages/server/src/services/professor-mari/documentation-tools.ts
@@ -1,0 +1,274 @@
+import type { Dirent } from "node:fs";
+import { lstat, readdir, readFile } from "node:fs/promises";
+import { join, relative, resolve, sep } from "node:path";
+
+const EXCLUDED_DOC_DIRS = new Set(["evidence", "pr-evidence", "screenshots", "examples", "i18n"]);
+const MAX_DOC_FILE_BYTES = 1024 * 1024;
+const DEFAULT_SEARCH_LIMIT = 5;
+const MAX_SEARCH_LIMIT = 8;
+const DEFAULT_READ_CHARS = 8_000;
+const MAX_READ_CHARS = 16_000;
+const MAX_EXCERPT_CHARS = 700;
+
+interface DocumentationSection {
+  path: string;
+  heading: string;
+  content: string;
+  startLine: number;
+}
+
+export interface DocumentationSearchResult {
+  path: string;
+  heading: string;
+  excerpt: string;
+  startLine: number;
+  score: number;
+}
+
+function normalizeDocPath(workspaceRoot: string, absolutePath: string) {
+  return relative(workspaceRoot, absolutePath).split(sep).join("/");
+}
+
+async function collectMarkdownFiles(dir: string, workspaceRoot: string): Promise<string[]> {
+  const files: string[] = [];
+  let entries: Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DOC_DIRS.has(entry.name.toLowerCase())) continue;
+      files.push(...(await collectMarkdownFiles(join(dir, entry.name), workspaceRoot)));
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".md")) continue;
+    const absolutePath = join(dir, entry.name);
+    if (normalizeDocPath(workspaceRoot, absolutePath).startsWith("docs/")) files.push(absolutePath);
+  }
+  return files;
+}
+
+async function canonicalDocumentationFiles(workspaceRoot: string): Promise<string[]> {
+  const root = resolve(workspaceRoot);
+  const files = await collectMarkdownFiles(join(root, "docs"), root);
+  const readme = join(root, "README.md");
+  try {
+    if ((await lstat(readme)).isFile()) files.unshift(readme);
+  } catch {
+    // Packaged or partial workspaces may omit the root README while retaining docs/.
+  }
+  return files;
+}
+
+async function readBoundedMarkdown(filePath: string): Promise<string | null> {
+  try {
+    const info = await lstat(filePath);
+    if (!info.isFile() || info.size > MAX_DOC_FILE_BYTES) return null;
+    return await readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function markdownSections(path: string, content: string): DocumentationSection[] {
+  const lines = content.split(/\r?\n/);
+  const headings = lines.flatMap((line, index) => {
+    const match = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/u);
+    return match ? [{ index, heading: match[2]!.trim() }] : [];
+  });
+  if (headings.length === 0) {
+    return [{ path, heading: "Document overview", content, startLine: 1 }];
+  }
+
+  const sections: DocumentationSection[] = [];
+  if (headings[0]!.index > 0) {
+    sections.push({
+      path,
+      heading: "Document overview",
+      content: lines.slice(0, headings[0]!.index).join("\n"),
+      startLine: 1,
+    });
+  }
+  headings.forEach((heading, index) => {
+    const end = headings[index + 1]?.index ?? lines.length;
+    sections.push({
+      path,
+      heading: heading.heading,
+      content: lines.slice(heading.index + 1, end).join("\n"),
+      startLine: heading.index + 1,
+    });
+  });
+  return sections;
+}
+
+function readMarkdownHeading(path: string, content: string, requestedHeading: string): DocumentationSection | null {
+  const lines = content.split(/\r?\n/);
+  const normalizedHeading = requestedHeading.toLocaleLowerCase();
+  for (const [index, line] of lines.entries()) {
+    const match = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/u);
+    if (!match || match[2]!.trim().toLocaleLowerCase() !== normalizedHeading) continue;
+    const level = match[1]!.length;
+    let end = lines.length;
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      const nextHeading = lines[cursor]!.match(/^(#{1,6})\s+/u);
+      if (nextHeading && nextHeading[1]!.length <= level) {
+        end = cursor;
+        break;
+      }
+    }
+    return {
+      path,
+      heading: match[2]!.trim(),
+      content: lines.slice(index + 1, end).join("\n"),
+      startLine: index + 1,
+    };
+  }
+  return null;
+}
+
+function queryTerms(query: string) {
+  return [...new Set(query.toLocaleLowerCase().match(/[\p{L}\p{N}][\p{L}\p{N}_-]*/gu) ?? [])].filter(
+    (term) => term.length > 1,
+  );
+}
+
+function countOccurrences(text: string, needle: string) {
+  if (!needle) return 0;
+  let count = 0;
+  let offset = 0;
+  while ((offset = text.indexOf(needle, offset)) !== -1) {
+    count += 1;
+    offset += Math.max(needle.length, 1);
+  }
+  return count;
+}
+
+function sectionScore(section: DocumentationSection, phrase: string, terms: string[]) {
+  const path = section.path.toLocaleLowerCase();
+  const heading = section.heading.toLocaleLowerCase();
+  const content = section.content.toLocaleLowerCase();
+  let score = countOccurrences(content, phrase) * 12;
+  if (heading.includes(phrase)) score += 30;
+  if (path.includes(phrase)) score += 18;
+  for (const term of terms) {
+    score += Math.min(countOccurrences(content, term), 12);
+    if (heading.includes(term)) score += 8;
+    if (path.includes(term)) score += 5;
+  }
+  return score;
+}
+
+function excerptForMatch(content: string, phrase: string, terms: string[]) {
+  const lines = content.split(/\r?\n/);
+  const needles = [phrase, ...terms].filter(Boolean);
+  const matchIndex = lines.findIndex((line) => {
+    const normalized = line.toLocaleLowerCase();
+    return needles.some((needle) => normalized.includes(needle));
+  });
+  const start = Math.max(0, matchIndex === -1 ? 0 : matchIndex - 1);
+  const excerpt = lines
+    .slice(start, start + 5)
+    .join("\n")
+    .trim();
+  if (excerpt.length <= MAX_EXCERPT_CHARS) return excerpt;
+  return `${excerpt.slice(0, MAX_EXCERPT_CHARS - 1).trimEnd()}…`;
+}
+
+export async function searchCanonicalDocumentation(
+  workspaceRoot: string,
+  query: string,
+  requestedLimit = DEFAULT_SEARCH_LIMIT,
+): Promise<DocumentationSearchResult[]> {
+  const normalizedQuery = query.trim().slice(0, 200);
+  if (normalizedQuery.length < 2) throw new Error("docs_search query must be at least 2 characters");
+  const phrase = normalizedQuery.toLocaleLowerCase();
+  const terms = queryTerms(normalizedQuery);
+  const limit = Math.max(1, Math.min(MAX_SEARCH_LIMIT, Math.trunc(requestedLimit) || DEFAULT_SEARCH_LIMIT));
+  const results: DocumentationSearchResult[] = [];
+
+  for (const filePath of await canonicalDocumentationFiles(workspaceRoot)) {
+    const content = await readBoundedMarkdown(filePath);
+    if (content === null) continue;
+    const path = normalizeDocPath(resolve(workspaceRoot), filePath);
+    for (const section of markdownSections(path, content)) {
+      const score = sectionScore(section, phrase, terms);
+      if (score === 0) continue;
+      results.push({
+        path: section.path,
+        heading: section.heading,
+        excerpt: excerptForMatch(section.content, phrase, terms),
+        startLine: section.startLine,
+        score,
+      });
+    }
+  }
+
+  return results
+    .sort((a, b) => b.score - a.score || a.path.localeCompare(b.path) || a.startLine - b.startLine)
+    .slice(0, limit);
+}
+
+function resolveCanonicalDocPath(workspaceRoot: string, requestedPath: string) {
+  const normalized = requestedPath.trim().replace(/^\.\//u, "").replace(/\\/gu, "/");
+  if (normalized !== "README.md" && (!normalized.startsWith("docs/") || !normalized.toLowerCase().endsWith(".md"))) {
+    throw new Error("docs_read path must be README.md or an English Markdown file under docs/");
+  }
+  const segments = normalized.split("/");
+  if (segments.some((segment) => !segment || segment === "." || segment === "..")) {
+    throw new Error("docs_read path is invalid");
+  }
+  if (segments[0] === "docs" && EXCLUDED_DOC_DIRS.has((segments[1] ?? "").toLowerCase())) {
+    throw new Error("docs_read path is outside the canonical user documentation set");
+  }
+  return { normalized, absolute: resolve(workspaceRoot, ...segments) };
+}
+
+export async function readCanonicalDocumentation(
+  workspaceRoot: string,
+  requestedPath: string,
+  requestedHeading?: string,
+  requestedMaxChars = DEFAULT_READ_CHARS,
+) {
+  const { normalized, absolute } = resolveCanonicalDocPath(workspaceRoot, requestedPath);
+  const content = await readBoundedMarkdown(absolute);
+  if (content === null) throw new Error(`Documentation file not found or too large: ${normalized}`);
+  const heading = requestedHeading?.trim();
+  const section = heading ? readMarkdownHeading(normalized, content, heading) : null;
+  if (heading && !section) throw new Error(`Heading not found in ${normalized}: ${heading}`);
+  const selected = section?.content ?? content;
+  const maxChars = Math.max(1_000, Math.min(MAX_READ_CHARS, Math.trunc(requestedMaxChars) || DEFAULT_READ_CHARS));
+  const truncated = selected.length > maxChars;
+  return {
+    path: normalized,
+    heading: section?.heading ?? markdownSections(normalized, content)[0]?.heading ?? "Document overview",
+    startLine: section?.startLine ?? 1,
+    content: truncated ? `${selected.slice(0, maxChars).trimEnd()}\n…` : selected,
+    truncated,
+  };
+}
+
+export function formatDocumentationSearch(query: string, results: DocumentationSearchResult[]) {
+  if (results.length === 0) {
+    return `No canonical documentation matches found for: ${query.trim()}`;
+  }
+  return [
+    `Canonical documentation matches for: ${query.trim()}`,
+    ...results.map(
+      (result, index) =>
+        `${index + 1}. Source: ${result.path} — Heading: ${result.heading} — Line: ${result.startLine}\n${result.excerpt}`,
+    ),
+  ].join("\n\n");
+}
+
+export function formatDocumentationRead(result: Awaited<ReturnType<typeof readCanonicalDocumentation>>) {
+  return [
+    `Source: ${result.path}`,
+    `Heading: ${result.heading}`,
+    `Starts at line: ${result.startLine}${result.truncated ? " (bounded excerpt)" : ""}`,
+    "",
+    result.content,
+  ].join("\n");
+}

--- a/packages/server/src/services/professor-mari/documentation-tools.ts
+++ b/packages/server/src/services/professor-mari/documentation-tools.ts
@@ -8,6 +8,8 @@ const MAX_DOC_CANDIDATES = 500;
 const MAX_DOC_DIRECTORIES = 250;
 const MAX_DOC_DEPTH = 8;
 const MAX_DOC_AGGREGATE_BYTES = 8 * 1024 * 1024;
+const MAX_DOC_SECTIONS = 20_000;
+const MAX_DOC_MATCHES = 5_000;
 const DEFAULT_SEARCH_LIMIT = 5;
 const MAX_SEARCH_LIMIT = 8;
 const DEFAULT_READ_CHARS = 8_000;
@@ -35,32 +37,31 @@ export interface DocumentationSearchResponse {
 }
 
 interface DocumentationDiscovery {
-  files: string[];
+  files: Array<{ absolutePath: string; path: string }>;
   totalBytes: number;
   directories: number;
-  truncated: boolean;
+  incomplete: boolean;
+  stopped: boolean;
 }
 
-function normalizeDocPath(workspaceRoot: string, absolutePath: string) {
-  return relative(workspaceRoot, absolutePath).split(sep).join("/");
-}
-
-async function addDocumentationCandidate(filePath: string, discovery: DocumentationDiscovery) {
+async function addDocumentationCandidate(filePath: string, path: string, discovery: DocumentationDiscovery) {
   if (discovery.files.length >= MAX_DOC_CANDIDATES) {
-    discovery.truncated = true;
+    discovery.incomplete = true;
+    discovery.stopped = true;
     return;
   }
   try {
     const info = await lstat(filePath);
     if (!info.isFile() || info.size > MAX_DOC_FILE_BYTES) {
-      if (info.isFile()) discovery.truncated = true;
+      if (info.isFile()) discovery.incomplete = true;
       return;
     }
     if (discovery.totalBytes + info.size > MAX_DOC_AGGREGATE_BYTES) {
-      discovery.truncated = true;
+      discovery.incomplete = true;
+      discovery.stopped = true;
       return;
     }
-    discovery.files.push(filePath);
+    discovery.files.push({ absolutePath: filePath, path });
     discovery.totalBytes += info.size;
   } catch {
     // A file can disappear during an update; omit it from this search.
@@ -69,13 +70,14 @@ async function addDocumentationCandidate(filePath: string, discovery: Documentat
 
 async function collectMarkdownFiles(
   dir: string,
-  workspaceRoot: string,
+  docsRoot: string,
   discovery: DocumentationDiscovery,
   depth: number,
 ): Promise<void> {
-  if (discovery.truncated) return;
+  if (discovery.stopped) return;
   if (depth > MAX_DOC_DEPTH || discovery.directories >= MAX_DOC_DIRECTORIES) {
-    discovery.truncated = true;
+    discovery.incomplete = true;
+    discovery.stopped = true;
     return;
   }
   discovery.directories += 1;
@@ -87,25 +89,41 @@ async function collectMarkdownFiles(
   }
 
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
-    if (discovery.truncated) return;
+    if (discovery.stopped) return;
     if (entry.isDirectory()) {
       if (EXCLUDED_DOC_DIRS.has(entry.name.toLowerCase())) continue;
-      await collectMarkdownFiles(join(dir, entry.name), workspaceRoot, discovery, depth + 1);
+      await collectMarkdownFiles(join(dir, entry.name), docsRoot, discovery, depth + 1);
       continue;
     }
     if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".md")) continue;
     const absolutePath = join(dir, entry.name);
-    if (normalizeDocPath(workspaceRoot, absolutePath).startsWith("docs/")) {
-      await addDocumentationCandidate(absolutePath, discovery);
-    }
+    const path = `docs/${relative(docsRoot, absolutePath).split(sep).join("/")}`;
+    await addDocumentationCandidate(absolutePath, path, discovery);
   }
 }
 
 async function canonicalDocumentationFiles(workspaceRoot: string): Promise<DocumentationDiscovery> {
-  const root = resolve(workspaceRoot);
-  const discovery: DocumentationDiscovery = { files: [], totalBytes: 0, directories: 0, truncated: false };
-  await addDocumentationCandidate(join(root, "README.md"), discovery);
-  await collectMarkdownFiles(join(root, "docs"), root, discovery, 0);
+  const root = await realpath(resolve(workspaceRoot));
+  const discovery: DocumentationDiscovery = {
+    files: [],
+    totalBytes: 0,
+    directories: 0,
+    incomplete: false,
+    stopped: false,
+  };
+  await addDocumentationCandidate(join(root, "README.md"), "README.md", discovery);
+  let docsRoot: string;
+  try {
+    docsRoot = await realpath(join(root, "docs"));
+  } catch {
+    return discovery;
+  }
+  if (!isPathWithin(root, docsRoot)) {
+    discovery.incomplete = true;
+    discovery.stopped = true;
+    return discovery;
+  }
+  await collectMarkdownFiles(docsRoot, docsRoot, discovery, 0);
   return discovery;
 }
 
@@ -122,14 +140,28 @@ async function readBoundedMarkdown(filePath: string, maxBytes = MAX_DOC_FILE_BYT
   }
 }
 
-function markdownSections(path: string, content: string): DocumentationSection[] {
+function markdownSections(
+  path: string,
+  content: string,
+  maxSections: number,
+): { sections: DocumentationSection[]; truncated: boolean } {
   const lines = content.split(/\r?\n/);
-  const headings = lines.flatMap((line, index) => {
+  const headings: Array<{ index: number; heading: string }> = [];
+  let overflowIndex: number | null = null;
+  for (const [index, line] of lines.entries()) {
     const match = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/u);
-    return match ? [{ index, heading: match[2]!.trim() }] : [];
-  });
+    if (!match) continue;
+    if (headings.length >= Math.max(1, maxSections)) {
+      overflowIndex = index;
+      break;
+    }
+    headings.push({ index, heading: match[2]!.trim() });
+  }
   if (headings.length === 0) {
-    return [{ path, heading: "Document overview", content, startLine: 1 }];
+    return {
+      sections: [{ path, heading: "Document overview", content, startLine: 1 }],
+      truncated: false,
+    };
   }
 
   const sections: DocumentationSection[] = [];
@@ -142,7 +174,7 @@ function markdownSections(path: string, content: string): DocumentationSection[]
     });
   }
   headings.forEach((heading, index) => {
-    const end = headings[index + 1]?.index ?? lines.length;
+    const end = headings[index + 1]?.index ?? overflowIndex ?? lines.length;
     sections.push({
       path,
       heading: heading.heading,
@@ -150,7 +182,14 @@ function markdownSections(path: string, content: string): DocumentationSection[]
       startLine: heading.index + 1,
     });
   });
-  return sections;
+  return {
+    sections: sections.slice(0, maxSections),
+    truncated: overflowIndex !== null || sections.length > maxSections,
+  };
+}
+
+function firstMarkdownHeading(content: string) {
+  return content.match(/^#{1,6}\s+(.+?)\s*#*\s*$/mu)?.[1]?.trim() ?? "Document overview";
 }
 
 function readMarkdownHeading(path: string, content: string, requestedHeading: string): DocumentationSection | null {
@@ -226,6 +265,10 @@ function excerptForMatch(content: string, phrase: string, terms: string[]) {
   return `${excerpt.slice(0, MAX_EXCERPT_CHARS - 1).trimEnd()}…`;
 }
 
+function compareSearchResults(a: DocumentationSearchResult, b: DocumentationSearchResult) {
+  return b.score - a.score || a.path.localeCompare(b.path) || a.startLine - b.startLine;
+}
+
 export async function searchCanonicalDocumentation(
   workspaceRoot: string,
   query: string,
@@ -239,40 +282,59 @@ export async function searchCanonicalDocumentation(
   const discovery = await canonicalDocumentationFiles(workspaceRoot);
   const results: DocumentationSearchResult[] = [];
   let bytesRead = 0;
-  let truncated = discovery.truncated;
+  let sectionCount = 0;
+  let matchCount = 0;
+  let truncated = discovery.incomplete;
 
-  for (const filePath of discovery.files) {
+  fileLoop: for (const file of discovery.files) {
     const remainingBytes = MAX_DOC_AGGREGATE_BYTES - bytesRead;
     if (remainingBytes <= 0) {
       truncated = true;
       break;
     }
-    const content = await readBoundedMarkdown(filePath, remainingBytes);
+    const content = await readBoundedMarkdown(file.absolutePath, remainingBytes);
     if (content === null) {
       truncated = true;
       continue;
     }
     bytesRead += Buffer.byteLength(content, "utf8");
-    const path = normalizeDocPath(resolve(workspaceRoot), filePath);
-    for (const section of markdownSections(path, content)) {
+    const remainingSections = MAX_DOC_SECTIONS - sectionCount;
+    if (remainingSections <= 0) {
+      truncated = true;
+      break;
+    }
+    const sectionBatch = markdownSections(file.path, content, remainingSections);
+    for (const section of sectionBatch.sections) {
+      sectionCount += 1;
       const score = sectionScore(section, phrase, terms);
-      if (score === 0) continue;
-      results.push({
-        path: section.path,
-        heading: section.heading,
-        excerpt: excerptForMatch(section.content, phrase, terms),
-        startLine: section.startLine,
-        score,
-      });
+      if (score > 0) {
+        matchCount += 1;
+        results.push({
+          path: section.path,
+          heading: section.heading,
+          excerpt: excerptForMatch(section.content, phrase, terms),
+          startLine: section.startLine,
+          score,
+        });
+        results.sort(compareSearchResults);
+        if (results.length > limit) results.pop();
+        if (matchCount >= MAX_DOC_MATCHES) {
+          truncated = true;
+          break fileLoop;
+        }
+      }
+      if (sectionCount >= MAX_DOC_SECTIONS) {
+        truncated = true;
+        break fileLoop;
+      }
+    }
+    if (sectionBatch.truncated) {
+      truncated = true;
+      break;
     }
   }
 
-  return {
-    results: results
-      .sort((a, b) => b.score - a.score || a.path.localeCompare(b.path) || a.startLine - b.startLine)
-      .slice(0, limit),
-    truncated,
-  };
+  return { results, truncated };
 }
 
 function isPathWithin(parent: string, child: string) {
@@ -330,7 +392,7 @@ export async function readCanonicalDocumentation(
   const truncated = selected.length > maxChars;
   return {
     path: normalized,
-    heading: section?.heading ?? markdownSections(normalized, content)[0]?.heading ?? "Document overview",
+    heading: section?.heading ?? firstMarkdownHeading(content),
     startLine: section?.startLine ?? 1,
     content: truncated ? `${selected.slice(0, maxChars).trimEnd()}\n…` : selected,
     truncated,

--- a/packages/server/src/services/professor-mari/documentation-tools.ts
+++ b/packages/server/src/services/professor-mari/documentation-tools.ts
@@ -1,9 +1,13 @@
 import type { Dirent } from "node:fs";
-import { lstat, readdir, readFile } from "node:fs/promises";
+import { lstat, readdir, readFile, realpath } from "node:fs/promises";
 import { join, relative, resolve, sep } from "node:path";
 
 const EXCLUDED_DOC_DIRS = new Set(["evidence", "pr-evidence", "screenshots", "examples", "i18n"]);
 const MAX_DOC_FILE_BYTES = 1024 * 1024;
+const MAX_DOC_CANDIDATES = 500;
+const MAX_DOC_DIRECTORIES = 250;
+const MAX_DOC_DEPTH = 8;
+const MAX_DOC_AGGREGATE_BYTES = 8 * 1024 * 1024;
 const DEFAULT_SEARCH_LIMIT = 5;
 const MAX_SEARCH_LIMIT = 8;
 const DEFAULT_READ_CHARS = 8_000;
@@ -25,49 +29,94 @@ export interface DocumentationSearchResult {
   score: number;
 }
 
+export interface DocumentationSearchResponse {
+  results: DocumentationSearchResult[];
+  truncated: boolean;
+}
+
+interface DocumentationDiscovery {
+  files: string[];
+  totalBytes: number;
+  directories: number;
+  truncated: boolean;
+}
+
 function normalizeDocPath(workspaceRoot: string, absolutePath: string) {
   return relative(workspaceRoot, absolutePath).split(sep).join("/");
 }
 
-async function collectMarkdownFiles(dir: string, workspaceRoot: string): Promise<string[]> {
-  const files: string[] = [];
+async function addDocumentationCandidate(filePath: string, discovery: DocumentationDiscovery) {
+  if (discovery.files.length >= MAX_DOC_CANDIDATES) {
+    discovery.truncated = true;
+    return;
+  }
+  try {
+    const info = await lstat(filePath);
+    if (!info.isFile() || info.size > MAX_DOC_FILE_BYTES) {
+      if (info.isFile()) discovery.truncated = true;
+      return;
+    }
+    if (discovery.totalBytes + info.size > MAX_DOC_AGGREGATE_BYTES) {
+      discovery.truncated = true;
+      return;
+    }
+    discovery.files.push(filePath);
+    discovery.totalBytes += info.size;
+  } catch {
+    // A file can disappear during an update; omit it from this search.
+  }
+}
+
+async function collectMarkdownFiles(
+  dir: string,
+  workspaceRoot: string,
+  discovery: DocumentationDiscovery,
+  depth: number,
+): Promise<void> {
+  if (discovery.truncated) return;
+  if (depth > MAX_DOC_DEPTH || discovery.directories >= MAX_DOC_DIRECTORIES) {
+    discovery.truncated = true;
+    return;
+  }
+  discovery.directories += 1;
   let entries: Dirent[];
   try {
     entries = await readdir(dir, { withFileTypes: true });
   } catch {
-    return files;
+    return;
   }
 
-  for (const entry of entries) {
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (discovery.truncated) return;
     if (entry.isDirectory()) {
       if (EXCLUDED_DOC_DIRS.has(entry.name.toLowerCase())) continue;
-      files.push(...(await collectMarkdownFiles(join(dir, entry.name), workspaceRoot)));
+      await collectMarkdownFiles(join(dir, entry.name), workspaceRoot, discovery, depth + 1);
       continue;
     }
     if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".md")) continue;
     const absolutePath = join(dir, entry.name);
-    if (normalizeDocPath(workspaceRoot, absolutePath).startsWith("docs/")) files.push(absolutePath);
+    if (normalizeDocPath(workspaceRoot, absolutePath).startsWith("docs/")) {
+      await addDocumentationCandidate(absolutePath, discovery);
+    }
   }
-  return files;
 }
 
-async function canonicalDocumentationFiles(workspaceRoot: string): Promise<string[]> {
+async function canonicalDocumentationFiles(workspaceRoot: string): Promise<DocumentationDiscovery> {
   const root = resolve(workspaceRoot);
-  const files = await collectMarkdownFiles(join(root, "docs"), root);
-  const readme = join(root, "README.md");
-  try {
-    if ((await lstat(readme)).isFile()) files.unshift(readme);
-  } catch {
-    // Packaged or partial workspaces may omit the root README while retaining docs/.
-  }
-  return files;
+  const discovery: DocumentationDiscovery = { files: [], totalBytes: 0, directories: 0, truncated: false };
+  await addDocumentationCandidate(join(root, "README.md"), discovery);
+  await collectMarkdownFiles(join(root, "docs"), root, discovery, 0);
+  return discovery;
 }
 
-async function readBoundedMarkdown(filePath: string): Promise<string | null> {
+async function readBoundedMarkdown(filePath: string, maxBytes = MAX_DOC_FILE_BYTES): Promise<string | null> {
   try {
     const info = await lstat(filePath);
-    if (!info.isFile() || info.size > MAX_DOC_FILE_BYTES) return null;
-    return await readFile(filePath, "utf8");
+    const byteLimit = Math.min(MAX_DOC_FILE_BYTES, Math.max(0, maxBytes));
+    if (!info.isFile() || info.size > byteLimit) return null;
+    const content = await readFile(filePath);
+    if (content.byteLength > byteLimit) return null;
+    return content.toString("utf8");
   } catch {
     return null;
   }
@@ -181,17 +230,29 @@ export async function searchCanonicalDocumentation(
   workspaceRoot: string,
   query: string,
   requestedLimit = DEFAULT_SEARCH_LIMIT,
-): Promise<DocumentationSearchResult[]> {
+): Promise<DocumentationSearchResponse> {
   const normalizedQuery = query.trim().slice(0, 200);
   if (normalizedQuery.length < 2) throw new Error("docs_search query must be at least 2 characters");
   const phrase = normalizedQuery.toLocaleLowerCase();
   const terms = queryTerms(normalizedQuery);
   const limit = Math.max(1, Math.min(MAX_SEARCH_LIMIT, Math.trunc(requestedLimit) || DEFAULT_SEARCH_LIMIT));
+  const discovery = await canonicalDocumentationFiles(workspaceRoot);
   const results: DocumentationSearchResult[] = [];
+  let bytesRead = 0;
+  let truncated = discovery.truncated;
 
-  for (const filePath of await canonicalDocumentationFiles(workspaceRoot)) {
-    const content = await readBoundedMarkdown(filePath);
-    if (content === null) continue;
+  for (const filePath of discovery.files) {
+    const remainingBytes = MAX_DOC_AGGREGATE_BYTES - bytesRead;
+    if (remainingBytes <= 0) {
+      truncated = true;
+      break;
+    }
+    const content = await readBoundedMarkdown(filePath, remainingBytes);
+    if (content === null) {
+      truncated = true;
+      continue;
+    }
+    bytesRead += Buffer.byteLength(content, "utf8");
     const path = normalizeDocPath(resolve(workspaceRoot), filePath);
     for (const section of markdownSections(path, content)) {
       const score = sectionScore(section, phrase, terms);
@@ -206,12 +267,22 @@ export async function searchCanonicalDocumentation(
     }
   }
 
-  return results
-    .sort((a, b) => b.score - a.score || a.path.localeCompare(b.path) || a.startLine - b.startLine)
-    .slice(0, limit);
+  return {
+    results: results
+      .sort((a, b) => b.score - a.score || a.path.localeCompare(b.path) || a.startLine - b.startLine)
+      .slice(0, limit),
+    truncated,
+  };
 }
 
-function resolveCanonicalDocPath(workspaceRoot: string, requestedPath: string) {
+function isPathWithin(parent: string, child: string) {
+  const normalizedParent = process.platform === "win32" ? parent.toLowerCase() : parent;
+  const normalizedChild = process.platform === "win32" ? child.toLowerCase() : child;
+  const prefix = normalizedParent.endsWith(sep) ? normalizedParent : `${normalizedParent}${sep}`;
+  return normalizedChild === normalizedParent || normalizedChild.startsWith(prefix);
+}
+
+async function resolveCanonicalDocPath(workspaceRoot: string, requestedPath: string) {
   const normalized = requestedPath.trim().replace(/^\.\//u, "").replace(/\\/gu, "/");
   if (normalized !== "README.md" && (!normalized.startsWith("docs/") || !normalized.toLowerCase().endsWith(".md"))) {
     throw new Error("docs_read path must be README.md or an English Markdown file under docs/");
@@ -220,10 +291,26 @@ function resolveCanonicalDocPath(workspaceRoot: string, requestedPath: string) {
   if (segments.some((segment) => !segment || segment === "." || segment === "..")) {
     throw new Error("docs_read path is invalid");
   }
-  if (segments[0] === "docs" && EXCLUDED_DOC_DIRS.has((segments[1] ?? "").toLowerCase())) {
+  if (segments.slice(1).some((segment) => EXCLUDED_DOC_DIRS.has(segment.toLowerCase()))) {
     throw new Error("docs_read path is outside the canonical user documentation set");
   }
-  return { normalized, absolute: resolve(workspaceRoot, ...segments) };
+  const workspace = await realpath(resolve(workspaceRoot));
+  const requested = resolve(workspace, ...segments);
+  const requestedInfo = await lstat(requested);
+  if (!requestedInfo.isFile()) throw new Error(`Documentation file not found: ${normalized}`);
+  const canonicalTarget = await realpath(requested);
+  if (normalized === "README.md") {
+    const canonicalReadme = await realpath(join(workspace, "README.md"));
+    if (canonicalTarget !== canonicalReadme || !isPathWithin(workspace, canonicalTarget)) {
+      throw new Error("docs_read README path escapes the canonical workspace boundary");
+    }
+  } else {
+    const canonicalDocsRoot = await realpath(join(workspace, "docs"));
+    if (!isPathWithin(workspace, canonicalDocsRoot) || !isPathWithin(canonicalDocsRoot, canonicalTarget)) {
+      throw new Error("docs_read path escapes the canonical documentation boundary");
+    }
+  }
+  return { normalized, absolute: canonicalTarget };
 }
 
 export async function readCanonicalDocumentation(
@@ -232,7 +319,7 @@ export async function readCanonicalDocumentation(
   requestedHeading?: string,
   requestedMaxChars = DEFAULT_READ_CHARS,
 ) {
-  const { normalized, absolute } = resolveCanonicalDocPath(workspaceRoot, requestedPath);
+  const { normalized, absolute } = await resolveCanonicalDocPath(workspaceRoot, requestedPath);
   const content = await readBoundedMarkdown(absolute);
   if (content === null) throw new Error(`Documentation file not found or too large: ${normalized}`);
   const heading = requestedHeading?.trim();
@@ -250,17 +337,21 @@ export async function readCanonicalDocumentation(
   };
 }
 
-export function formatDocumentationSearch(query: string, results: DocumentationSearchResult[]) {
+export function formatDocumentationSearch(query: string, response: DocumentationSearchResponse) {
+  const { results, truncated } = response;
   if (results.length === 0) {
-    return `No canonical documentation matches found for: ${query.trim()}`;
+    return `No canonical documentation matches found for: ${query.trim()}${truncated ? " (search stopped at the safe corpus limit)" : ""}`;
   }
   return [
     `Canonical documentation matches for: ${query.trim()}`,
+    truncated ? "Note: search stopped at the safe corpus limit; results may be incomplete." : "",
     ...results.map(
       (result, index) =>
         `${index + 1}. Source: ${result.path} — Heading: ${result.heading} — Line: ${result.startLine}\n${result.excerpt}`,
     ),
-  ].join("\n\n");
+  ]
+    .filter(Boolean)
+    .join("\n\n");
 }
 
 export function formatDocumentationRead(result: Awaited<ReturnType<typeof readCanonicalDocumentation>>) {

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -36,6 +36,12 @@ import { DATA_DIR } from "../../utils/data-dir.js";
 import { logger } from "../../lib/logger.js";
 import { PROFESSOR_MARI_AGENT_CATALOG_KNOWLEDGE } from "./official-agent-knowledge.js";
 import {
+  formatDocumentationRead,
+  formatDocumentationSearch,
+  readCanonicalDocumentation,
+  searchCanonicalDocumentation,
+} from "./documentation-tools.js";
+import {
   GENERATION_PARAMETER_SEND_KEYS,
   findKnownModel,
   LOCAL_SIDECAR_CONNECTION_ID,
@@ -127,6 +133,8 @@ type AssistantWorkspaceAction = {
 };
 
 const WORKSPACE_TOOLS: MariWorkspaceToolName[] = [
+  "docs_search",
+  "docs_read",
   "read",
   "grep",
   "find",
@@ -164,6 +172,33 @@ const SKIPPED_DIRS = new Set([
 ]);
 
 const WORKSPACE_TOOL_DEFINITIONS: WorkspaceToolDefinition[] = [
+  {
+    name: "docs_search",
+    description:
+      "Search Marinara's canonical local README and English documentation. Use this first for user-facing feature, configuration, installation, and troubleshooting questions. Results include the source path, heading, line, and a bounded excerpt.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: { type: "string", minLength: 2, maxLength: 200 },
+        limit: { type: "integer", minimum: 1, maximum: 8 },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "docs_read",
+    description:
+      "Read a canonical local documentation file or one exact heading with bounded output. Paths must be README.md or English Markdown files under docs/. Cite the returned path and heading in the answer.",
+    parameters: {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        heading: { type: "string" },
+        maxChars: { type: "integer", minimum: 1000, maximum: 16000 },
+      },
+      required: ["path"],
+    },
+  },
   {
     name: "read",
     description: "Read a text file from the workspace with optional 1-indexed line offset and line limit.",
@@ -474,7 +509,8 @@ Raw DB row contracts:
 - Generic \`mari db patch\` only accepts real table columns; app-visible nested fields must stay inside their owning JSON column instead of being written as invented top-level columns.
 
 Workspace files:
-Use workspace files to understand Marinara internals, answer source-code questions, or find content that is not available through CLI/app-data commands. Do not inspect source files instead of live app data when the user asks about saved characters, chats, agents, tools, presets, lorebooks, or other app content.`;
+For user-facing questions about Marinara features, configuration, installation, or troubleshooting, use \`docs_search\` and then \`docs_read\` before broad workspace searches. Cite the documentation path and heading in the answer. Use built-in or CLI help when exact command syntax matters. Inspect source only when canonical documentation is missing or ambiguous, or when the user explicitly asks about internals; if source inspection was required, say that the answer used an implementation-level source.
+Use other workspace files to understand Marinara internals, answer source-code questions, or find content that is not available through documentation, CLI, or app-data commands. Do not inspect source files instead of live app data when the user asks about saved characters, chats, agents, tools, presets, lorebooks, or other app content.`;
 
 function workspaceCommandProtocolPrompt() {
   const toolDocs = WORKSPACE_TOOL_DEFINITIONS.map(
@@ -488,7 +524,7 @@ Required schema:
 {
   "say": "visible text for the user, or empty string for silent work",
   "commands": [
-    { "name": "read|grep|find|ls|edit|write|bash|app_data", "arguments": {} }
+    { "name": "docs_search|docs_read|read|grep|find|ls|edit|write|bash|dependency|app_data", "arguments": {} }
   ],
   "suggestions": [
     { "label": "short button text", "prompt": "exact message to send if tapped", "entity": "characters|lorebooks|personas|presets|connections|agents|settings|chat", "tone": "danger|caution|success" }
@@ -1047,7 +1083,8 @@ function jsonPayloadStopValue(payload: Record<string, unknown>): boolean | undef
   return undefined;
 }
 
-const COMMAND_BLOCK_RE = /<(read|grep|find|ls|edit|write|bash|app_data)>\s*([\s\S]*?)\s*<\/\1>/gi;
+const COMMAND_BLOCK_RE =
+  /<(docs_search|docs_read|read|grep|find|ls|edit|write|bash|dependency|app_data)>\s*([\s\S]*?)\s*<\/\1>/gi;
 
 function parseXmlCommandCalls(content: string): WorkspaceCommandCall[] {
   const calls: WorkspaceCommandCall[] = [];
@@ -1075,17 +1112,17 @@ function parseQuotedParam(params: string, key: string): string | undefined {
 
 function parseBracketCommandCalls(content: string): WorkspaceCommandCall[] {
   const calls: WorkspaceCommandCall[] = [];
-  const re = /\[(read|grep|find|ls|bash):\s*([^\]\r\n]+)\]/gi;
+  const re = /\[(docs_search|docs_read|read|grep|find|ls|bash):\s*([^\]\r\n]+)\]/gi;
   for (const [index, match] of [...content.matchAll(re)].entries()) {
     const name = match[1];
     if (!name || !isWorkspaceToolName(name)) continue;
     const params = match[2] ?? "";
     const args: Record<string, unknown> = {};
-    for (const key of ["path", "pattern", "glob", "command"]) {
+    for (const key of ["path", "heading", "query", "pattern", "glob", "command"]) {
       const value = parseQuotedParam(params, key);
       if (value !== undefined) args[key] = value;
     }
-    for (const key of ["offset", "limit", "context", "timeout"]) {
+    for (const key of ["offset", "limit", "maxChars", "context", "timeout"]) {
       const numberMatch = params.match(new RegExp(`${key}=(-?[0-9]+)`, "i"));
       if (numberMatch) args[key] = Number.parseInt(numberMatch[1] ?? "", 10);
     }
@@ -1145,7 +1182,7 @@ function stripWorkspaceCommands(content: string): string {
   const withoutJson = removeJsonActionFrames(content).content;
   return withoutJson
     .replace(COMMAND_BLOCK_RE, "")
-    .replace(/\[(read|grep|find|ls|bash):\s*[^\]\r\n]+\]/gi, "")
+    .replace(/\[(docs_search|docs_read|read|grep|find|ls|bash):\s*[^\]\r\n]+\]/gi, "")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 }
@@ -1382,7 +1419,14 @@ function isWithin(parent: string, child: string): boolean {
 }
 
 function isReadOnlyWorkspaceCommand(command: WorkspaceCommandCall): boolean {
-  if (command.name === "read" || command.name === "grep" || command.name === "find" || command.name === "ls")
+  if (
+    command.name === "docs_search" ||
+    command.name === "docs_read" ||
+    command.name === "read" ||
+    command.name === "grep" ||
+    command.name === "find" ||
+    command.name === "ls"
+  )
     return true;
   if (command.name !== "app_data") return false;
   return appDataActionLooksReadOnly(command.arguments.action);
@@ -1493,6 +1537,10 @@ function workspaceCommandValidationIssue(command: WorkspaceCommandCall): string 
   };
 
   switch (command.name) {
+    case "docs_search":
+      return requireString("query");
+    case "docs_read":
+      return requireString("path");
     case "read":
       return requireString("path");
     case "grep":
@@ -2208,6 +2256,20 @@ ${sections.join("\n\n")}
 
   private async runWorkspaceCommand(command: WorkspaceCommandCall, signal: AbortSignal): Promise<string> {
     switch (command.name) {
+      case "docs_search": {
+        const query = stringArg(command.arguments, "query");
+        const limit = numberArg(command.arguments, "limit", 5, 1, 8);
+        return formatDocumentationSearch(query, await searchCanonicalDocumentation(this.workspaceRoot, query, limit));
+      }
+      case "docs_read":
+        return formatDocumentationRead(
+          await readCanonicalDocumentation(
+            this.workspaceRoot,
+            stringArg(command.arguments, "path"),
+            stringArg(command.arguments, "heading") || undefined,
+            numberArg(command.arguments, "maxChars", 8_000, 1_000, 16_000),
+          ),
+        );
       case "read":
         return this.commandRead(command.arguments);
       case "ls":

--- a/packages/shared/src/types/professor-mari-workspace.ts
+++ b/packages/shared/src/types/professor-mari-workspace.ts
@@ -3,6 +3,8 @@
 // ──────────────────────────────────────────────
 
 export type MariWorkspaceToolName =
+  | "docs_search"
+  | "docs_read"
   | "read"
   | "grep"
   | "find"

--- a/scripts/regressions/professor-mari-documentation.regression.ts
+++ b/scripts/regressions/professor-mari-documentation.regression.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -14,7 +14,9 @@ const workspaceRoot = await mkdtemp(join(tmpdir(), "marinara-doc-tools-"));
 
 try {
   await mkdir(join(workspaceRoot, "docs", "connections"), { recursive: true });
+  await mkdir(join(workspaceRoot, "docs", "connections", "examples"), { recursive: true });
   await mkdir(join(workspaceRoot, "docs", "examples"), { recursive: true });
+  await mkdir(join(workspaceRoot, "outside-docs"), { recursive: true });
   await writeFile(join(workspaceRoot, "README.md"), "# Marinara Engine\n\nInstall the engine with pnpm.\n", "utf8");
   await writeFile(
     join(workspaceRoot, "docs", "connections", "proxy.md"),
@@ -41,16 +43,31 @@ try {
     "# Proxy timeout\n\nThis internal example must not be searched.",
     "utf8",
   );
+  await writeFile(
+    join(workspaceRoot, "docs", "connections", "examples", "nested-ignored.md"),
+    "# Proxy timeout\n\nThis nested internal example must not be searched.",
+    "utf8",
+  );
+  await writeFile(join(workspaceRoot, "outside-docs", "secret.md"), "# Internal secret\n", "utf8");
+  await symlink(
+    join(workspaceRoot, "outside-docs"),
+    join(workspaceRoot, "docs", "connections", "linked-outside"),
+    process.platform === "win32" ? "junction" : "dir",
+  );
+  await writeFile(join(workspaceRoot, "docs", "zz-oversized.md"), "x".repeat(1024 * 1024 + 1), "utf8");
 
-  const results = await searchCanonicalDocumentation(workspaceRoot, "proxy timeout", 3);
+  const searchResponse = await searchCanonicalDocumentation(workspaceRoot, "proxy timeout", 3);
+  const results = searchResponse.results;
+  assert.equal(searchResponse.truncated, true);
   assert.equal(results[0]?.path, "docs/connections/proxy.md");
   assert.equal(results[0]?.heading, "Proxy timeout");
   assert.match(results[0]?.excerpt ?? "", /local provider/u);
   assert.ok(results.every((result) => !result.path.includes("examples")));
 
-  const formattedSearch = formatDocumentationSearch("proxy timeout", results);
+  const formattedSearch = formatDocumentationSearch("proxy timeout", searchResponse);
   assert.match(formattedSearch, /Source: docs\/connections\/proxy\.md/u);
   assert.match(formattedSearch, /Heading: Proxy timeout/u);
+  assert.match(formattedSearch, /safe corpus limit/u);
 
   const section = await readCanonicalDocumentation(workspaceRoot, "docs/connections/proxy.md", "Proxy timeout", 1_000);
   assert.match(section.content, /Increase the proxy timeout/u);
@@ -59,12 +76,20 @@ try {
   assert.match(formatDocumentationRead(section), /Source: docs\/connections\/proxy\.md/u);
 
   const readmeResults = await searchCanonicalDocumentation(workspaceRoot, "install engine", 3);
-  assert.equal(readmeResults[0]?.path, "README.md");
+  assert.equal(readmeResults.results[0]?.path, "README.md");
 
   await assert.rejects(() => readCanonicalDocumentation(workspaceRoot, "../outside.md"), /must be README\.md/u);
   await assert.rejects(
     () => readCanonicalDocumentation(workspaceRoot, "docs/connections/proxy.md", "Missing heading"),
     /Heading not found/u,
+  );
+  await assert.rejects(
+    () => readCanonicalDocumentation(workspaceRoot, "docs/connections/examples/nested-ignored.md"),
+    /outside the canonical user documentation set/u,
+  );
+  await assert.rejects(
+    () => readCanonicalDocumentation(workspaceRoot, "docs/connections/linked-outside/secret.md"),
+    /escapes the canonical documentation boundary/u,
   );
 
   const jsonAction = parseAssistantWorkspaceAction(

--- a/scripts/regressions/professor-mari-documentation.regression.ts
+++ b/scripts/regressions/professor-mari-documentation.regression.ts
@@ -54,11 +54,9 @@ try {
     join(workspaceRoot, "docs", "connections", "linked-outside"),
     process.platform === "win32" ? "junction" : "dir",
   );
-  await writeFile(join(workspaceRoot, "docs", "zz-oversized.md"), "x".repeat(1024 * 1024 + 1), "utf8");
-
   const searchResponse = await searchCanonicalDocumentation(workspaceRoot, "proxy timeout", 3);
   const results = searchResponse.results;
-  assert.equal(searchResponse.truncated, true);
+  assert.equal(searchResponse.truncated, false);
   assert.equal(results[0]?.path, "docs/connections/proxy.md");
   assert.equal(results[0]?.heading, "Proxy timeout");
   assert.match(results[0]?.excerpt ?? "", /local provider/u);
@@ -67,7 +65,10 @@ try {
   const formattedSearch = formatDocumentationSearch("proxy timeout", searchResponse);
   assert.match(formattedSearch, /Source: docs\/connections\/proxy\.md/u);
   assert.match(formattedSearch, /Heading: Proxy timeout/u);
-  assert.match(formattedSearch, /safe corpus limit/u);
+  assert.doesNotMatch(formattedSearch, /safe corpus limit/u);
+
+  const secretSearch = await searchCanonicalDocumentation(workspaceRoot, "internal secret", 3);
+  assert.equal(secretSearch.results.length, 0);
 
   const section = await readCanonicalDocumentation(workspaceRoot, "docs/connections/proxy.md", "Proxy timeout", 1_000);
   assert.match(section.content, /Increase the proxy timeout/u);
@@ -77,6 +78,12 @@ try {
 
   const readmeResults = await searchCanonicalDocumentation(workspaceRoot, "install engine", 3);
   assert.equal(readmeResults.results[0]?.path, "README.md");
+
+  await writeFile(join(workspaceRoot, "README.md"), "x".repeat(1024 * 1024 + 1), "utf8");
+  const oversizedReadmeSearch = await searchCanonicalDocumentation(workspaceRoot, "local provider timeout", 3);
+  assert.equal(oversizedReadmeSearch.results[0]?.path, "docs/connections/proxy.md");
+  assert.equal(oversizedReadmeSearch.truncated, true);
+  assert.match(formatDocumentationSearch("local provider timeout", oversizedReadmeSearch), /safe corpus limit/u);
 
   await assert.rejects(() => readCanonicalDocumentation(workspaceRoot, "../outside.md"), /must be README\.md/u);
   await assert.rejects(
@@ -107,6 +114,24 @@ try {
   );
   assert.equal(textualAction.commands[0]?.name, "docs_read");
   assert.equal(textualAction.commands[0]?.arguments.heading, "Proxy timeout");
+
+  const linkedWorkspaceRoot = await mkdtemp(join(tmpdir(), "marinara-doc-tools-linked-workspace-"));
+  const externalDocsRoot = await mkdtemp(join(tmpdir(), "marinara-doc-tools-external-docs-"));
+  try {
+    await writeFile(join(linkedWorkspaceRoot, "README.md"), "# Linked docs test\n", "utf8");
+    await writeFile(join(externalDocsRoot, "secret.md"), "# External corpus secret\n", "utf8");
+    await symlink(
+      externalDocsRoot,
+      join(linkedWorkspaceRoot, "docs"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    const linkedDocsSearch = await searchCanonicalDocumentation(linkedWorkspaceRoot, "external corpus secret", 3);
+    assert.equal(linkedDocsSearch.results.length, 0);
+    assert.equal(linkedDocsSearch.truncated, true);
+  } finally {
+    await rm(linkedWorkspaceRoot, { recursive: true, force: true });
+    await rm(externalDocsRoot, { recursive: true, force: true });
+  }
 
   console.log("Professor Mari documentation regression passed");
 } finally {

--- a/scripts/regressions/professor-mari-documentation.regression.ts
+++ b/scripts/regressions/professor-mari-documentation.regression.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  formatDocumentationRead,
+  formatDocumentationSearch,
+  readCanonicalDocumentation,
+  searchCanonicalDocumentation,
+} from "../../packages/server/src/services/professor-mari/documentation-tools.js";
+import { parseAssistantWorkspaceAction } from "../../packages/server/src/services/professor-mari/workspace-agent.service.js";
+
+const workspaceRoot = await mkdtemp(join(tmpdir(), "marinara-doc-tools-"));
+
+try {
+  await mkdir(join(workspaceRoot, "docs", "connections"), { recursive: true });
+  await mkdir(join(workspaceRoot, "docs", "examples"), { recursive: true });
+  await writeFile(join(workspaceRoot, "README.md"), "# Marinara Engine\n\nInstall the engine with pnpm.\n", "utf8");
+  await writeFile(
+    join(workspaceRoot, "docs", "connections", "proxy.md"),
+    [
+      "# Provider connections",
+      "",
+      "## Proxy timeout",
+      "",
+      "Increase the proxy timeout when a local provider needs longer to answer.",
+      "Keep the connection URL unchanged.",
+      "",
+      "### Windows launcher",
+      "",
+      "The packaged launcher uses the same timeout setting.",
+      "",
+      "## API keys",
+      "",
+      "Store keys in the connection editor.",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    join(workspaceRoot, "docs", "examples", "ignored.md"),
+    "# Proxy timeout\n\nThis internal example must not be searched.",
+    "utf8",
+  );
+
+  const results = await searchCanonicalDocumentation(workspaceRoot, "proxy timeout", 3);
+  assert.equal(results[0]?.path, "docs/connections/proxy.md");
+  assert.equal(results[0]?.heading, "Proxy timeout");
+  assert.match(results[0]?.excerpt ?? "", /local provider/u);
+  assert.ok(results.every((result) => !result.path.includes("examples")));
+
+  const formattedSearch = formatDocumentationSearch("proxy timeout", results);
+  assert.match(formattedSearch, /Source: docs\/connections\/proxy\.md/u);
+  assert.match(formattedSearch, /Heading: Proxy timeout/u);
+
+  const section = await readCanonicalDocumentation(workspaceRoot, "docs/connections/proxy.md", "Proxy timeout", 1_000);
+  assert.match(section.content, /Increase the proxy timeout/u);
+  assert.match(section.content, /packaged launcher/u);
+  assert.doesNotMatch(section.content, /Store keys/u);
+  assert.match(formatDocumentationRead(section), /Source: docs\/connections\/proxy\.md/u);
+
+  const readmeResults = await searchCanonicalDocumentation(workspaceRoot, "install engine", 3);
+  assert.equal(readmeResults[0]?.path, "README.md");
+
+  await assert.rejects(() => readCanonicalDocumentation(workspaceRoot, "../outside.md"), /must be README\.md/u);
+  await assert.rejects(
+    () => readCanonicalDocumentation(workspaceRoot, "docs/connections/proxy.md", "Missing heading"),
+    /Heading not found/u,
+  );
+
+  const jsonAction = parseAssistantWorkspaceAction(
+    JSON.stringify({
+      say: "",
+      commands: [{ name: "docs_search", arguments: { query: "proxy timeout" } }],
+      stop: false,
+    }),
+  );
+  assert.equal(jsonAction.commands[0]?.name, "docs_search");
+  assert.deepEqual(jsonAction.commands[0]?.arguments, { query: "proxy timeout" });
+
+  const textualAction = parseAssistantWorkspaceAction(
+    '<docs_read>{"path":"docs/connections/proxy.md","heading":"Proxy timeout"}</docs_read>',
+  );
+  assert.equal(textualAction.commands[0]?.name, "docs_read");
+  assert.equal(textualAction.commands[0]?.arguments.heading, "Proxy timeout");
+
+  console.log("Professor Mari documentation regression passed");
+} finally {
+  await rm(workspaceRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Why\n\nThree assigned issues had contained, provable fixes that improve Roleplay behavior and give Professor Mari a first-class path to canonical documentation. The remaining assigned issues need broader or security-sensitive investigation and are intentionally outside this sweep.\n\nCloses #4539\nCloses #4541\nCloses #4542\n\n## What changed\n\n- bounds long message edit fields and allows trackpad/touch scrolling in compressed chat layouts\n- overlaps outgoing and incoming sprite images during expression transitions so a crossfade never leaves the stage blank\n- adds bounded, read-only local documentation search/read tools for Home-screen Professor Mari\n- teaches Mari to consult canonical docs first, cite path and heading, and disclose source-code fallback\n- includes README alongside docs in both Docker runtime images\n\n## Root causes\n\n- the message editor expanded to its full content height while explicitly hiding vertical overflow\n- sprite transitions used wait mode, so the incoming keyed image did not mount until the outgoing image had fully disappeared\n- Professor Mari could only discover documentation through generic workspace file tools and had no docs-first source policy\n\n## Automated verification run\n\n- pnpm --filter @marinara-engine/client exec eslint src/components/chat/ChatMessage.tsx src/components/chat/SpriteOverlay.tsx\n- pnpm build:client\n- pnpm --filter @marinara-engine/server lint\n- pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/professor-mari-documentation.regression.ts\n- real-corpus docs_search probe for OpenRouter provider routing\n- git diff --check\n\n## Manual verification\n\n- [ ] Manually verify a long Roleplay message editor scrolls with both sidebars open\n- [ ] Manually verify fullbody sprite changes continuously overlap\n- [ ] Manually verify Professor Mari cites a documentation path and heading before implementation fallback\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-app documentation search and reading across the README and eligible documentation pages.
  * Documentation responses can include source references, excerpts, and targeted sections.
  * Added support for documentation commands across supported workspace interaction formats.

* **Bug Fixes**
  * Improved chat editing with a capped, vertically scrollable text area.
  * Smoothed sprite transitions by synchronizing entering and exiting animations.
  * Made README documentation available in production deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->