### PR TITLE
fix(noodle): stop image captioning from blocking its own background refresh

### DIFF
--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -1642,6 +1642,7 @@ export async function noodleRoutes(app: FastifyInstance) {
             },
         fallbackConnectionId: connectionId,
         connections,
+        admissionMode: admissionModeForRequest(req.headers),
       });
       const imageConnection = settings.enableImagePrompts
         ? settings.imageGenerationConnectionId

--- a/packages/server/src/services/generation/connection-admission.ts
+++ b/packages/server/src/services/generation/connection-admission.ts
@@ -22,7 +22,13 @@ export type ConnectionAdmissionMode =
   | {
       kind: "background";
       beforeAttempt?: () => void | ConnectionAttemptFinalizer | Promise<void | ConnectionAttemptFinalizer>;
-    };
+    }
+  /**
+   * A call that is a step inside someone else's attempt rather than an attempt of its own. It
+   * takes no slot and leaves no foreground stamp, because the work it feeds is already admitted
+   * and would otherwise be refused by its own preparation.
+   */
+  | { kind: "none" };
 
 /**
  * Marks a request the server issued to itself on a scheduler's behalf. Background admission is
@@ -113,6 +119,7 @@ async function beginConnectionAttempt(
   connectionId: string,
   mode: ConnectionAdmissionMode,
 ): Promise<{ release: () => void; finalize?: ConnectionAttemptFinalizer }> {
+  if (mode.kind === "none") return { release: () => undefined };
   if (mode.kind === "foreground") return { release: beginForegroundConnection(connectionId) };
 
   const admission = tryBackgroundConnection(connectionId, new Date());
@@ -259,5 +266,5 @@ export function withConnectionAdmissionProvider(
   connectionId: string,
   mode: ConnectionAdmissionMode = { kind: "foreground" },
 ): BaseLLMProvider {
-  return new ConnectionAdmissionProvider(provider, connectionId, mode);
+  return mode.kind === "none" ? provider : new ConnectionAdmissionProvider(provider, connectionId, mode);
 }

--- a/packages/server/src/services/generation/image-captioning-runtime.ts
+++ b/packages/server/src/services/generation/image-captioning-runtime.ts
@@ -184,11 +184,16 @@ export async function resolveImageCaptioningRuntime(args: {
       fallbackConnection,
       fallbackBaseUrl: fallbackConnection ? resolveBaseUrl(fallbackConnection) : "",
       category: "agents",
-      // Captioning is a step inside the caller's own attempt, not a separate one. Booking it as
-      // foreground during a background run stamps the connection foreground-active and then the
-      // caller's real generation — on that same connection — is refused for the whole idle
-      // window. The caller's admission already gates the attempt, so this step stays unaccounted.
-      admissionMode: args.admissionMode?.kind === "background" ? { kind: "none" } : args.admissionMode,
+      // On the caller's own connection, captioning is a step inside the caller's attempt, not a
+      // separate one. Booking it as foreground during a background run stamps the connection
+      // foreground-active and the caller's real generation is then refused for the whole idle
+      // window — the run blocks itself. That attempt is already admitted, so the step is not
+      // accounted twice. A captioning connection the caller did not admit gets no such exemption
+      // and stays under background admission.
+      admissionMode:
+        args.admissionMode?.kind === "background" && captionConnectionId === args.fallbackConnectionId
+          ? { kind: "none" }
+          : args.admissionMode,
     });
 
     return {

--- a/packages/server/src/services/generation/image-captioning-runtime.ts
+++ b/packages/server/src/services/generation/image-captioning-runtime.ts
@@ -10,6 +10,7 @@ import { getLocalSidecarProvider } from "../llm/local-sidecar.js";
 import type { BaseLLMProvider, ChatMessage } from "../llm/base-provider.js";
 import { createLLMProvider } from "../llm/provider-registry.js";
 import { withConnectionFallbackProvider } from "../llm/connection-fallback-provider.js";
+import type { ConnectionAdmissionMode } from "./connection-admission.js";
 import {
   appendReadableAttachmentsToContent,
   escapeXmlAttribute,
@@ -91,6 +92,8 @@ export async function resolveImageCaptioningRuntime(args: {
     getWithKey(connectionId: string): Promise<ImageCaptionConnection | null>;
     getFallbackForAgents(): Promise<ImageCaptionConnection | null>;
   };
+  /** Admission mode of the work this captioning run feeds. */
+  admissionMode?: ConnectionAdmissionMode;
 }): Promise<ImageCaptioningRuntime> {
   const { chatMeta, connections } = args;
   try {
@@ -181,6 +184,11 @@ export async function resolveImageCaptioningRuntime(args: {
       fallbackConnection,
       fallbackBaseUrl: fallbackConnection ? resolveBaseUrl(fallbackConnection) : "",
       category: "agents",
+      // Captioning is a step inside the caller's own attempt, not a separate one. Booking it as
+      // foreground during a background run stamps the connection foreground-active and then the
+      // caller's real generation — on that same connection — is refused for the whole idle
+      // window. The caller's admission already gates the attempt, so this step stays unaccounted.
+      admissionMode: args.admissionMode?.kind === "background" ? { kind: "none" } : args.admissionMode,
     });
 
     return {

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -1553,9 +1553,17 @@ assert.equal(abortedFallback.calls, 0, "user cancellation must not trigger a fal
       model: "caption-model",
       baseUrl: `http://127.0.0.1:${address.port}/v1`,
     };
+    // A captioning connection the caller never admitted is separate background work and must
+    // stay accounted; only the caller's own connection is exempt.
+    const separateCaptionConnection = { ...captionConnection, id: "separate-caption-connection" };
     const connectionsStub = {
       listRandomPool: async () => [],
-      getWithKey: async (id: string) => (id === captionConnection.id ? captionConnection : null),
+      getWithKey: async (id: string) =>
+        id === captionConnection.id
+          ? captionConnection
+          : id === separateCaptionConnection.id
+            ? separateCaptionConnection
+            : null,
       getFallbackForAgents: async () => null,
     };
 
@@ -1578,6 +1586,29 @@ assert.equal(abortedFallback.calls, 0, "user cancellation must not trigger a fal
         `captioning under ${mode.kind} admission must ${expectedAdmission ? "leave" : "block"} the connection's background slot`,
       );
     }
+
+    resetConnectionAdmissionForTests();
+    const separateRuntime = await resolveImageCaptioningRuntime({
+      chatMeta: { imageCaptioningEnabled: true, imageCaptioningConnectionId: separateCaptionConnection.id },
+      fallbackConnectionId: captionConnection.id,
+      connections: connectionsStub,
+      admissionMode: { kind: "background" },
+    });
+    assert.ok(separateRuntime.provider, "captioning runtime must resolve a provider");
+    const separateCaption = separateRuntime.provider.chatComplete([{ role: "user", content: "describe" }], {
+      model: "caption-model",
+    });
+    assert.equal(
+      tryBackgroundConnection(separateCaptionConnection.id, new Date()).acquired,
+      false,
+      "captioning on a connection the caller never admitted must still hold its own background slot",
+    );
+    await separateCaption;
+    assert.equal(
+      tryBackgroundConnection(captionConnection.id, new Date()).acquired,
+      true,
+      "captioning elsewhere must not consume the caller's generation connection",
+    );
   } finally {
     resetConnectionAdmissionForTests();
     await new Promise<void>((resolve, reject) =>

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -56,6 +56,7 @@ import {
 import { resolveStoredChatOptions } from "../../packages/server/src/services/generation/generation-parameters.js";
 import { resolveMainGenerationToolChoice } from "../../packages/server/src/services/generation/tool-resolution-runtime.js";
 import { generateImage, imageAdmissionKey } from "../../packages/server/src/services/image/image-generation.js";
+import { resolveImageCaptioningRuntime } from "../../packages/server/src/services/generation/image-captioning-runtime.js";
 import {
   BACKGROUND_CONNECTION_IDLE_MS,
   ConnectionAttemptRejectedError,
@@ -1528,6 +1529,59 @@ assert.equal(abortedFallback.calls, 0, "user cancellation must not trigger a fal
   } finally {
     await new Promise<void>((resolve, reject) =>
       responsesReasoningServer.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+}
+
+// A background refresh captions its prompt images on the same connection it then generates with.
+// Booking that captioning call as foreground stamps the connection foreground-active, and the
+// refresh's own generation is refused for the whole idle window — every scheduled run, forever,
+// while manual (foreground) refreshes keep working. Issue #4642.
+{
+  const captionServer = createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ choices: [{ message: { content: "a caption" }, finish_reason: "stop" }] }));
+  });
+  await new Promise<void>((resolve) => captionServer.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = captionServer.address();
+    assert.ok(address && typeof address === "object");
+    const captionConnection = {
+      id: "noodle-generation-connection",
+      provider: "custom",
+      apiKey: "test",
+      model: "caption-model",
+      baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    };
+    const connectionsStub = {
+      listRandomPool: async () => [],
+      getWithKey: async (id: string) => (id === captionConnection.id ? captionConnection : null),
+      getFallbackForAgents: async () => null,
+    };
+
+    for (const [mode, expectedAdmission] of [
+      [{ kind: "background" } as ConnectionAdmissionMode, true],
+      [{ kind: "foreground" } as ConnectionAdmissionMode, false],
+    ] as const) {
+      resetConnectionAdmissionForTests();
+      const runtime = await resolveImageCaptioningRuntime({
+        chatMeta: { imageCaptioningEnabled: true, imageCaptioningConnectionId: captionConnection.id },
+        fallbackConnectionId: captionConnection.id,
+        connections: connectionsStub,
+        admissionMode: mode,
+      });
+      assert.ok(runtime.provider, "captioning runtime must resolve a provider");
+      await runtime.provider.chatComplete([{ role: "user", content: "describe" }], { model: "caption-model" });
+      assert.equal(
+        tryBackgroundConnection(captionConnection.id, new Date()).acquired,
+        expectedAdmission,
+        `captioning under ${mode.kind} admission must ${expectedAdmission ? "leave" : "block"} the connection's background slot`,
+      );
+    }
+  } finally {
+    resetConnectionAdmissionForTests();
+    await new Promise<void>((resolve, reject) =>
+      captionServer.close((error) => (error ? reject(error) : resolve())),
     );
   }
 }


### PR DESCRIPTION
## Linked issue

Closes #4642

## Why this change

Scheduled Noodle refreshes have been failing since 2.4.1 with `Connection <id> is not available for background generation`, while manual refreshes keep working. The reporter's schedule sat at 0/6 slots indefinitely, and recreating connections only produced a new id with the same failure.

The message is misleading: it means "busy", not "missing", so the reported hunt for an absent `data/connections` folder was a red herring.

A refresh captions the images already on the timeline before generating new posts (`noodle-public-prompt.service.ts:491`, inside the prompt built at `noodle-public-generation.service.ts:246`, before the generation call at :302). The captioning provider was built with no admission mode, so `withConnectionFallbackProvider` defaulted it to `{kind:"foreground"}`. With the default "Use Noodle generation connection" captioning setting, that books a foreground slot on the exact connection the refresh is about to generate with. Releasing a foreground slot stamps `lastForegroundFinishedAt`, and background admission refuses for `BACKGROUND_CONNECTION_IDLE_MS` (30s) afterwards — so the refresh is refused by its own captioning pass, every scheduled run. Manual refreshes are foreground end to end and never reach that gate; the scheduler's 409 retry reproduces the same self-collision a minute later, forever.

Confirmed with the reporter: disabling image captioning makes scheduled refreshes fire again.

## What changed

- `resolveImageCaptioningRuntime` takes the caller's admission mode; under `background` the captioning provider books nothing (`{kind:"none"}`). Captioning is a step inside the caller's attempt, not a separate attempt, and the caller's own admission already gates it. Foreground behavior is unchanged, so chat captioning (`generate.routes.ts:1098`) is unaffected.
- The Noodle refresh route threads `admissionModeForRequest(req.headers)` into the captioning runtime.
- Regression case in `provider-compat.regression.ts`: captioning under background admission must leave the connection's background slot free; under foreground it must still take it.

Swept the rest of the scheduled path for other foreground-booking calls on the same connection — ambient profile generation is route-only, NoodleR services are not on this path, lorebook context is `previewOnly`. Captioning was the only one.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Nothing in this PR has been executed. `pnpm check` and `pnpm regression:providers` have not been run, and the new regression case has never been run even once — it is unverified in both directions. Needed before merge:

- Run `pnpm check`.
- Run `pnpm regression:providers` on this branch, and on `staging` to confirm the new case actually fails without the fix.
- Manually verify a scheduled refresh in the app: image captioning enabled with the captioning connection set to "Use Noodle generation connection", at least one image-bearing post already on the timeline, then wait for an automatic slot and confirm it generates instead of reporting the connection unavailable.
- Manually verify the foreground path is unchanged: send a chat message with an image attached and confirm captioning still runs normally.

Note the current regression covers the captioning seam (does captioning book a foreground slot), not the reported symptom (does a scheduled refresh complete). A refresh-level case using the `noodle-refresh-transaction` / `noodle-scheduler` harness would be the stronger test and is not included here.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image captioning connection handling during content refreshes.
  * Background captioning now uses the appropriate background connection capacity, while foreground captioning remains unaffected.
  * Prevented duplicate connection admission for captioning work already covered by an active generation request, improving reliability during refreshes.

* **Tests**
  * Added regression coverage to verify connection admission behavior for background and foreground image captioning, including proper cleanup after processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->