### PR TITLE
Fix assigned editor, Roleplay, and Noodle issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept the caret at the chosen insertion point while typing in expanded Character and Preset editors instead of repeatedly focusing the field and jumping to the end (#4656).
+- Restored a full, unobstructed hit target for Roleplay message edit controls so Save no longer reacts only near one corner (#4658).
+- Kept one stable live text node while Roleplay responses stream, avoiding Firefox DOM replacement and accessibility-tree churn on every animation frame (#4659).
+- Added an independent Noodle timeline image-size setting, defaulting to the GPT-Image-compatible 1024x1536 portrait canvas instead of reusing the Illustrator dimensions (#4660).
 - Made NoodleR stage-profile drafts tolerate single-item array responses, extra model fields, and decorated handles from local models while ignoring model-provided disclosure modes, discarding invalid values, and applying the requested valid mode (#4626).
 - Removed deprecated generation parameters from single and bulk prompt-preset exports and ignored them when importing older Marinara or SillyTavern preset files (#4650).
 - Kept the selected prompt checkmark above the Presets avatar frame instead of clipping it into the rounded image border (#4651).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2688,10 +2688,14 @@ test("Convo About Me keeps manual editing and native expanded-editor keyboard be
 
     await expandedEditor.evaluate((textarea) => {
       textarea.focus();
-      textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+      textarea.setSelectionRange(2, 2);
     });
-    await page.keyboard.type("!");
-    await expect(expandedEditor).toHaveValue("alpha\nbeta!");
+    await page.keyboard.type("X");
+    await page.waitForTimeout(40);
+    await expect.poll(() => expandedEditor.evaluate((textarea) => textarea.selectionStart)).toBe(3);
+    await page.keyboard.type("Y");
+    await expect(expandedEditor).toHaveValue("alXYpha\nbeta");
+    await page.keyboard.press(`${process.platform === "darwin" ? "Meta" : "Control"}+z`);
     await page.keyboard.press(`${process.platform === "darwin" ? "Meta" : "Control"}+z`);
     await expect(expandedEditor).toHaveValue("alpha\nbeta");
 
@@ -3108,7 +3112,11 @@ test("stopped and refused generations keep sent text cleared and accept the firs
           { times: 1 },
         );
       }
-      await message.getByLabel("Save edit", { exact: true }).click();
+      const saveButton = message.getByLabel("Save edit", { exact: true });
+      const saveButtonBox = await saveButton.boundingBox();
+      expect(saveButtonBox?.width).toBeGreaterThanOrEqual(44);
+      expect(saveButtonBox?.height).toBeGreaterThanOrEqual(44);
+      await saveButton.click();
       if (saveGate) {
         try {
           await expect(editor).toBeVisible();

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -603,13 +603,13 @@ const EditTextarea = memo(function EditTextarea({
         className="w-full resize-none overflow-y-auto overscroll-contain rounded-lg bg-black/30 px-3 py-2 text-white outline-none ring-1 ring-white/20 focus:ring-blue-400/50"
         style={{ fontSize, lineHeight: 1.5, maxHeight: "min(60dvh, 32rem)" }}
       />
-      <div className="flex items-center gap-1.5 justify-end">
+      <div className="relative z-10 flex items-center justify-end gap-1.5">
         <button
           type="button"
           onClick={onCancel}
           disabled={saving}
           aria-label={localizeUi("ui.chat.edittextarea.cancelEdit")}
-          className="rounded-md p-1 text-white/40 hover:bg-white/10 hover:text-white/70"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-white/40 hover:bg-white/10 hover:text-white/70 disabled:pointer-events-none disabled:opacity-50"
           title={localizeUi("ui.chat.edittextarea.cancelEsc")}
         >
           <X size="0.8125rem" />
@@ -619,7 +619,7 @@ const EditTextarea = memo(function EditTextarea({
           onClick={handleSave}
           disabled={saving}
           aria-label={localizeUi("ui.chat.edittextarea.saveEdit")}
-          className="rounded-md p-1 text-emerald-400/70 hover:bg-emerald-400/10 hover:text-emerald-400"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-emerald-400/70 hover:bg-emerald-400/10 hover:text-emerald-400 disabled:pointer-events-none disabled:opacity-50"
           title={localizeUi("ui.chat.edittextarea.saveCmdEnter")}
         >
           <Check size="0.8125rem" />

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -301,6 +301,8 @@ function RoleplayLiveStreamText({ chatId, emptyLabel }: { chatId: string; emptyL
   const emptyRef = useRef<HTMLSpanElement>(null);
 
   useLayoutEffect(() => {
+    const textNode = document.createTextNode("");
+    textRef.current?.replaceChildren(textNode);
     let frame: number | null = null;
     const readBuffer = () => {
       const state = useChatStore.getState();
@@ -309,7 +311,10 @@ function RoleplayLiveStreamText({ chatId, emptyLabel }: { chatId: string; emptyL
     const apply = () => {
       frame = null;
       const next = readBuffer();
-      if (textRef.current && textRef.current.textContent !== next) textRef.current.textContent = next;
+      if (textNode.data !== next) {
+        if (next.startsWith(textNode.data)) textNode.appendData(next.slice(textNode.data.length));
+        else textNode.data = next;
+      }
       if (emptyRef.current) emptyRef.current.hidden = next.length > 0;
     };
     const schedule = () => {

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -788,6 +788,14 @@ const SETTINGS_SEARCHABLE_CONTROLS: readonly SettingsSearchableControlMeta[] = [
     kind: "Input",
   },
   {
+    id: "image-noodle-size",
+    sectionId: "image-generation",
+    label: "Noodle image size",
+    description: "Set default Noodle timeline image dimensions.",
+    aliases: ["image", "resolution", "canvas", "noodle", "timeline"],
+    kind: "Input",
+  },
+  {
     id: "image-game-size",
     sectionId: "image-generation",
     label: "Game scene image size",
@@ -3578,6 +3586,9 @@ function ImageGenerationSettings() {
   const imageIllustrationWidth = useUIStore((s) => s.imageIllustrationWidth);
   const imageIllustrationHeight = useUIStore((s) => s.imageIllustrationHeight);
   const setImageIllustrationDimensions = useUIStore((s) => s.setImageIllustrationDimensions);
+  const imageNoodleWidth = useUIStore((s) => s.imageNoodleWidth);
+  const imageNoodleHeight = useUIStore((s) => s.imageNoodleHeight);
+  const setImageNoodleDimensions = useUIStore((s) => s.setImageNoodleDimensions);
   const imageGameWidth = useUIStore((s) => s.imageGameWidth);
   const imageGameHeight = useUIStore((s) => s.imageGameHeight);
   const setImageGameDimensions = useUIStore((s) => s.setImageGameDimensions);
@@ -3613,6 +3624,14 @@ function ImageGenerationSettings() {
           width={imageIllustrationWidth}
           height={imageIllustrationHeight}
           onCommit={setImageIllustrationDimensions}
+        />
+        <ImageDimensionRow
+          controlId="image-noodle-size"
+          label={localizeUi("settings.controls.noodleGeneration.label")}
+          help={localizeUi("settings.controls.noodleGeneration.help")}
+          width={imageNoodleWidth}
+          height={imageNoodleHeight}
+          onCommit={setImageNoodleDimensions}
         />
         <ImageDimensionRow
           controlId="image-game-size"

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -81,15 +81,18 @@ function ExpandedMacroEditor({
   const { t: localizeUi } = useUiTranslation();
   const [localValue, setLocalValue] = useState(value);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const valueRef = useRef(value);
+  valueRef.current = value;
 
   useEffect(() => {
     if (!open) {
       return;
     }
 
-    setLocalValue(value);
-    window.setTimeout(() => textareaRef.current?.focus(), 20);
-  }, [open, value]);
+    setLocalValue(valueRef.current);
+    const focusTimer = window.setTimeout(() => textareaRef.current?.focus(), 20);
+    return () => window.clearTimeout(focusTimer);
+  }, [open]);
 
   useEffect(() => {
     if (!open) {

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -643,6 +643,8 @@
   "settings.controls.musicPlayer.label": "Music Player",
   "settings.controls.narratorCyclingAvatars.help": "Cycle Narrator avatars through active characters. Turn this off to show active character avatars together.",
   "settings.controls.narratorCyclingAvatars.label": "Narrator's Cycling Avatars",
+  "settings.controls.noodleGeneration.help": "Used for generated images in public Noodle and private NoodleR timelines.",
+  "settings.controls.noodleGeneration.label": "Noodle timelines",
   "settings.controls.panelBackground.label": "Panel background",
   "settings.controls.portraits.help": "Used for generated character and NPC portraits.",
   "settings.controls.portraits.label": "Portraits",

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -675,6 +675,8 @@ interface UIState {
   imageBackgroundHeight: number;
   imageIllustrationWidth: number;
   imageIllustrationHeight: number;
+  imageNoodleWidth: number;
+  imageNoodleHeight: number;
   imageGameWidth: number;
   imageGameHeight: number;
   imagePortraitWidth: number;
@@ -995,6 +997,7 @@ interface UIState {
   setReviewImagePromptsBeforeSend: (v: boolean) => void;
   setImageBackgroundDimensions: (width: number, height: number) => void;
   setImageIllustrationDimensions: (width: number, height: number) => void;
+  setImageNoodleDimensions: (width: number, height: number) => void;
   setImageGameDimensions: (width: number, height: number) => void;
   setImagePortraitDimensions: (width: number, height: number) => void;
   setImageSelfieDimensions: (width: number, height: number) => void;
@@ -1201,6 +1204,8 @@ export function pickSyncedSettings(state: UIState) {
     imageBackgroundHeight: state.imageBackgroundHeight,
     imageIllustrationWidth: state.imageIllustrationWidth,
     imageIllustrationHeight: state.imageIllustrationHeight,
+    imageNoodleWidth: state.imageNoodleWidth,
+    imageNoodleHeight: state.imageNoodleHeight,
     imageGameWidth: state.imageGameWidth,
     imageGameHeight: state.imageGameHeight,
     imagePortraitWidth: state.imagePortraitWidth,
@@ -1398,6 +1403,8 @@ export const useUIStore = create<UIState>()(
       imageBackgroundHeight: 720,
       imageIllustrationWidth: 896,
       imageIllustrationHeight: 1280,
+      imageNoodleWidth: 1024,
+      imageNoodleHeight: 1536,
       imageGameWidth: 1280,
       imageGameHeight: 720,
       imagePortraitWidth: 1024,
@@ -2140,6 +2147,11 @@ export const useUIStore = create<UIState>()(
           imageIllustrationWidth: clampImageDimension(width),
           imageIllustrationHeight: clampImageDimension(height),
         }),
+      setImageNoodleDimensions: (width, height) =>
+        set({
+          imageNoodleWidth: clampImageDimension(width),
+          imageNoodleHeight: clampImageDimension(height),
+        }),
       setImageGameDimensions: (width, height) =>
         set({
           imageGameWidth: clampImageDimension(width),
@@ -2417,7 +2429,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 89,
+      version: 90,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -3013,6 +3025,11 @@ export const useUIStore = create<UIState>()(
         if (version <= 88 && persisted.reduceAmbientEffects === undefined) {
           persisted.reduceAmbientEffects = false;
         }
+        // v89 -> v90: give Noodle timeline images their own provider-compatible canvas.
+        if (version <= 89) {
+          if (persisted.imageNoodleWidth === undefined) persisted.imageNoodleWidth = 1024;
+          if (persisted.imageNoodleHeight === undefined) persisted.imageNoodleHeight = 1536;
+        }
         // v84 -> v85: keep the historical blank-line behavior for /continue by default.
         if (version <= 84 && persisted.continueAddsNewline === undefined) {
           persisted.continueAddsNewline = true;
@@ -3114,6 +3131,8 @@ export const useUIStore = create<UIState>()(
         imageBackgroundHeight: state.imageBackgroundHeight,
         imageIllustrationWidth: state.imageIllustrationWidth,
         imageIllustrationHeight: state.imageIllustrationHeight,
+        imageNoodleWidth: state.imageNoodleWidth,
+        imageNoodleHeight: state.imageNoodleHeight,
         imageGameWidth: state.imageGameWidth,
         imageGameHeight: state.imageGameHeight,
         imagePortraitWidth: state.imagePortraitWidth,

--- a/packages/server/src/services/image/image-generation-settings.ts
+++ b/packages/server/src/services/image/image-generation-settings.ts
@@ -14,6 +14,7 @@ export interface ImageGenerationSize {
 export interface ImageGenerationUserSettings {
   background: ImageGenerationSize;
   illustration: ImageGenerationSize;
+  noodle: ImageGenerationSize;
   game: ImageGenerationSize;
   portrait: ImageGenerationSize;
   selfie: ImageGenerationSize;
@@ -26,6 +27,7 @@ const IMAGE_DIMENSION_MAX = 4096;
 const DEFAULT_IMAGE_GENERATION_SETTINGS: ImageGenerationUserSettings = {
   background: { width: 1280, height: 720 },
   illustration: { width: 896, height: 1280 },
+  noodle: { width: 1024, height: 1536 },
   game: { width: 1280, height: 720 },
   portrait: { width: 1024, height: 1024 },
   selfie: { width: 896, height: 1152 },
@@ -86,6 +88,7 @@ export function parseImageGenerationUserSettings(raw: string | null): ImageGener
         "imageIllustrationHeight",
         DEFAULT_IMAGE_GENERATION_SETTINGS.illustration,
       ),
+      noodle: readSize(parsed, "imageNoodleWidth", "imageNoodleHeight", DEFAULT_IMAGE_GENERATION_SETTINGS.noodle),
       game: readSize(parsed, "imageGameWidth", "imageGameHeight", DEFAULT_IMAGE_GENERATION_SETTINGS.game),
       portrait: readSize(
         parsed,

--- a/packages/server/src/services/noodle/noodle-noodler-images.service.ts
+++ b/packages/server/src/services/noodle/noodle-noodler-images.service.ts
@@ -146,8 +146,8 @@ export async function generateNoodlerPostImage(input: {
     const previewSize = resolveImagePromptReviewSize({
       connection: input.imageConnection,
       prompt: finalPrompt,
-      width: imageSettings.illustration.width,
-      height: imageSettings.illustration.height,
+      width: imageSettings.noodle.width,
+      height: imageSettings.noodle.height,
       imageDefaults,
     });
     return {
@@ -171,8 +171,8 @@ export async function generateNoodlerPostImage(input: {
         prompt: finalPrompt,
         negativePrompt: finalNegativePrompt,
         model: imageModel,
-        width: imageSettings.illustration.width,
-        height: imageSettings.illustration.height,
+        width: imageSettings.noodle.width,
+        height: imageSettings.noodle.height,
         imageEndpointId: input.imageConnection.imageEndpointId || undefined,
         comfyWorkflow: input.imageConnection.comfyuiWorkflow || undefined,
         imageDefaults,

--- a/packages/server/src/services/noodle/noodle-public-images.service.ts
+++ b/packages/server/src/services/noodle/noodle-public-images.service.ts
@@ -225,8 +225,8 @@ export async function generateNoodlePostImage(input: {
     const previewSize = resolveImagePromptReviewSize({
       connection: input.imageConnection,
       prompt: finalPrompt,
-      width: imageSettings.illustration.width,
-      height: imageSettings.illustration.height,
+      width: imageSettings.noodle.width,
+      height: imageSettings.noodle.height,
       imageDefaults,
     });
     return {
@@ -250,8 +250,8 @@ export async function generateNoodlePostImage(input: {
         prompt: finalPrompt,
         negativePrompt: finalNegativePrompt,
         model: imageModel,
-        width: imageSettings.illustration.width,
-        height: imageSettings.illustration.height,
+        width: imageSettings.noodle.width,
+        height: imageSettings.noodle.height,
         imageEndpointId: input.imageConnection.imageEndpointId || undefined,
         comfyWorkflow: input.imageConnection.comfyuiWorkflow || undefined,
         imageDefaults,
@@ -294,8 +294,8 @@ export async function generateNoodlePostImage(input: {
           prompt: finalPrompt,
           provider,
           model: imageModel || "unknown",
-          width: imageSettings.illustration.width,
-          height: imageSettings.illustration.height,
+          width: imageSettings.noodle.width,
+          height: imageSettings.noodle.height,
         },
       } satisfies StagedNoodlePostMedia,
     };

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -135,7 +135,10 @@ import {
   searchStandardEmojiShortcodes,
 } from "../../packages/client/src/lib/emoji-shortcodes.js";
 import { persistGeneratedImageToEntityGalleries } from "../../packages/server/src/services/image/generated-image-entity-gallery.js";
-import { resolveIllustratorImageSize } from "../../packages/server/src/services/image/image-generation-settings.js";
+import {
+  parseImageGenerationUserSettings,
+  resolveIllustratorImageSize,
+} from "../../packages/server/src/services/image/image-generation-settings.js";
 import { generateIllustratorImageVariants } from "../../packages/server/src/services/image/illustrator-image-variants.js";
 import { fetchBotBrowserJson } from "../../packages/server/src/services/bot-browser/fetch-json.js";
 import { isAllowedResponseContentType, validateOutboundUrl } from "../../packages/server/src/utils/security.js";
@@ -584,6 +587,11 @@ assert.deepEqual(resolveIllustratorImageSize({ width: 960, height: 540 }, "portr
   width: 540,
   height: 960,
 });
+assert.deepEqual(parseImageGenerationUserSettings(null).noodle, { width: 1024, height: 1536 });
+assert.deepEqual(
+  parseImageGenerationUserSettings('{"imageNoodleWidth":1536,"imageNoodleHeight":1024}').noodle,
+  { width: 1536, height: 1024 },
+);
 
 const minimalProfessorMariPersona = buildPersonaCreateRow(
   { name: "Minimal helper persona" },
@@ -2427,6 +2435,10 @@ const chatMessageSource = readFileSync(
   new URL("../../packages/client/src/components/chat/ChatMessage.tsx", import.meta.url),
   "utf8",
 );
+const macroTextareaSource = readFileSync(
+  new URL("../../packages/client/src/components/ui/MacroTextarea.tsx", import.meta.url),
+  "utf8",
+);
 const roleplayHudSource = readFileSync(
   new URL("../../packages/client/src/components/chat/RoleplayHUD.tsx", import.meta.url),
   "utf8",
@@ -2449,6 +2461,16 @@ assert.match(
   chatMessageSource,
   /const cycleMergedNarratorAvatars = \(!isRoleplay \|\| roleplayNarratorAvatarCycling\) && !reduceAmbientEffects;/u,
   "Narrator avatar cycling must follow the Roleplay preference and stop with reduced ambient effects",
+);
+assert.match(
+  macroTextareaSource,
+  /const valueRef = useRef\(value\);[\s\S]{0,500}\}, \[open\]\);/u,
+  "Expanded macro editors must only initialize and focus when opened, not after every parent value update",
+);
+assert.match(
+  chatMessageSource,
+  /aria-label=\{localizeUi\("ui\.chat\.edittextarea\.saveEdit"\)\}[\s\S]{0,180}h-11 w-11/u,
+  "The Roleplay edit Save control must keep a full touch-sized hit target",
 );
 assert.equal(
   roleplayHudSource.match(/!reduceAmbientEffects && "animate-\[inventory-cycle_0\.4s_ease-out\]"/gu)?.length,

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -198,12 +198,17 @@ assert.match(professorMariHomeSource, /WORKSPACE_SETTLE_REQUEST_TIMEOUT_MS/u);
 assert.doesNotMatch(personalExtensionsHookSource, /refetchInterval/u);
 assert.match(chatSettingsDrawerSource, /active && agent\.id !== "illustrator"[\s\S]*?<AgentPromptTemplateSelect/u);
 assert.match(reducedAmbientEffectsHookSource, /manualPreference \|\| systemPreference/u);
-assert.match(uiStoreSource, /version: 89/u);
+assert.match(uiStoreSource, /version: 90/u);
 assert.match(globalStylesSource, /data-marinara-reduced-effects/u);
 assert.match(
   chatRoleplaySurfaceSource,
-  /function RoleplayLiveStreamText[\s\S]*?textContent = next[\s\S]*?requestAnimationFrame\(apply\)/u,
-  "Roleplay live text should update one text node at animation-frame cadence",
+  /function RoleplayLiveStreamText[\s\S]*?document\.createTextNode\(""\)[\s\S]*?textNode\.appendData[\s\S]*?requestAnimationFrame\(apply\)/u,
+  "Roleplay live text should retain one text node and append to it at animation-frame cadence",
+);
+assert.doesNotMatch(
+  chatRoleplaySurfaceSource,
+  /textRef\.current\.textContent = next/u,
+  "Roleplay streaming must not replace its live Text node on every frame",
 );
 assert.doesNotMatch(
   chatRoleplaySurfaceSource,


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository from `staging` or a same-repository `hotfix/*` branch to `main`.

## Linked issues

Closes #4656
Closes #4658
Closes #4659
Closes #4660

## Why this change

- Expanded Character and Preset editors could refocus after parent updates and move the caret to the end.
- The Roleplay edit Save control exposed only a small, intermittently obstructed pointer target.
- Roleplay streaming replaced its live text node every animation frame, amplifying Firefox rendering and accessibility work.
- Noodle timelines reused Illustrator dimensions, which stricter GPT-Image-compatible endpoints reject.

## What changed

- Initialize and focus the shared expanded macro editor only when it opens.
- Give Roleplay edit controls full 44px hit targets in their own stacking layer.
- Retain one live `Text` node while streaming, appending ordinary growth and replacing its data only for rewrites.
- Add a separately persisted Noodle timeline canvas, default it to 1024x1536, and use it for public Noodle and private NoodleR preview and generation requests.
- Add focused regression and browser coverage plus Unreleased changelog entries.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Verification notes

Automated validation completed locally:

- `pnpm check`
- Focused Playwright coverage for middle-of-text caret stability
- Focused Playwright coverage for 44px Roleplay edit targets and save behavior on desktop and mobile
- New regression assertions for stable Roleplay stream nodes and Noodle dimension parsing

The broader Roleplay and open-issues regression scripts reached the new assertions successfully, then encountered unrelated stale source-shape assertions already present on `staging`.

Manual follow-up requested:

- Manually reprofile a long Roleplay stream in Firefox with Inspector closed.
- Manually verify a custom Noodle canvas against the configured external image endpoint.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence

Focused Playwright checks passed in desktop Chromium and mobile Chromium; the expanded editor check is desktop-only by existing suite design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an independent Noodle timeline image-size setting, defaulting to a 1024×1536 canvas.
  * Noodle image previews, generation, and gallery images now use the configured dimensions.

* **Bug Fixes**
  * Improved caret retention and selection behavior in expanded text editing.
  * Enlarged Roleplay message edit controls for easier touch interaction.
  * Improved streaming text updates for Firefox and accessibility by preserving stable text content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->