### PR TITLE
Fix assigned issue sweep for folders, assets, and agent menus

### DIFF
--- a/packages/client/src/components/chat/AgentSettingsControls.tsx
+++ b/packages/client/src/components/chat/AgentSettingsControls.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight, Settings2, Trash2 } from "lucide-react";
 import { useTranslation as useUiTranslation } from "react-i18next";
 import type { AgentPromptTemplateOption } from "@marinara-engine/shared";
 import { cn } from "../../lib/utils";
+import { useUIStore } from "../../stores/ui.store";
 import { SettingsSwitch } from "../panels/settings/SettingControls";
 
 export function AgentCategorySection({
@@ -170,12 +171,20 @@ export function AgentSettingsCard({
   children?: ReactNode;
 }) {
   const { t: localizeUi } = useUiTranslation();
-  const [open, setOpen] = useState(true);
+  const rememberedOpen = useUIStore((state) => (id ? state.chatSettingsExpandedSections[id] : undefined));
+  const setSectionExpanded = useUIStore((state) => state.setChatSettingsSectionExpanded);
+  const [localOpen, setLocalOpen] = useState(true);
+  const open = id ? (rememberedOpen ?? true) : localOpen;
   const contentId = useId();
   const toggleLabel = localizeUi(
     open ? "ui.chat.agentsettingscard.collapseValue1" : "ui.chat.agentsettingscard.expandValue1",
     { value1: title },
   );
+  const toggleOpen = () => {
+    const next = !open;
+    if (id) setSectionExpanded(id, next);
+    else setLocalOpen(next);
+  };
 
   return (
     <div
@@ -187,7 +196,7 @@ export function AgentSettingsCard({
       <div className="flex items-start p-3">
         <button
           type="button"
-          onClick={() => setOpen((current) => !current)}
+          onClick={toggleOpen}
           aria-expanded={open}
           aria-controls={contentId}
           aria-label={toggleLabel}

--- a/packages/client/src/lib/asset-fuzzy-match.ts
+++ b/packages/client/src/lib/asset-fuzzy-match.ts
@@ -50,16 +50,19 @@ function tagScore(prose: string, tag: string, category: string): number {
 function bestMatch(prose: string, tags: string[], category: string): string | null {
   if (!tags.length) return null;
   const minOverlap = category === "backgrounds" ? 2 : 1;
-  let best: string | null = null;
+  let best: string[] = [];
   let bestScore = minOverlap - 1;
   for (const tag of tags) {
     const s = tagScore(prose, tag, category);
+    if (s < minOverlap) continue;
     if (s > bestScore) {
       bestScore = s;
-      best = tag;
+      best = [tag];
+    } else if (s === bestScore) {
+      best.push(tag);
     }
   }
-  return best;
+  return best.length > 0 ? best[Math.floor(Math.random() * best.length)]! : null;
 }
 
 /**

--- a/packages/server/src/services/mari-db/mari-db.service.ts
+++ b/packages/server/src/services/mari-db/mari-db.service.ts
@@ -68,9 +68,11 @@ type Plan = {
   request: ParsedMutationRequest;
 };
 type ParsedMutationRequest = {
-  kind: "insert" | "patch" | "replace" | "delete" | "transform" | "theme-create" | "theme-update" | "theme-set-active";
+  kind: "insert" | "patch" | "replace" | "delete" | "transform" | "theme-create" | "theme-update" | "theme-set-active" | "character-move-folder";
   table: string | "all";
   id?: string;
+  characterId?: string;
+  folderId?: string;
   where?: string;
   row?: Row;
   patch?: Row;
@@ -1723,6 +1725,22 @@ export class MariDbService {
     context: { command: string; sessionId: string; cwd?: string },
   ): Promise<MariDbCommandResult> {
     switch (sub) {
+      case "folder.list": {
+        const rows = (await this.rawRows("character_groups"))
+          .map((row) => parseRow("character_groups", row))
+          .sort((a, b) => String(a.name ?? "").localeCompare(String(b.name ?? "")));
+        return {
+          ok: true,
+          mode: "read",
+          command: context.command,
+          output: rows.map((row) => ({
+            id: row.id,
+            name: row.name,
+            description: row.description,
+            characterIds: row.characterIds,
+          })),
+        };
+      }
       case "list": {
         const limit = normalizeLimit(firstNumber(args, ["limit"]), 50, 1000);
         const search = firstString(args, ["search", "query"])?.toLowerCase();
@@ -1844,6 +1862,51 @@ export class MariDbService {
             table: "characters",
             id,
             row,
+            apply: firstBoolean(args, ["apply"]) === true,
+            cascade: false,
+            reason: firstString(args, ["reason"]) ?? null,
+            cwd: context.cwd,
+          },
+          context.command,
+          context.sessionId,
+        );
+      }
+      case "movetofolder": {
+        const characterId = requiredString(args, ["characterId", "id"], "character id");
+        const character = await this.getRawById(getMeta("characters"), characterId);
+        if (!character) throw new Error(`Character ${characterId} not found`);
+
+        const requestedFolderId = firstString(args, ["folderId"]);
+        const requestedFolderName = firstString(args, ["folderName", "folder"]);
+        if (!requestedFolderId && !requestedFolderName) {
+          throw new Error("character.moveToFolder needs folderId or folderName");
+        }
+
+        const groups = await this.rawRows("character_groups");
+        const matches = requestedFolderId
+          ? groups.filter((group) => group.id === requestedFolderId)
+          : groups.filter(
+              (group) =>
+                typeof group.name === "string" &&
+                group.name.trim().toLowerCase() === requestedFolderName!.trim().toLowerCase(),
+            );
+        if (matches.length === 0) {
+          throw new Error(
+            requestedFolderId
+              ? `Character folder ${requestedFolderId} not found`
+              : `Character folder ${requestedFolderName} not found`,
+          );
+        }
+        if (matches.length > 1) {
+          throw new Error(`More than one character folder is named ${requestedFolderName}; use folderId instead`);
+        }
+
+        return this.executeMutation(
+          {
+            kind: "character-move-folder",
+            table: "character_groups",
+            characterId,
+            folderId: String(matches[0]!.id),
             apply: firstBoolean(args, ["apply"]) === true,
             cascade: false,
             reason: firstString(args, ["reason"]) ?? null,
@@ -4402,6 +4465,7 @@ export class MariDbService {
     else if (request.kind === "theme-create") changes = await this.planThemeCreate(request, timestamp, issues);
     else if (request.kind === "theme-update") changes = await this.planThemeUpdate(request, timestamp, issues);
     else if (request.kind === "theme-set-active") changes = await this.planThemeSetActive(request, timestamp, issues);
+    else if (request.kind === "character-move-folder") changes = await this.planCharacterMoveFolder(request, timestamp);
     else changes = await this.planTransform(request, timestamp, allocateId);
 
     const personalExtensionChanges = changes.filter((change) => change.table === "installed_extensions");
@@ -4520,6 +4584,49 @@ export class MariDbService {
     this.fillTimestamps(meta, next, false, timestamp);
     const afterRaw = serializeRow(meta.name, next);
     return [{ table: meta.name, id: rowId(meta, existing), action: "replace", before: parseRow(meta.name, existing), after: parseRow(meta.name, afterRaw), beforeRaw: existing, afterRaw, apply: true }];
+  }
+
+  private async planCharacterMoveFolder(request: ParsedMutationRequest, timestamp: string): Promise<PlanChange[]> {
+    const characterId = String(request.characterId ?? "");
+    const targetFolderId = String(request.folderId ?? "");
+    const meta = getMeta("character_groups");
+    const groups = await this.rawRows(meta.name);
+    if (!groups.some((group) => group.id === targetFolderId)) {
+      throw new Error(`Character folder ${targetFolderId} not found`);
+    }
+
+    return groups
+      .map((group): PlanChange | null => {
+        const parsed = parseRow(meta.name, group);
+        if (!Array.isArray(parsed.characterIds)) {
+          throw new Error(`Character folder ${String(group.id)} has invalid membership data`);
+        }
+        const currentIds = parsed.characterIds.filter((id): id is string => typeof id === "string" && !!id);
+        const withoutCharacter = currentIds.filter((id) => id !== characterId);
+        const nextIds =
+          group.id === targetFolderId && !withoutCharacter.includes(characterId)
+            ? [...withoutCharacter, characterId]
+            : withoutCharacter;
+        if (nextIds.length === currentIds.length && nextIds.every((id, index) => id === currentIds[index])) {
+          return null;
+        }
+        const afterRaw = serializeRow(meta.name, {
+          ...parsed,
+          characterIds: nextIds,
+          updatedAt: timestamp,
+        });
+        return {
+          table: meta.name,
+          id: rowId(meta, group),
+          action: "update",
+          before: parsed,
+          after: parseRow(meta.name, afterRaw),
+          beforeRaw: group,
+          afterRaw,
+          apply: true,
+        };
+      })
+      .filter((change): change is PlanChange => change !== null);
   }
 
   private async planDelete(request: ParsedMutationRequest, issues: MariDbValidationIssue[]): Promise<PlanChange[]> {

--- a/packages/server/src/services/mari-db/mari-db.service.ts
+++ b/packages/server/src/services/mari-db/mari-db.service.ts
@@ -1632,6 +1632,7 @@ export class MariDbService {
   private pending = new Map<string, PendingRecord>();
   private history: MariDbHistoryEntry[] = [];
   private writeQueue: Promise<unknown> = Promise.resolve();
+  private characterFolderMutationQueue: Promise<void> = Promise.resolve();
 
   constructor(private readonly db: DB) {}
 
@@ -1872,49 +1873,51 @@ export class MariDbService {
         );
       }
       case "movetofolder": {
-        const characterId = requiredString(args, ["characterId", "id"], "character id");
-        const character = await this.getRawById(getMeta("characters"), characterId);
-        if (!character) throw new Error(`Character ${characterId} not found`);
+        return this.withCharacterFolderMutationLock(async () => {
+          const characterId = requiredString(args, ["characterId", "id"], "character id");
+          const character = await this.getRawById(getMeta("characters"), characterId);
+          if (!character) throw new Error(`Character ${characterId} not found`);
 
-        const requestedFolderId = firstString(args, ["folderId"]);
-        const requestedFolderName = firstString(args, ["folderName", "folder"]);
-        if (!requestedFolderId && !requestedFolderName) {
-          throw new Error("character.moveToFolder needs folderId or folderName");
-        }
+          const requestedFolderId = firstString(args, ["folderId"]);
+          const requestedFolderName = firstString(args, ["folderName", "folder"]);
+          if (!requestedFolderId && !requestedFolderName) {
+            throw new Error("character.moveToFolder needs folderId or folderName");
+          }
 
-        const groups = await this.rawRows("character_groups");
-        const matches = requestedFolderId
-          ? groups.filter((group) => group.id === requestedFolderId)
-          : groups.filter(
-              (group) =>
-                typeof group.name === "string" &&
-                group.name.trim().toLowerCase() === requestedFolderName!.trim().toLowerCase(),
+          const groups = await this.rawRows("character_groups");
+          const matches = requestedFolderId
+            ? groups.filter((group) => group.id === requestedFolderId)
+            : groups.filter(
+                (group) =>
+                  typeof group.name === "string" &&
+                  group.name.trim().toLowerCase() === requestedFolderName!.trim().toLowerCase(),
+              );
+          if (matches.length === 0) {
+            throw new Error(
+              requestedFolderId
+                ? `Character folder ${requestedFolderId} not found`
+                : `Character folder ${requestedFolderName} not found`,
             );
-        if (matches.length === 0) {
-          throw new Error(
-            requestedFolderId
-              ? `Character folder ${requestedFolderId} not found`
-              : `Character folder ${requestedFolderName} not found`,
-          );
-        }
-        if (matches.length > 1) {
-          throw new Error(`More than one character folder is named ${requestedFolderName}; use folderId instead`);
-        }
+          }
+          if (matches.length > 1) {
+            throw new Error(`More than one character folder is named ${requestedFolderName}; use folderId instead`);
+          }
 
-        return this.executeMutation(
-          {
-            kind: "character-move-folder",
-            table: "character_groups",
-            characterId,
-            folderId: String(matches[0]!.id),
-            apply: firstBoolean(args, ["apply"]) === true,
-            cascade: false,
-            reason: firstString(args, ["reason"]) ?? null,
-            cwd: context.cwd,
-          },
-          context.command,
-          context.sessionId,
-        );
+          return this.executeMutation(
+            {
+              kind: "character-move-folder",
+              table: "character_groups",
+              characterId,
+              folderId: String(matches[0]!.id),
+              apply: firstBoolean(args, ["apply"]) === true,
+              cascade: false,
+              reason: firstString(args, ["reason"]) ?? null,
+              cwd: context.cwd,
+            },
+            context.command,
+            context.sessionId,
+          );
+        });
       }
       default:
         return { ok: false, mode: "read", command: context.command, error: "Unsupported character app_data action." };
@@ -4602,10 +4605,13 @@ export class MariDbService {
           throw new Error(`Character folder ${String(group.id)} has invalid membership data`);
         }
         const currentIds = parsed.characterIds.filter((id): id is string => typeof id === "string" && !!id);
+        const matchingIdCount = currentIds.filter((id) => id === characterId).length;
         const withoutCharacter = currentIds.filter((id) => id !== characterId);
         const nextIds =
-          group.id === targetFolderId && !withoutCharacter.includes(characterId)
-            ? [...withoutCharacter, characterId]
+          group.id === targetFolderId
+            ? matchingIdCount === 1
+              ? currentIds
+              : [...withoutCharacter, characterId]
             : withoutCharacter;
         if (nextIds.length === currentIds.length && nextIds.every((id, index) => id === currentIds[index])) {
           return null;
@@ -4627,6 +4633,15 @@ export class MariDbService {
         };
       })
       .filter((change): change is PlanChange => change !== null);
+  }
+
+  private withCharacterFolderMutationLock<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.characterFolderMutationQueue.then(operation);
+    this.characterFolderMutationQueue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
   }
 
   private async planDelete(request: ParsedMutationRequest, issues: MariDbValidationIssue[]): Promise<PlanChange[]> {

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -311,7 +311,7 @@ const WORKSPACE_TOOL_DEFINITIONS: WorkspaceToolDefinition[] = [
   {
     name: "app_data",
     description:
-      "Read or change live app data through structured actions, without shell commands. Use this for characters, personas, lorebooks, lorebook entries, themes, Personal Extension drafts, agents, and prompt presets.",
+      "Read or change live app data through structured actions, without shell commands. Use this for characters, character folders, personas, lorebooks, lorebook entries, themes, Personal Extension drafts, agents, and prompt presets.",
     parameters: {
       type: "object",
       properties: {
@@ -323,6 +323,8 @@ const WORKSPACE_TOOL_DEFINITIONS: WorkspaceToolDefinition[] = [
             "character.search",
             "character.create",
             "character.update",
+            "character.folder.list",
+            "character.moveToFolder",
             "persona.list",
             "persona.active",
             "persona.get",
@@ -362,6 +364,8 @@ const WORKSPACE_TOOL_DEFINITIONS: WorkspaceToolDefinition[] = [
         },
         id: { type: "string" },
         characterId: { type: "string" },
+        folderId: { type: "string" },
+        folderName: { type: "string" },
         personaId: { type: "string" },
         lorebookId: { type: "string" },
         entryId: { type: "string" },
@@ -467,7 +471,7 @@ ${PROFESSOR_MARI_AGENT_CATALOG_KNOWLEDGE}
 
 Workspace defaults:
 - Marinara's first-party agents and larger optional features are downloaded from **Agents → Download Agents**. Fresh installs start without them; maps, Conversation calls, and Conversation games are packages too. Tell users to install the desired package, enable it for the chat, and restart Marinara Engine when the catalog prompts them. Existing pre-package installs are migrated automatically without losing settings or history.
-- Use the structured \`app_data\` workspace command, not shell, for character/persona/lorebook/lorebook-entry/theme/Personal Extension/agent/preset reads, creation, and updates.
+- Use the structured \`app_data\` workspace command, not shell, for character/character-folder/persona/lorebook/lorebook-entry/theme/Personal Extension/agent/preset reads, creation, and updates.
 - Use Mari CLI commands for images, wiki reads, code/workspace tasks, agents, tools, raw DB work, or anything \`app_data\` does not cover. Only write raw files when no CLI/helper path fits.
 - You may create and update Personal Extension drafts with \`personal_extension.create\` and \`personal_extension.update\`. These actions always disable changed code and clear its approval. Browser Extensions receive active chat and Character IDs through \`marinara.context\`; request \`read_active_characters\` or \`read_active_persona\` only when the extension truly needs bounded active-record fields. Never claim to approve, enable, or run an extension: only the user can review the exact code hash and requested permissions, then choose **Review and Run** in **Settings → Addons → Personal Extensions**.
 - For user-facing Browser Extension UI, use \`marinara.ui.registerContribution(...)\`. It can add a trusted Marinara-rendered top-bar button, Extensions menu item, right-side panel, or button in the Chats, Bots, Characters, Personas, Lorebooks, Presets, Connections, Agents, and Settings surfaces. For a side-panel \`button\`, set \`surface\` to the requested surface and choose \`position: "header"\`, \`"before-content"\`, or \`"after-content"\`; omit both fields for the top bar. The \`icon\` may be any kebab-case Lucide icon name supported by Marinara. Panels may contain headings, text, preformatted output, buttons, text inputs, selects, toggles, sliders, color controls, and spacers. Use \`onActivate\` and \`onEvent\` for behavior and update the returned handle when the view changes. Never write extension code that expects \`document\`, \`window\`, \`innerHTML\`, host CSS selectors, React internals, unrestricted \`fetch\`, or direct Marinara API access; those capabilities are deliberately absent.
@@ -482,12 +486,12 @@ Workspace defaults:
 - When the user asks you to write or revise a character or persona About Me, inspect that entity first, compose a short self-authored Conversation profile in their own voice, and save it to the real \`aboutMe\` field with \`character.update\` or \`persona.update\`. Do not create a separate document, put it in description, or ask for a special About Me model connection.
 
 Command families:
-- \`app_data\`: no-shell structured actions for characters, personas, lorebooks, lorebook entries, themes, Personal Extension drafts, agents, and prompt presets. Prefer this before shell commands for those objects.
+- \`app_data\`: no-shell structured actions for characters, character folders, personas, lorebooks, lorebook entries, themes, Personal Extension drafts, agents, and prompt presets. Prefer this before shell commands for those objects.
 - \`mari db\`: generic live app data and storage-backed rows, including customization tables such as \`agent_configs\` and \`custom_tools\` when no narrower helper exists.
 - \`mari themes\`: synced custom themes and active theme state.
 - \`mari images\`: image-generation connections, HITL image prompt previews, generated/edited preview assets, and assignment/deletion for avatars, personas, lorebooks, sprites, backgrounds, and galleries.
 - \`mari wiki\`: read-only Fandom/MediaWiki discovery and page reads.
-- \`mari characters\`: list, get, search, create, update, delete. Prefer this helper for character edits, including backstory, appearance, and About Me changes.
+- \`mari characters\`: list, get, search, create, update, delete. Prefer this helper for character edits, including backstory, appearance, and About Me changes. Use \`app_data\` \`character.folder.list\` and \`character.moveToFolder\` for character folders.
 - \`mari personas\`: list, active, get, search, create, update, delete. Prefer this helper for persona edits.
 - \`mari lorebooks\`: list, get, entries <lorebook-id>, search, create, update <lorebook-id>, add-entry <lorebook-id>, update-entry <entry-id>, delete-entry <entry-id>, link-character, unlink-character, delete.
 - \`mari presets\`: no dedicated shell helper — use \`app_data\` \`preset.*\` for preset reads/writes. \`preset.create\` and \`preset.update\` can include \`groups\`, \`sections\`, and \`choiceBlocks\` for preset variables. Use \`mari db\` only for advanced raw-table repairs after inspecting schemas.
@@ -550,8 +554,9 @@ Field rules:
 ${MARI_GUIDED_SEQUENCES}
 
 \`app_data\` quick reference:
-- Reads: \`character.list|get|search\`, \`persona.list|active|get|search\`, \`lorebook.list|get|entries|search\`, \`theme.list|active|get\`, \`personal_extension.list|get|search\`, \`agent.list|get|search\`, \`preset.list|get|search\`.
-- Writes: \`character.create|update\`, \`persona.create|update\`, \`lorebook.create|update|addEntry|updateEntry\`, \`theme.create|update|setActive\`, \`personal_extension.create|update\`, \`agent.create|update\`, \`preset.create|update\`.
+- Reads: \`character.list|get|search|folder.list\`, \`persona.list|active|get|search\`, \`lorebook.list|get|entries|search\`, \`theme.list|active|get\`, \`personal_extension.list|get|search\`, \`agent.list|get|search\`, \`preset.list|get|search\`.
+- Writes: \`character.create|update|moveToFolder\`, \`persona.create|update\`, \`lorebook.create|update|addEntry|updateEntry\`, \`theme.create|update|setActive\`, \`personal_extension.create|update\`, \`agent.create|update\`, \`preset.create|update\`.
+- Character folders: call \`character.folder.list\` to resolve the destination, then \`character.moveToFolder\` with \`characterId\` and either \`folderId\` or \`folderName\`. A move removes the character from its previous folder. When the user explicitly asks for the move, set \`apply:true\`, then verify with \`character.folder.list\`.
 - Put write fields in \`data\` for creates and \`patch\` for updates. Use \`entryId\` for \`lorebook.updateEntry\`; use \`lorebookId\` only for a lorebook or for \`lorebook.addEntry\`.
 - New creates: use \`apply:true\` immediately for \`character.create\`, \`persona.create\`, \`lorebook.create\`, \`lorebook.addEntry\`, \`agent.create\`, \`preset.create\`, and non-activating \`theme.create\` when the user asked you to create it. Verify with a read before claiming success.
 - Character generation: put the full card in \`data\`; do not create a name-only placeholder. \`firstMes\` and \`firstMessage\` both map to the opening message.

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -9,7 +9,7 @@ import { chatModeSchema } from "../../packages/shared/src/schemas/chat.schema.js
 import playwrightConfig from "../../playwright.config.js";
 import { resolveDevSharedBuildScript } from "../dev-shared-build.mjs";
 import { validatePullRequestTriage } from "../validate-pr-triage.mjs";
-import { characterCardVersions, characters, chatPresets, chats, messages } from "../../packages/server/src/db/schema/index.js";
+import { characterCardVersions, characterGroups, characters, chatPresets, chats, messages } from "../../packages/server/src/db/schema/index.js";
 import { eq } from "../../packages/server/src/db/file-query.js";
 import { parseBuildMeta, resolveBuildBranch } from "../../packages/server/src/config/build-info.js";
 
@@ -1508,6 +1508,46 @@ try {
     },
     "character.update must preserve every omitted Character Card field through the real merge and persistence path",
   );
+
+  const characterFolderTimestamp = "2026-08-04T12:00:00.000Z";
+  await db.insert(characterGroups).values({
+    id: "character-folder-source",
+    name: "Source Folder",
+    description: "",
+    characterIds: JSON.stringify([characterId]),
+    createdAt: characterFolderTimestamp,
+    updatedAt: characterFolderTimestamp,
+  });
+  await db.insert(characterGroups).values({
+    id: "character-folder-target",
+    name: "Target Folder",
+    description: "",
+    characterIds: "[]",
+    createdAt: characterFolderTimestamp,
+    updatedAt: characterFolderTimestamp,
+  });
+
+  const folderListResult = await mariDb.executeAction({ action: "character.folder.list" });
+  assert.equal(folderListResult.ok, true, "Professor Mari must be able to list character folders");
+  assert.deepEqual(
+    (folderListResult.output as Array<{ id: string }>).map((folder) => folder.id),
+    ["character-folder-source", "character-folder-target"],
+  );
+
+  const folderMoveResult = await mariDb.executeAction({
+    action: "character.moveToFolder",
+    characterId,
+    folderName: "Target Folder",
+    reason: "Regression coverage for issue #4568",
+    apply: true,
+  });
+  assert.equal(folderMoveResult.ok, true, "Professor Mari must be able to move a character into a named folder");
+
+  const foldersAfterMove = await db.select().from(characterGroups);
+  const sourceFolder = foldersAfterMove.find((folder) => folder.id === "character-folder-source");
+  const targetFolder = foldersAfterMove.find((folder) => folder.id === "character-folder-target");
+  assert.deepEqual(JSON.parse(sourceFolder?.characterIds ?? "[]"), []);
+  assert.deepEqual(JSON.parse(targetFolder?.characterIds ?? "[]"), [characterId]);
 
   for (const approval of mariDb.getPendingApprovals()) {
     await mariDb.keepAppliedReview(approval.id);

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -1549,6 +1549,101 @@ try {
   assert.deepEqual(JSON.parse(sourceFolder?.characterIds ?? "[]"), []);
   assert.deepEqual(JSON.parse(targetFolder?.characterIds ?? "[]"), [characterId]);
 
+  const unchangedFolderTimestamp = "2026-08-04T12:30:00.000Z";
+  const unchangedMembership = ["neighbor-before", characterId, "neighbor-after"];
+  await db
+    .update(characterGroups)
+    .set({ characterIds: JSON.stringify(unchangedMembership), updatedAt: unchangedFolderTimestamp })
+    .where(eq(characterGroups.id, "character-folder-target"));
+  const noOpFolderMoveResult = await mariDb.executeAction({
+    action: "character.moveToFolder",
+    characterId,
+    folderId: "character-folder-target",
+    apply: true,
+  });
+  assert.equal(noOpFolderMoveResult.ok, true);
+  const unchangedFolder = (await db.select().from(characterGroups)).find(
+    (folder) => folder.id === "character-folder-target",
+  );
+  assert.deepEqual(JSON.parse(unchangedFolder?.characterIds ?? "[]"), unchangedMembership);
+  assert.equal(unchangedFolder?.updatedAt, unchangedFolderTimestamp);
+
+  for (const id of ["character-folder-duplicate-a", "character-folder-duplicate-b"]) {
+    await db.insert(characterGroups).values({
+      id,
+      name: "Duplicate Folder",
+      description: "",
+      characterIds: "[]",
+      createdAt: characterFolderTimestamp,
+      updatedAt: characterFolderTimestamp,
+    });
+  }
+  const ambiguousFolderMoveResult = await mariDb.executeAction({
+    action: "character.moveToFolder",
+    characterId,
+    folderName: "Duplicate Folder",
+    apply: true,
+  });
+  assert.equal(ambiguousFolderMoveResult.ok, false, "Duplicate folder names must require an explicit folder ID");
+  const duplicateFoldersAfterAmbiguousMove = (await db.select().from(characterGroups)).filter((folder) =>
+    folder.id.startsWith("character-folder-duplicate-"),
+  );
+  assert.deepEqual(
+    duplicateFoldersAfterAmbiguousMove.map((folder) => JSON.parse(folder.characterIds)),
+    [[], []],
+  );
+
+  const duplicateFolderIdMoveResult = await mariDb.executeAction({
+    action: "character.moveToFolder",
+    characterId,
+    folderId: "character-folder-duplicate-a",
+    apply: true,
+  });
+  assert.equal(duplicateFolderIdMoveResult.ok, true, "An explicit folder ID must disambiguate duplicate names");
+  const duplicateFoldersAfterIdMove = (await db.select().from(characterGroups)).filter((folder) =>
+    folder.id.startsWith("character-folder-duplicate-"),
+  );
+  const selectedDuplicateFolder = duplicateFoldersAfterIdMove.find((folder) => folder.id.endsWith("-a"));
+  const unselectedDuplicateFolder = duplicateFoldersAfterIdMove.find((folder) => folder.id.endsWith("-b"));
+  assert.deepEqual(JSON.parse(selectedDuplicateFolder?.characterIds ?? "[]"), [characterId]);
+  assert.deepEqual(JSON.parse(unselectedDuplicateFolder?.characterIds ?? "[]"), []);
+
+  const concurrentCharacterId = "character-folder-concurrent-character";
+  const concurrentCharacterCreateResult = await mariDb.executeAction({
+    action: "character.create",
+    characterId: concurrentCharacterId,
+    data: { name: "Concurrent Folder Character" },
+    apply: true,
+  });
+  assert.equal(concurrentCharacterCreateResult.ok, true);
+  await db.insert(characterGroups).values({
+    id: "character-folder-concurrent-target",
+    name: "Concurrent Target",
+    description: "",
+    characterIds: "[]",
+    createdAt: characterFolderTimestamp,
+    updatedAt: characterFolderTimestamp,
+  });
+  const concurrentFolderMoves = await Promise.all(
+    [characterId, concurrentCharacterId].map((movingCharacterId) =>
+      mariDb.executeAction({
+        action: "character.moveToFolder",
+        characterId: movingCharacterId,
+        folderId: "character-folder-concurrent-target",
+        apply: true,
+      }),
+    ),
+  );
+  assert.ok(concurrentFolderMoves.every((result) => result.ok), "Concurrent folder moves must both succeed");
+  const concurrentTargetFolder = (await db.select().from(characterGroups)).find(
+    (folder) => folder.id === "character-folder-concurrent-target",
+  );
+  assert.deepEqual(
+    JSON.parse(concurrentTargetFolder?.characterIds ?? "[]").sort(),
+    [characterId, concurrentCharacterId].sort(),
+    "Serialized folder moves must preserve both memberships",
+  );
+
   for (const approval of mariDb.getPendingApprovals()) {
     await mariDb.keepAppliedReview(approval.id);
   }


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issues

Closes #4568
Closes #4569
Closes #4570

## Why this change

Three assigned workflows were behaving inconsistently: Professor Mari could not place characters into folders, equally good fuzzy game-asset matches always favored the first file, and Game mode agent menus forgot their collapsed state whenever Chat Settings reopened.

## What changed

- Added structured character-folder listing and moves to Professor Mari's `app_data` tool. Moves use the existing reversible mutation journal, remove stale membership from other folders, and reject ambiguous folder names.
- Randomly select among equally scored fuzzy asset matches while keeping exact matches and generated-background fallback unchanged.
- Persist each agent settings card's expanded/collapsed state through the existing Chat Settings preference map.
- Added real temporary-database regression coverage for listing folders and moving a character between them.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Focused automated checks completed:

- `pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts`
- `pnpm --filter @marinara-engine/server lint`
- `pnpm --filter @marinara-engine/client exec eslint src/components/chat/AgentSettingsControls.tsx src/lib/asset-fuzzy-match.ts`
- Deterministic inline coverage for first/last equal-score fuzzy candidates and unknown-background fallback
- `git diff --check`

### Manual verification notes

- Manual browser verification remains for the maintainer. The folder behavior is covered through the real temporary-database mutation path; the UI changes are small state and selection-logic fixes.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing documentation, localization copy, or release metadata changed.

## UI evidence (if applicable)

No visual redesign. The agent-menu change only restores a previously selected collapsed state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organize characters into folders and move them between folders by name or ID.
  * List and manage character folders through the assistant.
  * Settings cards now remember their expanded or collapsed state.

* **Improvements**
  * Asset matching now randomly selects among equally suitable matches.

* **Bug Fixes**
  * Improved folder moves with validation for missing folders, duplicate names, and concurrent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->