### PR TITLE
Fix transient Roleplay message edit failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Retried one transient Roleplay message-edit save failure so remote sessions persist the edit without requiring another manual Save action (#4678).
 - Included the active Conversation cast's avatar references and appearance descriptions in guided group selfies (#4676).
 - Added native Arli.ai image generation with authenticated text-to-image and image-to-image requests (#4672).
 - Let Professor Mari read complete lorebook entry bodies through her structured app-data tools instead of receiving only truncated entry previews (#4673).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1,4 +1,4 @@
-import { expect, test, type APIRequestContext, type Locator, type Page } from "@playwright/test";
+import { expect, test, type APIRequestContext, type Locator, type Page, type Route } from "@playwright/test";
 import AdmZip from "adm-zip";
 import { readFileSync } from "node:fs";
 import { createServer } from "node:http";
@@ -3121,48 +3121,55 @@ test("stopped and refused generations keep sent text cleared and accept the firs
       await editor.fill(nextContent);
       const saveGate = options.delaySave ? createDeferred() : null;
       let saveAttempts = 0;
+      const messagePath = `/api/chats/${chatId}/messages/${messageId}`;
+      const messageRoute = `**${messagePath}`;
+      let saveRouteHandler: ((route: Route) => Promise<void>) | null = null;
       if (saveGate || options.failFirstSave) {
-        const messagePath = `/api/chats/${chatId}/messages/${messageId}`;
-        await page.route(
-          (url) => url.pathname === messagePath,
-          async (route) => {
-            saveAttempts += 1;
-            if (saveAttempts === 1 && saveGate) await saveGate.promise;
-            if (saveAttempts === 1 && options.failFirstSave) {
-              await route.fulfill({
-                status: 503,
-                contentType: "application/json",
-                body: JSON.stringify({ error: "Temporary message save failure" }),
-              });
-              return;
-            }
+        saveRouteHandler = async (route) => {
+          if (route.request().method() !== "PATCH") {
             await route.continue();
-          },
-          { times: options.failFirstSave ? 2 : 1 },
-        );
+            return;
+          }
+          saveAttempts += 1;
+          if (saveAttempts === 1 && saveGate) await saveGate.promise;
+          if (saveAttempts === 1 && options.failFirstSave) {
+            await route.fulfill({
+              status: 503,
+              contentType: "application/json",
+              body: JSON.stringify({ error: "Temporary message save failure" }),
+            });
+            return;
+          }
+          await route.continue();
+        };
+        await page.route(messageRoute, saveRouteHandler);
       }
-      const saveButton = message.getByLabel("Save edit", { exact: true });
-      const saveButtonBox = await saveButton.boundingBox();
-      expect(saveButtonBox?.width).toBeGreaterThanOrEqual(44);
-      expect(saveButtonBox?.height).toBeGreaterThanOrEqual(44);
-      await saveButton.click();
-      if (saveGate) {
-        try {
-          await expect(editor).toBeVisible();
-          await expect(editor).toHaveValue(nextContent);
-          await expect(message.getByLabel("Cancel edit", { exact: true })).toBeDisabled();
-          await expect(message.getByLabel("Save edit", { exact: true })).toBeDisabled();
-          await editor.press("Escape");
-          await expect(editor).toBeVisible();
-        } finally {
-          saveGate.resolve();
+      try {
+        const saveButton = message.getByLabel("Save edit", { exact: true });
+        const saveButtonBox = await saveButton.boundingBox();
+        expect(saveButtonBox?.width).toBeGreaterThanOrEqual(44);
+        expect(saveButtonBox?.height).toBeGreaterThanOrEqual(44);
+        await saveButton.click();
+        if (saveGate) {
+          try {
+            await expect(editor).toBeVisible();
+            await expect(editor).toHaveValue(nextContent);
+            await expect(message.getByLabel("Cancel edit", { exact: true })).toBeDisabled();
+            await expect(message.getByLabel("Save edit", { exact: true })).toBeDisabled();
+            await editor.press("Escape");
+            await expect(editor).toBeVisible();
+          } finally {
+            saveGate.resolve();
+          }
         }
+        if (options.failFirstSave) await expect.poll(() => saveAttempts).toBe(2);
+        await expect(message).toContainText(nextContent);
+        await expect
+          .poll(async () => (await readMessages()).find((candidate) => candidate.id === messageId)?.content)
+          .toBe(nextContent);
+      } finally {
+        if (saveRouteHandler) await page.unroute(messageRoute, saveRouteHandler);
       }
-      if (options.failFirstSave) await expect.poll(() => saveAttempts).toBe(2);
-      await expect(message).toContainText(nextContent);
-      await expect
-        .poll(async () => (await readMessages()).find((candidate) => candidate.id === messageId)?.content)
-        .toBe(nextContent);
     };
 
     await input.fill("Original message with retained draft");
@@ -3182,6 +3189,7 @@ test("stopped and refused generations keep sent text cleared and accept the firs
       delaySave: true,
       failFirstSave: true,
     });
+    await editMessageOnce(firstMessage!.id, "Second edit to the same message stays newest");
     await expect(input).toHaveValue("Unsent composer text");
 
     await input.fill("Original message with cleared draft");
@@ -3236,7 +3244,7 @@ test("stopped and refused generations keep sent text cleared and accept the firs
 
     await page.reload();
     await expect(page.locator(`[data-message-id="${firstMessage!.id}"]`)).toContainText(
-      "Edited on the first save with retained draft",
+      "Second edit to the same message stays newest",
     );
     await expect(page.locator(`[data-message-id="${secondMessage!.id}"]`)).toContainText(
       "Edited on the first save with cleared draft",

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -3108,23 +3108,37 @@ test("stopped and refused generations keep sent text cleared and accept the firs
       const response = await request.get(`/api/chats/${chatId}/messages`);
       return (await response.json()) as Array<{ id: string; role: string; content: string }>;
     };
-    const editMessageOnce = async (messageId: string, nextContent: string, delaySave = false) => {
+    const editMessageOnce = async (
+      messageId: string,
+      nextContent: string,
+      options: { delaySave?: boolean; failFirstSave?: boolean } = {},
+    ) => {
       const message = page.locator(`[data-message-id="${messageId}"]`);
       if (mobile) await message.click();
       else await message.hover();
       await message.getByTitle("Edit", { exact: true }).click();
       const editor = message.locator("textarea");
       await editor.fill(nextContent);
-      const saveGate = delaySave ? createDeferred() : null;
-      if (saveGate) {
+      const saveGate = options.delaySave ? createDeferred() : null;
+      let saveAttempts = 0;
+      if (saveGate || options.failFirstSave) {
         const messagePath = `/api/chats/${chatId}/messages/${messageId}`;
         await page.route(
           (url) => url.pathname === messagePath,
           async (route) => {
-            await saveGate.promise;
+            saveAttempts += 1;
+            if (saveAttempts === 1 && saveGate) await saveGate.promise;
+            if (saveAttempts === 1 && options.failFirstSave) {
+              await route.fulfill({
+                status: 503,
+                contentType: "application/json",
+                body: JSON.stringify({ error: "Temporary message save failure" }),
+              });
+              return;
+            }
             await route.continue();
           },
-          { times: 1 },
+          { times: options.failFirstSave ? 2 : 1 },
         );
       }
       const saveButton = message.getByLabel("Save edit", { exact: true });
@@ -3144,6 +3158,7 @@ test("stopped and refused generations keep sent text cleared and accept the firs
           saveGate.resolve();
         }
       }
+      if (options.failFirstSave) await expect.poll(() => saveAttempts).toBe(2);
       await expect(message).toContainText(nextContent);
       await expect
         .poll(async () => (await readMessages()).find((candidate) => candidate.id === messageId)?.content)
@@ -3163,7 +3178,10 @@ test("stopped and refused generations keep sent text cleared and accept the firs
     await backgroundTab.goto("about:blank");
     await page.bringToFront();
     await backgroundTab.close();
-    await editMessageOnce(firstMessage!.id, "Edited on the first save with retained draft", true);
+    await editMessageOnce(firstMessage!.id, "Edited on the first save with retained draft", {
+      delaySave: true,
+      failFirstSave: true,
+    });
     await expect(input).toHaveValue("Unsent composer text");
 
     await input.fill("Original message with cleared draft");

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -11,14 +11,13 @@ import {
   type QueryClient,
 } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { api } from "../lib/api-client";
+import { api, ApiError } from "../lib/api-client";
 import { useChatStore } from "../stores/chat.store";
 import { useAgentStore } from "../stores/agent.store";
 import { useGameStateStore } from "../stores/game-state.store";
 import { useEncounterStore } from "../stores/encounter.store";
 import { useUIStore } from "../stores/ui.store";
 import { clearBrowserRuntimeCaches } from "../lib/browser-runtime";
-import { ApiError } from "../lib/api-client";
 import { lorebookKeys } from "./use-lorebooks";
 import { achievementKeys, trackAchievementEvent } from "./use-achievements";
 import type {
@@ -50,6 +49,7 @@ export const chatKeys = {
 };
 
 const RECENT_MESSAGE_CONTENT_EDIT_TTL_MS = 5 * 60 * 1000;
+const MESSAGE_CONTENT_UPDATE_RETRY_DELAY_MS = 300;
 const chatMetadataMutationVersions = new Map<string, number>();
 const chatMetadataFieldVersions = new Map<string, Map<string, number>>();
 
@@ -64,6 +64,14 @@ interface RecentMessageContentEdit {
 const recentMessageContentEdits = new Map<string, RecentMessageContentEdit>();
 let recentMessageContentEditRevision = 0;
 const messageContentUpdateQueues = new Map<string, Promise<void>>();
+
+function shouldRetryMessageContentUpdate(failureCount: number, error: unknown) {
+  if (failureCount >= 1) return false;
+  if (error instanceof ApiError) {
+    return error.status === 408 || error.status === 425 || error.status === 429 || error.status >= 500;
+  }
+  return error instanceof TypeError;
+}
 
 function enqueueMessageContentUpdate(chatId: string | null, messageId: string, content: string) {
   const queueKey = `${chatId ?? ""}:${messageId}`;
@@ -1064,6 +1072,10 @@ export function useUpdateMessage(chatId: string | null) {
   return useMutation({
     mutationFn: ({ messageId, content }: { messageId: string; content: string }) =>
       enqueueMessageContentUpdate(chatId, messageId, content),
+    // Message content PATCHes are idempotent. Retry one transient transport or
+    // server failure so remote sessions do not require a second manual save.
+    retry: shouldRetryMessageContentUpdate,
+    retryDelay: MESSAGE_CONTENT_UPDATE_RETRY_DELAY_MS,
     onMutate: async ({ messageId, content }) => {
       if (!chatId) return;
       // Cancel in-flight refetches (e.g. from generation events) so they

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -65,12 +65,23 @@ const recentMessageContentEdits = new Map<string, RecentMessageContentEdit>();
 let recentMessageContentEditRevision = 0;
 const messageContentUpdateQueues = new Map<string, Promise<void>>();
 
-function shouldRetryMessageContentUpdate(failureCount: number, error: unknown) {
-  if (failureCount >= 1) return false;
+function shouldRetryMessageContentUpdate(error: unknown) {
   if (error instanceof ApiError) {
     return error.status === 408 || error.status === 425 || error.status === 429 || error.status >= 500;
   }
   return error instanceof TypeError;
+}
+
+async function patchMessageContent(chatId: string | null, messageId: string, content: string) {
+  try {
+    return await api.patch<Message>(`/chats/${chatId}/messages/${messageId}`, { content });
+  } catch (error) {
+    if (!shouldRetryMessageContentUpdate(error)) throw error;
+    // Keep the retry inside the queued operation so a newer edit cannot be
+    // persisted first and then overwritten by this older content.
+    await new Promise((resolve) => setTimeout(resolve, MESSAGE_CONTENT_UPDATE_RETRY_DELAY_MS));
+    return api.patch<Message>(`/chats/${chatId}/messages/${messageId}`, { content });
+  }
 }
 
 function enqueueMessageContentUpdate(chatId: string | null, messageId: string, content: string) {
@@ -78,7 +89,7 @@ function enqueueMessageContentUpdate(chatId: string | null, messageId: string, c
   const previous = messageContentUpdateQueues.get(queueKey) ?? Promise.resolve();
   const request = previous
     .catch(() => undefined)
-    .then(() => api.patch<Message>(`/chats/${chatId}/messages/${messageId}`, { content }));
+    .then(() => patchMessageContent(chatId, messageId, content));
   const settled = request.then(
     () => undefined,
     () => undefined,
@@ -1072,10 +1083,6 @@ export function useUpdateMessage(chatId: string | null) {
   return useMutation({
     mutationFn: ({ messageId, content }: { messageId: string; content: string }) =>
       enqueueMessageContentUpdate(chatId, messageId, content),
-    // Message content PATCHes are idempotent. Retry one transient transport or
-    // server failure so remote sessions do not require a second manual save.
-    retry: shouldRetryMessageContentUpdate,
-    retryDelay: MESSAGE_CONTENT_UPDATE_RETRY_DELAY_MS,
     onMutate: async ({ messageId, content }) => {
       if (!chatId) return;
       // Cancel in-flight refetches (e.g. from generation events) so they


### PR DESCRIPTION
## Why

Roleplay message edits could still fail on remote Termux/Tailscale sessions after the previous cache and editor-state fixes. The five earlier PRs protected generation cleanup, cache ordering, stale snapshots, editor lifetime, and the Save hit target, but the final content `PATCH` still trusted a single transport attempt. One transient network or server failure therefore left the edit unpersisted and showed the recovery toast from #4678.

Closes #4678

## What changed

- Retry one idempotent message-content `PATCH` after 300 ms for network failures and HTTP 408, 425, 429, or 5xx responses.
- Keep permanent 4xx failures immediate so authorization, validation, and missing-message errors are not hidden.
- Extend the existing stopped-generation browser regression to delay Save, switch tabs, return a 503 on the first attempt, and require the retry to persist through server readback and reload.
- Add the user-facing fix to the Unreleased changelog.

## Validation

- [ ] `pnpm check`
- [ ] `pnpm localization:check`
- [ ] Desktop Chromium stopped-generation edit regression
- [ ] Mobile Chromium stopped-generation edit regression
- [ ] Manually verify editing after stopping generation over a real Tailscale connection

Automated validation completed while preparing the PR: `pnpm check`, `pnpm localization:check`, and the focused Playwright regression on desktop and mobile Chromium (2 passed). The validation boxes remain unchecked for maintainer verification.

## Manual verification

Manually reproduce the original remote Termux/Tailscale path and confirm that a brief connection interruption does not require a second Save click.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically retries message edits once after transient network or service failures.
  * Remote message edits can recover without requiring another manual save.
  * Permanent and non-transient errors continue to surface without unnecessary retries.

* **Tests**
  * Added coverage for delayed saves, failed initial attempts, recovery, and persistence after reload.

* **Documentation**
  * Documented the automatic retry behavior in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->