### PR TITLE
Skip idle NoodleR reserve scans and back off disabled Noodle refresh polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Matched the **Add character to active chat** button to the neighboring Character row actions in folders and standalone rows on desktop and mobile.
+- Stopped the NoodleR reserve poll from scanning the prepared-post and Noodle post tables every minute when automatic posting is off and no reserve posts exist, and backed the automatic timeline-refresh poll off to 15 minutes while refreshes are disabled, cutting idle CPU wake-ups on phone and Termux installs (#4630).
 
 ## [2.4.2]
 

--- a/packages/server/src/services/noodle/noodle-autopost-scheduler.service.ts
+++ b/packages/server/src/services/noodle/noodle-autopost-scheduler.service.ts
@@ -25,6 +25,14 @@ export async function withNoodleAutoPostPaused<T>(run: () => Promise<T>): Promis
   }
 }
 
+/** True when nothing can be prepared or published, so the poll only has existing rows to tidy. */
+export function noodlerReservePollIsIdle(settings: {
+  enableNoodler: boolean;
+  autoPostingScheduleEnabled: boolean;
+}): boolean {
+  return !settings.enableNoodler || !settings.autoPostingScheduleEnabled;
+}
+
 export function startNoodleAutoPostScheduler(app: FastifyInstance) {
   let stopped = false;
   let running: Promise<void> = Promise.resolve();
@@ -47,6 +55,17 @@ export function startNoodleAutoPostScheduler(app: FastifyInstance) {
       return;
     }
     try {
+      // Reconciliation walks every prepared post and every Noodle post. With posting off and no
+      // reserve rows there is nothing for it to repair or publish, so skip the scan entirely
+      // rather than materializing both tables once a minute for the server's lifetime.
+      const noodle = createNoodleStorage(app.db);
+      const settings = await noodle.getSettings();
+      if (
+        noodlerReservePollIsIdle(settings) &&
+        (await noodle.listNoodlerPreparedPosts()).length === 0
+      ) {
+        return;
+      }
       await reconcileNoodlerReserve(app.db);
       const outcome = await prepareNextNoodlerReservePost(app.db);
       if (outcome === "prepared") logger.info("[noodle-autopost] Prepared one future NoodleR post");

--- a/packages/server/src/services/noodle/noodle-autopost-scheduler.service.ts
+++ b/packages/server/src/services/noodle/noodle-autopost-scheduler.service.ts
@@ -60,12 +60,7 @@ export function startNoodleAutoPostScheduler(app: FastifyInstance) {
       // rather than materializing both tables once a minute for the server's lifetime.
       const noodle = createNoodleStorage(app.db);
       const settings = await noodle.getSettings();
-      if (
-        noodlerReservePollIsIdle(settings) &&
-        (await noodle.listNoodlerPreparedPosts()).length === 0
-      ) {
-        return;
-      }
+      if (noodlerReservePollIsIdle(settings) && !(await noodle.hasNoodlerPreparedPosts())) return;
       await reconcileNoodlerReserve(app.db);
       const outcome = await prepareNextNoodlerReservePost(app.db);
       if (outcome === "prepared") logger.info("[noodle-autopost] Prepared one future NoodleR post");

--- a/packages/server/src/services/noodle/noodle-refresh-scheduler.service.ts
+++ b/packages/server/src/services/noodle/noodle-refresh-scheduler.service.ts
@@ -13,6 +13,9 @@ import {
 
 const NOODLE_SCHEDULER_INITIAL_DELAY_MS = 20_000;
 const NOODLE_SCHEDULER_MAX_POLL_MS = 60_000;
+// Nothing is scheduled while automatic refresh is off, so the poll only needs to notice that the
+// setting changed. A minute-by-minute wake for that costs battery on phone installs for nothing.
+const NOODLE_SCHEDULER_DISABLED_POLL_MS = 15 * 60_000;
 const NOODLE_SCHEDULER_CONFIGURATION_RETRY_MS = 15 * 60_000;
 const NOODLE_SCHEDULER_BUSY_RETRY_MS = 60_000;
 const NOODLE_SCHEDULER_RATE_LIMIT_RETRY_MS = 5 * 60_000;
@@ -42,7 +45,7 @@ export function noodleRefreshRetryDelayMs(statusCode: number, failureAttempts: n
 }
 
 export function nextNoodleSchedulerPollDelayMs(schedule: PersistedNoodleRefreshSchedule, at: Date): number {
-  if (schedule.refreshesPerDay === 0) return NOODLE_SCHEDULER_MAX_POLL_MS;
+  if (schedule.refreshesPerDay === 0) return NOODLE_SCHEDULER_DISABLED_POLL_MS;
   const now = at.getTime();
   const retryAt = schedule.nextAttemptAt ? Date.parse(schedule.nextAttemptAt) : Number.NaN;
   if (Number.isFinite(retryAt) && retryAt > now) {

--- a/packages/server/src/services/storage/noodle.storage.ts
+++ b/packages/server/src/services/storage/noodle.storage.ts
@@ -1854,6 +1854,12 @@ export function createNoodleStorage(db: DB) {
       }));
     },
 
+    /** Existence check for the idle scheduler poll, so it never materializes or parses rows. */
+    async hasNoodlerPreparedPosts(): Promise<boolean> {
+      const rows = await db.select({ id: noodlerPreparedPosts.id }).from(noodlerPreparedPosts).limit(1);
+      return rows.length > 0;
+    },
+
     /**
      * Unlinking media before the discard is durable can leave a still-publishable row whose
      * image bytes are gone, so the state is committed first and the file removed afterwards.

--- a/scripts/regressions/noodle-scheduler.regression.ts
+++ b/scripts/regressions/noodle-scheduler.regression.ts
@@ -101,6 +101,7 @@ assert.equal(nextNoodleSchedulerPollDelayMs(disabled, nextDay), 15 * 60_000);
 
 assert.equal(noodlerReservePollIsIdle({ enableNoodler: false, autoPostingScheduleEnabled: false }), true);
 assert.equal(noodlerReservePollIsIdle({ enableNoodler: true, autoPostingScheduleEnabled: false }), true);
+assert.equal(noodlerReservePollIsIdle({ enableNoodler: false, autoPostingScheduleEnabled: true }), true);
 assert.equal(noodlerReservePollIsIdle({ enableNoodler: true, autoPostingScheduleEnabled: true }), false);
 
 assert.equal(noodleRefreshRetryDelayMs(409, 0), 60_000);

--- a/scripts/regressions/noodle-scheduler.regression.ts
+++ b/scripts/regressions/noodle-scheduler.regression.ts
@@ -15,6 +15,7 @@ import {
   nextNoodleSchedulerPollDelayMs,
   noodleRefreshRetryDelayMs,
 } from "../../packages/server/src/services/noodle/noodle-refresh-scheduler.service.js";
+import { noodlerReservePollIsIdle } from "../../packages/server/src/services/noodle/noodle-autopost-scheduler.service.js";
 
 const day = new Date(2026, 6, 10, 12, 0, 0, 0);
 const start = new Date(day.getFullYear(), day.getMonth(), day.getDate()).getTime();
@@ -95,7 +96,12 @@ assert.equal(rolled.lastAutomaticRefreshAt, reconfigured.lastAutomaticRefreshAt)
 
 const disabled = reconcileNoodleRefreshSchedule(rolled, 0, nextDay);
 assert.equal(noodleRefreshSchedulerStatus(disabled, nextDay).state, "disabled");
-assert.equal(nextNoodleSchedulerPollDelayMs(disabled, nextDay), 60_000);
+// A disabled schedule backs the poll off instead of waking every minute for nothing.
+assert.equal(nextNoodleSchedulerPollDelayMs(disabled, nextDay), 15 * 60_000);
+
+assert.equal(noodlerReservePollIsIdle({ enableNoodler: false, autoPostingScheduleEnabled: false }), true);
+assert.equal(noodlerReservePollIsIdle({ enableNoodler: true, autoPostingScheduleEnabled: false }), true);
+assert.equal(noodlerReservePollIsIdle({ enableNoodler: true, autoPostingScheduleEnabled: true }), false);
 
 assert.equal(noodleRefreshRetryDelayMs(409, 0), 60_000);
 assert.equal(noodleRefreshRetryDelayMs(400, 0), 15 * 60_000);


### PR DESCRIPTION
## Why

Two Noodle background schedulers wake every 60 seconds forever, even with the features disabled and nothing to do. On a phone/Termux install that is a permanent idle drain for no user-visible benefit (#4630, found during a mobile-battery investigation).

- The NoodleR reserve poll called `reconcileNoodlerReserve` before any settings check. That path full-scans `noodlerPreparedPosts` **and** `noodlePosts` and `JSON.parse`s every post's metadata — O(all posts) per minute on the file-native store, with automatic posting off and zero prepared rows.
- The timeline-refresh poll re-armed at the 60 s cap when `refreshesPerDay === 0`, so a disabled schedule still woke 1440 times a day to learn nothing changed.

## What changed

- `noodle-autopost-scheduler.service.ts`: the periodic `poll()` now reads settings first and returns early when automatic posting is disabled **and** there are no prepared reserve rows to tidy. The one cheap read it does (`listNoodlerPreparedPosts`) replaces both full table materializations. The **startup** reconcile stays unconditional, per the scheduler's own comment about upgrades beginning their hold while posting is disabled.
- `noodle-refresh-scheduler.service.ts`: a disabled schedule (`refreshesPerDay === 0`) now backs the poll off to 15 minutes instead of 60 seconds. Enabling the feature is noticed within one backoff window; nothing else changes about the retry/failure delays.
- Extracted `noodlerReservePollIsIdle` so the skip condition is directly assertable, and covered both behaviors in `noodle-scheduler.regression.ts`.

Behavior when the features are *enabled*, or when prepared rows exist while disabled, is unchanged — reconciliation still runs so stale rows are still discarded.

## Validation

- [ ] `pnpm check`
- [ ] `pnpm regression:noodle`

Run locally: server `lint` (tsc) passes; `noodle-scheduler`, `noodle-autopost`, and `noodle-refresh-transaction` regressions pass. Client `eslint` needs `NODE_OPTIONS=--max-old-space-size=8192` in this sandbox (pre-existing OOM, unrelated to this change).

## Test plan

- [ ] Start the server with Noodler/automatic posting disabled and no prepared posts; confirm no prepared/post table scans fire on the 60 s poll (log or breakpoint in `reconcileNoodlerPreparedPosts`), and that the startup reconcile still runs once.
- [ ] With automatic posting disabled but prepared reserve rows present, confirm the poll still reconciles and discards them.
- [ ] Enable automatic posting and verify preparation and publishing behave as before.
- [ ] Set Noodle automatic timeline refresh to 0/day and confirm the scheduler re-arms at 15 min; re-enable it and confirm the next refresh runs on schedule.

Closes #4630.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced background polling for inactive NoodleR reserve scans.
  * Disabled automatic posting schedules now pause reserve processing when no prepared posts are available.
  * Disabled automatic refresh schedules now check for updates every 15 minutes instead of every minute.

* **Bug Fixes**
  * Improved scheduler behavior when automatic posting or refresh features are disabled.
  * Ensured timelines refresh appropriately after posting or refresh actions are disabled.
  * Added regression coverage for active and idle scheduling states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->