### PR TITLE
fix(client): move the secret-plot reader off the shared chat-messages query

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -128,7 +128,7 @@ import {
   useChats,
   useConnectChat,
   useDisconnectChat,
-  useChatMessages,
+  useChatMessagePeek,
   useChatMemories,
   useDeleteChatMemory,
   useClearChatMemories,
@@ -1647,14 +1647,20 @@ export function ChatSettingsDrawer({
     8,
     100,
   );
-  const secretPlotMessagesQuery = useChatMessages(
+  // #4721: this reader must NOT observe the shared chatKeys.messages infinite
+  // query — pageSize lives in that query's option closures (not its key), so a
+  // second observer with pageSize 100 hijacks the transcript's queryFn and
+  // getNextPageParam: refetches fetch 100 rows regardless of the user's
+  // messages-per-page and hasNextPage mis-evaluates, hiding "Load More". The
+  // peek hook keys by limit and returns the same newest-N window.
+  const secretPlotMessagesQuery = useChatMessagePeek(
     chat.id,
     100,
     open && directorActive && supportsNarrativeDirectorSecretPlot && narrativeDirectorSecretPlotEnabled,
   );
   const secretPlotMessages = useMemo<Message[]>(
-    () => secretPlotMessagesQuery.data?.pages.flat() ?? [],
-    [secretPlotMessagesQuery.data?.pages],
+    () => secretPlotMessagesQuery.data ?? [],
+    [secretPlotMessagesQuery.data],
   );
   const illustratorIncludeCharacterAppearance =
     typeof metadata.illustratorIncludeCharacterAppearance === "boolean"

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -301,11 +301,16 @@ export function useChatMessages(chatId: string | null, pageSize: number = 0, ena
 }
 
 /**
- * Last few messages of a chat, for read-only previews (sidebar hover peek).
+ * Newest messages of a chat as one flat window, for read-only consumers
+ * (sidebar hover peek, the Director secret-plot panel).
  *
  * Deliberately does NOT share `chatKeys.messages` — that key ignores page size, so writing
  * a short slice into it would leave ChatArea's paginated view starting from a truncated
- * cache the next time that chat is opened.
+ * cache the next time that chat is opened. The reverse direction is just as important
+ * (#4721): merely OBSERVING the shared key with a different pageSize overwrites the
+ * transcript query's option closures (queryFn limit, getNextPageParam), because React
+ * Query keeps one options set per key and the last observer wins. Read-only windows
+ * belong here, keyed by their limit.
  */
 export function useChatMessagePeek(chatId: string | null, limit = 4, enabled = false) {
   return useQuery({
@@ -1046,6 +1051,9 @@ export function useCreateMessage(chatId: string | null) {
     onSuccess: () => {
       if (chatId) {
         qc.invalidateQueries({ queryKey: chatKeys.messages(chatId) });
+        // Peek windows (sidebar hover, secret-plot panel) cache the same rows
+        // under their own limit-keyed queries — keep them live too (#4721).
+        qc.invalidateQueries({ queryKey: chatKeys.messagePeek(chatId) });
         qc.invalidateQueries({ queryKey: chatKeys.messageCount(chatId) });
         qc.invalidateQueries({ queryKey: chatKeys.list() });
         qc.invalidateQueries({ queryKey: lorebookKeys.active(chatId) });
@@ -1061,6 +1069,7 @@ export function useDeleteMessage(chatId: string | null) {
     onSuccess: () => {
       if (chatId) {
         qc.invalidateQueries({ queryKey: chatKeys.messages(chatId) });
+        qc.invalidateQueries({ queryKey: chatKeys.messagePeek(chatId) });
         qc.invalidateQueries({ queryKey: chatKeys.messageCount(chatId) });
         qc.invalidateQueries({ queryKey: chatKeys.list() });
         qc.invalidateQueries({ queryKey: lorebookKeys.active(chatId) });
@@ -1076,6 +1085,7 @@ export function useDeleteMessages(chatId: string | null) {
     onSuccess: () => {
       if (chatId) {
         qc.invalidateQueries({ queryKey: chatKeys.messages(chatId) });
+        qc.invalidateQueries({ queryKey: chatKeys.messagePeek(chatId) });
         qc.invalidateQueries({ queryKey: chatKeys.messageCount(chatId) });
         qc.invalidateQueries({ queryKey: chatKeys.list() });
         qc.invalidateQueries({ queryKey: lorebookKeys.active(chatId) });
@@ -1149,6 +1159,7 @@ export function useUpdateMessage(chatId: string | null) {
         const { streamingChatId, isStreaming } = useChatStore.getState();
         if (isStreaming && streamingChatId === chatId) return;
         qc.invalidateQueries({ queryKey: chatKeys.messages(chatId) });
+        qc.invalidateQueries({ queryKey: chatKeys.messagePeek(chatId) });
         qc.invalidateQueries({ queryKey: lorebookKeys.active(chatId) });
       }
     },

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -742,6 +742,10 @@ async function refreshMessagesAuthoritatively(
   // Also refresh the total message count used for absolute numbering
   qc.invalidateQueries({ queryKey: chatKeys.messageCount(chatId) });
   qc.invalidateQueries({ queryKey: lorebookKeys.active(chatId) });
+  // Peek windows (sidebar hover, secret-plot panel) cache the same rows under
+  // their own limit-keyed queries; a mounted panel must not keep serving a
+  // pre-generation snapshot (#4721).
+  qc.invalidateQueries({ queryKey: chatKeys.messagePeek(chatId) });
 
   // Forced refreshes run in their own coalescing lane so a rare recovery
   // caller is never folded into a routine run that would skip the fetch.

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -5961,4 +5961,36 @@ try {
   assert.equal(hasRoleplayDmThreadMarkers({}), false);
 }
 
+{
+  // #4721: the chat transcript's infinite query keys ONLY by chat id — its
+  // pageSize lives in the option closures, so ANY second observer with a
+  // different pageSize hijacks the transcript's queryFn/getNextPageParam
+  // (last observer wins in React Query). The Chat Settings drawer's
+  // secret-plot reader did exactly that with a hardcoded 100: while the
+  // drawer was open, transcript refetches ignored the user's
+  // messages-per-page and "Load More" vanished on a mis-evaluated
+  // hasNextPage. Read-only newest-N windows must go through the peek hook,
+  // which keys by limit.
+  const drawerSource = readFileSync(
+    join(REPOSITORY_ROOT, "packages/client/src/components/chat/ChatSettingsDrawer.tsx"),
+    "utf8",
+  );
+  assert.doesNotMatch(
+    drawerSource,
+    /useChatMessages\(/u,
+    "Chat Settings must not observe the shared chatKeys.messages infinite query (#4721)",
+  );
+  assert.match(
+    drawerSource,
+    /useChatMessagePeek\(\s*chat\.id,\s*100,/u,
+    "The secret-plot reader must fetch its newest-100 window through the limit-keyed peek hook",
+  );
+  const useChatsSource = readFileSync(join(REPOSITORY_ROOT, "packages/client/src/hooks/use-chats.ts"), "utf8");
+  assert.match(
+    useChatsSource,
+    /queryKey: \[\.\.\.chatKeys\.messagePeek\(chatId \?\? ""\), limit\]/u,
+    "The peek hook's query key must include its limit so different windows never share options",
+  );
+}
+
 console.info("Open-issue regressions passed.");


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #4721

## Why this change

- The chat transcript's infinite query keys only by chat id — its page size lives in the query's **option closures** (`queryFn`, `getNextPageParam`), not in the key. React Query keeps one options set per key, and the last observer to render wins. The Chat Settings drawer's Director secret-plot reader mounted a second observer on that same key with a hardcoded `pageSize: 100`, so while the drawer was open (its `enabled` gate doesn't matter — observers write options regardless), transcript refetches fetched 100-row pages regardless of the user's messages-per-page, `ChatArea`'s defensive trim then discarded the surplus rows, and `hasNextPage` mis-evaluated (`lastPage.length < 100` for 20-row pages → `undefined`) — hiding **Load More** while older history still existed.

## What changed

- [`ChatSettingsDrawer.tsx`](packages/client/src/components/chat/ChatSettingsDrawer.tsx): the secret-plot reader now uses **`useChatMessagePeek(chat.id, 100, …)`** — the existing limit-keyed, read-only newest-window hook (same endpoint and window, key includes the limit so different windows can never share options). No new machinery; the panel consumes the same newest-100 messages as before. A comment at the call site documents why the shared key is off-limits for feature readers.
- [`use-chats.ts`](packages/client/src/hooks/use-chats.ts): the peek hook's doc comment now covers both directions of the trap — writing a short window into the shared key *and* merely observing it with a different page size.
- [`open-issues.regression.ts`](scripts/regressions/open-issues.regression.ts): a source-scan pin — the drawer must not observe the shared messages query, the secret-plot reader must go through the limit-keyed peek, and the peek's key must keep including its limit.
- **Peek liveness** (from this change's adversarial review): the peek caches were invalidated nowhere, so a message landing while a peek consumer stayed mounted (desktop generation continuing under the non-modal drawer) would leave the secret-plot panel one turn behind — and a Regenerate would then anchor `forMessageId` on the older assistant message, silently re-plotting against truncated history. The authoritative post-generation refresh and the message create/edit/delete mutations now invalidate `chatKeys.messagePeek(chatId)` alongside `chatKeys.messages(chatId)` (the sidebar hover peek benefits identically).

The review sweep also confirmed the **tracker panel** carries the same mis-share (hardcoded `pageSize: 20` vs a non-default messages-per-page) — pre-existing and on a different surface, so it's filed separately as #4724 rather than expanded into this PR.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Verified on the production build with a 60-message chat at messages-per-page 20 and a fetch-wrapper request counter:

- The exact defect vector: with Chat Settings **open**, a stale reconnect refetch of the transcript fires at **`limit=20`** (previously the drawer's 100-closure could own the shared options) with zero `limit=100` requests, and **Load More stays visible**.
- Load More with the drawer open walks the correct 20-row cursor (`before=…|41` → messages 21–40) with no gap.
- Opening the drawer triggers no message fetches when the secret-plot gate is off.

Still to verify manually (contributor to-do):
- Manually verify the Director secret-plot panel in a chat with the Director agent active and secret plot enabled: the panel lists recent messages and plot generation still works (the reader now goes through the peek query; same window, same order).

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing docs impact — internal query-wiring fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chat Settings reliability when loading recent secret-plot messages.
  * Ensured newly created, deleted, or updated messages appear promptly in recent-message views.
  * Refreshed recent messages automatically after content generation.

* **Tests**
  * Added regression coverage to verify recent-message loading and cache refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->