### PR TITLE
Scope group cross-chat awareness to the replying character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Scoped cross-chat awareness in individual group conversations to the character currently replying (#4688).
 - Reconciled just-sent Roleplay messages with their saved IDs before editing so the first edit after stopping generation persists (#4678).
 - Retried one transient Roleplay message-edit save failure so remote sessions persist the edit without requiring another manual Save action (#4678).
 - Kept Persona tags, stats, saved statuses, avatar crops, tracker colors, and conversation settings intact across loading, editing, duplicating, restoring, and switching Personas by returning one consistent Persona API shape (#4646).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -3003,6 +3003,139 @@ test("provider concurrency errors appear in generation toasts", async ({ page },
   }
 });
 
+test("individual group awareness includes only the replying character's sibling chats", async ({
+  page,
+  request,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Individual group prompt scoping is covered on desktop.");
+
+  const suffix = Date.now().toString(36);
+  const providerRequests: Array<Record<string, unknown>> = [];
+  const providerServer = createServer((incoming, response) => {
+    const chunks: Buffer[] = [];
+    incoming.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+    incoming.on("end", () => {
+      if (incoming.method !== "POST" || incoming.url !== "/v1/chat/completions") {
+        response.writeHead(404, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: "Unexpected individual-group provider request" }));
+        return;
+      }
+      providerRequests.push(JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>);
+      response.writeHead(200, {
+        "content-type": "text/event-stream",
+        connection: "close",
+        "cache-control": "no-cache",
+      });
+      response.end(
+        [
+          `data: ${JSON.stringify({ choices: [{ index: 0, delta: { content: "Scoped reply." }, finish_reason: null }] })}`,
+          `data: ${JSON.stringify({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}`,
+          "data: [DONE]",
+          "",
+        ].join("\n\n"),
+      );
+    });
+  });
+  await new Promise<void>((resolve) => providerServer.listen(0, "127.0.0.1", resolve));
+
+  const characterIds: string[] = [];
+  const chatIds: string[] = [];
+  let connectionId = "";
+  try {
+    const address = providerServer.address();
+    if (!address || typeof address === "string") throw new Error("Individual-group provider fixture did not bind");
+
+    const connectionResponse = await request.post("/api/connections", {
+      data: {
+        name: `Individual Awareness Provider ${suffix}`,
+        provider: "custom",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        apiKey: "e2e-individual-awareness",
+        model: "individual-awareness-model",
+        maxContext: 32_768,
+      },
+    });
+    expect(connectionResponse.ok(), await connectionResponse.text()).toBeTruthy();
+    connectionId = ((await connectionResponse.json()) as { id: string }).id;
+
+    const characterNames = [`Awareness Alpha ${suffix}`, `Awareness Beta ${suffix}`];
+    for (const name of characterNames) {
+      const characterResponse = await request.post("/api/characters", {
+        data: { data: { name, description: `${name} keeps their own conversation history.` } },
+      });
+      expect(characterResponse.ok(), await characterResponse.text()).toBeTruthy();
+      characterIds.push(((await characterResponse.json()) as { id: string }).id);
+    }
+
+    const groupChatResponse = await request.post("/api/chats", {
+      data: {
+        name: `Individual Awareness Group ${suffix}`,
+        mode: "conversation",
+        characterIds,
+        connectionId,
+      },
+    });
+    expect(groupChatResponse.ok(), await groupChatResponse.text()).toBeTruthy();
+    const groupChatId = ((await groupChatResponse.json()) as { id: string }).id;
+    chatIds.push(groupChatId);
+    const metadataResponse = await request.patch(`/api/chats/${groupChatId}/metadata`, {
+      data: {
+        conversationSetupComplete: true,
+        crossChatAwareness: true,
+        enableAgents: false,
+        groupChatMode: "individual",
+        groupResponseOrder: "sequential",
+      },
+    });
+    expect(metadataResponse.ok(), await metadataResponse.text()).toBeTruthy();
+
+    const siblingSecrets = [`ALPHA_SIBLING_SECRET_${suffix}`, `BETA_SIBLING_SECRET_${suffix}`];
+    for (let index = 0; index < characterIds.length; index += 1) {
+      const siblingChatResponse = await request.post("/api/chats", {
+        data: {
+          name: `Sibling ${characterNames[index]}`,
+          mode: "conversation",
+          characterIds: [characterIds[index]],
+        },
+      });
+      expect(siblingChatResponse.ok(), await siblingChatResponse.text()).toBeTruthy();
+      const siblingChatId = ((await siblingChatResponse.json()) as { id: string }).id;
+      chatIds.push(siblingChatId);
+      const siblingMessageResponse = await request.post(`/api/chats/${siblingChatId}/messages`, {
+        data: { role: "user", content: siblingSecrets[index] },
+      });
+      expect(siblingMessageResponse.ok(), await siblingMessageResponse.text()).toBeTruthy();
+    }
+
+    await page.addInitScript(
+      (activeChatId) => localStorage.setItem("marinara-active-chat-id", activeChatId),
+      groupChatId,
+    );
+    await page.goto("/");
+    await page.locator('textarea[placeholder*="/ for commands"]').fill("What happened recently?");
+    await page.getByRole("button", { name: "Send", exact: true }).click();
+    await expect.poll(() => providerRequests.length).toBe(2);
+    await expect(page.getByRole("button", { name: "Stop generating", exact: true })).toHaveCount(0);
+
+    for (let index = 0; index < characterNames.length; index += 1) {
+      const responderPrompt = providerRequests.find((providerRequest) =>
+        JSON.stringify(providerRequest).includes(`Respond only as ${characterNames[index]}.`),
+      );
+      expect(responderPrompt, `Missing provider prompt for ${characterNames[index]}`).toBeTruthy();
+      const serializedPrompt = JSON.stringify(responderPrompt);
+      expect(serializedPrompt).toContain(siblingSecrets[index]);
+      expect(serializedPrompt).not.toContain(siblingSecrets[index === 0 ? 1 : 0]);
+    }
+  } finally {
+    await Promise.allSettled(chatIds.map((chatId) => request.delete(`/api/chats/${chatId}`)));
+    await Promise.allSettled(characterIds.map((characterId) => request.delete(`/api/characters/${characterId}`)));
+    if (connectionId) await request.delete(`/api/connections/${connectionId}`).catch(() => undefined);
+    await new Promise<void>((resolve, reject) => {
+      providerServer.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
 test("stopped and refused generations keep sent text cleared and accept the first edit", async ({ page, request }, testInfo) => {
   test.setTimeout(120_000);
   const mobile = testInfo.project.name.includes("mobile");

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1617,6 +1617,8 @@ export async function generateRoutes(app: FastifyInstance) {
         // (#3448) — set where each is computed, read after all are known.
         let conversationContextBlockValue = "";
         let conversationContextBlocksByCharacterId = new Map<string, string>();
+        let conversationCrossChatAwarenessEnabled = false;
+        let conversationScopesAwarenessToResponder = false;
         let conversationLorebookBlockValue = "";
         let conversationMemoriesBlockValue = "";
         let conversationReplyRulesBlockValue = "";
@@ -2392,6 +2394,7 @@ export async function generateRoutes(app: FastifyInstance) {
           identityFallbackPromptTemplateSources.push(conversationPromptTemplate);
           conversationContextMacroSlots = resolveConversationContextMacroSlots(conversationPromptTemplate);
           const individualConversationGroup = isGroup && promptGroupChatMode === "individual";
+          conversationScopesAwarenessToResponder = individualConversationGroup && !input.impersonate;
           const aliasedConversationPrompt = (
             individualConversationGroup
               ? conversationPromptTemplate
@@ -2503,7 +2506,8 @@ export async function generateRoutes(app: FastifyInstance) {
           // ── Cross-chat awareness: show messages from other chats this character is in ──
           // (awarenessBlock is injected later, after persona info)
           const crossChatEnabled = chatMeta.crossChatAwareness !== false; // on by default
-          if (crossChatEnabled && !input.regenerateMessageId) {
+          conversationCrossChatAwarenessEnabled = crossChatEnabled;
+          if (crossChatEnabled && !input.regenerateMessageId && !conversationScopesAwarenessToResponder) {
             const { buildAwarenessBlock } = await import("../services/conversation/awareness.service.js");
             const charNameMap = new Map<string, string>();
             for (let ci = 0; ci < characterIds.length; ci++) {
@@ -3168,7 +3172,7 @@ export async function generateRoutes(app: FastifyInstance) {
           );
         }
 
-        if (chatMode === "conversation") {
+        if (chatMode === "conversation" && !conversationScopesAwarenessToResponder) {
           convoAwarenessBlock = await mergeConversationCharacterMemories({
             chars,
             characterIds,
@@ -5274,6 +5278,40 @@ export async function generateRoutes(app: FastifyInstance) {
           // and a merged generation that may voice several characters at once
           // stays on the hand-free spectator view.
           let gameAwareMessagesForGen = await prepareConversationLorebookForResponder(targetCharId, messagesForGen);
+          if (conversationScopesAwarenessToResponder && targetCharId) {
+            let responderAwarenessBlock: string | null = null;
+            if (conversationCrossChatAwarenessEnabled && !input.regenerateMessageId) {
+              const { buildAwarenessBlock } = await import("../services/conversation/awareness.service.js");
+              responderAwarenessBlock = await buildAwarenessBlock(
+                app.db,
+                input.chatId,
+                [targetCharId],
+                new Map(charInfo.map((character) => [character.id, character.name])),
+                personaName,
+                input.userMessage ?? "",
+                1500,
+                promptTimeZone,
+                wrapFormat,
+              );
+            }
+            responderAwarenessBlock = await mergeConversationCharacterMemories({
+              chars,
+              characterIds: [targetCharId],
+              awarenessBlock: responderAwarenessBlock,
+              timeZone: promptTimeZone,
+              wrapFormat,
+            });
+            if (responderAwarenessBlock) {
+              gameAwareMessagesForGen = [...gameAwareMessagesForGen];
+              const firstUserIdx = gameAwareMessagesForGen.findIndex(
+                (message) => message.role === "user" || message.role === "assistant",
+              );
+              gameAwareMessagesForGen.splice(firstUserIdx >= 0 ? firstUserIdx : gameAwareMessagesForGen.length, 0, {
+                role: "system",
+                content: responderAwarenessBlock,
+              });
+            }
+          }
           if (turnGameContextForSeat) {
             const viewerSeatId = input.impersonate
               ? chat.personaId || "human"


### PR DESCRIPTION
## Linked issue

Closes #4688

## Why this change

- Individual-mode group conversations built one cross-chat awareness block from the entire cast before the responder loop. Every character therefore received sibling-chat context belonging only to other characters.

## What changed

- Defer awareness assembly for individual group turns until the replying character is known.
- Build the awareness and character-memory block using only that responder ID.
- Preserve shared awareness behavior for merged groups and impersonation.
- Add a provider-capture regression that verifies each character receives their own sibling-chat context and excludes the other character’s context.
- Add the user-facing fix to the Unreleased changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm regression:prompt`
- `pnpm check`
- Playwright desktop Chromium: `individual group awareness includes only the replying character’s sibling chats`
- Before the fix, the captured Alpha prompt contained Beta’s unique sibling-chat secret. After the fix, both provider requests contain only the replying character’s corresponding secret.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Prompt assembly behavior only; no visual changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved group conversations using individual response mode by limiting cross-chat context and character memories to the character currently replying.
  * Other conversation modes continue to use shared conversation awareness.

* **Bug Fixes**
  * Prevented characters from receiving unrelated sibling-chat information during group responses.

* **Tests**
  * Added end-to-end coverage verifying character-specific context isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->