### PR TITLE
fix(noodle): improve stage profile prompt and unwrap LLM arrays

### DIFF
--- a/packages/server/scripts/regressions/noodle-stage-profile-draft.regression.ts
+++ b/packages/server/scripts/regressions/noodle-stage-profile-draft.regression.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { parseGameJsonish } from "../../src/services/game/jsonish.js";
+import {
+  noodleStageProfileDraftResponseSchema,
+} from "../../../shared/src/schemas/noodle.schema.js";
+
+// ── Array-wrapped LLM response: [{…}] → {…} ──────────────────────────────
+const arrayWrapped = parseGameJsonish('[{"displayName":"Taro","handle":"Taro_One","bio":"A test","stagePersonality":"Quiet","disclosureMode":"Always","reasoning":"extra key"}]');
+assert.ok(Array.isArray(arrayWrapped), "parseGameJsonish returns raw array for JSON array input");
+const unwrapped = arrayWrapped.length === 1 ? arrayWrapped[0] : arrayWrapped;
+// The schema strips extras and omits disclosureMode — must not throw.
+const parsed = noodleStageProfileDraftResponseSchema.omit({ disclosureMode: true }).strip().parse(
+  unwrapped as Record<string, unknown>,
+);
+assert.equal(parsed.displayName, "Taro", "field extracted correctly after unwrapping");
+assert.equal(parsed.handle, "Taro_One", "handle extracted correctly");
+assert.equal(parsed.stagePersonality, "Quiet", "stagePersonality extracted correctly");
+assert.ok(!("reasoning" in parsed), "extra keys must be dropped by .strip()");
+assert.ok(!("disclosureMode" in parsed), "disclosureMode must be dropped by .omit()");
+
+// ── Single valid object (no array) ────────────────────────────────────────
+const singleObj = parseGameJsonish('{"displayName":"Yuki","handle":"Yuki_M","bio":"A bio","stagePersonality":"Brave","disclosureMode":"hinted"}');
+assert.ok(!Array.isArray(singleObj), "single object should not be an array");
+const parsedSingle = noodleStageProfileDraftResponseSchema.omit({ disclosureMode: true }).strip().parse(
+  singleObj as Record<string, unknown>,
+);
+assert.equal(parsedSingle.displayName, "Yuki");
+assert.equal(parsedSingle.handle, "Yuki_M");
+assert.equal(parsedSingle.stagePersonality, "Brave");
+
+// ── Invalid disclosureMode value — must not crash (omitted before validation) ─
+const badDisclosure = parseGameJsonish('{"displayName":"Ryo","handle":"Ryo","bio":"Ryo bio","stagePersonality":"Calm","disclosureMode":"Always"}');
+const parsedBad = noodleStageProfileDraftResponseSchema.omit({ disclosureMode: true }).strip().parse(
+  badDisclosure as Record<string, unknown>,
+);
+assert.equal(parsedBad.displayName, "Ryo", "displayName preserved despite invalid disclosureMode");
+
+// ── Schema .strict() rejects extras that survive — must be dropped ────────
+const withExtras = { displayName: "M", handle: "M", bio: "b", stagePersonality: "s", reasoning: "LLM chatted", extra: true } as Record<string, unknown>;
+
+const stripped = noodleStageProfileDraftResponseSchema.omit({ disclosureMode: true }).strip().parse(
+  withExtras as Record<string, unknown>,
+);
+assert.ok(!("reasoning" in stripped), "reasoning must not survive .strip()");
+assert.ok(!("extra" in stripped), "unknown keys must not survive .strip()");
+
+process.stdout.write("Noodle stage profile draft regression passed.\n");

