### PR TITLE
Fix Add character action sizing in Character folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+### Fixed
+
+- Matched the **Add character to active chat** button to the neighboring Character row actions in folders and standalone rows on desktop and mobile.
+
 ## [2.4.2]
 
 ### Added

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1866,7 +1866,8 @@ test("Characters can be dragged from the right panel into the active chat", asyn
   }
 });
 
-test("Character row actions can add a resource to the active chat without dragging", async ({ page, request }) => {
+test("Character row actions can add a resource to the active chat without dragging", async ({ page, request }, testInfo) => {
+  const mobile = testInfo.project.name.includes("mobile");
   const suffix = Date.now().toString(36);
   const characterName = `Chat Action Character ${suffix}`;
   const characterResponse = await request.post("/api/characters", {
@@ -1879,6 +1880,11 @@ test("Character row actions can add a resource to the active chat without draggi
   });
   expect(chatResponse.ok()).toBeTruthy();
   const chat = (await chatResponse.json()) as { id: string };
+  const groupResponse = await request.post("/api/characters/groups", {
+    data: { name: `Chat Action Folder ${suffix}`, characterIds: [character.id] },
+  });
+  expect(groupResponse.ok()).toBeTruthy();
+  const group = (await groupResponse.json()) as { id: string };
 
   try {
     await page.goto("/");
@@ -1889,10 +1895,36 @@ test("Character row actions can add a resource to the active chat without draggi
     await expect(page.locator("[data-chat-resource-drop-surface]")).toBeVisible();
     await page.locator('[data-tour="panel-characters"]').click();
 
-    const characterRow = page.locator('[data-touch-drag-card="character"]').filter({ hasText: characterName });
-    await characterRow.hover();
+    const folderRow = page.locator(`[data-character-folder-id="${group.id}"]`);
+    const folderHeader = folderRow.locator(':scope > [role="button"]');
+    await folderHeader.click();
+    await expect(folderHeader).toHaveAttribute("aria-expanded", "true");
+
+    const characterRow = folderRow.locator('[data-touch-drag-card="character"]').filter({ hasText: characterName });
+    if (!mobile) await characterRow.hover();
     const addAction = characterRow.locator('[data-chat-resource-action="character"]');
+    const duplicateAction = characterRow.getByRole("button", { name: "Duplicate", exact: true });
+    const deleteAction = characterRow.getByRole("button", { name: "Delete", exact: true });
     await expect(addAction).toBeVisible();
+    const [addBox, duplicateBox, deleteBox] = await Promise.all([
+      addAction.boundingBox(),
+      duplicateAction.boundingBox(),
+      deleteAction.boundingBox(),
+    ]);
+    expect(addBox).not.toBeNull();
+    expect(duplicateBox).not.toBeNull();
+    expect(deleteBox).not.toBeNull();
+    expect(addBox!.width).toBeCloseTo(duplicateBox!.width, 1);
+    expect(addBox!.height).toBeCloseTo(duplicateBox!.height, 1);
+    expect(addBox!.width).toBeCloseTo(deleteBox!.width, 1);
+    expect(addBox!.height).toBeCloseTo(deleteBox!.height, 1);
+    const [addRadius, duplicateRadius, deleteRadius] = await Promise.all(
+      [addAction, duplicateAction, deleteAction].map((button) =>
+        button.evaluate((element) => getComputedStyle(element).borderRadius),
+      ),
+    );
+    expect(addRadius).toBe(duplicateRadius);
+    expect(addRadius).toBe(deleteRadius);
     await addAction.click();
 
     await expect.poll(() => getChatCharacterIds(request, chat.id)).toContain(character.id);
@@ -1900,6 +1932,7 @@ test("Character row actions can add a resource to the active chat without draggi
   } finally {
     await Promise.all([
       request.delete(`/api/chats/${chat.id}`).catch(() => undefined),
+      request.delete(`/api/characters/groups/${group.id}`).catch(() => undefined),
       request.delete(`/api/characters/${character.id}`).catch(() => undefined),
     ]);
   }

--- a/packages/client/src/components/chat/ChatResourceActionButton.tsx
+++ b/packages/client/src/components/chat/ChatResourceActionButton.tsx
@@ -9,10 +9,12 @@ export function ChatResourceActionButton({
   payload,
   className,
   iconClassName,
+  size = "small",
 }: {
   payload: ChatResourceDragPayload;
   className?: string;
   iconClassName?: string;
+  size?: "small" | "row";
 }) {
   const { t } = useTranslation();
   const chat = useChatStore((state) => state.activeChat);
@@ -28,7 +30,11 @@ export function ChatResourceActionButton({
         event.stopPropagation();
         requestChatResourceAssignment(payload);
       }}
-      className={cn("mari-chrome-control mari-chrome-control--small p-1.5", className)}
+      className={cn(
+        "mari-chrome-control",
+        size === "small" && "mari-chrome-control--small p-1.5",
+        className,
+      )}
       title={label}
       aria-label={label}
     >

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -1262,7 +1262,8 @@ export function CharactersPanel() {
                         >
                           <ChatResourceActionButton
                             payload={{ version: 1, kind: "character", ids: [memberId], label: memberName }}
-                            className="flex !h-5 !min-h-5 !w-5 items-center justify-center !rounded-md !p-0"
+                            size="row"
+                            className="flex h-5 min-h-5 w-5 items-center justify-center rounded-md p-0 active:scale-90"
                             iconClassName="h-2.5 w-2.5 shrink-0"
                           />
                           <button
@@ -1599,6 +1600,7 @@ export function CharactersPanel() {
                 >
                   <ChatResourceActionButton
                     payload={{ version: 1, kind: "character", ids: [char.id], label: charName }}
+                    size="row"
                     className="mari-character-row-action flex w-7 items-center justify-center max-md:w-6"
                     iconClassName="h-4 w-4 shrink-0 max-md:h-3.5 max-md:w-3.5"
                   />


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Follow-up to #4611

## Why this change

- The earlier sizing fix forced the Add character action to a 20px square with important utilities, while neighboring duplicate and delete controls still inherited the Character row's taller minimum height and corner radius.
- This made Add visibly shorter and differently shaped in expanded Character folders on desktop and mobile.

## What changed

- Added an explicit row-sizing mode to the shared chat resource action button so Character rows own its dimensions.
- Applied the same row sizing contract in expanded folders and standalone Character rows.
- Extended the rendered-browser regression to compare Add, duplicate, and delete width, height, and corner radius in a Character folder.
- Added an Unreleased changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated checks run by Codex:

- `pnpm check`
- `pnpm exec playwright test -c playwright.config.ts e2e/core-flows.e2e.ts -g "Character row actions can add a resource"` (desktop and mobile, 2 passed)

### Manual verification notes

- Manually verify the expanded-folder toolbar in light and dark themes.
- Manually confirm Add, duplicate, and delete remain identical in shape at desktop and mobile widths.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing documentation change is needed. `CHANGELOG.md` is updated under `[Unreleased]`.

## UI evidence

- Rendered geometry is covered in the desktop and mobile Playwright regression.
- Before/after screenshots still need to be attached before marking this PR ready for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the size, placement, and styling of the “Add character to active chat” button across standalone and folder character rows on desktop and mobile.
  * Ensured character action buttons have consistent dimensions and rounded corners.
  * Improved mobile character-folder interactions and cleanup in end-to-end flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->