### PR TITLE
fix: clear stale conversationCommandContent when message content is edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Made edits to Conversation replies that contained character commands reach the model instead of the original wording (#4728).
 - Kept the full desktop Roleplay edit checkmark above overlapping message layers so its entire visible hit target remains clickable (#4700).
 - Made the Windows launcher and installer detect Node.js by running it directly instead of requiring `where.exe` (#4701).
 - Added the standard expanded editor and macro guide controls to Roleplay summary editors (#4710).

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -1040,7 +1040,25 @@ export function createChatsStorage(db: DB) {
     async updateMessageContent(id: string, content: string) {
       return withPatchQueue(messageExtraPatchQueues, id, async () => {
         const existing = await this.getMessage(id);
-        await db.update(messages).set({ content }).where(eq(messages.id, id));
+
+        // Conversation-mode prompt history prefers `conversationCommandContent` (the raw
+        // reply before command stripping) over `content`, so a rewrite of the visible text
+        // must also drop the stale raw copy or the edit never reaches the model. Command-only
+        // anchors keep theirs: their `content` is empty by design and the raw copy is the
+        // message's only text. Written directly rather than via updateMessageExtra, which
+        // shares this queue key and would deadlock.
+        const existingExtra = parseExtraRecord(existing?.extra);
+        const clearCommandContent =
+          typeof existingExtra.conversationCommandContent === "string" &&
+          existingExtra.conversationCommandContent.trim() !== "" &&
+          existingExtra.commandOnly !== true &&
+          content !== (existing?.content ?? "");
+
+        const messagePatch: Record<string, unknown> = { content };
+        if (clearCommandContent) {
+          messagePatch.extra = JSON.stringify({ ...existingExtra, conversationCommandContent: null });
+        }
+        await db.update(messages).set(messagePatch).where(eq(messages.id, id));
         if (existing) {
           await invalidateMemoryChunksFrom(db, existing.chatId, existing.createdAt);
         }
@@ -1050,7 +1068,12 @@ export function createChatsStorage(db: DB) {
           const swipes = await this.getSwipes(id);
           const activeSwipe = swipes.find((s: any) => s.index === msg.activeSwipeIndex);
           if (activeSwipe) {
-            await db.update(messageSwipes).set({ content }).where(eq(messageSwipes.id, activeSwipe.id));
+            const swipePatch: Record<string, unknown> = { content };
+            if (clearCommandContent) {
+              const swipeExtra = parseExtraRecord(activeSwipe.extra);
+              swipePatch.extra = JSON.stringify({ ...swipeExtra, conversationCommandContent: null });
+            }
+            await db.update(messageSwipes).set(swipePatch).where(eq(messageSwipes.id, activeSwipe.id));
           }
         }
         return msg;

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -1071,7 +1071,15 @@ export function createChatsStorage(db: DB) {
             const swipePatch: Record<string, unknown> = { content };
             if (clearCommandContent) {
               const swipeExtra = parseExtraRecord(activeSwipe.extra);
-              swipePatch.extra = JSON.stringify({ ...swipeExtra, conversationCommandContent: null });
+              // Clear only a raw copy this swipe itself carries, and never a
+              // command-only carrier's.
+              if (
+                typeof swipeExtra.conversationCommandContent === "string" &&
+                swipeExtra.conversationCommandContent.trim() !== "" &&
+                swipeExtra.commandOnly !== true
+              ) {
+                swipePatch.extra = JSON.stringify({ ...swipeExtra, conversationCommandContent: null });
+              }
             }
             await db.update(messageSwipes).set(swipePatch).where(eq(messageSwipes.id, activeSwipe.id));
           }


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #4728

## Why this change

- Conversation-mode prompt history prefers `extra.conversationCommandContent` (the raw reply before command stripping) over `content` for assistant messages, and editing a message never cleared that field. Once a reply carried a command, edits to it never reached the model: the UI, database, and exports showed the edit while every later prompt kept sending the original wording.

## What changed

- Clear `conversationCommandContent` in `updateMessageContent` when the visible content changes, mirrored onto the active swipe row the same way `content` already is.
- Keep the field on no-op saves and on hidden `commandOnly` anchor messages, whose `content` is empty by design and whose only text is this field.
- Apply the clear with direct `db.update` writes inside the existing patch-queue section, since `withPatchQueue` is not re-entrant and a nested `updateMessageExtra` call would deadlock.
- Preserve per-swipe extras and untouched swipes' raw text. Continue, regeneration, and game-mode paths are unaffected.
- Prose-guardian rewrites, which apply through the same function, now reach prompt history too.
- Edited messages lose their command markers in the model-visible transcript. The commands themselves already executed at generation time.
- Add the user-facing fix to the Unreleased changelog.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Edited a Conversation reply carrying a `[schedule_update]` raw copy through the chat UI on a local test build. The edit persisted to `content`, its `conversationCommandContent` was cleared, and an untouched command reply in the same chat kept its raw copy.
- Drove the patched storage layer and prompt formatter directly: an edit to a command reply returns the edited text in Conversation prompt history, a no-op save keeps the raw copy, `commandOnly` anchors keep theirs, swipe-then-edit follows the edit while swiping back restores the untouched swipe's raw text, and Roleplay behavior is unchanged.
- `pnpm check`, `regression:regeneration-context`, `regression:prompt`, and `regression:conversation-summary` pass locally.
- Peek Prompt on a reply generated after an edit no longer contains the deleted wording.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->

No UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Edited conversation replies containing character commands now send the updated wording to the model.
  * Updated message content no longer retains stale command data, keeping active conversation variations synchronized.
* **Documentation**
  * Added an Unreleased changelog entry describing the conversation reply behavior improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->