### PR TITLE
fix(ci): stabilize required checks for organization members

### DIFF
--- a/.github/workflows/owner-approval-review-signal.yml
+++ b/.github/workflows/owner-approval-review-signal.yml
@@ -1,0 +1,15 @@
+name: Owner Approval Review Signal
+
+on:
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+permissions: {}
+
+jobs:
+  signal:
+    name: Signal trusted owner approval refresh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record review event
+        run: echo "A trusted workflow will re-evaluate the staging owner-approval status."

--- a/.github/workflows/owner-approval-review.yml
+++ b/.github/workflows/owner-approval-review.yml
@@ -1,0 +1,73 @@
+name: Owner Approval Review Evaluator
+
+on:
+  workflow_run:
+    workflows: [Owner Approval Review Signal]
+    types: [completed]
+
+concurrency:
+  group: owner-approval-review-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    name: Re-evaluate staging owner approval
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Resolve pull request
+        id: pull-request
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            let pullRequests = context.payload.workflow_run.pull_requests || [];
+            if (pullRequests.length === 0) {
+              const response = await github.request(
+                'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls',
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: context.payload.workflow_run.head_sha,
+                },
+              );
+              pullRequests = response.data;
+            }
+
+            const pullNumbers = [...new Set(pullRequests.map((pullRequest) => pullRequest.number))];
+            if (pullNumbers.length === 0) {
+              core.notice('The review signal is not associated with a pull request.');
+              return;
+            }
+            if (pullNumbers.length !== 1) {
+              core.setFailed('The review signal is associated with more than one pull request.');
+              return;
+            }
+
+            core.setOutput('number', String(pullNumbers[0]));
+
+      - name: Checkout trusted default branch
+        if: steps.pull-request.outputs.number != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        if: steps.pull-request.outputs.number != ''
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Publish owner approval status
+        if: steps.pull-request.outputs.number != ''
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MEMBERS_TOKEN_CONFIGURED: ${{ secrets.PASTA_DEVS_MEMBERS_TOKEN != '' }}
+          PASTA_DEVS_MEMBERS_TOKEN: ${{ secrets.PASTA_DEVS_MEMBERS_TOKEN }}
+          PR_NUMBER: ${{ steps.pull-request.outputs.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node scripts/evaluate-owner-approval.mjs

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Run project checks
         run: pnpm check
 
+      - name: Validate pull request gate topology
+        run: node scripts/validate-pr-triage.mjs
+
+      - name: Test owner approval evaluator
+        run: node scripts/test-owner-approval.mjs
+
       - name: Check version drift
         run: pnpm version:check
 

--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -141,17 +141,12 @@ jobs:
       pull-requests: read
     steps:
       - name: Exempt trusted contributor
-        if: >-
-          github.event.pull_request.author_association == 'MEMBER' ||
-          github.event.pull_request.author_association == 'OWNER' ||
-          github.event.pull_request.author_association == 'COLLABORATOR'
+        if: contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association)
         run: echo "Trusted contributor; pull request template validation is not required."
 
       - name: Check Pull Request body against template
         if: >-
-          github.event.pull_request.author_association != 'MEMBER' &&
-          github.event.pull_request.author_association != 'OWNER' &&
-          github.event.pull_request.author_association != 'COLLABORATOR'
+          !contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association)
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |

--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -4,8 +4,6 @@ on:
   pull_request_target:
     types: [opened, reopened, edited, synchronize, ready_for_review]
     branches: [staging, main]
-  pull_request_review:
-    types: [submitted, dismissed]
 
 concurrency:
   group: pull-request-triage-${{ github.event.pull_request.number }}
@@ -14,9 +12,6 @@ concurrency:
 jobs:
   branch-policy:
     name: Branch policy check
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      (github.event.action != 'edited' || contains(toJSON(github.event.changes), '"base"'))
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -49,107 +44,34 @@ jobs:
           echo "::error::Contributions must target staging. Main accepts only SpicyMarinara's same-repository staging promotion or hotfix/* PR."
           exit 1
 
-  external-contributor-approval:
-    name: "${{ github.event.pull_request.base.ref == 'staging' && ((github.event_name == 'pull_request_target' && (github.event.action != 'edited' || contains(toJSON(github.event.changes), '\"base\"'))) || (github.event_name == 'pull_request_review' && github.event.review.user.login == 'SpicyMarinara' && (github.event.action == 'dismissed' || github.event.review.state == 'approved' || github.event.review.state == 'changes_requested' || github.event.review.state == 'commented'))) && 'Owner approval for outside contributors' || 'Ignore unrelated triage event' }}"
+  owner-approval:
+    name: Evaluate staging owner approval
+    if: github.event.pull_request.base.ref == 'staging'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
-    env:
-      APPROVAL_EVENT_RELEVANT: "${{ github.event.pull_request.base.ref == 'staging' && ((github.event_name == 'pull_request_target' && (github.event.action != 'edited' || contains(toJSON(github.event.changes), '\"base\"'))) || (github.event_name == 'pull_request_review' && github.event.review.user.login == 'SpicyMarinara' && (github.event.action == 'dismissed' || github.event.review.state == 'approved' || github.event.review.state == 'changes_requested' || github.event.review.state == 'commented'))) }}"
+      statuses: write
     steps:
