### PR TITLE
fix(storyboard): harden fallback rendering

### DIFF
--- a/packages/client/src/components/chat/RoleplayStoryboardMessageMedia.tsx
+++ b/packages/client/src/components/chat/RoleplayStoryboardMessageMedia.tsx
@@ -121,10 +121,9 @@ export function RoleplayStoryboardMessageMedia({
         <div className="flex min-h-20 items-center justify-center gap-2 px-4 py-5 text-xs text-white/55">
           {rendering ? <Loader2 size={14} className="animate-spin" /> : null}
           <span className="line-clamp-2 text-center">
-            {storyboard?.error ||
-              (rendering
-                ? localizeUi("ui.game.gamesurfacecomponent.creatingStoryboard")
-                : localizeUi("game.storyboard.status.failed"))}
+            {rendering
+              ? localizeUi("ui.game.gamesurfacecomponent.creatingStoryboard")
+              : localizeUi("game.storyboard.status.failed")}
           </span>
         </div>
       )}

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -246,8 +246,11 @@ import { applyStoryboardAgentSettings } from "../services/game/storyboard-agent-
 import {
   STORYBOARD_FALLBACK_BEAT_MAX_CHARS,
   compactStoryboardFallbackBeat,
+  compactStoryboardTextAtWordBoundary,
   createStoryboardReviewPlanEnvelope,
+  formatStoryboardFallbackSectionText,
   resolveStoryboardReviewPlanEnvelope,
+  storyboardPlanHasRenderableKeyframe,
 } from "../services/game/storyboard-planner-fallback.js";
 import {
   selectPreviousSuccessfulStoryboard,
@@ -716,11 +719,7 @@ function collectIllustrationCharacterAssets(opts: {
 }
 
 function compactIllustratorAppearanceLine(value: string): string {
-  const clean = value.trim().replace(/\s+/g, " ");
-  if (clean.length <= 1500) return clean;
-  const clipped = clean.slice(0, 1497).trimEnd();
-  const wordBoundary = clipped.lastIndexOf(" ");
-  return `${(wordBoundary > 0 ? clipped.slice(0, wordBoundary) : clipped).trimEnd()}...`;
+  return compactStoryboardTextAtWordBoundary(value, 1500);
 }
 
 export function buildGameIllustratorAppearanceContextBlock(characterDescriptions: string[]): string {
@@ -4980,7 +4979,7 @@ function storyboardSectionsForRange(
 }
 
 function storyboardSectionText(section: StoryboardSourceSection): string {
-  return section.speaker ? `${section.speaker}: ${section.content}` : section.content;
+  return formatStoryboardFallbackSectionText(section.content, section.speaker);
 }
 
 function dominantStoryboardSectionKind(sections: StoryboardSourceSection[]): StoryboardAnchorKind | "" {
@@ -11107,7 +11106,12 @@ export async function gameRoutes(app: FastifyInstance) {
       if (input.plannedStoryboard !== undefined) {
         const reviewedStoryboard = resolveStoryboardReviewPlanEnvelope(input.plannedStoryboard);
         illustratorErrorMessage = reviewedStoryboard.plannerError;
-        usedFallbackStoryboardPlanner = reviewedStoryboard.usedFallbackPlanner;
+        const reviewedPlanHasRenderableKeyframe = storyboardPlanHasRenderableKeyframe(reviewedStoryboard.plan);
+        usedFallbackStoryboardPlanner = reviewedStoryboard.usedFallbackPlanner || !reviewedPlanHasRenderableKeyframe;
+        if (!reviewedPlanHasRenderableKeyframe && !illustratorErrorMessage) {
+          illustratorErrorMessage =
+            "Reviewed storyboard contained no usable keyframes. Marinara used narration-based fallback keyframes and skipped video generation.";
+        }
         plan = sanitizeStoryboardPlan(reviewedStoryboard.plan, {
           ...storyboardPlanSanitizerOptions,
           narrationBeatMaxChars: usedFallbackStoryboardPlanner ? STORYBOARD_FALLBACK_BEAT_MAX_CHARS : undefined,
@@ -11138,18 +11142,7 @@ export async function gameRoutes(app: FastifyInstance) {
           const rawPlan = extraction.content.trim();
           if (debugLogsEnabled) debugLog("[debug/game/storyboard-illustrator] raw response:\n%s", rawPlan);
           const parsedPlan = parseJSON(rawPlan);
-          const parsedKeyframes = asStoryboardRecord(parsedPlan).keyframes;
-          const hasRenderableKeyframe =
-            Array.isArray(parsedKeyframes) &&
-            parsedKeyframes.some((rawFrame) => {
-              const frame = asStoryboardRecord(rawFrame);
-              return Boolean(
-                compactStoryboardText(frame.narrationBeat, 1200) ||
-                compactStoryboardText(frame.imagePrompt, 6500) ||
-                compactStoryboardText(frame.mangaPanelPrompt, 5000),
-              );
-            });
-          if (!hasRenderableKeyframe) {
+          if (!storyboardPlanHasRenderableKeyframe(parsedPlan)) {
             throw new Error("Storyboard Illustrator returned no usable keyframes");
           }
           plan = sanitizeStoryboardPlan(parsedPlan, storyboardPlanSanitizerOptions);
@@ -11263,16 +11256,15 @@ export async function gameRoutes(app: FastifyInstance) {
             storyboardReferenceImageLimit,
           ),
         };
-        return { plannedFrame, characterPrompts, illustration, illustrationAssets };
+        const ensureCharacterAppearance = includeCharacterAppearanceAtRender && characterPrompts.length === 0;
+        return { plannedFrame, characterPrompts, illustration, illustrationAssets, ensureCharacterAppearance };
       };
 
       if (input.previewOnly) {
         const items = await Promise.all(
           plan.keyframes.map(async (_frame, frameIndex) => {
-            const { plannedFrame, illustration, illustrationAssets } = buildStoryboardFrameIllustration(
-              frameIndex,
-              "storyboard-preview",
-            );
+            const { plannedFrame, illustration, illustrationAssets, ensureCharacterAppearance } =
+              buildStoryboardFrameIllustration(frameIndex, "storyboard-preview");
             const compiled = await buildSceneIllustrationProviderPrompt({
               chatId: input.chatId,
               title: illustration.title,
@@ -11280,6 +11272,7 @@ export async function gameRoutes(app: FastifyInstance) {
               reason: illustration.reason,
               characters: illustration.characters,
               characterDescriptions: illustrationAssets.characterDescriptions,
+              ensureCharacterAppearance,
               slug: illustration.slug,
               genre,
               setting,
@@ -11419,10 +11412,8 @@ export async function gameRoutes(app: FastifyInstance) {
           return { generatedImage: false, generatedVideo: false, imageFailure: true, videoFailure: false };
         }
         await storyboards.updateKeyframe(frame.id, { status: "rendering_image", error: null });
-        const { plannedFrame, characterPrompts, illustration, illustrationAssets } = buildStoryboardFrameIllustration(
-          frame.index,
-          storyboardRow.id.slice(0, 8),
-        );
+        const { plannedFrame, characterPrompts, illustration, illustrationAssets, ensureCharacterAppearance } =
+          buildStoryboardFrameIllustration(frame.index, storyboardRow.id.slice(0, 8));
         await storyboards.updateKeyframe(frame.id, {
           imagePrompt: plannedFrame.imagePrompt,
           mangaPanelPrompt: plannedFrame.mangaPanelPrompt,
@@ -11457,6 +11448,7 @@ export async function gameRoutes(app: FastifyInstance) {
             reason: illustration.reason,
             characters: illustration.characters,
             characterDescriptions: illustrationAssets.characterDescriptions,
+            ensureCharacterAppearance,
             slug: illustration.slug,
             genre,
             setting,

--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -905,6 +905,8 @@ export interface SceneIllustrationGenRequest {
   reason?: string;
   characters?: string[];
   characterDescriptions?: string[];
+  /** Ensure requested appearance notes survive a selected formatter that omits the appearance variable. */
+  ensureCharacterAppearance?: boolean;
   slug?: string;
   genre?: string;
   setting?: string;
@@ -1160,10 +1162,16 @@ async function buildSceneIllustrationRawPrompt(req: SceneIllustrationGenRequest)
       : req.promptOverridesStorage
         ? await loadPrompt(req.promptOverridesStorage, GAME_SCENE_ILLUSTRATION, sceneIllustrationVars)
         : GAME_SCENE_ILLUSTRATION.defaultBuilder(sceneIllustrationVars);
-  const finalPrompt =
-    imagePromptInstructionsLine && !rawIllustrationPrompt.includes(imagePromptInstructionsLine)
-      ? `${rawIllustrationPrompt}\n${imagePromptInstructionsLine}`
+  const rawPromptWithRequiredAppearance =
+    req.ensureCharacterAppearance &&
+    sceneIllustrationVars.appearanceNotesBlock &&
+    !rawIllustrationPrompt.includes(sceneIllustrationVars.appearanceNotesBlock)
+      ? `${rawIllustrationPrompt}\n${sceneIllustrationVars.appearanceNotesBlock}`
       : rawIllustrationPrompt;
+  const finalPrompt =
+    imagePromptInstructionsLine && !rawPromptWithRequiredAppearance.includes(imagePromptInstructionsLine)
+      ? `${rawPromptWithRequiredAppearance}\n${imagePromptInstructionsLine}`
+      : rawPromptWithRequiredAppearance;
   return finalPrompt;
 }
 

--- a/packages/server/src/services/game/storyboard-planner-fallback.ts
+++ b/packages/server/src/services/game/storyboard-planner-fallback.ts
@@ -10,15 +10,49 @@ export interface StoryboardReviewPlanEnvelope {
   usedFallbackPlanner: boolean;
 }
 
-export function compactStoryboardFallbackBeat(value: unknown): string {
+export function compactStoryboardTextAtWordBoundary(value: unknown, maxChars: number): string {
+  if (maxChars <= 0) return "";
   const text = typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
-  if (text.length <= STORYBOARD_FALLBACK_BEAT_MAX_CHARS) return text;
+  if (text.length <= maxChars) return text;
+  if (maxChars <= 3) return ".".repeat(maxChars);
 
-  const contentLimit = STORYBOARD_FALLBACK_BEAT_MAX_CHARS - 3;
+  const contentLimit = maxChars - 3;
   const candidate = text.slice(0, contentLimit + 1);
   const wordBoundary = candidate.lastIndexOf(" ");
   const cutoff = wordBoundary > 0 ? wordBoundary : contentLimit;
   return `${candidate.slice(0, cutoff).trimEnd()}...`;
+}
+
+export function compactStoryboardFallbackBeat(value: unknown): string {
+  return compactStoryboardTextAtWordBoundary(value, STORYBOARD_FALLBACK_BEAT_MAX_CHARS);
+}
+
+export function storyboardPlanHasRenderableKeyframe(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const keyframes = (value as Record<string, unknown>).keyframes;
+  if (!Array.isArray(keyframes)) return false;
+  return keyframes.some((rawFrame) => {
+    if (!rawFrame || typeof rawFrame !== "object" || Array.isArray(rawFrame)) return false;
+    const frame = rawFrame as Record<string, unknown>;
+    return [frame.narrationBeat, frame.imagePrompt, frame.mangaPanelPrompt].some(
+      (candidate) => typeof candidate === "string" && candidate.trim().length > 0,
+    );
+  });
+}
+
+export function formatStoryboardFallbackSectionText(content: string, speaker?: string | null): string {
+  const cleanContent = content.trim();
+  const cleanSpeaker = speaker?.trim() ?? "";
+  if (!cleanSpeaker) return cleanContent;
+  const escapedSpeaker = cleanSpeaker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const prefixPattern = new RegExp(`^${escapedSpeaker}\\s*:\\s*`, "iu");
+  let body = cleanContent;
+  while (body) {
+    const existingPrefix = body.match(prefixPattern);
+    if (!existingPrefix) break;
+    body = body.slice(existingPrefix[0].length).trim();
+  }
+  return body ? `${cleanSpeaker}: ${body}` : `${cleanSpeaker}:`;
 }
 
 export function createStoryboardReviewPlanEnvelope(args: {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -286,8 +286,11 @@ import {
 import {
   STORYBOARD_FALLBACK_BEAT_MAX_CHARS,
   compactStoryboardFallbackBeat,
+  compactStoryboardTextAtWordBoundary,
   createStoryboardReviewPlanEnvelope,
+  formatStoryboardFallbackSectionText,
   resolveStoryboardReviewPlanEnvelope,
+  storyboardPlanHasRenderableKeyframe,
 } from "../../packages/server/src/services/game/storyboard-planner-fallback.js";
 
 const fallbackBeatWords = Array.from({ length: 400 }, (_, index) => `storyboard-beat-${index}`);
@@ -295,6 +298,20 @@ const compactedFallbackBeat = compactStoryboardFallbackBeat(fallbackBeatWords.jo
 assert.ok(compactedFallbackBeat.length <= STORYBOARD_FALLBACK_BEAT_MAX_CHARS);
 assert.ok(compactedFallbackBeat.endsWith("..."));
 assert.ok(fallbackBeatWords.includes(compactedFallbackBeat.slice(0, -3).split(" ").at(-1) ?? ""));
+assert.equal(compactStoryboardTextAtWordBoundary("  silver   hair blue eyes  ", 18), "silver hair...");
+assert.equal(formatStoryboardFallbackSectionText("Morgana-: Hold the hatch.", "Morgana-"), "Morgana-: Hold the hatch.");
+assert.equal(
+  formatStoryboardFallbackSectionText("Morgana-: Morgana-: Hold the hatch.", "Morgana-"),
+  "Morgana-: Hold the hatch.",
+);
+assert.equal(formatStoryboardFallbackSectionText("Hold the hatch.", "Morgana-"), "Morgana-: Hold the hatch.");
+assert.equal(
+  formatStoryboardFallbackSectionText("Shellback Tollkeeper: Run, little coins!", "Shellback Tollkeeper"),
+  "Shellback Tollkeeper: Run, little coins!",
+);
+assert.equal(storyboardPlanHasRenderableKeyframe({ keyframes: [] }), false);
+assert.equal(storyboardPlanHasRenderableKeyframe({ keyframes: [{ narrationBeat: "  " }] }), false);
+assert.equal(storyboardPlanHasRenderableKeyframe({ keyframes: [{ imagePrompt: "A usable frame" }] }), true);
 const fallbackReviewEnvelope = createStoryboardReviewPlanEnvelope({
   plan: { keyframes: [{ narrationBeat: compactedFallbackBeat }] },
   plannerError: "Planner response was malformed; used fallback storyboard planner and skipped video generation.",
@@ -3518,6 +3535,10 @@ const cases: RegressionCase[] = [
       assert.match(gameRouteSource, /if \(input\.previewOnly\)/);
       assert.match(gameRouteSource, /createStoryboardReviewPlanEnvelope\(\{/);
       assert.match(gameRouteSource, /plannerWarning: illustratorErrorMessage/);
+      assert.match(
+        gameRouteSource,
+        /usedFallbackStoryboardPlanner = reviewedStoryboard\.usedFallbackPlanner \|\| !reviewedPlanHasRenderableKeyframe/u,
+      );
       assert.match(gameSurfaceSource, /preview\.plannerWarning/);
       assert.match(gameRouteSource, /storyboardPromptOverrideById\.get\(`storyboard:\$\{frame\.index\}`\)/);
       assert.match(gameRouteSource, /\[debug\/game\/storyboard-image-preview\]/);
@@ -4099,6 +4120,27 @@ const cases: RegressionCase[] = [
         separatedVisibilityCompiled.prompt,
         "SCENE Lyra standing in a moonlit forest\nSCOPE Final visibility rule: Only depict these named visible characters: Lyra.",
       );
+
+      const fallbackFirstFrameCompiled = await buildSceneIllustrationProviderPrompt({
+        chatId: "prompt-regression",
+        prompt: "Lyra standing in a moonlit forest",
+        characters: ["Lyra"],
+        characterDescriptions: [`Lyra's Appearance: ${appearance}`],
+        ensureCharacterAppearance: true,
+        storyboardImagePromptTemplateId: "storyboard-first-frame",
+        storyboardImagePromptTemplates: [
+          {
+            id: "storyboard-first-frame",
+            name: "Storyboard First Frame",
+            promptTemplate: "${scenePrompt}",
+          },
+        ],
+        imgModel: "unused",
+        imgBaseUrl: "",
+        imgApiKey: "",
+      });
+      assert.match(fallbackFirstFrameCompiled.prompt, /Character appearance notes:\s*Lyra's Appearance:/u);
+      assert.equal(fallbackFirstFrameCompiled.prompt.match(/Character appearance notes:/gu)?.length, 1);
 
       const compiledWithoutAttachedAppearance = await buildSceneIllustrationProviderPrompt({
         chatId: "prompt-regression",


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #4595

## Why this change

- The fallback path could lose its effective fallback state after storyboard review, repeat structured speaker labels, omit collected appearance notes from selected image formatters, and display the same degraded error twice.
- This follows up the valid CodeRabbit findings left on #4591 and the provider-facing prompt behavior observed in debug logs.

## What changed

- Detect non-renderable reviewed plans before sanitization so fallback appearance and video safeguards remain active.
- Normalize fallback speaker prefixes and share word-boundary truncation logic.
- Require collected fallback appearance notes in the final provider prompt when a selected formatter omits them.
- Remove duplicate Roleplay storyboard error rendering.
- Add prompt regressions for empty plans, repeated speakers, truncation, and formatter-omitted appearance.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated proof performed by Codex:

- `pnpm check`
- `pnpm regression:prompt`
- `git diff --check`

### Manual verification notes

- Manually force a storyboard planner failure with character appearance enabled and `Storyboard First Frame` selected.
- Confirm the final provider prompt contains each requested character appearance once and does not duplicate structured speaker labels.
- Confirm a degraded Roleplay storyboard displays its detailed error once.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not captured. The UI change removes duplicate fallback error text; human verification remains pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved storyboard fallback generation when planned keyframes cannot be rendered.
  * Character appearance details are now preserved in storyboard previews and generated scene images.
  * Video generation is skipped when no usable storyboard frame is available.

* **Bug Fixes**
  * Improved storyboard text formatting, including cleaner speaker labels and word-boundary truncation.
  * Empty storyboard states now show clearer rendering or failure status messages.
  * Reduced repeated character appearance details in generated image prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->