### PR TITLE
fix(noodle): improve stage profile prompt and unwrap LLM arrays

### DIFF
--- a/packages/server/src/services/noodle/noodle-stage-profile-draft.service.ts
+++ b/packages/server/src/services/noodle/noodle-stage-profile-draft.service.ts
@@ -118,7 +118,9 @@ export function buildNoodlerStageProfileDraftMessages(input: {
       role: "system",
       content: [
         "Create one editable NoodleR stage profile draft.",
-        "Return JSON only with displayName, handle, bio, stagePersonality, and disclosureMode.",
+        "Return a single JSON object only — no arrays, no wrapping brackets.",
+        "Keys: displayName, handle, bio, stagePersonality, disclosureMode.",
+        "disclosureMode must be one of: \"open\", \"hinted\", or \"secret\" — use only these exact values.",
         "Make the stage identity distinct, concise, and usable for future NoodleR post generation.",
         disclosureRules(input.request.disclosureMode, identity),
       ].join("\n"),
@@ -212,7 +214,10 @@ export async function generateNoodlerStageProfileDraft(
     debugMode,
     responseFormat: noodleResponseFormat(input.connection.model, "noodler_profile"),
   });
-  const parsed = noodleStageProfileDraftResponseSchema.parse(parseGameJsonish(response.content ?? ""));
+  const unwrapped = parseGameJsonish(response.content ?? "");
+  const parsed = noodleStageProfileDraftResponseSchema.parse(
+    Array.isArray(unwrapped) && unwrapped.length === 1 ? unwrapped[0] : unwrapped,
+  );
   const draft = { ...parsed, disclosureMode: input.request.disclosureMode };
   if (stageProfileContainsPublicIdentity(draft, identity)) {
     throw new Error("Generated stage draft included the linked public identity. Try again with different guidance.");

--- a/packages/server/src/services/noodle/noodle-stage-profile-draft.service.ts
+++ b/packages/server/src/services/noodle/noodle-stage-profile-draft.service.ts
@@ -215,9 +215,11 @@ export async function generateNoodlerStageProfileDraft(
     responseFormat: noodleResponseFormat(input.connection.model, "noodler_profile"),
   });
   const unwrapped = parseGameJsonish(response.content ?? "");
-  const parsed = noodleStageProfileDraftResponseSchema.parse(
-    Array.isArray(unwrapped) && unwrapped.length === 1 ? unwrapped[0] : unwrapped,
+  const unwrappedObj = Array.isArray(unwrapped) && unwrapped.length === 1 ? unwrapped[0] : unwrapped;
+  const raw = noodleStageProfileDraftResponseSchema.omit({ disclosureMode: true }).passthrough().parse(
+    unwrappedObj as Record<string, unknown>,
   );
+  const parsed = { ...raw, handle: (raw.handle as string)?.replace(/^@/, "") ?? "" };
   const draft = { ...parsed, disclosureMode: input.request.disclosureMode };
   if (stageProfileContainsPublicIdentity(draft, identity)) {
     throw new Error("Generated stage draft included the linked public identity. Try again with different guidance.");


### PR DESCRIPTION
Update the system prompt to tell LLMs to return a single JSON object (no arrays) and specify valid disclosureMode enum values. Also add a minimal array unwrap guard for when local models still wrap the object in brackets.

Skipped ZodError catch — the prompt fixes are more reliable.

> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

-

## What changed

<!-- List the key changes in this PR -->

-

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

-

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stage-profile generation by requiring a single, consistently structured JSON response with documented expected keys.
  * Added support for LLM responses returned as either a JSON object or a single-item array.
  * Tightened `disclosureMode` handling to only allow supported exact values (while making it non-mandatory during validation).
  * Normalized user handles by removing a leading `@` when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->