### PR TITLE
fix(autonomous): poll lightweight candidate ids instead of the full chat list every 30s

### DIFF
--- a/packages/client/src/hooks/use-autonomous-messaging.ts
+++ b/packages/client/src/hooks/use-autonomous-messaging.ts
@@ -14,7 +14,6 @@ import { useChatStore } from "../stores/chat.store";
 import { useUIStore, type UserStatus } from "../stores/ui.store";
 import { useGenerate } from "./use-generate";
 import { chatKeys } from "./use-chats";
-import { characterKeys } from "./use-characters";
 
 interface AutonomousCheckResult {
   shouldTrigger: boolean;
@@ -141,8 +140,15 @@ export function useAutonomousMessaging(
           userStatus: toAutonomousPresenceStatus(userStatus),
         });
 
-        // Refresh character data so sidebar status dots update
-        qc.invalidateQueries({ queryKey: characterKeys.list() });
+        // No per-tick character-list invalidation here (#4704): it refetched
+        // the full character list every 30s but never served its stated
+        // purpose — the sidebar status dots read ["characters","summaries"],
+        // which this key doesn't match. Dot freshness actually comes from
+        // chat-metadata status snapshots/overrides plus the summaries query's
+        // staleTime and focus refetches (ConversationPresenceCard's signature
+        // invalidation targets the same mismatched list() key, so it doesn't
+        // refresh the dots either); generation completions invalidate the
+        // character list independently.
 
         if (result.shouldTrigger && result.characterIds.length > 0) {
           const characterId = result.characterIds[0]!;

--- a/packages/client/src/hooks/use-background-autonomous.ts
+++ b/packages/client/src/hooks/use-background-autonomous.ts
@@ -9,7 +9,7 @@ import { useEffect, useRef } from "react";
 import { normalizeAvatarCrop, type AvatarCrop, type Chat, type Message } from "@marinara-engine/shared";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { api } from "../lib/api-client";
+import { api, ApiError } from "../lib/api-client";
 import { shouldSuppressAutonomousMessages, toAutonomousPresenceStatus } from "../lib/user-status";
 import { useChatStore } from "../stores/chat.store";
 import { useUIStore } from "../stores/ui.store";
@@ -57,6 +57,47 @@ function parseMeta(chat: RawChat): Record<string, unknown> {
 }
 
 /**
+ * Fetch the ids of chats eligible for background autonomous messaging.
+ *
+ * Prefers the lightweight server-filtered endpoint (#4704). Falls back to the
+ * legacy full-list fetch with local filtering when the endpoint is missing or
+ * returns an unexpected shape (an older server routes the path to GET /:id),
+ * so a new client against an old server keeps working instead of going
+ * silently dead. A definitive 404 latches the fallback for the session so we
+ * don't pay a guaranteed-404 round-trip on every tick; transient errors keep
+ * retrying, and a page reload after a server upgrade resets the latch.
+ */
+let candidatesEndpointUnavailable = false;
+
+async function fetchAutonomousCandidates(): Promise<Array<{ id: string }>> {
+  if (!candidatesEndpointUnavailable) {
+    try {
+      const candidates = await api.get<Array<{ id: string }>>("/chats/autonomous-candidates");
+      if (Array.isArray(candidates) && candidates.every((entry) => entry && typeof entry.id === "string")) {
+        return candidates;
+      }
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 404) {
+        candidatesEndpointUnavailable = true;
+        console.debug("[background-autonomous] Server predates /chats/autonomous-candidates; using legacy chat-list polling");
+      }
+      // Fall through to the legacy path either way.
+    }
+  }
+  const allChats = await api.get<RawChat[]>("/chats");
+  return allChats.filter((chat) => {
+    if (chat.mode !== "conversation") return false;
+    try {
+      const meta = parseMeta(chat);
+      if (meta.internalAssistant === "professor-mari") return false;
+      return !!meta.autonomousMessages;
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
  * Background polling for autonomous messages on inactive conversation chats.
  * Fetches the chat list on each tick so the effect doesn't depend on
  * external React state (which would reset the timer on every re-render).
@@ -84,29 +125,25 @@ export function useBackgroundAutonomousPolling() {
 
       const activeChatId = useChatStore.getState().activeChatId;
 
-      // Fetch the current chat list directly from the API each tick.
-      // This avoids the effect depending on useChats() data which would
-      // cause frequent timer restarts.
-      let allChats: RawChat[];
+      // Fetch only the autonomous-candidate chat ids (server-filtered, #4704) —
+      // the previous full /chats fetch materialized and serialized every chat
+      // (plus ran the DM-cleanup scans) every 30 seconds. Fetching directly
+      // rather than via useChats() also keeps the effect free of data deps
+      // that would restart the timer.
+      let candidateChats: Array<{ id: string }>;
       try {
-        allChats = await api.get<RawChat[]>("/chats");
+        candidateChats = await fetchAutonomousCandidates();
       } catch {
         schedulePoll();
         return;
       }
 
-      // Find conversation chats with autonomous messaging enabled, excluding active chat
-      const backgroundChats = allChats.filter((chat) => {
+      // Client-side exclusions the server can't know: the open chat and
+      // chats we're already generating for.
+      const backgroundChats = candidateChats.filter((chat) => {
         if (chat.id === activeChatId) return false;
         if (generatingForRef.current.has(chat.id)) return false;
-        if (chat.mode !== "conversation") return false;
-        try {
-          const meta = parseMeta(chat);
-          if (meta.internalAssistant === "professor-mari") return false;
-          return !!meta.autonomousMessages;
-        } catch {
-          return false;
-        }
+        return true;
       });
 
       const userStatus = useUIStore.getState().userStatus;

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -125,6 +125,10 @@ import {
 } from "../services/generation/roleplay-summary-runtime.js";
 import { resolveLorebookTokenBudget } from "../services/generation/lorebook-generation-runtime.js";
 import { resolveGameGmPromptTemplate } from "../services/generation/game-gm-prompt-runtime.js";
+import {
+  isBackgroundAutonomousCandidate,
+  hasRoleplayDmThreadMarkers,
+} from "../services/conversation/autonomous-candidates.js";
 
 type TrackerWrapFormat = "xml" | "markdown" | "none";
 type EntryStateOverrides = Record<string, { ephemeral?: number | null; enabled?: boolean }>;
@@ -628,6 +632,28 @@ export async function chatsRoutes(app: FastifyInstance) {
     await cleanupEmptyRoleplayDmChats();
     const chats = await storage.list();
     return chats.filter((chat) => !shouldHideProfessorMariChat(chat)).map(normalizeChatForResponse);
+  });
+
+  // Lightweight candidate ids for the background-autonomous poller (#4704):
+  // the poller only needs ids, so skip the full-list materialization,
+  // metadata serialization, and DM-cleanup scans the / route performs.
+  // Static path — Fastify prefers it over GET /:id.
+  app.get("/autonomous-candidates", async () => {
+    const chats = await storage.list();
+    const candidates = chats.filter(isBackgroundAutonomousCandidate);
+    // Exclude EMPTIED Roleplay DM threads: the legacy poll's GET /chats ran
+    // cleanupEmptyRoleplayDmChats as a side effect, and an emptied thread with
+    // stale in-memory activity state could otherwise receive an autonomous
+    // message, permanently exempting it from cleanup. countMessages runs only
+    // for DM-marker candidates, so the scan cost this route avoids stays avoided.
+    const eligible = [];
+    for (const chat of candidates) {
+      if (hasRoleplayDmThreadMarkers(parseChatMetadata(chat.metadata))) {
+        if ((await storage.countMessages(chat.id)) === 0) continue;
+      }
+      eligible.push({ id: chat.id });
+    }
+    return eligible;
   });
 
   app.get("/internal/professor-mari/chats", async () => {

--- a/packages/server/src/services/conversation/autonomous-candidates.ts
+++ b/packages/server/src/services/conversation/autonomous-candidates.ts
@@ -1,0 +1,35 @@
+/**
+ * Background-autonomous candidate filter (#4704): conversation chats with
+ * autonomous messaging enabled, excluding the Professor Mari home assistant.
+ * Mirrors the client-side legacy filter in use-background-autonomous.ts (kept
+ * there as the old-server fallback) — the two must stay in sync. Kept as a
+ * pure predicate so the /chats/autonomous-candidates route and the regression
+ * suite share one definition. Unparseable or missing metadata disqualifies.
+ */
+/**
+ * Roleplay DM threads are garbage-collected when emptied (see
+ * cleanupEmptyRoleplayDmChats in chats.routes.ts). The candidates route must
+ * exclude EMPTY chats carrying these markers: the legacy poll path ran the
+ * cleanup as a GET /chats side effect, and without that an emptied DM thread
+ * with stale in-memory activity state could receive an autonomous message —
+ * permanently exempting it from cleanup. Same marker expression as the
+ * cleanup; keep the two in sync.
+ */
+export function hasRoleplayDmThreadMarkers(metadata: Record<string, unknown>): boolean {
+  return metadata.roleplayDmThread === true || typeof metadata.dmOriginChatId === "string";
+}
+
+export function isBackgroundAutonomousCandidate(chat: { mode?: string | null; metadata?: unknown }): boolean {
+  if (chat.mode !== "conversation") return false;
+  const raw = chat.metadata;
+  if (!raw) return false;
+  let meta: Record<string, unknown>;
+  try {
+    meta = typeof raw === "string" ? (JSON.parse(raw) as Record<string, unknown>) : (raw as Record<string, unknown>);
+  } catch {
+    return false;
+  }
+  if (!meta || typeof meta !== "object") return false;
+  if (meta.internalAssistant === "professor-mari") return false;
+  return !!meta.autonomousMessages;
+}

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -5821,4 +5821,50 @@ try {
   );
 }
 
+{
+  // #4704: the background-autonomous poller's server-side candidate filter
+  // must mirror the legacy client filter exactly (conversation mode with
+  // autonomousMessages enabled, excluding the Professor Mari home assistant;
+  // bad or missing metadata disqualifies).
+  const { isBackgroundAutonomousCandidate } = await import(
+    "../../packages/server/src/services/conversation/autonomous-candidates.js"
+  );
+  const meta = (extra: Record<string, unknown>) => JSON.stringify({ autonomousMessages: true, ...extra });
+  assert.equal(isBackgroundAutonomousCandidate({ mode: "conversation", metadata: meta({}) }), true);
+  assert.equal(
+    isBackgroundAutonomousCandidate({ mode: "conversation", metadata: { autonomousMessages: true } }),
+    true,
+    "object metadata accepted",
+  );
+  assert.equal(isBackgroundAutonomousCandidate({ mode: "roleplay", metadata: meta({}) }), false, "non-conversation excluded");
+  assert.equal(
+    isBackgroundAutonomousCandidate({ mode: "conversation", metadata: meta({ internalAssistant: "professor-mari" }) }),
+    false,
+    "Professor Mari home chat excluded",
+  );
+  assert.equal(
+    isBackgroundAutonomousCandidate({ mode: "conversation", metadata: JSON.stringify({ autonomousMessages: false }) }),
+    false,
+    "autonomous disabled excluded",
+  );
+  assert.equal(
+    isBackgroundAutonomousCandidate({ mode: "conversation", metadata: "{not json" }),
+    false,
+    "unparseable metadata excluded",
+  );
+  assert.equal(isBackgroundAutonomousCandidate({ mode: "conversation" }), false, "missing metadata excluded");
+
+  // The candidates route excludes EMPTIED Roleplay DM threads (the legacy poll
+  // ran the DM cleanup as a GET /chats side effect); the marker expression must
+  // stay in sync with cleanupEmptyRoleplayDmChats.
+  const { hasRoleplayDmThreadMarkers } = await import(
+    "../../packages/server/src/services/conversation/autonomous-candidates.js"
+  );
+  assert.equal(hasRoleplayDmThreadMarkers({ roleplayDmThread: true }), true);
+  assert.equal(hasRoleplayDmThreadMarkers({ dmOriginChatId: "chat-1" }), true);
+  assert.equal(hasRoleplayDmThreadMarkers({ roleplayDmThread: false }), false);
+  assert.equal(hasRoleplayDmThreadMarkers({ dmOriginChatId: 42 }), false, "non-string origin id is not a marker");
+  assert.equal(hasRoleplayDmThreadMarkers({}), false);
+}
+
 console.info("Open-issue regressions passed.");


### PR DESCRIPTION
<!-- Target branch: `staging`. -->

## Linked issue

Closes #4704 (from the Termux battery follow-up audit; related: #4629/#4643 fixed the extension-poll half, #4705 covers the server-side scheduler sweep)

## Why this change

The background-autonomous poller fetched the **full `/chats` list every 30 seconds on every open client**, even with zero autonomous chats — and each of those GETs also ran the empty-DM-cleanup pass (an O(total-messages) `countMessages` scan per DM thread on the file-native store). On a Termux self-host the phone pays both the radio and the server CPU for that, forever. It was the heaviest remaining idle network cost after #4643.

## What changed

- **New `GET /chats/autonomous-candidates`** — returns only `[{ id }]` for conversation chats with autonomous messaging enabled (excluding the Professor Mari home assistant), via a pure predicate (`services/conversation/autonomous-candidates.ts`) shared with the regression suite. No full-list serialization, no cleanup scans. Static path, so Fastify prefers it over `GET /:id`.
- **Empty-DM-thread guard** — the legacy poll's `GET /chats` ran `cleanupEmptyRoleplayDmChats` as a side effect; without it, an emptied DM thread with stale in-memory activity state could receive an autonomous message and permanently exempt itself from cleanup. The route excludes zero-message chats carrying the DM markers (`countMessages` runs only for DM-marker candidates, so the scan cost the endpoint exists to avoid stays avoided). Marker expression mirrors the cleanup's, with a sync-note comment on both sides.
- **Poller swap** (`use-background-autonomous.ts`) — same 30s cadence (cross-device discovery unchanged at ≤1 tick), same client-side exclusions (active chat, in-flight generations). Against pre-#4704 servers it **falls back to the legacy full-list fetch** with identical local filtering; a definitive 404 latches the fallback for the session (transient errors keep retrying; reload after a server upgrade resets it), with a one-time `console.debug` note.
- **Removed the mis-wired per-tick invalidation** (`use-autonomous-messaging.ts`) — it refetched the full character list every 30s during open autonomous conversations, but its stated purpose (sidebar status dots) reads `["characters","summaries"]`, which the invalidated key never matched. Dot freshness actually comes from chat-metadata status snapshots plus the summaries query's staleTime/focus refetches.

**Review provenance:** the fix design was red-teamed before implementation (including an explicit trace proving message-edit persistence is fully independent of this poll — the concern is answered in #4704), and the implementation then went through a second adversarial review that found 3 issues, all fixed here: the empty-DM cleanup dependency (the old poll was accidentally load-bearing), the fallback lacking a 404 latch, and a wrong comment. Zero findings refuted.

**Known pre-existing (not fixed here):** `ConversationPresenceCard`'s signature invalidation targets the same mismatched `characterKeys.list()` key — flagged during review; happy to file/fix separately.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated/scripted checks already performed (green):

- `pnpm check` (lint + production build) — run twice (post-implementation, post-review-fixes)
- `regression:issues` open-issues lane — passes with new cases for the candidate predicate (mode/metadata/Mari/unparseable) and the DM-marker helper
- **Live on the built app**: the poller's first tick hits `GET /api/chats/autonomous-candidates` (zero legacy `/chats` calls observed); direct probe returns `200` with the `[{id}]` shape (empty array on a no-autonomous install, which the shape check accepts without falling back); hidden-tab gating still skips ticks

Still to verify manually (please tick above once done):

1. A chat with autonomous messages enabled still receives background messages (≤30s discovery), with notification/badge/toast behavior unchanged.
2. DND: presence still propagates to candidate chats while suppressed.
3. Against an older server build (or by renaming the route): background autonomous still works via the fallback, and the console shows the one-time legacy-fallback debug line.
4. Roleplay DM flow: emptied DM threads still get cleaned up on normal navigation, and no autonomous message ever lands in an emptied thread.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing docs cover the polling internals; no version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved background autonomous messaging to identify eligible conversations more efficiently.
  * Added filtering to exclude inactive, empty, malformed, or unsupported conversations.
  * Added fallback behavior when the optimized candidate lookup is unavailable.

* **Bug Fixes**
  * Prevented unnecessary character-list refreshes during autonomous messaging checks.

* **Tests**
  * Added coverage for candidate eligibility and Roleplay conversation detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->