### PR TITLE
Inset avatar AI control and simplify intent hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Installed the pinned pnpm automatically when the Windows installer cannot use Corepack, an existing pnpm, or its temporary runner (#4662).
 - Exposed saved prompt choices for active Roleplay tracker agents in Chat Settings, matching the existing Game-mode selector (#4663).
-- Centered the avatar-upload camera over the mini preview in Character and Persona editors (#4665).
+- Centered the avatar-upload camera and inset the AI-generation action so both controls remain fully visible over the mini preview in Character and Persona editors (#4665).
+- Simplified proactive Conversation intent hints so check-ins follow the selected moment without extra tone instructions.
 - Distributed mobile topbar icons evenly across the available screen width without changing the desktop layout (#4666).
 - Kept the caret at the chosen insertion point while typing in expanded Character and Preset editors instead of repeatedly focusing the field and jumping to the end (#4656).
 - Restored a full, unobstructed hit target for Roleplay message edit controls so Save no longer reacts only near one corner (#4658).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2413,8 +2413,15 @@ test("Character and Persona avatar actions stay separated and visually balanced"
     expect(generateBox.width).toBeLessThanOrEqual(9);
     expect(generateBox.height).toBeGreaterThanOrEqual(7.5);
     expect(generateBox.height).toBeLessThanOrEqual(9);
-    expect(generateBox.x + generateBox.width).toBeLessThanOrEqual(tileBox.x + tileBox.width + 1);
-    expect(generateBox.y).toBeGreaterThanOrEqual(tileBox.y - 1);
+    const minimumGenerateInset = (page.viewportSize()?.width ?? 768) < 768 ? 1.5 : 2.5;
+    expect(generateBox.x).toBeGreaterThanOrEqual(tileBox.x + minimumGenerateInset);
+    expect(generateBox.y).toBeGreaterThanOrEqual(tileBox.y + minimumGenerateInset);
+    expect(generateBox.x + generateBox.width).toBeLessThanOrEqual(
+      tileBox.x + tileBox.width - minimumGenerateInset,
+    );
+    expect(generateBox.y + generateBox.height).toBeLessThanOrEqual(
+      tileBox.y + tileBox.height - minimumGenerateInset,
+    );
     expect(Math.abs(cameraBox.x + cameraBox.width / 2 - (tileBox.x + tileBox.width / 2))).toBeLessThanOrEqual(1);
     expect(Math.abs(cameraBox.y + cameraBox.height / 2 - (tileBox.y + tileBox.height / 2))).toBeLessThanOrEqual(1);
     const overlapsCamera =

--- a/packages/client/src/components/ui/EditorAvatarTileActions.tsx
+++ b/packages/client/src/components/ui/EditorAvatarTileActions.tsx
@@ -21,7 +21,7 @@ export function EditorAvatarTileActions({ generationAvailable, onGenerate }: Edi
             event.stopPropagation();
             onGenerate();
           }}
-          className="absolute right-0 top-0 inline-flex h-2 w-2 items-center justify-center rounded-full bg-[var(--card)]/95 text-[var(--primary)] shadow-md ring-1 ring-[var(--border)] transition-colors before:absolute before:-inset-2 hover:bg-[var(--accent)]"
+          className="absolute right-0.5 top-0.5 inline-flex h-2 w-2 items-center justify-center rounded-full bg-[var(--card)]/95 text-[var(--primary)] shadow-md ring-1 ring-[var(--border)] transition-colors before:absolute before:-inset-2 hover:bg-[var(--accent)] max-md:right-px max-md:top-px"
           title={t("editor.avatar.generate.label")}
           aria-label={t("editor.avatar.generate.label")}
         >

--- a/packages/server/src/services/conversation/intent.service.ts
+++ b/packages/server/src/services/conversation/intent.service.ts
@@ -4,14 +4,14 @@ import type { ConversationMessageIntent } from "@marinara-engine/shared";
 export type MessageIntent = ConversationMessageIntent;
 
 const INTENT_HINTS: Record<MessageIntent, string> = {
-  check_in: "You have a free moment and feel like reaching out. The user has been quiet.",
+  check_in: "You have a free moment and the user has been quiet.",
   long_absence_check_in:
-    "The user has been away for a long while. Send one warm, low-pressure check-in without sounding needy or escalating.",
+    "The user has been away for a long while. Check in with them.",
   came_back_online: "You were unavailable earlier when the user wrote. You just became free and are getting back to them.",
   after_busy: "You just wrapped up a busy stretch. You have some breathing room now.",
   good_morning: "You just woke up and are starting your day. This is your first message of the morning.",
   good_night: "You are winding down for the night and checking in before you go offline.",
-  meal_break: "You are on a short break - eating or stepping away briefly. A good moment to drop a quick message.",
+  meal_break: "You are on a short break, eating or stepping away briefly. A good moment to drop a quick message.",
   transition_ping: "You just moved from one thing to another and thought of the user.",
 };
 


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #4665

## Why this change

- The avatar AI-generation control sat directly against the mini-avatar border, so the rounded tile clipped the edge of its ring.
- Mobile has less room around the centered camera than desktop, so both breakpoints cannot safely use the same inset.
- This PR also includes a maintainer-directed simplification of three proactive Conversation intent hints so they do not impose extra tone guidance.

## What changed

- Inset the AI-generation control by two pixels on desktop and one pixel on mobile.
- Strengthened Character and Persona editor geometry coverage to require the complete control to remain inside the avatar tile without overlapping the camera.
- Simplified the `check_in`, `long_absence_check_in`, and `meal_break` hint text without changing intent selection, scheduling, cooldowns, or routing.
- Updated the Unreleased changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Additional automated validation completed:

- `pnpm check`
- `pnpm exec playwright test e2e/core-flows.e2e.ts --grep "Character and Persona avatar actions stay separated and visually balanced" --project=desktop-chromium --project=mobile-chromium`
- Exact compiled assertions for the three changed Conversation intent hints
- `pnpm regression:prompt`

### Manual verification notes

- Manually verify the top-right AI-generation control in Character and Persona mini-avatar tiles on desktop.
- Manually verify the mobile control remains separate from the centered camera.
- Manually sample proactive Conversation turns for the three changed intent hints.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Focused desktop and mobile Playwright geometry checks pass for both Character and Persona editors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar generation controls so the action remains visible and properly inset across standard and compact previews.
  * Simplified proactive conversation prompts to better follow the selected moment without adding unnecessary tone guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->