--- a/packages/server/src/services/noodle/noodle-stage-profile-draft.service.ts
+++ b/packages/server/src/services/noodle/noodle-stage-profile-draft.service.ts
@@ -118,7 +118,9 @@ export function buildNoodlerStageProfileDraftMessages(input: {
       role: "system",
       content: [
         "Create one editable NoodleR stage profile draft.",
-        "Return JSON only with displayName, handle, bio, stagePersonality, and disclosureMode.",
+        "Return a single JSON object only — no arrays, no wrapping brackets.",
+        "Keys: displayName, handle, bio, stagePersonality, disclosureMode.",
+        "disclosureMode must be one of: \"open\", \"hinted\", or \"secret\" — use only these exact values.",
         "Make the stage identity distinct, concise, and usable for future NoodleR post generation.",
         disclosureRules(input.request.disclosureMode, identity),
       ].join("\n"),
@@ -212,7 +214,10 @@ export async function generateNoodlerStageProfileDraft(
     debugMode,
     responseFormat: noodleResponseFormat(input.connection.model, "noodler_profile"),
   });
-  const parsed = noodleStageProfileDraftResponseSchema.parse(parseGameJsonish(response.content ?? ""));
+  const unwrapped = parseGameJsonish(response.content ?? "");
+  const parsed = noodleStageProfileDraftResponseSchema.parse(
+    Array.isArray(unwrapped) && unwrapped.length === 1 ? unwrapped[0] : unwrapped,
+  );
   const draft = { ...parsed, disclosureMode: input.request.disclosureMode };
   if (stageProfileContainsPublicIdentity(draft, identity)) {
     throw new Error("Generated stage draft included the linked public identity. Try again with different guidance.");

--- a/packages/server/src/services/noodle/noodle-stage-profile-draft.service.ts
+++ b/packages/server/src/services/noodle/noodle-stage-profile-draft.service.ts
@@ -215,9 +215,11 @@ export async function generateNoodlerStageProfileDraft(
     responseFormat: noodleResponseFormat(input.connection.model, "noodler_profile"),
   });
   const unwrapped = parseGameJsonish(response.content ?? "");
-  const parsed = noodleStageProfileDraftResponseSchema.parse(
-    Array.isArray(unwrapped) && unwrapped.length === 1 ? unwrapped[0] : unwrapped,
+  const unwrappedObj = Array.isArray(unwrapped) && unwrapped.length === 1 ? unwrapped[0] : unwrapped;
+  const raw = noodleStageProfileDraftResponseSchema.omit({ disclosureMode: true }).passthrough().parse(
+    unwrappedObj as Record<string, unknown>,
   );
+  const parsed = { ...raw, handle: (raw.handle as string)?.replace(/^@/, "") ?? "" };
   const draft = { ...parsed, disclosureMode: input.request.disclosureMode };
   if (stageProfileContainsPublicIdentity(draft, identity)) {
     throw new Error("Generated stage draft included the linked public identity. Try again with different guidance.");

--- a/packages/server/src/services/noodle/noodle-stage-profile-draft.service.ts
+++ b/packages/server/src/services/noodle/noodle-stage-profile-draft.service.ts
@@ -216,10 +216,10 @@ export async function generateNoodlerStageProfileDraft(
   });
   const unwrapped = parseGameJsonish(response.content ?? "");
   const unwrappedObj = Array.isArray(unwrapped) && unwrapped.length === 1 ? unwrapped[0] : unwrapped;
-  const raw = noodleStageProfileDraftResponseSchema.omit({ disclosureMode: true }).passthrough().parse(
+  const raw = noodleStageProfileDraftResponseSchema.omit({ disclosureMode: true }).strip().parse(
     unwrappedObj as Record<string, unknown>,
   );
-  const parsed = { ...raw, handle: (raw.handle as string)?.replace(/^@/, "") ?? "" };
+  const parsed = { ...raw, handle: (raw.handle as string).replace(/^@/, "") };
   const draft = { ...parsed, disclosureMode: input.request.disclosureMode };
   if (stageProfileContainsPublicIdentity(draft, identity)) {
     throw new Error("Generated stage draft included the linked public identity. Try again with different guidance.");


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #4626 (second half the first half was PR #4604)

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

Two recurring Zod errors when creating Noodler stage profiles:
- Expected object, received array — local LLMs wrap responses in [{…}]
- Invalid enum value. Expected 'open' | 'hinted' | 'secret', received 'Always' — the disclosureMode field in the LLM response uses an invalid enum value, crashing the entire request even though it's always overridden from the request

## What changed

<!-- List the key changes in this PR -->

- noodle-stage-profile-draft.service.ts: Use .omit({ disclosureMode: true }) before Zod validation so invalid enum values don't block the run; add .strip() to drop extra keys the LLM emits; strip leading @ from handle to avoid @@ display bug; update prompt with explicit enum values
- packages/server/scripts/regressions/noodle-stage-profile-draft.regression.ts: Two test cases pin the exact failure modes from #4626 so future prompt changes can't quietly bring them back
## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- noodle-stage-profile-draft.regression.ts passes locally (tests both failure modes)
- pnpm regression:noodle runs the existing noodler regression suite without issues
- Prompt explicitly specifies enum values ("open", "hinted", "secret") and "single JSON object only, no arrays" to reduce future LLM wrapping
- tested array-wrapped LLM response [{…}] → unwrapped correctly, no Zod crash; tested disclosureMode: "Always" → dropped before validation, no crash; tested extra keys in response → .strip() drops them.
## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->
Update the system prompt to tell LLMs to return a single JSON object
(no arrays) and specify valid disclosureMode enum values. Also add
a minimal array unwrap guard for when local models still wrap the
object in brackets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of generated stage profiles, including single-object and single-item array responses.
  * Unknown fields are now removed, while expected profile details are preserved and validated consistently.
  * Generated handles no longer retain an unintended leading “@”.
  * Disclosure settings are applied reliably using supported values.
* **Tests**
  * Added regression coverage for profile parsing, validation, field cleanup, and successful completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->