### PR TITLE
fix: preserve summary history and group selfie references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Included the active Conversation cast's avatar references and appearance descriptions in guided group selfies (#4676).
 - Added native Arli.ai image generation with authenticated text-to-image and image-to-image requests (#4672).
 - Let Professor Mari read complete lorebook entry bodies through her structured app-data tools instead of receiving only truncated entry previews (#4673).
 - Removed conflicting color-environment and unused React Compiler/Babel warnings from test and lint runs, refreshed smoke coverage for the current release, schema, agent, and Noodle settings surfaces, and preserved a reader's exact mobile chat position when the keyboard opens (#4670).
-- Kept source Chat Summary entries as inactive history after combining summaries in Roleplay mode instead of deleting them.
+- Kept source Chat Summary entries as inactive history after combining summaries in Roleplay mode instead of deleting them, and revealed that history immediately after each combine.
 - Removed local Character and Persona avatar files when their cards are deleted individually or through Danger Zone, including avatars retained only by deleted card-version history (#4668).
 - Installed the pinned pnpm automatically when the Windows installer cannot use Corepack, an existing pnpm, or its temporary runner (#4662).
 - Exposed saved prompt choices for active Roleplay tracker agents in Chat Settings, matching the existing Game-mode selector (#4663).

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -782,6 +782,7 @@ export function SummaryPopover({
       {
         onSuccess: (data) => {
           setSelectedEntryIds(new Set());
+          setShowInactiveSummaries(true);
           const entryId = data.entry?.id;
           if (entryId) setExpandedEntryIds((current) => new Set(current).add(entryId));
         },

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -9291,6 +9291,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     : null,
                   promptConnection: conn,
                   promptConnectionId: conn.id,
+                  generationGuide: input.generationGuide,
                   debugMode: input.debugMode,
                   serviceTier,
                   db: app.db,

--- a/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
@@ -58,6 +58,25 @@ type PersonaReference = {
   appearance?: string | null;
 } | null;
 
+const GROUP_SELFIE_REQUEST_RE =
+  /\bgroup\s+(?:selfie|photo|picture)\b|\b(?:selfie|photo|picture)\b[^\n.!?]{0,80}\b(?:together|everyone|everybody|all (?:of us|participants|characters))\b/iu;
+
+export function resolveConversationSelfieRequestedNames(args: {
+  speakerName: string;
+  chatCharacters: ReadonlyArray<{ name: string }>;
+  generationGuide?: string | null;
+  commandContext?: string | null;
+  imagePrompt?: string | null;
+}): string[] {
+  const requestText = [args.generationGuide, args.commandContext, args.imagePrompt]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .join("\n");
+  const names = GROUP_SELFIE_REQUEST_RE.test(requestText)
+    ? args.chatCharacters.map((character) => character.name)
+    : [args.speakerName];
+  return Array.from(new Set(names.map((name) => name.trim()).filter(Boolean)));
+}
+
 export async function handleConversationSelfieCommand(args: {
   command: CharacterCommand;
   characterId: string | null;
@@ -69,6 +88,7 @@ export async function handleConversationSelfieCommand(args: {
   persona: PersonaReference;
   promptConnection: IllustratorPromptConnection;
   promptConnectionId: string;
+  generationGuide?: string | null;
   debugMode?: boolean;
   serviceTier: "flex" | "priority" | null;
   db: DB;
@@ -230,6 +250,13 @@ async function generateSelfie(
   const selfieUseAvatarReferences = args.chatMeta.selfieUseAvatarReferences === true;
   const selfieIncludeCharacterAppearance = args.chatMeta.selfieIncludeCharacterAppearance === true;
   if (selfieUseAvatarReferences || selfieIncludeCharacterAppearance) {
+    const requestedNames = resolveConversationSelfieRequestedNames({
+      speakerName: args.charName,
+      chatCharacters: args.charInfo,
+      generationGuide: args.generationGuide,
+      commandContext: args.command.context,
+      imagePrompt,
+    });
     const referenceResolution = await resolveIllustratorCharacterReferences({
       charactersStore: args.chars,
       chatCharacters: args.charInfo.map((character) => ({
@@ -239,7 +266,7 @@ async function generateSelfie(
         appearance: character.appearance,
       })),
       persona: null,
-      requestedNames: [args.charName],
+      requestedNames,
       promptText: [args.charName, args.command.context ?? "", imagePrompt].join("\n"),
       fallbackToChatCharacters: false,
       maxReferences: 6,

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -3139,7 +3139,12 @@ assert.match(
 );
 assert.match(
   conversationSelfieRuntimeSource,
-  /resolveIllustratorCharacterReferences\(\{[\s\S]{0,800}persona: null,[\s\S]{0,800}maxReferences: 6/u,
+  /resolveConversationSelfieRequestedNames\(\{[\s\S]{0,400}generationGuide: args\.generationGuide/u,
+  "Conversation group selfies must carry the guided request into reference selection",
+);
+assert.match(
+  conversationSelfieRuntimeSource,
+  /resolveIllustratorCharacterReferences\(\{[\s\S]{0,800}persona: null,[\s\S]{0,200}requestedNames,[\s\S]{0,300}maxReferences: 6/u,
   "Conversation group selfies must keep all depicted character references without attaching the photographer persona",
 );
 assert.match(
@@ -4520,6 +4525,39 @@ assert.equal(
   compileChatSummaryEntries(retainedSummaryEntries),
   "Combined A and B\n\nUntouched",
   "Compiled Chat Summary output must exclude deactivated source entries",
+);
+const secondCombinedSummaryEntry = createChatSummaryEntry({
+  id: "combined-again",
+  content: "Combined summary of summaries",
+  title: "Combined again",
+  enabled: true,
+  rangeStartIndex: 1,
+  rangeEndIndex: 6,
+  createdAt: summaryCombineEntries[0]!.createdAt,
+  updatedAt: "2026-08-06T10:00:00.000Z",
+});
+const retainedSecondGenerationEntries = combineChatSummaryEntryHistory(
+  retainedSummaryEntries,
+  new Set(["combined", "untouched"]),
+  secondCombinedSummaryEntry,
+  secondCombinedSummaryEntry.updatedAt,
+);
+assert.deepEqual(
+  retainedSecondGenerationEntries.map((entry) => entry.id),
+  ["combined-again", "combined", "source-a", "source-b", "untouched"],
+  "A summary of summaries must retain both generations of source history",
+);
+for (const sourceId of ["combined", "source-a", "source-b", "untouched"]) {
+  assert.equal(
+    retainedSecondGenerationEntries.find((entry) => entry.id === sourceId)?.enabled,
+    false,
+    `${sourceId} must remain as inactive history after combining summaries again`,
+  );
+}
+assert.match(
+  summaryPopoverSource,
+  /onSuccess: \(data\) => \{\s*setSelectedEntryIds\(new Set\(\)\);\s*setShowInactiveSummaries\(true\)/u,
+  "The Chat Summary popover must reveal retained inactive sources after combining",
 );
 assert.match(
   summaryPopoverSource,

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -69,6 +69,7 @@ import {
   buildGmFormatReminder,
   buildPartyRecruitCardPrompt,
 } from "../../packages/server/src/services/game/gm-prompts.js";
+import { resolveConversationSelfieRequestedNames } from "../../packages/server/src/services/generation/conversation-selfie-command-runtime.js";
 import {
   normalizeCyoaChoiceOutput,
   normalizeCyoaDialogueQuotes,
@@ -3961,6 +3962,23 @@ const cases: RegressionCase[] = [
       });
       assert.deepEqual(groupSelfieResolution.characterIds, ["character-maukie", "character-dottore"]);
       assert.equal(groupSelfieResolution.personaId, null);
+      assert.deepEqual(
+        resolveConversationSelfieRequestedNames({
+          speakerName: "Maukie",
+          chatCharacters: [{ name: "Maukie" }, { name: "Dottore" }],
+          generationGuide: buildNarratorInstructionMessage("group selfie"),
+          imagePrompt: "Two friends crowd into the frame.",
+        }),
+        ["Maukie", "Dottore"],
+      );
+      assert.deepEqual(
+        resolveConversationSelfieRequestedNames({
+          speakerName: "Maukie",
+          chatCharacters: [{ name: "Maukie" }, { name: "Dottore" }],
+          imagePrompt: "Maukie takes a casual selfie at home.",
+        }),
+        ["Maukie"],
+      );
     },
   },
   {


### PR DESCRIPTION
## Linked issue

Closes #4676

## Why this change

- A guided group-selfie request was not carried from `/guided` into Conversation selfie reference selection. The runtime therefore started from only the speaking character, so another participant could appear in generated prose without receiving their saved appearance or avatar reference.
- Roleplay summary combining already retained selected sources as inactive metadata, but the popover hid them immediately. On a summary-of-summaries combine, every prior summary therefore looked deleted even though it was still stored.

## What changed

- Detect guided group-selfie intent from the guide, selfie context, or generated image prompt and request the existing reference resolver for the active Conversation cast. Ordinary selfies continue to request only the speaking character.
- Reveal inactive Chat Summary entries after a successful combine so the retained sources remain visibly present and deactivated.
- Add positive and negative group-selfie coverage plus a second-generation summary-combine regression that proves both generations remain inactive history.
- Update the Unreleased changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated: `pnpm check` passed (Impeccable context, localization, lint/type checks, server/client production builds).
- Automated: `pnpm regression:prompt` passed, including guided group-selfie selection and the ordinary-selfie negative control.
- Automated: the new summary-of-summaries and UI reveal assertions pass in `open-issues.regression.ts`. The broader script later stops on a pre-existing `staging` source assertion for the current Summary Prompt editor layout; the same assertion does not match `origin/staging`.
- No live-provider group selfie was generated, and no browser screenshot was captured. Manual verification should combine two summaries twice in Roleplay and generate a guided two-character Conversation group selfie with avatar references and appearance descriptions enabled.

## Risk boundary

- Entrypoints: Conversation `[selfie]` command execution and Roleplay Chat Summary combine success state.
- Positive proof: `/guided group selfie` selects the active cast; combining a combined summary retains every older entry as inactive.
- Negative proof: an ordinary single-character selfie still selects only its speaker.
- Untested: provider-specific reference-image limits and a live image-generation request.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

- No documentation, translation, or version metadata changes are needed. `CHANGELOG.md` is updated.

## UI evidence (if applicable)

- No screenshot captured. The UI change uses the existing inactive-summary rows and Show/Hide inactive control; it adds no new layout or copy.