### PR TITLE
Simplify summary prompt editing and native widget deletion

### DIFF
--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -1517,9 +1517,11 @@ export function SummaryPopover({
                   </div>
                 </div>
 
-                <div className="h-36 overflow-y-auto whitespace-pre-wrap rounded-md bg-[var(--background)]/25 px-2 py-1.5 font-mono text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
-                  {activeSummaryPrompt}
-                </div>
+                {!templateEditorOpen && (
+                  <div className="h-36 overflow-y-auto whitespace-pre-wrap rounded-md bg-[var(--background)]/25 px-2 py-1.5 font-mono text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+                    {activeSummaryPrompt}
+                  </div>
+                )}
 
                 {templateEditorOpen && (
                   <div className="space-y-2 border-t border-[var(--border)] pt-2">
@@ -1571,14 +1573,6 @@ export function SummaryPopover({
 
                     {(templateNameDraft || templatePromptDraft) && (
                       <div className="space-y-1.5 rounded-lg bg-[var(--background)]/30 p-2 ring-1 ring-[var(--border)]">
-                        <div className="space-y-1">
-                          <p className="text-[0.625rem] font-semibold text-[var(--muted-foreground)]">
-                            {localizeUi("ui.chat.summarypopover.currentChatSummaryPrompt")}
-                          </p>
-                          <div className="max-h-24 overflow-y-auto whitespace-pre-wrap rounded-md bg-[var(--card)] px-2 py-1.5 font-mono text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
-                            {activeSummaryPrompt}
-                          </div>
-                        </div>
                         <input
                           value={templateNameDraft}
                           onChange={(event) => setTemplateNameDraft(event.target.value)}

--- a/packages/client/src/components/game/GameWidgetPanel.tsx
+++ b/packages/client/src/components/game/GameWidgetPanel.tsx
@@ -12,6 +12,7 @@ import { Pencil, Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import type { HudWidget } from "@marinara-engine/shared";
 import { useUpdateGameWidgets } from "../../hooks/use-game";
+import { showConfirmDialog } from "../../lib/app-dialogs";
 import { cn } from "../../lib/utils";
 import { useGameModeStore } from "../../stores/game-mode.store";
 import { useRenderTimer } from "../../lib/perf-diagnostics";
@@ -819,14 +820,21 @@ export function GameWidgetSessionPrepModal({
   );
 
   const handleRemoveWidget = useCallback(
-    (widgetId: string) => {
+    async (widgetId: string) => {
       const target = draftWidgets.find((widget) => widget.id === widgetId);
       if (!target) return;
-      if (!window.confirm(copy.removeConfirm.replace("{label}", target.label))) return;
+      const confirmed = await showConfirmDialog({
+        title: localizeUi("ui.game.gamewidgetsessionprepmodal.removeWidget"),
+        message: copy.removeConfirm.replace("{label}", target.label),
+        confirmLabel: localizeUi("settings.notifications.customSound.actions.remove"),
+        cancelLabel: localizeUi("chat.delete.dialog.cancel"),
+        tone: "destructive",
+      });
+      if (!confirmed) return;
 
       setDraftWidgets((current) => current.filter((widget) => widget.id !== widgetId));
     },
-    [copy.removeConfirm, draftWidgets],
+    [copy.removeConfirm, draftWidgets, localizeUi],
   );
 
   const handleSaveWidget = useCallback(
@@ -896,7 +904,7 @@ export function GameWidgetSessionPrepModal({
                     </button>
                     <button
                       type="button"
-                      onClick={() => handleRemoveWidget(widget.id)}
+                      onClick={() => void handleRemoveWidget(widget.id)}
                       disabled={interactionsLocked}
                       className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--destructive)]/25 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10 disabled:opacity-50"
                     >

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -4694,6 +4694,7 @@
   "ui.game.gamewidgetfilecontrols.exportWidgets": "Export Widgets",
   "ui.game.gamewidgetfilecontrols.failedToImportGameWidgets": "Failed to import game widgets.",
   "ui.game.gamewidgetfilecontrols.importWidgets": "Import Widgets",
+  "ui.game.gamewidgetsessionprepmodal.removeWidget": "Remove widget?",
   "ui.game.gamewidgetsetupeditor.accent": "Accent",
   "ui.game.gamewidgetsetupeditor.exportedWidgets_one": "Exported {{count}} widget.",
   "ui.game.gamewidgetsetupeditor.exportedWidgets_other": "Exported {{count}} widgets.",


### PR DESCRIPTION
## Why

Roleplay Summary Prompt editing repeats the active prompt in multiple read-only and editable fields, which makes the editor harder to understand. Game starting-widget deletion also relies on the browser confirmation API, which Firefox users can permanently suppress for the session and then lose the ability to delete more widgets.

## Changes

- simplify Roleplay Summary Prompt edit mode so the read-only preview is hidden while templates and the current editable prompt are shown
- remove the duplicated prompt heading and read-only prompt body from the template editor
- replace starting-widget browser confirmation with Marinara Engine native destructive confirmation dialog

## Validation

- focused ESLint for `SummaryPopover.tsx` and `GameWidgetPanel.tsx`
- localization catalog and static JSX localization audits
- `git diff --check`

## Test plan

- [ ] Manually verify the Roleplay Summary Prompt read-only preview appears only outside edit mode
- [ ] Manually verify template selection, creating a template, editing, saving, and cancelling still work
- [ ] Manually verify deleting a Game starting widget uses the native confirmation dialog
- [ ] Manually verify confirming deletes the widget and cancelling preserves it

Closes #4587
Closes #4584