### PR TITLE
Persist the first edit after stopping Roleplay generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Reconciled just-sent Roleplay messages with their saved IDs before editing so the first edit after stopping generation persists (#4678).
 - Retried one transient Roleplay message-edit save failure so remote sessions persist the edit without requiring another manual Save action (#4678).
 - Kept Persona tags, stats, saved statuses, avatar crops, tracker colors, and conversation settings intact across loading, editing, duplicating, restoring, and switching Personas by returning one consistent Persona API shape (#4646).
 - Included the active Conversation cast's avatar references and appearance descriptions in guided group selfies (#4676).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -3192,7 +3192,9 @@ test("stopped and refused generations keep sent text cleared and accept the firs
     await page.route(messagesRouteMatcher, stoppedRefreshHandler);
     try {
       await page.evaluate((messageId) => {
-        document.querySelector<HTMLButtonElement>("button.mari-chat-send-btn")?.click();
+        const stopButton = document.querySelector<HTMLButtonElement>("button.mari-chat-send-btn");
+        if (!stopButton) throw new Error("Stop generation control is unavailable");
+        stopButton.click();
         window.dispatchEvent(new CustomEvent("marinara:start-edit-message", { detail: { messageId } }));
       }, justSentMessageId);
       const justSentEditor = justSentMessage.locator("textarea");

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -3003,11 +3003,7 @@ test("provider concurrency errors appear in generation toasts", async ({ page },
   }
 });
 
-test("stopped and refused generations keep sent text cleared and accept the first edit", async ({
-  context,
-  page,
-  request,
-}, testInfo) => {
+test("stopped and refused generations keep sent text cleared and accept the first edit", async ({ page, request }, testInfo) => {
   test.setTimeout(120_000);
   const mobile = testInfo.project.name.includes("mobile");
 
@@ -3165,8 +3161,10 @@ test("stopped and refused generations keep sent text cleared and accept the firs
         if (options.failFirstSave) await expect.poll(() => saveAttempts).toBe(2);
         await expect(message).toContainText(nextContent);
         await expect
-          .poll(async () => (await readMessages()).find((candidate) => candidate.id === messageId)?.content)
-          .toBe(nextContent);
+          .poll(async () =>
+            (await readMessages()).some((candidate) => candidate.role === "user" && candidate.content === nextContent),
+          )
+          .toBe(true);
       } finally {
         if (saveRouteHandler) await page.unroute(messageRoute, saveRouteHandler);
       }
@@ -3176,20 +3174,60 @@ test("stopped and refused generations keep sent text cleared and accept the firs
     await sendButton.click();
     await expect(input).toHaveValue("");
     await input.fill("Unsent composer text");
-    await stopCurrentGeneration(1);
+    await expect.poll(() => providerRequests.length).toBe(1);
+    const justSentMessage = page
+      .locator("[data-message-id]")
+      .filter({ hasText: "Original message with retained draft" });
+    await expect(justSentMessage).toBeVisible();
+    const justSentMessageId = await justSentMessage.getAttribute("data-message-id");
+    expect(justSentMessageId).toBeTruthy();
+    const stoppedRefreshGate = createDeferred();
+    const messagesPath = `/api/chats/${chatId}/messages`;
+    const messagesRouteMatcher = (url: URL) => url.pathname === messagesPath;
+    let holdStoppedRefresh = true;
+    const stoppedRefreshHandler = async (route: Route) => {
+      if (holdStoppedRefresh && route.request().method() === "GET") await stoppedRefreshGate.promise;
+      await route.continue().catch(() => undefined);
+    };
+    await page.route(messagesRouteMatcher, stoppedRefreshHandler);
+    try {
+      await page.evaluate((messageId) => {
+        document.querySelector<HTMLButtonElement>("button.mari-chat-send-btn")?.click();
+        window.dispatchEvent(new CustomEvent("marinara:start-edit-message", { detail: { messageId } }));
+      }, justSentMessageId);
+      const justSentEditor = justSentMessage.locator("textarea");
+      await expect(justSentEditor).toBeVisible();
+      await justSentEditor.fill("Edited on the first save with retained draft");
+      const firstSaveRequest = page.waitForRequest(
+        (candidate) =>
+          candidate.method() === "PATCH" &&
+          new URL(candidate.url()).pathname === `/api/chats/${chatId}/messages/${justSentMessageId}`,
+      );
+      await justSentMessage.getByLabel("Save edit", { exact: true }).click();
+      await firstSaveRequest;
+    } finally {
+      holdStoppedRefresh = false;
+      stoppedRefreshGate.resolve();
+      if (!page.isClosed()) await page.unroute(messagesRouteMatcher, stoppedRefreshHandler);
+    }
+    await expect
+      .poll(
+        async () =>
+          (await readMessages()).some(
+            (message) => message.role === "user" && message.content === "Edited on the first save with retained draft",
+          ),
+        { timeout: 10_000 },
+      )
+      .toBe(true);
+    await expect(sendButton.locator("svg.lucide-circle-stop")).toHaveCount(0);
     const firstMessage = (await readMessages()).find(
-      (message) => message.role === "user" && message.content === "Original message with retained draft",
+      (message) => message.role === "user" && message.content === "Edited on the first save with retained draft",
     );
     expect(firstMessage).toBeTruthy();
-    const backgroundTab = await context.newPage();
-    await backgroundTab.goto("about:blank");
-    await page.bringToFront();
-    await backgroundTab.close();
-    await editMessageOnce(firstMessage!.id, "Edited on the first save with retained draft", {
+    await editMessageOnce(firstMessage!.id, "Second edit to the same message stays newest", {
       delaySave: true,
       failFirstSave: true,
     });
-    await editMessageOnce(firstMessage!.id, "Second edit to the same message stays newest");
     await expect(input).toHaveValue("Unsent composer text");
 
     await input.fill("Original message with cleared draft");

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -639,13 +639,33 @@ export function upsertPersistedMessages(qc: QueryClient, chatId: string, incomin
     }
 
     const persistedById = new Map(sortedIncoming.map((msg) => [msg.id, msg]));
+    // A just-sent user row starts with a temporary ID. Match its submission ID
+    // once the server returns the durable row so edits cannot target the temporary ID.
+    const persistedUserBySubmissionId = new Map(
+      sortedIncoming.flatMap((msg) => {
+        const submissionId = parseMessageExtraRecord(msg.extra).submissionId;
+        return msg.role === "user" &&
+          !msg.id.startsWith("__optimistic_") &&
+          typeof submissionId === "string" &&
+          submissionId
+          ? [[submissionId, msg] as const]
+          : [];
+      }),
+    );
     const existingIds = new Set<string>();
 
     const pages = old.pages.map((page) =>
-      page.map((msg) => {
-        existingIds.add(msg.id);
-        const persisted = persistedById.get(msg.id);
-        return persisted ? mergeCachedGeneratedMessage(msg, persisted) : msg;
+      page.flatMap((msg) => {
+        const submissionId = parseMessageExtraRecord(msg.extra).submissionId;
+        const persisted =
+          persistedById.get(msg.id) ??
+          (msg.id.startsWith("__optimistic_") && typeof submissionId === "string"
+            ? persistedUserBySubmissionId.get(submissionId)
+            : undefined);
+        const nextMessage = persisted ? mergeCachedGeneratedMessage(msg, persisted) : msg;
+        if (existingIds.has(nextMessage.id)) return [];
+        existingIds.add(nextMessage.id);
+        return [nextMessage];
       }),
     );
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -901,6 +901,7 @@ export async function generateRoutes(app: FastifyInstance) {
     const discordWebhookUrl = typeof earlyMeta.discordWebhookUrl === "string" ? earlyMeta.discordWebhookUrl : "";
     let pendingUserDiscordMsg = "";
     let currentTurnUserMessageId: string | null = null;
+    let currentTurnUserMessage: Awaited<ReturnType<typeof chats.createMessage>> | null = null;
     let committedSpatialTransition: {
       commandId: string;
       currentLocationId: string | null;
@@ -980,12 +981,13 @@ export async function generateRoutes(app: FastifyInstance) {
       // Spatial owner-turn packages own message creation, so merge the
       // Engine-owned correlation into their durable row before generation.
       if (input.pendingSpatialTransition && userMsg?.id && (input.attachments.length > 0 || input.submissionId)) {
-        await chats
+        const updatedUserMsg = await chats
           .updateMessageExtra(userMsg.id, {
             ...(input.attachments.length ? { attachments: input.attachments } : {}),
             ...(input.submissionId ? { submissionId: input.submissionId } : {}),
           })
           .catch(releaseActiveGenerationAndRethrow);
+        if (updatedUserMsg) userMsg = updatedUserMsg;
       }
 
       // Snapshot Persona info for per-message tracking. Only Conversation may
@@ -994,7 +996,7 @@ export async function generateRoutes(app: FastifyInstance) {
         const snapshotPersonas = await chars.listPersonas().catch(releaseActiveGenerationAndRethrow);
         const snapshotPersona = resolveActivePersonaCandidate(snapshotPersonas, chat.personaId, requestChatMode);
         if (snapshotPersona) {
-          await chats
+          const updatedUserMsg = await chats
             .updateMessageExtra(userMsg.id, {
               personaSnapshot: {
                 personaId: snapshotPersona.id,
@@ -1011,8 +1013,10 @@ export async function generateRoutes(app: FastifyInstance) {
               },
             })
             .catch(releaseActiveGenerationAndRethrow);
+          if (updatedUserMsg) userMsg = updatedUserMsg;
         }
       }
+      currentTurnUserMessage = userMsg;
 
       // Mirror user message to Discord (deferred — personaName resolved later)
       pendingUserDiscordMsg = discordWebhookUrl && input.userMessage ? input.userMessage : "";
@@ -1135,6 +1139,10 @@ export async function generateRoutes(app: FastifyInstance) {
 
     // Set up SSE headers
     startSseReply(reply, { "X-Accel-Buffering": "no" });
+    if (currentTurnUserMessage) {
+      // Let the client replace its optimistic row before the user can edit it.
+      sendSseEvent(reply, { type: "message_saved", data: currentTurnUserMessage });
+    }
     if (committedSpatialTransition) {
       sendSseEvent(reply, {
         type: "spatial_transition_committed",


### PR DESCRIPTION
## Linked issue

Closes #4678

## Why this change

- A user message is persisted before generation starts, but the Roleplay UI continued rendering its temporary optimistic ID until a later message refresh. If generation was stopped and the message was edited immediately, the first PATCH targeted that temporary ID and the edit was discarded.

## What changed

- Emit the saved user message when the generation stream opens.
- Reconcile the optimistic row with its durable server row through their existing submission ID, while preventing duplicate cache rows.
- Extend the Roleplay regression to stop generation and save the first edit before the stopped-generation refresh can resolve.
- Add the user-facing fix to the Unreleased changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated Playwright: exact stopped-generation first-edit regression passes on desktop Chromium.
- Automated Playwright: the same regression passes on mobile Chromium.
- The test also retains coverage for a delayed save with one forced transient 503 retry and for provider refusal cleanup.
- Before the fix, the exact regression failed because the edited text never reached the durable user message.
- Manual verification by Mari is intentionally pending while this PR remains a draft.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Behavioral fix only; no visual changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message synchronization after generation so newly sent messages receive their saved identifiers promptly.
  * Fixed the first edit to a newly generated message not being persisted reliably.
  * Improved handling of repeated edits, including save retries when an earlier save fails.
  * Prevented duplicate messages when temporary and saved message records are reconciled.
  * Improved message persistence during interrupted or refused generation flows.
  * Ensured edits continue to apply correctly after message metadata is updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->