-      - name: Ignore unrelated triage event
-        if: env.APPROVAL_EVENT_RELEVANT != 'true'
-        run: exit 0
+      - name: Checkout trusted base revision
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
 
-      - name: Classify pull request author
-        if: env.APPROVAL_EVENT_RELEVANT == 'true'
-        id: internal-author
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Publish owner approval status
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           MEMBERS_TOKEN_CONFIGURED: ${{ secrets.PASTA_DEVS_MEMBERS_TOKEN != '' }}
-        with:
-          # Fine-grained PAT or GitHub App token with Pasta-Devs "Members: read".
-          github-token: ${{ secrets.PASTA_DEVS_MEMBERS_TOKEN || github.token }}
-          script: |
-            const organization = context.repo.owner;
-            const ownerLogin = 'SpicyMarinara';
-            const authorLogin = context.payload.pull_request.user.login;
-
-            if (authorLogin.toLowerCase() === ownerLogin.toLowerCase()) {
-              core.notice(`${authorLogin} is the repository owner; owner approval is not required.`);
-              core.setOutput('internal', 'true');
-              return;
-            }
-
-            if (process.env.MEMBERS_TOKEN_CONFIGURED !== 'true') {
-              core.setFailed('PASTA_DEVS_MEMBERS_TOKEN is required to verify Pasta-Devs organization membership.');
-              return;
-            }
-
-            async function getOrganizationMembership(username) {
-              return github.request('GET /orgs/{org}/memberships/{username}', {
-                org: organization,
-                username,
-              });
-            }
-
-            let organizationMembership;
-            try {
-              ({ data: organizationMembership } = await getOrganizationMembership(authorLogin));
-            } catch (error) {
-              if (error.status === 404) {
-                core.notice(`${authorLogin} is not a ${organization} organization member; owner approval is required.`);
-                core.setOutput('internal', 'false');
-                return;
-              }
-              core.setFailed(`Could not verify ${authorLogin}'s ${organization} membership (${error.status ?? 'unknown status'}).`);
-              return;
-            }
-
-            if (organizationMembership.state !== 'active') {
-              core.notice(`${authorLogin}'s ${organization} membership is not active; owner approval is required.`);
-              core.setOutput('internal', 'false');
-              return;
-            }
-
-            if (organizationMembership.role === 'admin' || organizationMembership.role === 'member') {
-              core.notice(`${authorLogin} is an active ${organization} ${organizationMembership.role}; owner approval is not required.`);
-              core.setOutput('internal', 'true');
-              return;
-            }
-
-            core.notice(`${authorLogin} does not have a trusted ${organization} organization role; owner approval is required.`);
-            core.setOutput('internal', 'false');
-
-      - name: Require owner approval for outside staging contributions
-        if: env.APPROVAL_EVENT_RELEVANT == 'true' && steps.internal-author.outputs.internal != 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            const pullNumber = context.payload.pull_request.number;
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullNumber,
-            });
-
-            const reviews = await github.paginate(github.rest.pulls.listReviews, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullNumber,
-              per_page: 100,
-            });
-            const ownerReviews = reviews
-              .filter((review) => review.user?.login?.toLowerCase() === 'spicymarinara')
-              .sort((left, right) => left.id - right.id);
-            const latestOwnerReview = ownerReviews.at(-1);
-
-            if (latestOwnerReview?.state === 'APPROVED' && latestOwnerReview.commit_id === pr.head?.sha) {
-              core.notice('Outside contribution approved by SpicyMarinara.');
-              return;
-            }
-
-            core.setFailed('Outside and first-time contributions to staging require an approving review from SpicyMarinara.');
+          PASTA_DEVS_MEMBERS_TOKEN: ${{ secrets.PASTA_DEVS_MEMBERS_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node scripts/evaluate-owner-approval.mjs
 
   label:
     name: Auto-label
@@ -214,16 +136,22 @@ jobs:
   template-check:
     name: Pull Request template check
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.author_association != 'MEMBER' &&
-      github.event.pull_request.author_association != 'OWNER' &&
-      github.event.pull_request.author_association != 'COLLABORATOR'
     permissions:
       contents: read
       pull-requests: read
     steps:
+      - name: Exempt trusted contributor
+        if: >-
+          github.event.pull_request.author_association == 'MEMBER' ||
+          github.event.pull_request.author_association == 'OWNER' ||
+          github.event.pull_request.author_association == 'COLLABORATOR'
+        run: echo "Trusted contributor; pull request template validation is not required."
+
       - name: Check Pull Request body against template
+        if: >-
+          github.event.pull_request.author_association != 'MEMBER' &&
+          github.event.pull_request.author_association != 'OWNER' &&
+          github.event.pull_request.author_association != 'COLLABORATOR'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |

--- a/scripts/evaluate-owner-approval.mjs
+++ b/scripts/evaluate-owner-approval.mjs
@@ -15,9 +15,11 @@ async function githubRequest({ token, method = "GET", path, body }) {
     headers: {
       Accept: "application/vnd.github+json",
       Authorization: `Bearer ${token}`,
+      ...(body === undefined ? {} : { "Content-Type": "application/json" }),
       "X-GitHub-Api-Version": "2022-11-28",
       "User-Agent": "marinara-owner-approval-gate",
     },
+    signal: AbortSignal.timeout(15_000),
     ...(body === undefined ? {} : { body: JSON.stringify(body) }),
   });
 
@@ -120,8 +122,13 @@ export async function evaluateOwnerApproval({ env = process.env, request = githu
       description = "Active Pasta-Devs member; owner approval is not required.";
     } else if (state !== "error") {
       const reviews = await listPullRequestReviews(request, githubToken, repositoryPath, pullNumber);
+      const decisiveStates = new Set(["APPROVED", "CHANGES_REQUESTED", "DISMISSED"]);
       const latestOwnerReview = reviews
-        .filter((review) => review.user?.login?.toLowerCase() === "spicymarinara")
+        .filter(
+          (review) =>
+            review.user?.login?.toLowerCase() === "spicymarinara" &&
+            decisiveStates.has(review.state),
+        )
         .sort((left, right) => left.id - right.id)
         .at(-1);
 
@@ -130,15 +137,26 @@ export async function evaluateOwnerApproval({ env = process.env, request = githu
         description = "Outside contribution approved by SpicyMarinara for the current commit.";
       }
     }
-
-    await publishStatus();
   } catch (error) {
     state = "error";
     description = "Owner approval evaluation failed unexpectedly; failing closed.";
     console.error(
       `Owner approval evaluation failed with status ${error?.status ?? "unknown"}; publishing error status.`,
     );
-    await publishStatus();
+  }
+
+  const maximumPublishAttempts = 3;
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      await publishStatus();
+      break;
+    } catch (error) {
+      if (attempt >= maximumPublishAttempts) throw error;
+      console.warn(
+        `Owner approval status publish attempt ${attempt} failed with status ${error?.status ?? "unknown"}; retrying.`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, attempt * 250));
+    }
   }
 
   console.info(`${OWNER_APPROVAL_CONTEXT}: ${state} (${description})`);

