### PR TITLE
Hide generated World Maps directives from chat text

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -8997,6 +8997,20 @@ export async function generateRoutes(app: FastifyInstance) {
                 ) {
                   const edData = editorResult.data as Record<string, unknown>;
                   const editedText = typeof edData.editedText === "string" ? edData.editedText : "";
+                  let sanitizedEditedText = editedText;
+                  if (
+                    hierarchicalMapsEnabledForChat &&
+                    (requestChatMode === "roleplay" || requestChatMode === "game")
+                  ) {
+                    const parsedRewriteSpatial = extractAssistantSpatialDirective(editedText);
+                    if (parsedRewriteSpatial.matched) {
+                      sanitizedEditedText = parsedRewriteSpatial.cleanContent;
+                      logger.warn(
+                        "[text-rewrite] Stripped package-owned spatial directive from rewritten message %s",
+                        messageId,
+                      );
+                    }
+                  }
                   const changes = Array.isArray(edData.changes)
                     ? (edData.changes as Array<{ description: string }>)
                     : [{ description: "Rewrote the assistant response." }];
@@ -9009,7 +9023,7 @@ export async function generateRoutes(app: FastifyInstance) {
                         ? explicitlyRequestsTextRewrite(editNeededValue)
                         : true;
                   const droppedProtectedMarkup =
-                    strictEditNeeded && textRewriteDropsProtectedMarkup(currentResponseForRewrite, editedText);
+                    strictEditNeeded && textRewriteDropsProtectedMarkup(currentResponseForRewrite, sanitizedEditedText);
                   if (droppedProtectedMarkup) {
                     logger.warn(
                       "[text-rewrite] Skipping %s rewrite because it dropped protected markup from message %s",
@@ -9028,11 +9042,11 @@ export async function generateRoutes(app: FastifyInstance) {
                     !input.impersonate &&
                     !input.regenerateMessageId &&
                     !input.continueMessageId &&
-                    editedText.trim().length > 0 &&
+                    sanitizedEditedText.trim().length > 0 &&
                     isRepeatedConversationResponse(
                       await chats.listMessages(input.chatId),
                       rewriteCharacterId,
-                      editedText,
+                      sanitizedEditedText,
                       { excludeMessageId: messageId },
                     );
                   if (repeatsPriorConversationResponse) {
@@ -9045,16 +9059,16 @@ export async function generateRoutes(app: FastifyInstance) {
                     rewriteAllowed &&
                     !droppedProtectedMarkup &&
                     !repeatsPriorConversationResponse &&
-                    editedText.trim().length > 0 &&
-                    editedText !== currentResponseForRewrite;
+                    sanitizedEditedText.trim().length > 0 &&
+                    sanitizedEditedText !== currentResponseForRewrite;
                   if (changedMessage) {
                     const originalText = strictEditNeeded ? originalResponseBeforeRewrite : null;
-                    currentResponseForRewrite = editedText;
-                    await chats.updateMessageContent(messageId, editedText);
+                    currentResponseForRewrite = sanitizedEditedText;
+                    await chats.updateMessageContent(messageId, sanitizedEditedText);
                     if (originalText) {
                       await chats.updateMessageExtra(messageId, {
                         proseGuardianOriginalText: originalText,
-                        proseGuardianRewrittenText: editedText,
+                        proseGuardianRewrittenText: sanitizedEditedText,
                         proseGuardianRewrittenAt: new Date().toISOString(),
                       });
                     }
@@ -9063,7 +9077,7 @@ export async function generateRoutes(app: FastifyInstance) {
                       `data: ${JSON.stringify({
                         type: "text_rewrite",
                         data: {
-                          editedText,
+                          editedText: sanitizedEditedText,
                           changes,
                           rewriteApplied: true,
                           ...(originalText ? { originalText, agentType: editorResult.agentType } : {}),

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -6280,7 +6280,7 @@ export async function generateRoutes(app: FastifyInstance) {
           if (hierarchicalMapsEnabledForChat && (requestChatMode === "roleplay" || requestChatMode === "game")) {
             const parsedSpatial = extractAssistantSpatialDirective(fullResponse);
             assistantSpatialDirective = input.impersonate ? null : parsedSpatial.directive;
-            if (parsedSpatial.cleanContent !== fullResponse) {
+            if (parsedSpatial.matched) {
               fullResponse = parsedSpatial.cleanContent;
               contentReplaced = true;
             }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -5932,6 +5932,8 @@ export async function generateRoutes(app: FastifyInstance) {
             debugLog("[generate/game/raw] chatId=%s characterId=%s END", input.chatId, targetCharId ?? "gm");
           }
 
+          let contentReplaced = false;
+
           // Some models inline reasoning blocks instead of using provider-native
           // thinking channels. Lift those blocks into message.extra.thinking.
           const inlineThinking = extractLeadingThinkingBlocks(fullResponse, customThinkingTags);
@@ -5940,9 +5942,7 @@ export async function generateRoutes(app: FastifyInstance) {
               fullThinking = fullThinking ? fullThinking + "\n\n" + inlineThinking.thinking : inlineThinking.thinking;
             }
             fullResponse = inlineThinking.content;
-            if (!holdForTextRewrite) {
-              reply.raw.write(`data: ${JSON.stringify({ type: "content_replace", data: fullResponse })}\n\n`);
-            }
+            contentReplaced = true;
           }
 
           // ── LOG_LEVEL=debug or Settings -> Advanced -> Debug mode: log full response + usage to server console ──
@@ -5991,7 +5991,6 @@ export async function generateRoutes(app: FastifyInstance) {
           let parsedRawCommandCount = 0;
           let assistantSpatialDirective: ReturnType<typeof extractAssistantSpatialDirective>["directive"] = null;
           let conversationCommandContent: string | null = null;
-          let contentReplaced = false;
           if (tailMessages.assistantPrefillInjected && assistantPrefill && fullResponse.startsWith(assistantPrefill)) {
             const responseAfterPrefill = fullResponse.slice(assistantPrefill.length);
             if (responseAfterPrefill.startsWith(assistantPrefill)) {

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -75,6 +75,7 @@ import {
 } from "../services/spatial-context/projection.js";
 import { isHierarchicalMapsEnabledForChat } from "../services/spatial-context/activation.js";
 import {
+  createAssistantSpatialDirectiveStreamFilter,
   extractAssistantSpatialDirective,
   materializeAssistantSpatialState,
 } from "../services/spatial-context/state-resolution.js";
@@ -4824,7 +4825,11 @@ export async function generateRoutes(app: FastifyInstance) {
         const TOKEN_CHUNK_SIZE = 6;
         const TOKEN_CHUNK_YIELD_EVERY = 64;
         let tokenChunksSinceYield = 0;
-        const sendTokenTextChunked = async (text: string) => {
+        const spatialDirectiveStreamFilter =
+          hierarchicalMapsEnabledForChat && (requestChatMode === "roleplay" || requestChatMode === "game")
+            ? createAssistantSpatialDirectiveStreamFilter()
+            : null;
+        const emitTokenTextChunked = async (text: string) => {
           for (let i = 0; i < text.length; i += TOKEN_CHUNK_SIZE) {
             const chunk = text.slice(i, i + TOKEN_CHUNK_SIZE);
             trySendSseEvent(reply, { type: "token", data: chunk });
@@ -4834,18 +4839,13 @@ export async function generateRoutes(app: FastifyInstance) {
             }
           }
         };
+        const sendTokenTextChunked = async (text: string) => {
+          const visibleText = spatialDirectiveStreamFilter?.push(text) ?? text;
+          if (visibleText) await emitTokenTextChunked(visibleText);
+        };
         const writeContentChunked = async (text: string) => {
-          for (let i = 0; i < text.length; i += TOKEN_CHUNK_SIZE) {
-            const chunk = text.slice(i, i + TOKEN_CHUNK_SIZE);
-            fullResponse += chunk;
-            tokenChunksSinceYield += 1;
-            if (!holdForTextRewrite) {
-              trySendSseEvent(reply, { type: "token", data: chunk });
-            }
-            if (tokenChunksSinceYield % TOKEN_CHUNK_YIELD_EVERY === 0) {
-              await yieldToEventLoop();
-            }
-          }
+          fullResponse += text;
+          if (!holdForTextRewrite) await sendTokenTextChunked(text);
         };
 
         const resolveMessageSpeakerName = (message: any): string => {
@@ -5914,6 +5914,11 @@ export async function generateRoutes(app: FastifyInstance) {
             }
           }
 
+          if (!holdForTextRewrite) {
+            const pendingSpatialText = spatialDirectiveStreamFilter?.flush() ?? "";
+            if (pendingSpatialText) await emitTokenTextChunked(pendingSpatialText);
+          }
+
           const durationMs = Date.now() - genStartTime;
 
           if (input.debugMode && chatMode === "game") {
@@ -6272,13 +6277,9 @@ export async function generateRoutes(app: FastifyInstance) {
             }
           }
 
-          if (
-            !input.impersonate &&
-            hierarchicalMapsEnabledForChat &&
-            (requestChatMode === "roleplay" || requestChatMode === "game")
-          ) {
+          if (hierarchicalMapsEnabledForChat && (requestChatMode === "roleplay" || requestChatMode === "game")) {
             const parsedSpatial = extractAssistantSpatialDirective(fullResponse);
-            assistantSpatialDirective = parsedSpatial.directive;
+            assistantSpatialDirective = input.impersonate ? null : parsedSpatial.directive;
             if (parsedSpatial.cleanContent !== fullResponse) {
               fullResponse = parsedSpatial.cleanContent;
               contentReplaced = true;
@@ -6287,6 +6288,12 @@ export async function generateRoutes(app: FastifyInstance) {
               logger.debug(
                 "[generate/spatial] Parsed assistant %s directive for chat %s",
                 assistantSpatialDirective.type,
+                input.chatId,
+              );
+            } else if (input.impersonate && parsedSpatial.directive) {
+              logger.debug(
+                "[generate/spatial] Stripped impersonated %s directive for chat %s",
+                parsedSpatial.directive.type,
                 input.chatId,
               );
             }

--- a/packages/server/src/services/spatial-context/state-resolution.ts
+++ b/packages/server/src/services/spatial-context/state-resolution.ts
@@ -12,6 +12,61 @@ export interface ParsedAssistantSpatialDirective {
 }
 
 const ASSISTANT_SPATIAL_COMMAND_RE = /\[spatial_(move|discover):\s*([^\]\r\n]*)\]/giu;
+const ASSISTANT_SPATIAL_COMMAND_PREFIXES = ["[spatial_move:", "[spatial_discover:"] as const;
+
+export interface AssistantSpatialDirectiveStreamFilter {
+  push(content: string): string;
+  flush(): string;
+}
+
+/** Hide package-owned commands while they stream, before final response cleanup can replace the visible text. */
+export function createAssistantSpatialDirectiveStreamFilter(): AssistantSpatialDirectiveStreamFilter {
+  let candidate = "";
+  let commandOpen = false;
+
+  return {
+    push(content) {
+      let visible = "";
+      for (const character of content) {
+        if (!candidate) {
+          if (character === "[") candidate = character;
+          else visible += character;
+          continue;
+        }
+
+        candidate += character;
+        if (commandOpen) {
+          if (character === "]") {
+            candidate = "";
+            commandOpen = false;
+          } else if (character === "\n" || character === "\r" || candidate.length > 8_192) {
+            visible += candidate;
+            candidate = "";
+            commandOpen = false;
+          }
+          continue;
+        }
+
+        const normalized = candidate.toLowerCase();
+        if (ASSISTANT_SPATIAL_COMMAND_PREFIXES.some((prefix) => prefix === normalized)) {
+          commandOpen = true;
+          continue;
+        }
+        if (ASSISTANT_SPATIAL_COMMAND_PREFIXES.some((prefix) => prefix.startsWith(normalized))) continue;
+
+        visible += candidate;
+        candidate = "";
+      }
+      return visible;
+    },
+    flush() {
+      const remaining = candidate;
+      candidate = "";
+      commandOpen = false;
+      return remaining;
+    },
+  };
+}
 
 function parseCommandAttributes(body: string): Map<string, string> {
   const values = new Map<string, string>();

--- a/packages/server/src/services/spatial-context/state-resolution.ts
+++ b/packages/server/src/services/spatial-context/state-resolution.ts
@@ -9,10 +9,12 @@ export type AssistantSpatialDirective =
 export interface ParsedAssistantSpatialDirective {
   cleanContent: string;
   directive: AssistantSpatialDirective | null;
+  matched: boolean;
 }
 
 const ASSISTANT_SPATIAL_COMMAND_RE = /\[spatial_(move|discover):\s*([^\]\r\n]*)\]/giu;
 const ASSISTANT_SPATIAL_COMMAND_PREFIXES = ["[spatial_move:", "[spatial_discover:"] as const;
+const ASSISTANT_SPATIAL_COMMAND_PREFIX_ONLY_RE = /^\[spatial_(?:move|discover):\s*$/iu;
 
 export interface AssistantSpatialDirectiveStreamFilter {
   push(content: string): string;
@@ -39,7 +41,10 @@ export function createAssistantSpatialDirectiveStreamFilter(): AssistantSpatialD
           if (character === "]") {
             candidate = "";
             commandOpen = false;
-          } else if (character === "\n" || character === "\r" || candidate.length > 8_192) {
+          } else if (
+            candidate.length > 8_192 ||
+            ((character === "\n" || character === "\r") && !ASSISTANT_SPATIAL_COMMAND_PREFIX_ONLY_RE.test(candidate))
+          ) {
             visible += candidate;
             candidate = "";
             commandOpen = false;
@@ -82,7 +87,9 @@ function parseCommandAttributes(body: string): Map<string, string> {
 /** Extract the last valid package-owned location command and hide all such commands from chat text. */
 export function extractAssistantSpatialDirective(content: string): ParsedAssistantSpatialDirective {
   let directive: AssistantSpatialDirective | null = null;
+  let matched = false;
   for (const match of content.matchAll(ASSISTANT_SPATIAL_COMMAND_RE)) {
+    matched = true;
     const command = match[1]?.toLowerCase();
     const values = parseCommandAttributes(match[2] ?? "");
     if (command === "move") {
@@ -103,12 +110,16 @@ export function extractAssistantSpatialDirective(content: string): ParsedAssista
       };
     }
   }
+  if (!matched) {
+    return { cleanContent: content, directive: null, matched: false };
+  }
   return {
     cleanContent: content
       .replace(ASSISTANT_SPATIAL_COMMAND_RE, "")
       .replace(/\n{3,}/gu, "\n\n")
       .trim(),
     directive,
+    matched: true,
   };
 }
 

--- a/scripts/regressions/spatial-context.regression.ts
+++ b/scripts/regressions/spatial-context.regression.ts
@@ -299,6 +299,7 @@ assert.deepEqual(
   {
     cleanContent: "The lift opens onto Level 1.",
     directive: { type: "move", destinationId: "tower_level_1" },
+    matched: true,
   },
 );
 assert.deepEqual(
@@ -313,7 +314,18 @@ assert.deepEqual(
       relation: "enter",
       description: "A concealed observatory above the tower.",
     },
+    matched: true,
   },
+);
+const ordinaryImpersonatedContent = "\n[Stage direction]\n\n\nContinue through the door.\n";
+assert.deepEqual(
+  extractAssistantSpatialDirective(ordinaryImpersonatedContent),
+  {
+    cleanContent: ordinaryImpersonatedContent,
+    directive: null,
+    matched: false,
+  },
+  "Ordinary bracketed impersonated prose must retain all surrounding whitespace",
 );
 const streamedSpatialDirective = createAssistantSpatialDirectiveStreamFilter();
 assert.equal(streamedSpatialDirective.push("We arrive at the infirmary.\n[spa"), "We arrive at the infirmary.\n");
@@ -323,6 +335,11 @@ assert.equal(streamedSpatialDirective.flush(), "");
 const streamedOrdinaryBracket = createAssistantSpatialDirectiveStreamFilter();
 assert.equal(streamedOrdinaryBracket.push("[Stage direction] Continue."), "[Stage direction] Continue.");
 assert.equal(streamedOrdinaryBracket.flush(), "");
+const streamedDirectiveSplitAfterPrefix = createAssistantSpatialDirectiveStreamFilter();
+assert.equal(streamedDirectiveSplitAfterPrefix.push("[spatial_move:\n"), "");
+assert.equal(streamedDirectiveSplitAfterPrefix.push(' destination_id="moonwell"'), "");
+assert.equal(streamedDirectiveSplitAfterPrefix.push("]Arrival text."), "Arrival text.");
+assert.equal(streamedDirectiveSplitAfterPrefix.flush(), "");
 
 const validDefinition = definition(
   [

--- a/scripts/regressions/spatial-context.regression.ts
+++ b/scripts/regressions/spatial-context.regression.ts
@@ -328,6 +328,17 @@ assert.deepEqual(
   },
   "Ordinary bracketed impersonated prose must retain all surrounding whitespace",
 );
+assert.deepEqual(
+  extractAssistantSpatialDirective(
+    'The rewrite keeps this sentence.\n[spatial_move: destination_id="rewrite-must-not-apply"]',
+  ),
+  {
+    cleanContent: "The rewrite keeps this sentence.",
+    directive: { type: "move", destinationId: "rewrite-must-not-apply" },
+    matched: true,
+  },
+  "Text-rewrite output must expose clean content while its directive is discarded by the route",
+);
 const streamedSpatialDirective = createAssistantSpatialDirectiveStreamFilter();
 assert.equal(streamedSpatialDirective.push("We arrive at the infirmary.\n[spa"), "We arrive at the infirmary.\n");
 assert.equal(streamedSpatialDirective.push('tial_move: destination_id="moonwell"'), "");
@@ -367,6 +378,28 @@ assert.doesNotMatch(
 assert.ok(
   spatialSanitizationStart > inlineThinkingEnd && consolidatedReplacementStart > spatialSanitizationStart,
   "The consolidated content replacement must run after spatial sanitization",
+);
+const textRewriteStart = generateRouteSource.indexOf("// ── Text rewrite/editing agents:");
+const textRewriteEnd = generateRouteSource.indexOf(
+  "if (holdForTextRewrite && !textRewriteApplied",
+  textRewriteStart,
+);
+assert.ok(textRewriteStart >= 0 && textRewriteEnd > textRewriteStart, "Text-rewrite route block is present");
+const textRewriteSource = generateRouteSource.slice(textRewriteStart, textRewriteEnd);
+assert.match(
+  textRewriteSource,
+  /const parsedRewriteSpatial = extractAssistantSpatialDirective\(editedText\);/u,
+  "Text-rewrite output must run through spatial sanitization",
+);
+assert.match(
+  textRewriteSource,
+  /updateMessageContent\(messageId, sanitizedEditedText\)/u,
+  "Text-rewrite persistence must use sanitized content",
+);
+assert.match(
+  textRewriteSource,
+  /type: "text_rewrite",[\s\S]*?editedText: sanitizedEditedText/u,
+  "Text-rewrite events must emit sanitized content",
 );
 
 const validDefinition = definition(

--- a/scripts/regressions/spatial-context.regression.ts
+++ b/scripts/regressions/spatial-context.regression.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import type {
   ResolvedOwnerSpatialProjection,
   SpatialContextDefinition,
@@ -340,6 +341,33 @@ assert.equal(streamedDirectiveSplitAfterPrefix.push("[spatial_move:\n"), "");
 assert.equal(streamedDirectiveSplitAfterPrefix.push(' destination_id="moonwell"'), "");
 assert.equal(streamedDirectiveSplitAfterPrefix.push("]Arrival text."), "Arrival text.");
 assert.equal(streamedDirectiveSplitAfterPrefix.flush(), "");
+
+const generateRouteSource = readFileSync(
+  new URL("../../packages/server/src/routes/generate.routes.ts", import.meta.url),
+  "utf8",
+);
+const inlineThinkingStart = generateRouteSource.indexOf(
+  "const inlineThinking = extractLeadingThinkingBlocks(fullResponse, customThinkingTags);",
+);
+const inlineThinkingEnd = generateRouteSource.indexOf("// ── LOG_LEVEL=debug", inlineThinkingStart);
+const spatialSanitizationStart = generateRouteSource.indexOf(
+  "const parsedSpatial = extractAssistantSpatialDirective(fullResponse);",
+  inlineThinkingEnd,
+);
+const consolidatedReplacementStart = generateRouteSource.indexOf(
+  "if (contentReplaced) {",
+  spatialSanitizationStart,
+);
+assert.ok(inlineThinkingStart >= 0 && inlineThinkingEnd > inlineThinkingStart, "Inline-thinking route block is present");
+assert.doesNotMatch(
+  generateRouteSource.slice(inlineThinkingStart, inlineThinkingEnd),
+  /type:\s*"content_replace"/u,
+  "Inline-thinking cleanup must not emit content before spatial sanitization",
+);
+assert.ok(
+  spatialSanitizationStart > inlineThinkingEnd && consolidatedReplacementStart > spatialSanitizationStart,
+  "The consolidated content replacement must run after spatial sanitization",
+);
 
 const validDefinition = definition(
   [

--- a/scripts/regressions/spatial-context.regression.ts
+++ b/scripts/regressions/spatial-context.regression.ts
@@ -33,6 +33,7 @@ import {
   updateGameMapBinding,
 } from "../../packages/server/src/services/spatial-context/game-map-binding.js";
 import {
+  createAssistantSpatialDirectiveStreamFilter,
   extractAssistantSpatialDirective,
   materializeAssistantSpatialState,
   resolveEffectiveSpatialState,
@@ -314,6 +315,14 @@ assert.deepEqual(
     },
   },
 );
+const streamedSpatialDirective = createAssistantSpatialDirectiveStreamFilter();
+assert.equal(streamedSpatialDirective.push("We arrive at the infirmary.\n[spa"), "We arrive at the infirmary.\n");
+assert.equal(streamedSpatialDirective.push('tial_move: destination_id="moonwell"'), "");
+assert.equal(streamedSpatialDirective.push("]"), "");
+assert.equal(streamedSpatialDirective.flush(), "");
+const streamedOrdinaryBracket = createAssistantSpatialDirectiveStreamFilter();
+assert.equal(streamedOrdinaryBracket.push("[Stage direction] Continue."), "[Stage direction] Continue.");
+assert.equal(streamedOrdinaryBracket.flush(), "");
 
 const validDefinition = definition(
   [


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target staging. Only SpicyMarinara may promote this repository staging branch or a same-repository hotfix branch to main.

## Linked issue

Closes #4433

Paired World Maps release: Pasta-Devs/Marinara-Agents#220

## Why this change

- World Maps movement directives could appear transiently while streaming and persist in user-visible messages generated by `/impersonate`.
- Once persisted, the raw hidden directive was replayed in later prompt history, making the intermittent leak repeat.
- Inline-thinking cleanup could emit an early `content_replace` before the same spatial sanitization ran.

## What changed

- Withhold complete `spatial_move` and `spatial_discover` directives from Roleplay and Game token streams.
- Strip those directives from impersonated output before the generated user message is saved, while the queued movement still commits through the authoritative transition payload.
- Preserve non-directive impersonated content byte-for-byte, including bracketed prose and surrounding/repeated newlines.
- Accept whitespace-only line breaks immediately after a directive prefix without leaking the candidate stream.
- Route inline-thinking cleanup through the consolidated post-processing replacement, after spatial sanitization.
- Sanitize post-processing text rewrites before duplicate/protected-markup checks, persistence, rewrite metadata, and `text_rewrite` emission; directives introduced only by a rewrite are discarded and never applied.
- Add regression coverage for split chunks, ordinary content preservation, and replacement event order.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed CONTRIBUTING.md

Automated evidence:

- `pnpm regression:spatial` passes at exact head `e8e62c79d8f026f274117206ebb84d3f7630f6a7`.
- `pnpm lint` passes.
- Exact committed `pnpm build` passes and embeds Engine commit `e8e62c79d8f0`.
- Exact World Maps 1.3.1 artifact lifecycle passes against this head, including guided queue isolation, impersonate success/provider failure/stale rejection, restart, uninstall/reinstall, backup, and restore.
- Earlier GitHub `pnpm-validate` and `container-build-test` checks passed; current-head checks remain authoritative in the checks tab.
- The repository-level `pnpm check` wrapper still stops at the Impeccable wrapper's invalid nested-JSON report; its substantive regression, lint, localization, build, catalog, and lifecycle checks were run separately.

Review follow-up:

- `d557ea7dd` preserves ordinary impersonated content and fixes whitespace-only directive-prefix streaming.
- `95ebe4b51` prevents inline-thinking `content_replace` from preceding spatial sanitization.
- `e8e62c79d` strips spatial directives introduced by post-processing text rewrites before persistence or emission.
- Every current inline CodeRabbit thread was replied to and resolved without manually triggering another review.

### Exact artifacts

- Engine head: `e8e62c79d8f026f274117206ebb84d3f7630f6a7`
- Client entry: `assets/index-34m9qbDB.js`
- Compiled `generate.routes.js` SHA-256: `e86efa97e00e55690e3e571393a41921a8c9180fb3467188543eec680893bc85`
- Paired World Maps head: `c82af3fafb435a32b4a1cfd082fcbba01dd89057`
- World Maps ZIP SHA-256: `7c296732b9c4a1fd30f507794a3d96645d67378e14ef7ea156df41096fae614b`
- World Maps client SHA-256: `cc74f11979213c6f6fed54db60493bd9b84e069082126865741afcdcdf1e5773`
- World Maps server SHA-256: `ea0af5f7c206aff577db94a2ee854b21d79c2e79776bb74bcd70ceb4f512ee76`

### Local review installation

- The exact Engine and World Maps files above are running in the locked local review environment at `http://100.93.53.36:7860/`.
- `marinara.service` is active/running; `/api/health` reports Engine `2.4.1+e8e62c79d8f0` and World Maps `1.3.1` as `active` / `ready` with both server and client loaded.
- Engine client/server dist directories match the exact PR worktree byte-for-byte. The served `assets/index-34m9qbDB.js` SHA-256 is `0d6c98fa66f0777f51b77b83fbb2a24e09ee93e3ef7f3582c069139ed889f424`, matching the validated build.
- World Maps was installed through the package manager as `1.3.1`; the served client SHA-256 is `cc74f11979213c6f6fed54db60493bd9b84e069082126865741afcdcdf1e5773`, matching the installed and PR-head payloads. The active server payload matches `ea0af5f7c206aff577db94a2ee854b21d79c2e79776bb74bcd70ceb4f512ee76`.

### Manual verification notes

- Recheck ordinary Roleplay/Game generation, `/guided`, regeneration, continuation, and `/impersonate` with World Maps active.
- Confirm no `[spatial_move: ...]` or `[spatial_discover: ...]` text appears while streaming, during inline-thinking replacement, or in the saved message.
- Confirm a valid queued impersonate movement commits once while guided/regenerated/continued assistant turns do not consume it.
- Confirm provider failure and stale movement leave recoverable review state without a phantom commit.
- Confirm ordinary bracketed prose and its whitespace remain unchanged.
- Confirm a post-processing text-rewrite agent cannot persist, emit, or apply a spatial directive it introduces.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the docs-i18n branch updated to match, or a docs-i18n follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- The change is stream/persistence cleanup. Automated proof covers split-stream filtering, exact ordinary-content preservation, inline-thinking replacement order, and saved impersonate output.
- Agent-operated desktop (1440x900) and mobile (390x844) Chromium smoke loaded the exact live build with a populated React root, no page exceptions, no failed requests, and no horizontal overflow. The visible 2.4.1 update dialog was correctly framed on both viewports.
- The browser reported only the expected plain-HTTP COOP warning and an unrelated missing saved background (`grassy dirt path`, HTTP 404). User workflow verification remains separate and unchecked above.
