### PR TITLE
fix(storyboard): preserve fallback warnings and appearance intent

### DIFF
--- a/packages/client/src/components/chat/RoleplayStoryboardMessageMedia.tsx
+++ b/packages/client/src/components/chat/RoleplayStoryboardMessageMedia.tsx
@@ -1,5 +1,5 @@
 import type { GameTurnStoryboard, GameTurnStoryboardKeyframe } from "@marinara-engine/shared";
-import { ChevronLeft, ChevronRight, Loader2, PanelsTopLeft } from "lucide-react";
+import { ChevronLeft, ChevronRight, Loader2, PanelsTopLeft, TriangleAlert } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation as useUiTranslation } from "react-i18next";
 import { cn } from "../../lib/utils";
@@ -71,6 +71,21 @@ export function RoleplayStoryboardMessageMedia({
           </span>
         ) : null}
       </div>
+
+      {storyboard?.error ? (
+        <div
+          className="flex items-start gap-2 border-b border-amber-200/20 bg-amber-300/12 px-3 py-2 text-amber-50"
+          role="status"
+        >
+          <TriangleAlert size={14} className="mt-0.5 shrink-0 text-amber-200" />
+          <div className="min-w-0">
+            <p className="text-[0.6875rem] font-semibold">
+              {localizeUi("ui.game.gamesurfacecomponent.storyboardDegradedResult")}
+            </p>
+            <p className="line-clamp-3 text-[0.625rem] leading-4 text-amber-50/75">{storyboard.error}</p>
+          </div>
+        </div>
+      ) : null}
 
       {activeFrame?.video ? (
         <video

--- a/packages/client/src/components/game/GameStoryboardViewer.tsx
+++ b/packages/client/src/components/game/GameStoryboardViewer.tsx
@@ -7,6 +7,7 @@ import {
   Pause,
   Play,
   RotateCcw,
+  TriangleAlert,
   Volume2,
   VolumeX,
   X,
@@ -127,6 +128,21 @@ export function GameStoryboardInlineViewer({
             </span>
           </div>
 
+          {storyboard?.error ? (
+            <div
+              className="flex items-start gap-2 border-b border-amber-200/20 bg-amber-300/12 px-3 py-2 text-amber-50"
+              role="status"
+            >
+              <TriangleAlert size={14} className="mt-0.5 shrink-0 text-amber-200" />
+              <div className="min-w-0">
+                <p className="text-[0.6875rem] font-semibold">
+                  {localizeUi("ui.game.gamesurfacecomponent.storyboardDegradedResult")}
+                </p>
+                <p className="line-clamp-3 text-[0.625rem] leading-4 text-amber-50/75">{storyboard.error}</p>
+              </div>
+            </div>
+          ) : null}
+
           {frame?.video ? (
             <video
               ref={videoRef}
@@ -223,10 +239,7 @@ export function GameStoryboardInlineViewer({
               </div>
             </div>
             <p className="line-clamp-2 text-[0.6875rem] leading-4 text-white/58">
-              {frame?.anchorQuote ||
-                frame?.narrationBeat ||
-                storyboard?.error ||
-                localizeUi("game.storyboard.generatingKeyframes")}
+              {frame?.anchorQuote || frame?.narrationBeat || localizeUi("game.storyboard.generatingKeyframes")}
             </p>
             {storyboard?.keyframes.length ? (
               <div className="flex gap-1">

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -5872,6 +5872,12 @@ function GameSurfaceComponent({
 
         if (preview) {
           plannedStoryboard = preview.plannedStoryboard;
+          if (preview.plannerWarning) {
+            toast.warning(localizeUi("ui.game.gamesurfacecomponent.storyboardDegradedResult"), {
+              description: preview.plannerWarning,
+              duration: 12_000,
+            });
+          }
           if (preview.items.length > 0) {
             let overrides: GameImagePromptOverride[] | null | typeof IMAGE_PROMPT_REVIEW_TIMED_OUT | undefined;
             try {
@@ -5907,18 +5913,25 @@ function GameSurfaceComponent({
       if (!("storyboard" in result)) return;
       applyGeneratedStoryboardToCache(result.storyboard, { refetchTurnStoryboards: true });
       const frameCount = result.storyboard.keyframes.length;
-      toast.success(
-        isGameTurnStoryboardRendering(result.storyboard)
-          ? localizeUi("ui.game.gamesurfacecomponent.storyboardPlannedWithValue1KeyframesImagesAreRendering", {
-              value1: frameCount,
-            })
-          : result.storyboard.status === "partial"
-            ? localizeUi("ui.game.gamesurfacecomponent.storyboardSavedWithValue1KeyframesSomeMediaFailed", {
+      if (result.storyboard.error) {
+        toast.warning(localizeUi("ui.game.gamesurfacecomponent.storyboardDegradedResult"), {
+          description: result.storyboard.error,
+          duration: 12_000,
+        });
+      } else {
+        toast.success(
+          isGameTurnStoryboardRendering(result.storyboard)
+            ? localizeUi("ui.game.gamesurfacecomponent.storyboardPlannedWithValue1KeyframesImagesAreRendering", {
                 value1: frameCount,
               })
-            : localizeUi("ui.game.gamesurfacecomponent.storyboardSavedWithValue1Keyframes", { value1: frameCount }),
-        { duration: 2200 },
-      );
+            : result.storyboard.status === "partial"
+              ? localizeUi("ui.game.gamesurfacecomponent.storyboardSavedWithValue1KeyframesSomeMediaFailed", {
+                  value1: frameCount,
+                })
+              : localizeUi("ui.game.gamesurfacecomponent.storyboardSavedWithValue1Keyframes", { value1: frameCount }),
+          { duration: 2200 },
+        );
+      }
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : localizeUi("ui.game.gamesurfacecomponent.storyboardGenerationFailed"),
@@ -5985,7 +5998,14 @@ function GameSurfaceComponent({
         debugMode: useUIStore.getState().debugMode,
       })
       .then((result) => {
-        if ("storyboard" in result) applyGeneratedStoryboardToCache(result.storyboard);
+        if (!("storyboard" in result)) return;
+        applyGeneratedStoryboardToCache(result.storyboard);
+        if (result.storyboard.error) {
+          toast.warning(localizeUi("ui.game.gamesurfacecomponent.storyboardDegradedResult"), {
+            description: result.storyboard.error,
+            duration: 12_000,
+          });
+        }
       })
       .catch((error) => {
         console.warn("[game/storyboard] auto storyboard generation failed", error);
@@ -6004,6 +6024,7 @@ function GameSurfaceComponent({
     latestAssistantStoryboardSections,
     latestAssistantSwipeIndex,
     latestTurnStoryboardRendering,
+    localizeUi,
     manualStoryboardReviewActive,
     applyGeneratedStoryboardToCache,
     storyboardGenerating,

--- a/packages/client/src/hooks/use-game-storyboards.ts
+++ b/packages/client/src/hooks/use-game-storyboards.ts
@@ -44,6 +44,12 @@ export type GameStoryboardPromptPreviewItem = {
   height: number;
 };
 
+export type GameStoryboardPromptPreviewResult = {
+  items: GameStoryboardPromptPreviewItem[];
+  plannedStoryboard: unknown;
+  plannerWarning: string | null;
+};
+
 const RENDERING_STORYBOARD_STATUSES = new Set(["planning", "rendering_images", "rendering_videos"]);
 
 export function isGameTurnStoryboardRendering(storyboard: GameTurnStoryboard | null | undefined): boolean {
@@ -112,7 +118,7 @@ export function useGenerateGameTurnStoryboard() {
 export function usePreviewGameTurnStoryboardPrompts() {
   return useMutation({
     mutationFn: (input: GenerateGameTurnStoryboardInput) =>
-      api.post<{ items: GameStoryboardPromptPreviewItem[]; plannedStoryboard: unknown }>("/game/storyboard/generate", {
+      api.post<GameStoryboardPromptPreviewResult>("/game/storyboard/generate", {
         ...input,
         previewOnly: true,
       }),

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -4650,6 +4650,7 @@
   "ui.game.gamesurfacecomponent.startGame": "Start Game",
   "ui.game.gamesurfacecomponent.storyboard": "Storyboard",
   "ui.game.gamesurfacecomponent.storyboardBackgroundDisplayIsActiveSoSceneBackgroundGeneration": "Storyboard background display is active, so scene background generation is disabled",
+  "ui.game.gamesurfacecomponent.storyboardDegradedResult": "Storyboard degraded result",
   "ui.game.gamesurfacecomponent.storyboardGenerationFailed": "Storyboard generation failed.",
   "ui.game.gamesurfacecomponent.storyboardPlannedWithValue1KeyframesImagesAreRendering": "Storyboard planned with {{value1}} keyframes; images are rendering.",
   "ui.game.gamesurfacecomponent.storyboardPromptPreviewTimedOutContinuingWithTheDefault": "Storyboard prompt preview timed out. Continuing with the default prompts.",

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -244,6 +244,12 @@ import {
 import { createAppSettingsStorage } from "../services/storage/app-settings.storage.js";
 import { applyStoryboardAgentSettings } from "../services/game/storyboard-agent-settings.js";
 import {
+  STORYBOARD_FALLBACK_BEAT_MAX_CHARS,
+  compactStoryboardFallbackBeat,
+  createStoryboardReviewPlanEnvelope,
+  resolveStoryboardReviewPlanEnvelope,
+} from "../services/game/storyboard-planner-fallback.js";
+import {
   selectPreviousSuccessfulStoryboard,
   selectRoleplayStoryboardEpisode,
 } from "../services/roleplay/storyboard-episode.js";
@@ -5336,7 +5342,7 @@ function fallbackStoryboardPlan(args: {
     keyframes: chunks.map((chunk, index) => {
       const firstSection = chunk.sections[0] ?? null;
       const lastSection = chunk.sections[chunk.sections.length - 1] ?? null;
-      const beat = compactStoryboardText(chunk.text, 900);
+      const beat = compactStoryboardFallbackBeat(chunk.text);
       const title = `Keyframe ${index + 1}`;
       const imagePrompt = `Manga illustration keyframe, cinematic anime panel, expressive character acting, detailed environment, dramatic lighting. ${beat}`;
       const reconciledCharacters = reconcileStoryboardCharactersForFrame({
@@ -5383,6 +5389,7 @@ function sanitizeStoryboardPlan(
     aspectRatio: GameSceneVideoAspectRatio;
     allowedCharacterNames?: string[];
     maxVisibleCharacters?: number;
+    narrationBeatMaxChars?: number;
   },
 ): PlannedStoryboard {
   const root = asStoryboardRecord(raw);
@@ -5393,7 +5400,7 @@ function sanitizeStoryboardPlan(
     .map((rawFrame, index): PlannedStoryboardKeyframe | null => {
       const frame = asStoryboardRecord(rawFrame);
       const fallbackFrame = fallback.keyframes[index] ?? fallback.keyframes[0] ?? null;
-      const narrationBeat = compactStoryboardText(frame.narrationBeat, 1200);
+      const narrationBeat = compactStoryboardText(frame.narrationBeat, args.narrationBeatMaxChars ?? 1200);
       const mangaPanelPrompt = compactStoryboardText(frame.mangaPanelPrompt, 5000);
       const imagePrompt = compactStoryboardText(frame.imagePrompt, 6500) || mangaPanelPrompt || narrationBeat;
       if (!narrationBeat && !imagePrompt) return null;
@@ -11030,7 +11037,7 @@ export async function gameRoutes(app: FastifyInstance) {
         charAvatarByName: storyboardCharacterContext.charAvatarByName,
         charDescriptionByName: storyboardCharacterContext.charDescriptionByName,
         includeReferenceImages: false,
-        includeCharacterDescriptions: true,
+        includeCharacterDescriptions: includeCharacterAppearance,
         maxReferenceImages: 0,
       });
       const storyboardAppearanceContextBlock = buildGameIllustratorAppearanceContextBlock(
@@ -11098,7 +11105,13 @@ export async function gameRoutes(app: FastifyInstance) {
       } as const;
       let usedFallbackStoryboardPlanner = false;
       if (input.plannedStoryboard !== undefined) {
-        plan = sanitizeStoryboardPlan(input.plannedStoryboard, storyboardPlanSanitizerOptions);
+        const reviewedStoryboard = resolveStoryboardReviewPlanEnvelope(input.plannedStoryboard);
+        illustratorErrorMessage = reviewedStoryboard.plannerError;
+        usedFallbackStoryboardPlanner = reviewedStoryboard.usedFallbackPlanner;
+        plan = sanitizeStoryboardPlan(reviewedStoryboard.plan, {
+          ...storyboardPlanSanitizerOptions,
+          narrationBeatMaxChars: usedFallbackStoryboardPlanner ? STORYBOARD_FALLBACK_BEAT_MAX_CHARS : undefined,
+        });
         if (debugLogsEnabled) {
           debugLog("[debug/game/storyboard-illustrator] using reviewed client storyboard plan");
         }
@@ -11145,10 +11158,11 @@ export async function gameRoutes(app: FastifyInstance) {
             throw abortReasonAsError(storyboardAbortSignal, "Game storyboard generation cancelled");
           }
           usedFallbackStoryboardPlanner = true;
-          illustratorErrorMessage =
-            err instanceof Error
-              ? `${err.message}; used fallback storyboard planner and skipped video generation.`
-              : "Used fallback storyboard planner and skipped video generation.";
+          const plannerFailureReason = compactStoryboardText(err instanceof Error ? err.message : "", 900);
+          illustratorErrorMessage = [
+            plannerFailureReason ? `Storyboard planner failed: ${plannerFailureReason}` : "Storyboard planner failed.",
+            "Marinara used narration-based fallback keyframes and skipped video generation.",
+          ].join(" ");
           logger.warn(
             err,
             "[game/storyboard] Storyboard Illustrator failed; using fallback images and skipping video generation",
@@ -11164,6 +11178,7 @@ export async function gameRoutes(app: FastifyInstance) {
           });
         }
       }
+      const includeCharacterAppearanceAtRender = includeCharacterAppearance && usedFallbackStoryboardPlanner;
 
       const imgModel = imgConn.model || "";
       const imgBaseUrl = imgConn.baseUrl || "https://image.pollinations.ai";
@@ -11217,7 +11232,7 @@ export async function gameRoutes(app: FastifyInstance) {
               prompts: plannedFrame.characterPrompts,
               characters: plannedFrame.characters,
               characterDescriptions: charDescriptionByName,
-              includeCharacterAppearance,
+              includeCharacterAppearance: includeCharacterAppearanceAtRender,
             })
           : [];
         const illustration: SceneIllustrationRequest = {
@@ -11237,7 +11252,7 @@ export async function gameRoutes(app: FastifyInstance) {
           charAvatarByName,
           charDescriptionByName,
           includeReferenceImages: useAvatarReferences,
-          includeCharacterDescriptions: includeCharacterAppearance,
+          includeCharacterDescriptions: includeCharacterAppearanceAtRender && characterPrompts.length === 0,
           maxReferenceImages: Math.max(0, storyboardReferenceImageLimit - (spatialLocationReferenceImage ? 1 : 0)),
         });
         const illustrationAssets = {
@@ -11316,7 +11331,15 @@ export async function gameRoutes(app: FastifyInstance) {
             };
           }),
         );
-        return { items, plannedStoryboard: plan };
+        return {
+          items,
+          plannedStoryboard: createStoryboardReviewPlanEnvelope({
+            plan,
+            plannerError: illustratorErrorMessage,
+            usedFallbackPlanner: usedFallbackStoryboardPlanner,
+          }),
+          plannerWarning: illustratorErrorMessage,
+        };
       }
 
       const snapshot =

--- a/packages/server/src/services/game/storyboard-planner-fallback.ts
+++ b/packages/server/src/services/game/storyboard-planner-fallback.ts
@@ -1,0 +1,60 @@
+export const STORYBOARD_FALLBACK_BEAT_MAX_CHARS = 2000;
+
+const STORYBOARD_REVIEW_PLAN_KIND = "marinara-storyboard-review-plan-v1";
+const STORYBOARD_PLANNER_ERROR_MAX_CHARS = 1200;
+
+export interface StoryboardReviewPlanEnvelope {
+  kind: typeof STORYBOARD_REVIEW_PLAN_KIND;
+  plan: unknown;
+  plannerError: string | null;
+  usedFallbackPlanner: boolean;
+}
+
+export function compactStoryboardFallbackBeat(value: unknown): string {
+  const text = typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
+  if (text.length <= STORYBOARD_FALLBACK_BEAT_MAX_CHARS) return text;
+
+  const contentLimit = STORYBOARD_FALLBACK_BEAT_MAX_CHARS - 3;
+  const candidate = text.slice(0, contentLimit + 1);
+  const wordBoundary = candidate.lastIndexOf(" ");
+  const cutoff = wordBoundary > 0 ? wordBoundary : contentLimit;
+  return `${candidate.slice(0, cutoff).trimEnd()}...`;
+}
+
+export function createStoryboardReviewPlanEnvelope(args: {
+  plan: unknown;
+  plannerError: string | null;
+  usedFallbackPlanner: boolean;
+}): StoryboardReviewPlanEnvelope {
+  return {
+    kind: STORYBOARD_REVIEW_PLAN_KIND,
+    plan: args.plan,
+    plannerError: args.plannerError,
+    usedFallbackPlanner: args.usedFallbackPlanner,
+  };
+}
+
+export function resolveStoryboardReviewPlanEnvelope(value: unknown): {
+  plan: unknown;
+  plannerError: string | null;
+  usedFallbackPlanner: boolean;
+} {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { plan: value, plannerError: null, usedFallbackPlanner: false };
+  }
+
+  const record = value as Record<string, unknown>;
+  if (record.kind !== STORYBOARD_REVIEW_PLAN_KIND || !("plan" in record)) {
+    return { plan: value, plannerError: null, usedFallbackPlanner: false };
+  }
+
+  const plannerError =
+    typeof record.plannerError === "string"
+      ? record.plannerError.trim().slice(0, STORYBOARD_PLANNER_ERROR_MAX_CHARS) || null
+      : null;
+  return {
+    plan: record.plan,
+    plannerError,
+    usedFallbackPlanner: record.usedFallbackPlanner === true || plannerError != null,
+  };
+}

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -283,6 +283,28 @@ import {
   applyStoryboardAgentSettings,
   shouldSuppressIllustratorForegroundForStoryboard,
 } from "../../packages/server/src/services/game/storyboard-agent-settings.js";
+import {
+  STORYBOARD_FALLBACK_BEAT_MAX_CHARS,
+  compactStoryboardFallbackBeat,
+  createStoryboardReviewPlanEnvelope,
+  resolveStoryboardReviewPlanEnvelope,
+} from "../../packages/server/src/services/game/storyboard-planner-fallback.js";
+
+const fallbackBeatWords = Array.from({ length: 400 }, (_, index) => `storyboard-beat-${index}`);
+const compactedFallbackBeat = compactStoryboardFallbackBeat(fallbackBeatWords.join(" "));
+assert.ok(compactedFallbackBeat.length <= STORYBOARD_FALLBACK_BEAT_MAX_CHARS);
+assert.ok(compactedFallbackBeat.endsWith("..."));
+assert.ok(fallbackBeatWords.includes(compactedFallbackBeat.slice(0, -3).split(" ").at(-1) ?? ""));
+const fallbackReviewEnvelope = createStoryboardReviewPlanEnvelope({
+  plan: { keyframes: [{ narrationBeat: compactedFallbackBeat }] },
+  plannerError: "Planner response was malformed; used fallback storyboard planner and skipped video generation.",
+  usedFallbackPlanner: true,
+});
+assert.deepEqual(resolveStoryboardReviewPlanEnvelope(fallbackReviewEnvelope), {
+  plan: fallbackReviewEnvelope.plan,
+  plannerError: fallbackReviewEnvelope.plannerError,
+  usedFallbackPlanner: true,
+});
 
 const assistantCadenceMessages = [
   { id: "illustrator-anchor", role: "assistant" },
@@ -3494,7 +3516,9 @@ const cases: RegressionCase[] = [
       );
       assert.match(storyboardHookSource, /previewOnly: true/);
       assert.match(gameRouteSource, /if \(input\.previewOnly\)/);
-      assert.match(gameRouteSource, /return \{ items, plannedStoryboard: plan \}/);
+      assert.match(gameRouteSource, /createStoryboardReviewPlanEnvelope\(\{/);
+      assert.match(gameRouteSource, /plannerWarning: illustratorErrorMessage/);
+      assert.match(gameSurfaceSource, /preview\.plannerWarning/);
       assert.match(gameRouteSource, /storyboardPromptOverrideById\.get\(`storyboard:\$\{frame\.index\}`\)/);
       assert.match(gameRouteSource, /\[debug\/game\/storyboard-image-preview\]/);
     },
@@ -3848,7 +3872,7 @@ const cases: RegressionCase[] = [
     },
   },
   {
-    name: "Game planner always receives card appearance while final attachment stays optional",
+    name: "Storyboard appearance is gated and injected once across planner and fallback paths",
     async run() {
       const appearance = "auburn hair, green eyes, leather jacket";
       const description = "A verbose roleplay card description that must not be sent as visual appearance.";
@@ -4171,8 +4195,19 @@ const cases: RegressionCase[] = [
       assert.doesNotMatch(gameSurfaceSource, /useGamePromptTemplate/u);
       assert.match(gameRouteSource, /characterAppearanceContextBlock:\s*storyboardAppearanceContextBlock/u);
       assert.equal(gameRouteSource.match(/^\s+characterAppearanceContextBlock,\s*$/gmu)?.length, 2);
-      assert.equal(gameRouteSource.match(/includeCharacterDescriptions:\s*true,/gu)?.length, 1);
+      assert.equal(gameRouteSource.match(/includeCharacterDescriptions:\s*true,/gu)?.length ?? 0, 0);
       assert.equal(gameRouteSource.match(/includeCharacterDescriptions:\s*includeCharacterAppearance,/gu)?.length, 5);
+      assert.equal(
+        gameRouteSource.match(
+          /includeCharacterDescriptions:\s*includeCharacterAppearanceAtRender && characterPrompts\.length === 0,/gu,
+        )?.length,
+        1,
+      );
+      assert.match(
+        gameRouteSource,
+        /const includeCharacterAppearanceAtRender = includeCharacterAppearance && usedFallbackStoryboardPlanner/u,
+      );
+      assert.match(gameRouteSource, /Marinara used narration-based fallback keyframes and skipped video generation/u);
       assert.equal(gameRouteSource.match(/meta\.storyboardAgentIncludeCharacterAppearance !== false/gu)?.length, 1);
       assert.equal(gameRouteSource.match(/meta\.storyboardAgentUseAvatarReferences !== false/gu)?.length, 1);
       assert.equal(gameRouteSource.match(/meta\.gameImageIncludeCharacterAppearance !== false/gu)?.length, 2);


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #4544

## Why this change

- Storyboard planner failures could be hidden after prompt review, while appearance injection ignored the user-facing toggle or duplicated character details across planning and rendering.
- Fallback keyframe narration was limited to 900 characters, reducing useful scene context for degraded renders.

## What changed

- Preserve planner failure and fallback provenance through preview, final submission, saved storyboard metadata, warning toasts, and persistent Game/Roleplay viewer warnings.
- Make **Attach Card Appearance** authoritative and inject appearance once: through a successful planner, or during fallback rendering.
- Increase fallback narration beats to 2,000 characters with word-boundary truncation while retaining downstream provider prompt limits.
- Add deterministic regression coverage for fallback envelopes, truncation, warning propagation, and appearance-path behavior.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated: `pnpm regression:prompt`
- Automated: `pnpm check`
- Manually verify planner success/fallback with prompt review on and off, and **Attach Card Appearance** on and off.
- Manually verify warning bands and warning toasts in Game and Roleplay Storyboard surfaces on desktop and mobile.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Pending exact local review deployment and browser verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer storyboard warning banners and localized messages for degraded or failed results.
  * Added warning notifications for planner issues during manual and automatic storyboard generation.
  * Storyboard previews now provide plan details, fallback status, and planner warnings.

* **Bug Fixes**
  * Improved fallback storyboard handling and readability.
  * Prevented video generation when storyboard planning falls back after an error.
  * Avoided displaying raw errors as storyboard descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->