--- a/scripts/evaluate-owner-approval.mjs
+++ b/scripts/evaluate-owner-approval.mjs
@@ -1,0 +1,153 @@
+import { pathToFileURL } from "node:url";
+
+export const OWNER_APPROVAL_CONTEXT = "Owner approval for outside contributors";
+
+function requireValue(value, name) {
+  if (!value) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+async function githubRequest({ token, method = "GET", path, body }) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    method,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "marinara-owner-approval-gate",
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+
+  const responseBody = await response.text();
+  const data = responseBody ? JSON.parse(responseBody) : undefined;
+
+  if (!response.ok) {
+    const error = new Error(data?.message || `GitHub API request failed with status ${response.status}.`);
+    error.status = response.status;
+    throw error;
+  }
+
+  return data;
+}
+
+async function listPullRequestReviews(request, token, repositoryPath, pullNumber) {
+  const reviews = [];
+
+  for (let page = 1; ; page += 1) {
+    const batch = await request({
+      token,
+      path: `/repos/${repositoryPath}/pulls/${pullNumber}/reviews?per_page=100&page=${page}`,
+    });
+    reviews.push(...batch);
+    if (batch.length < 100) break;
+  }
+
+  return reviews;
+}
+
+export async function evaluateOwnerApproval({ env = process.env, request = githubRequest } = {}) {
+  const repository = requireValue(env.GITHUB_REPOSITORY, "GITHUB_REPOSITORY");
+  const githubToken = requireValue(env.GITHUB_TOKEN, "GITHUB_TOKEN");
+  const pullNumber = Number.parseInt(requireValue(env.PR_NUMBER, "PR_NUMBER"), 10);
+  const [organization, repositoryName] = repository.split("/");
+
+  if (!organization || !repositoryName || !Number.isSafeInteger(pullNumber) || pullNumber <= 0) {
+    throw new Error("GITHUB_REPOSITORY and PR_NUMBER must identify a valid pull request.");
+  }
+
+  const repositoryPath = `${encodeURIComponent(organization)}/${encodeURIComponent(repositoryName)}`;
+  const pullRequest = await request({
+    token: githubToken,
+    path: `/repos/${repositoryPath}/pulls/${pullNumber}`,
+  });
+
+  if (pullRequest.state !== "open" || pullRequest.base?.ref !== "staging") {
+    console.info(`Skipping #${pullNumber}; it is not an open pull request targeting staging.`);
+    return { skipped: true };
+  }
+
+  const authorLogin = pullRequest.user?.login;
+  const headSha = pullRequest.head?.sha;
+  requireValue(authorLogin, "pull request author login");
+  requireValue(headSha, "pull request head SHA");
+
+  let state = "failure";
+  let description = "Outside contribution requires current SpicyMarinara approval.";
+  let internal = authorLogin.toLowerCase() === "spicymarinara";
+
+  const publishStatus = () =>
+    request({
+      token: githubToken,
+      method: "POST",
+      path: `/repos/${repositoryPath}/statuses/${encodeURIComponent(headSha)}`,
+      body: {
+        state,
+        context: OWNER_APPROVAL_CONTEXT,
+        description,
+        target_url: env.RUN_URL,
+      },
+    });
+
+  try {
+    if (!internal) {
+      if (env.MEMBERS_TOKEN_CONFIGURED !== "true" || !env.PASTA_DEVS_MEMBERS_TOKEN) {
+        state = "error";
+        description = "Could not verify Pasta-Devs membership; failing closed.";
+      } else {
+        try {
+          const membership = await request({
+            token: env.PASTA_DEVS_MEMBERS_TOKEN,
+            path: `/orgs/${encodeURIComponent(organization)}/memberships/${encodeURIComponent(authorLogin)}`,
+          });
+          internal =
+            membership.state === "active" &&
+            (membership.role === "admin" || membership.role === "member");
+        } catch (error) {
+          if (error.status !== 404) {
+            state = "error";
+            description = "Could not verify Pasta-Devs membership; failing closed.";
+            console.error(`Membership lookup failed with status ${error?.status ?? "unknown"}.`);
+          }
+        }
+      }
+    }
+
+    if (internal) {
+      state = "success";
+      description = "Active Pasta-Devs member; owner approval is not required.";
+    } else if (state !== "error") {
+      const reviews = await listPullRequestReviews(request, githubToken, repositoryPath, pullNumber);
+      const latestOwnerReview = reviews
+        .filter((review) => review.user?.login?.toLowerCase() === "spicymarinara")
+        .sort((left, right) => left.id - right.id)
+        .at(-1);
+
+      if (latestOwnerReview?.state === "APPROVED" && latestOwnerReview.commit_id === headSha) {
+        state = "success";
+        description = "Outside contribution approved by SpicyMarinara for the current commit.";
+      }
+    }
+
+    await publishStatus();
+  } catch (error) {
+    state = "error";
+    description = "Owner approval evaluation failed unexpectedly; failing closed.";
+    console.error(
+      `Owner approval evaluation failed with status ${error?.status ?? "unknown"}; publishing error status.`,
+    );
+    await publishStatus();
+  }
+
+  console.info(`${OWNER_APPROVAL_CONTEXT}: ${state} (${description})`);
+  return { skipped: false, state, description, internal };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  evaluateOwnerApproval().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test-owner-approval.mjs
+++ b/scripts/test-owner-approval.mjs
@@ -153,6 +153,18 @@ async function runCase(options, env = {}) {
     membershipError: notFound,
     reviews: [
       { id: 1, state: "APPROVED", commit_id: "head-sha", user: { login: "SpicyMarinara" } },
+      { id: 2, state: "DISMISSED", commit_id: "head-sha", user: { login: "SpicyMarinara" } },
+    ],
+  });
+  assert.equal(status.state, "failure");
+}
+
+{
+  const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+  const { status } = await runCase({
+    membershipError: notFound,
+    reviews: [
+      { id: 1, state: "APPROVED", commit_id: "head-sha", user: { login: "SpicyMarinara" } },
       { id: 2, state: "COMMENTED", commit_id: "head-sha", user: { login: "SpicyMarinara" } },
     ],
   });

--- a/scripts/test-owner-approval.mjs
+++ b/scripts/test-owner-approval.mjs
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { evaluateOwnerApproval, OWNER_APPROVAL_CONTEXT } from "./evaluate-owner-approval.mjs";
+
+const basePullRequest = {
+  state: "open",
+  base: { ref: "staging" },
+  head: { sha: "head-sha" },
+  user: { login: "OutsideContributor" },
+};
+
+function createMock({
+  pullRequest = basePullRequest,
+  membership,
+  membershipError,
+  reviews = [],
+  reviewsError,
+  statusFailures = 0,
+}) {
+  const statuses = [];
+  let statusAttempts = 0;
+  const request = async ({ token, method = "GET", path, body }) => {
+    if (method === "POST" && path.endsWith("/statuses/head-sha")) {
+      assert.equal(token, "github-token");
+      statusAttempts += 1;
+      if (statusAttempts <= statusFailures) {
+        throw Object.assign(new Error("Status unavailable"), { status: 503 });
+      }
+      statuses.push(body);
+      return body;
+    }
+    if (path.includes("/pulls/42/reviews")) {
+      if (reviewsError) throw reviewsError;
+      return reviews;
+    }
+    if (path.endsWith("/pulls/42")) return pullRequest;
+    if (path.includes("/memberships/")) {
+      assert.equal(token, "members-token");
+      if (membershipError) throw membershipError;
+      return membership;
+    }
+    throw new Error(`Unexpected request: ${method} ${path}`);
+  };
+  return { request, statuses, getStatusAttempts: () => statusAttempts };
+}
+
+async function evaluateCase(options, env = {}) {
+  const mock = createMock(options);
+  const result = await evaluateOwnerApproval({
+    request: mock.request,
+    env: {
+      GITHUB_REPOSITORY: "Pasta-Devs/Marinara-Engine",
+      GITHUB_TOKEN: "github-token",
+      MEMBERS_TOKEN_CONFIGURED: "true",
+      PASTA_DEVS_MEMBERS_TOKEN: "members-token",
+      PR_NUMBER: "42",
+      RUN_URL: "https://github.example/actions/runs/1",
+      ...env,
+    },
+  });
+  return { ...mock, result };
+}
+
+async function runCase(options, env = {}) {
+  const outcome = await evaluateCase(options, env);
+  assert.equal(outcome.statuses.length, 1);
+  assert.equal(outcome.statuses[0].context, OWNER_APPROVAL_CONTEXT);
+  return { ...outcome, status: outcome.statuses[0] };
+}
+
+{
+  const { result, statuses } = await evaluateCase({
+    pullRequest: { ...basePullRequest, state: "closed" },
+  });
+  assert.equal(result.skipped, true);
+  assert.equal(statuses.length, 0);
+}
+
+{
+  const { result, status } = await runCase({
+    pullRequest: { ...basePullRequest, user: { login: "MemberDeveloper" } },
+    membership: { state: "active", role: "member" },
+  });
+  assert.equal(result.internal, true);
+  assert.equal(status.state, "success");
+}
+
+{
+  const { result, status } = await runCase({
+    pullRequest: { ...basePullRequest, user: { login: "OrganizationOwner" } },
+    membership: { state: "active", role: "admin" },
+  });
+  assert.equal(result.internal, true);
+  assert.equal(status.state, "success");
+}
+
+{
+  const { result, status } = await runCase({
+    pullRequest: { ...basePullRequest, user: { login: "PendingMember" } },
+    membership: { state: "pending", role: "member" },
+  });
+  assert.equal(result.internal, false);
+  assert.equal(status.state, "failure");
+}
+
+{
+  const { status } = await runCase(
+    { pullRequest: { ...basePullRequest, user: { login: "SpicyMarinara" } } },
+    { MEMBERS_TOKEN_CONFIGURED: "false", PASTA_DEVS_MEMBERS_TOKEN: "" },
+  );
+  assert.equal(status.state, "success");
+}
+
+{
+  const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+  const { status } = await runCase({ membershipError: notFound });
+  assert.equal(status.state, "failure");
+}
+
+{
+  const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+  const { status } = await runCase({
+    membershipError: notFound,
+    reviews: [
+      { id: 1, state: "APPROVED", commit_id: "head-sha", user: { login: "SpicyMarinara" } },
+      { id: 2, state: "CHANGES_REQUESTED", commit_id: "head-sha", user: { login: "SpicyMarinara" } },
+    ],
+  });
+  assert.equal(status.state, "failure");
+}
+
+{
+  const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+  const { status } = await runCase({
+    membershipError: notFound,
+    reviews: [
+      { id: 1, state: "APPROVED", commit_id: "head-sha", user: { login: "SpicyMarinara" } },
+    ],
+  });
+  assert.equal(status.state, "success");
+}
+
+{
+  const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+  const { status } = await runCase({
+    membershipError: notFound,
+    reviews: [
+      { id: 1, state: "APPROVED", commit_id: "stale-sha", user: { login: "SpicyMarinara" } },
+    ],
+  });
+  assert.equal(status.state, "failure");
+}
+
+{
+  const { status } = await runCase(
+    {},
+    { MEMBERS_TOKEN_CONFIGURED: "false", PASTA_DEVS_MEMBERS_TOKEN: "" },
+  );
+  assert.equal(status.state, "error");
+}
+
+{
+  const forbidden = Object.assign(new Error("Forbidden"), { status: 403 });
+  const { status } = await runCase({ membershipError: forbidden });
+  assert.equal(status.state, "error");
+}
+
+{
+  const unavailable = Object.assign(new Error("Service unavailable"), { status: 503 });
+  const { status } = await runCase({
+    membershipError: Object.assign(new Error("Not Found"), { status: 404 }),
+    reviewsError: unavailable,
+  });
+  assert.equal(status.state, "error");
+}
+
+{
+  const { status, getStatusAttempts } = await runCase({
+    pullRequest: { ...basePullRequest, user: { login: "MemberDeveloper" } },
+    membership: { state: "active", role: "member" },
+    statusFailures: 1,
+  });
+  assert.equal(status.state, "error");
+  assert.equal(getStatusAttempts(), 2);
+}
+
+console.info("Owner approval evaluator tests passed.");

--- a/scripts/test-owner-approval.mjs
+++ b/scripts/test-owner-approval.mjs
@@ -76,6 +76,14 @@ async function runCase(options, env = {}) {
 }
 
 {
+  const { result, statuses } = await evaluateCase({
+    pullRequest: { ...basePullRequest, base: { ref: "main" } },
+  });
+  assert.equal(result.skipped, true);
+  assert.equal(statuses.length, 0);
+}
+
+{
   const { result, status } = await runCase({
     pullRequest: { ...basePullRequest, user: { login: "MemberDeveloper" } },
     membership: { state: "active", role: "member" },
@@ -144,6 +152,18 @@ async function runCase(options, env = {}) {
   const { status } = await runCase({
     membershipError: notFound,
     reviews: [
+      { id: 1, state: "APPROVED", commit_id: "head-sha", user: { login: "SpicyMarinara" } },
+      { id: 2, state: "COMMENTED", commit_id: "head-sha", user: { login: "SpicyMarinara" } },
+    ],
+  });
+  assert.equal(status.state, "success");
+}
+
+{
+  const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+  const { status } = await runCase({
+    membershipError: notFound,
+    reviews: [
       { id: 1, state: "APPROVED", commit_id: "stale-sha", user: { login: "SpicyMarinara" } },
     ],
   });
@@ -179,7 +199,7 @@ async function runCase(options, env = {}) {
     membership: { state: "active", role: "member" },
     statusFailures: 1,
   });
-  assert.equal(status.state, "error");
+  assert.equal(status.state, "success");
   assert.equal(getStatusAttempts(), 2);
 }
 

--- a/scripts/validate-pr-triage.mjs
+++ b/scripts/validate-pr-triage.mjs
@@ -50,9 +50,10 @@ export function validatePullRequestTriage() {
   assert.notEqual(triggersSectionStart, -1, "Missing workflow trigger section");
   assert.notEqual(triggersSectionEnd, -1, "Missing end of workflow trigger section");
   assert.notEqual(jobsSectionStart, -1, "Missing workflow jobs section");
-  assert.equal(
-    triageWorkflow.slice(triggersSectionStart + 1, triggersSectionEnd),
-    "on:\n  pull_request_target:\n    types: [opened, reopened, edited, synchronize, ready_for_review]\n    branches: [staging, main]\n",
+  const triggersSection = triageWorkflow.slice(triggersSectionStart + 1, triggersSectionEnd);
+  assert.match(
+    triggersSection,
+    /on:\s*\n\s*pull_request_target:\s*\n\s*types:\s*\[opened,\s*reopened,\s*edited,\s*synchronize,\s*ready_for_review\]\s*\n\s*branches:\s*\[staging,\s*main\]/u,
   );
 
   const jobIds = [
@@ -109,12 +110,15 @@ export function validatePullRequestTriage() {
     exemptionStep,
     [
       "      - name: Exempt trusted contributor",
-      "        if: >-",
-      "          github.event.pull_request.author_association == 'MEMBER' ||",
-      "          github.event.pull_request.author_association == 'OWNER' ||",
-      "          github.event.pull_request.author_association == 'COLLABORATOR'",
+      "        if: contains(fromJSON('[\"MEMBER\",\"OWNER\",\"COLLABORATOR\"]'), github.event.pull_request.author_association)",
       '        run: echo "Trusted contributor; pull request template validation is not required."',
     ].join("\n"),
+  );
+
+  const templateStep = extractNamedStep(triageWorkflow, "Check Pull Request body against template");
+  assert.match(
+    templateStep,
+    /if: >-\n\s*!contains\(fromJSON\('\["MEMBER","OWNER","COLLABORATOR"\]'\), github\.event\.pull_request\.author_association\)/u,
   );
 
   assert.match(codeOwners, /^\* @SpicyMarinara$/mu);

--- a/scripts/validate-pr-triage.mjs
+++ b/scripts/validate-pr-triage.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+function extractNamedStep(workflow, stepName) {
+  const marker = `      - name: ${stepName}\n`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `Missing workflow step: ${stepName}`);
+
+  const contentStart = start + marker.length;
+  const nextStep = workflow.indexOf("\n      - ", contentStart);
+  const nextJobMatch = workflow.slice(contentStart).match(/\n  [A-Za-z_][A-Za-z0-9_-]*:\s*\n/u);
+  const nextJob = nextJobMatch?.index === undefined ? -1 : contentStart + nextJobMatch.index;
+  const boundaries = [nextStep, nextJob].filter((boundary) => boundary !== -1);
+  const end = boundaries.length > 0 ? Math.min(...boundaries) : undefined;
+
+  return workflow.slice(start, end).trimEnd();
+}
+
+function extractJob(workflow, jobId) {
+  const marker = `  ${jobId}:\n`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `Missing workflow job: ${jobId}`);
+
+  const contentStart = start + marker.length;
+  const nextJobMatch = workflow.slice(contentStart).match(/\n  [A-Za-z_][A-Za-z0-9_-]*:\s*\n/u);
+  const end = nextJobMatch?.index === undefined ? undefined : contentStart + nextJobMatch.index;
+  return workflow.slice(start, end).trimEnd();
+}
+
+export function validatePullRequestTriage() {
+  const triageWorkflow = readFileSync(
+    new URL("../.github/workflows/pull-request-triage.yml", import.meta.url),
+    "utf8",
+  );
+  const reviewSignal = readFileSync(
+    new URL("../.github/workflows/owner-approval-review-signal.yml", import.meta.url),
+    "utf8",
+  );
+  const reviewEvaluator = readFileSync(
+    new URL("../.github/workflows/owner-approval-review.yml", import.meta.url),
+    "utf8",
+  );
+  const approvalEvaluator = readFileSync(new URL("./evaluate-owner-approval.mjs", import.meta.url), "utf8");
+  const codeOwners = readFileSync(new URL("../.github/CODEOWNERS", import.meta.url), "utf8");
+  const triggersSectionStart = triageWorkflow.indexOf("\non:\n");
+  const triggersSectionEnd = triageWorkflow.indexOf("\nconcurrency:\n", triggersSectionStart);
+  const jobsSectionStart = triageWorkflow.indexOf("\njobs:\n");
+
+  assert.notEqual(triggersSectionStart, -1, "Missing workflow trigger section");
+  assert.notEqual(triggersSectionEnd, -1, "Missing end of workflow trigger section");
+  assert.notEqual(jobsSectionStart, -1, "Missing workflow jobs section");
+  assert.equal(
+    triageWorkflow.slice(triggersSectionStart + 1, triggersSectionEnd),
+    "on:\n  pull_request_target:\n    types: [opened, reopened, edited, synchronize, ready_for_review]\n    branches: [staging, main]\n",
+  );
+
+  const jobIds = [
+    ...triageWorkflow
+      .slice(jobsSectionStart + "\njobs:\n".length)
+      .matchAll(/^  ([A-Za-z_][A-Za-z0-9_-]*):\s*$/gmu),
+  ].map((match) => match[1]);
+  assert.ok(jobIds.includes("branch-policy"));
+  assert.ok(jobIds.includes("owner-approval"));
+  assert.ok(jobIds.includes("template-check"));
+  assert.doesNotMatch(triageWorkflow, /pull_request_review|github\.event\.review/u);
+
+  const ownerApprovalJob = extractJob(triageWorkflow, "owner-approval");
+  assert.match(ownerApprovalJob, /if: github\.event\.pull_request\.base\.ref == 'staging'/u);
+  assert.match(ownerApprovalJob, /statuses: write/u);
+  assert.match(ownerApprovalJob, /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/u);
+  assert.match(ownerApprovalJob, /PASTA_DEVS_MEMBERS_TOKEN/u);
+  assert.match(ownerApprovalJob, /run: node scripts\/evaluate-owner-approval\.mjs/u);
+  assert.doesNotMatch(ownerApprovalJob, /github\.event\.pull_request\.head/u);
+
+  assert.match(
+    reviewSignal,
+    /on:\n  pull_request_review:\n    types: \[submitted, edited, dismissed\]/u,
+  );
+  assert.match(reviewSignal, /permissions: \{\}/u);
+  assert.doesNotMatch(reviewSignal, /secrets\.|github\.token|actions\/checkout|PASTA_DEVS_MEMBERS_TOKEN/u);
+
+  assert.match(
+    reviewEvaluator,
+    /on:\n  workflow_run:\n    workflows: \[Owner Approval Review Signal\]\n    types: \[completed\]/u,
+  );
+  assert.match(
+    reviewEvaluator,
+    /group: owner-approval-review-\$\{\{ github\.event\.workflow_run\.pull_requests\[0\]\.number \|\| github\.event\.workflow_run\.head_sha \}\}\n  cancel-in-progress: true/u,
+  );
+  assert.match(reviewEvaluator, /statuses: write/u);
+  assert.match(reviewEvaluator, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/u);
+  assert.match(reviewEvaluator, /GET \/repos\/\{owner\}\/\{repo\}\/commits\/\{commit_sha\}\/pulls/u);
+  assert.match(reviewEvaluator, /commit_sha: context\.payload\.workflow_run\.head_sha/u);
+  assert.match(reviewEvaluator, /PASTA_DEVS_MEMBERS_TOKEN/u);
+  assert.match(reviewEvaluator, /run: node scripts\/evaluate-owner-approval\.mjs/u);
+  assert.doesNotMatch(reviewEvaluator, /ref:.*workflow_run|head_repository/u);
+
+  assert.match(approvalEvaluator, /\/orgs\/\$\{encodeURIComponent\(organization\)\}\/memberships\//u);
+  assert.match(approvalEvaluator, /membership\.state === "active"/u);
+  assert.match(approvalEvaluator, /membership\.role === "admin" \|\| membership\.role === "member"/u);
+  assert.match(approvalEvaluator, /latestOwnerReview\?\.state === "APPROVED"/u);
+  assert.match(approvalEvaluator, /latestOwnerReview\.commit_id === headSha/u);
+  assert.match(approvalEvaluator, /\/statuses\/\$\{encodeURIComponent\(headSha\)\}/u);
+  assert.match(approvalEvaluator, /Owner approval for outside contributors/u);
+
+  const exemptionStep = extractNamedStep(triageWorkflow, "Exempt trusted contributor");
+  assert.equal(
+    exemptionStep,
+    [
+      "      - name: Exempt trusted contributor",
+      "        if: >-",
+      "          github.event.pull_request.author_association == 'MEMBER' ||",
+      "          github.event.pull_request.author_association == 'OWNER' ||",
+      "          github.event.pull_request.author_association == 'COLLABORATOR'",
+      '        run: echo "Trusted contributor; pull request template validation is not required."',
+    ].join("\n"),
+  );
+
+  assert.match(codeOwners, /^\* @SpicyMarinara$/mu);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  validatePullRequestTriage();
+  console.info("Pull request workflow gates are stable and use a trusted token-backed staging approval status.");
+}


### PR DESCRIPTION
## Why this change

Active Pasta-Devs members can be blocked from merging otherwise-ready pull requests because the workflow currently active from `main` publishes required jobs as `SKIPPED`. GitHub still requires successful `Branch policy check` and `Pull Request template check` contexts, so organization membership is recognized correctly while the merge remains blocked.

`pull_request_target` and review-triggered workflow topology must live on the default branch before it can protect staging PRs reliably. This hotfix carries only the already-tested CI correction from `staging`, without promoting unrelated staging work.

## What changed

- Keep required branch-policy and template jobs present for trusted contributors.
- Publish the staging owner-approval result through a trusted base-side status evaluator.
- Separate untrusted review signaling from the workflow that reads organization membership and writes commit statuses.
- Add topology and evaluator regression scripts to the pull-request validation job.

## Validation

Automated evidence already run locally:

- `node scripts/validate-pr-triage.mjs`
- `node scripts/test-owner-approval.mjs`

Manual verification for the maintainer:

- [ ] Confirm a Pasta-Devs member PR receives successful required triage contexts.
- [ ] Confirm an outside contributor still requires current `SpicyMarinara` approval.
- [ ] Confirm a new owner review refreshes the approval status for the current head.

Fixes #4562


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated owner-approval evaluation for staging pull requests.
  * Approval checks now account for contributor membership and current-commit reviews.
  * Evaluation results are published as pull-request status checks.

* **Bug Fixes**
  * Improved handling of closed pull requests, stale approvals, missing data, and temporary service failures.

* **Tests**
  * Added coverage for approval outcomes, API errors, retries, and status reporting.
  * Added validation for pull-request workflow configuration and required repository settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->