### PR TITLE
Fix NovelAI style plate and setup dropdown follow-up regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept NovelAI V4.5 style-plate uploads inside the Connection editor by decoding oversized images directly to a bounded preview and avoiding redundant copies of their encoded data (#4748).
+- Replaced the Windows Chromium native Connection and Preset popups in new Conversation and Roleplay setup with readable themed selectors (#4750).
 - Kept explicitly disabled Boolean preset choices empty instead of injecting their first option into prompts (#4740).
 - Resolved current DeepSeek, MiMo, GLM, and Kimi output limits through NanoGPT, OpenRouter, and custom OAI-compatible connections, and stopped Professor Mari before executing tool calls from truncated output (#4741).
 - Sent explicit OpenRouter prompt-caching markers for every compatible model, including Gemini, instead of limiting the option to Claude (#4742).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1672,11 +1672,21 @@ test("NovelAI style plate upload keeps the connection editor mounted", async ({ 
     await editor.locator('input[type="file"][accept*="image/png"]').setInputFiles({
       name: "style-plate.png",
       mimeType: "image/png",
-      buffer: readFileSync(new URL("../packages/client/public/logo.png", import.meta.url)),
+      buffer: readFileSync(new URL("../packages/client/public/sprites/mari/Mari_wave.png", import.meta.url)),
     });
 
     await expect(editor).toBeVisible();
-    await expect(editor.getByRole("img", { name: "NovelAI style plate preview" })).toBeVisible();
+    const preview = editor.getByRole("img", { name: "NovelAI style plate preview" });
+    await expect(preview).toBeVisible();
+    await expect(preview).toHaveAttribute("src", /^data:image\/jpeg;base64,/u);
+    await expect
+      .poll(async () => (await preview.getAttribute("src"))?.length ?? Number.POSITIVE_INFINITY)
+      .toBeLessThan(6 * 1024 * 1024);
+    expect(
+      await preview.evaluate((image) =>
+        Math.max((image as HTMLImageElement).naturalWidth, (image as HTMLImageElement).naturalHeight),
+      ),
+    ).toBeLessThanOrEqual(1536);
     expect(errors).toEqual([]);
   } catch (error) {
     testFailure = error;
@@ -2339,22 +2349,30 @@ test("Character Chat actions reuse mode selection and seed the chosen setup wiza
     const roleplayWizard = page.locator('[data-component="ChatSetupWizard"]');
     await expect(roleplayWizard).toBeVisible();
     await expect(roleplayWizard).toHaveClass(/mari-chat-setup-wizard/u);
-    const roleplayConnectionSelect = roleplayWizard.getByLabel("Connection", { exact: true });
-    await expect(roleplayConnectionSelect).toHaveCSS("color-scheme", "dark");
-    const [optionStyle, selectStyle] = await Promise.all([
-      roleplayConnectionSelect.locator("option").first().evaluate((option) => {
-        const style = getComputedStyle(option);
-        return { backgroundColor: style.backgroundColor, color: style.color };
-      }),
-      roleplayConnectionSelect.evaluate((select) => {
-        const style = getComputedStyle(select);
-        return { backgroundColor: style.backgroundColor, color: style.color };
-      }),
-    ]);
-    expect(optionStyle).toEqual(selectStyle);
+    const roleplayConnectionSelect = roleplayWizard.getByRole("combobox", { name: "Connection", exact: true });
+    await roleplayConnectionSelect.click();
+    const connectionListbox = roleplayWizard.getByRole("listbox", { name: "Connection", exact: true });
+    await expect(connectionListbox).toBeVisible();
+    const connectionListboxStyle = await connectionListbox.evaluate((listbox) => {
+      const style = getComputedStyle(listbox);
+      return { backgroundColor: style.backgroundColor, color: style.color };
+    });
+    expect(connectionListboxStyle.backgroundColor).not.toBe("rgb(255, 255, 255)");
+    await connectionListbox.getByRole("option", { name: "None", exact: true }).click();
+    await expect(connectionListbox).toBeHidden();
     await roleplayWizard.getByRole("button", { name: "Next", exact: true }).click();
     await expect(roleplayWizard.getByRole("heading", { name: "Pick a Preset", exact: true })).toBeVisible();
-    await expect(roleplayWizard.getByRole("combobox")).toHaveCSS("color-scheme", "dark");
+    const presetSelect = roleplayWizard.getByRole("combobox", { name: "Preset", exact: true });
+    await presetSelect.click();
+    const presetListbox = roleplayWizard.getByRole("listbox", { name: "Preset", exact: true });
+    await expect(presetListbox).toBeVisible();
+    expect(
+      await presetListbox.evaluate((listbox) => {
+        const style = getComputedStyle(listbox);
+        return { backgroundColor: style.backgroundColor, color: style.color };
+      }),
+    ).toEqual(connectionListboxStyle);
+    await presetListbox.getByRole("option", { name: "None", exact: true }).click();
     await roleplayWizard.getByRole("button", { name: "Next", exact: true }).click();
     const participantsHeading = roleplayWizard.getByRole("heading", {
       name: "Persona & Characters",

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2358,6 +2358,7 @@ test("Character Chat actions reuse mode selection and seed the chosen setup wiza
       return { backgroundColor: style.backgroundColor, color: style.color };
     });
     expect(connectionListboxStyle.backgroundColor).not.toBe("rgb(255, 255, 255)");
+    expect(connectionListboxStyle.color).not.toBe(connectionListboxStyle.backgroundColor);
     await connectionListbox.getByRole("option", { name: "None", exact: true }).click();
     await expect(connectionListbox).toBeHidden();
     await roleplayWizard.getByRole("button", { name: "Next", exact: true }).click();

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -6,6 +6,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { toast } from "sonner";
 import {
   ChevronRight,
+  ChevronDown,
   Plug,
   BookOpen,
   Check,
@@ -261,6 +262,123 @@ const WIZARD_PRIMARY_BUTTON_CLASS =
 const WIZARD_SECONDARY_BUTTON_CLASS =
   "flex items-center justify-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--foreground)] transition-all hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50";
 const CHARACTER_PICKER_PAGE_SIZE = 50;
+
+type WizardSelectOption = {
+  value: string;
+  label: string;
+};
+
+function WizardSelect({
+  id,
+  value,
+  options,
+  ariaLabel,
+  onChange,
+}: {
+  id?: string;
+  value: string;
+  options: WizardSelectOption[];
+  ariaLabel: string;
+  onChange: (value: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const listboxId = useId();
+  const selectedOption = options.find((option) => option.value === value) ?? options[0];
+
+  const focusSelectedOption = () => {
+    window.requestAnimationFrame(() => {
+      const optionButtons = rootRef.current?.querySelectorAll<HTMLButtonElement>('[role="option"]');
+      const selectedIndex = Math.max(
+        0,
+        options.findIndex((option) => option.value === value),
+      );
+      optionButtons?.[selectedIndex]?.focus();
+    });
+  };
+
+  return (
+    <div
+      ref={rootRef}
+      className="relative"
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) setOpen(false);
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && open) {
+          event.preventDefault();
+          setOpen(false);
+          triggerRef.current?.focus();
+        }
+      }}
+    >
+      <button
+        ref={triggerRef}
+        id={id}
+        type="button"
+        role="combobox"
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        onClick={() => setOpen((current) => !current)}
+        onKeyDown={(event) => {
+          if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+          event.preventDefault();
+          if (!open) setOpen(true);
+          focusSelectedOption();
+        }}
+        className={cn(WIZARD_INPUT_CLASS, "flex items-center justify-between gap-2 pr-3 text-left")}
+      >
+        <span className="min-w-0 flex-1 truncate">{selectedOption?.label}</span>
+        <ChevronDown
+          size="0.75rem"
+          className={cn("shrink-0 text-[var(--muted-foreground)] transition-transform", open && "rotate-180")}
+        />
+      </button>
+      {open && (
+        <div
+          id={listboxId}
+          role="listbox"
+          aria-label={ariaLabel}
+          className="mt-1 max-h-48 overflow-y-auto rounded-lg border border-[var(--border)] bg-[var(--secondary)] p-1 shadow-xl"
+        >
+          {options.map((option, index) => {
+            const selected = option.value === value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                role="option"
+                aria-selected={selected}
+                onClick={() => {
+                  onChange(option.value);
+                  setOpen(false);
+                  triggerRef.current?.focus();
+                }}
+                onKeyDown={(event) => {
+                  if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+                  event.preventDefault();
+                  const nextIndex =
+                    event.key === "ArrowDown" ? Math.min(options.length - 1, index + 1) : Math.max(0, index - 1);
+                  rootRef.current?.querySelectorAll<HTMLButtonElement>('[role="option"]')[nextIndex]?.focus();
+                }}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-xs text-[var(--foreground)] hover:bg-[var(--accent)]",
+                  selected && "bg-[var(--primary)]/10 text-[var(--primary)]",
+                )}
+              >
+                <span className="min-w-0 flex-1 truncate">{option.label}</span>
+                {selected && <Check size="0.75rem" className="shrink-0" />}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
 
 function readChatMetadata(chat: Chat): Record<string, unknown> {
   const raw = (chat as unknown as { metadata?: string | Record<string, unknown> }).metadata;
@@ -1127,19 +1245,16 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
 
       <div className="space-y-1.5">
         <label className={WIZARD_FIELD_LABEL}>{localizeUi("ui.chat.conversationquicksetup.connection")}</label>
-        <select
+        <WizardSelect
           value={selectedConnectionId}
-          onChange={(event) => setConnection(event.target.value || null)}
-          className={WIZARD_INPUT_CLASS}
-        >
-          <option value="">{localizeUi("ui.game.gamesurfacecomponent.none")}</option>
-          <option value="random">{localizeUi("ui.game.gamesurfacecomponent.random")}</option>
-          {connectionOptions.map((connection) => (
-            <option key={connection.id} value={connection.id}>
-              {connection.name}
-            </option>
-          ))}
-        </select>
+          ariaLabel={localizeUi("ui.chat.conversationquicksetup.connection")}
+          options={[
+            { value: "", label: localizeUi("ui.game.gamesurfacecomponent.none") },
+            { value: "random", label: localizeUi("ui.game.gamesurfacecomponent.random") },
+            ...connectionOptions.map((connection) => ({ value: connection.id, label: connection.name })),
+          ]}
+          onChange={(nextValue) => setConnection(nextValue || null)}
+        />
         {connectionOptions.length === 0 && (
           <button
             onClick={() => {
@@ -1167,18 +1282,15 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
     <div className="space-y-3">
       <div className="space-y-2">
         <label className={WIZARD_FIELD_LABEL}>{localizeUi("ui.chat.conversationquicksetup.conversationPrompt")}</label>
-        <select
+        <WizardSelect
           value={selectedPromptPresetId ?? ""}
-          onChange={(event) => setPreset(event.target.value || null)}
-          className={WIZARD_INPUT_CLASS}
-        >
-          <option value="">{localizeUi("ui.game.gamesurfacecomponent.none")}</option>
-          {promptPresetOptions.map((preset) => (
-            <option key={preset.id} value={preset.id}>
-              {preset.name}
-            </option>
-          ))}
-        </select>
+          ariaLabel={localizeUi("ui.chatSettings.conversationpromptsection.promptPreset")}
+          options={[
+            { value: "", label: localizeUi("ui.game.gamesurfacecomponent.none") },
+            ...promptPresetOptions.map((preset) => ({ value: preset.id, label: preset.name })),
+          ]}
+          onChange={(nextValue) => setPreset(nextValue || null)}
+        />
         <p className="text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
           {localizeUi("ui.chat.conversationquicksetup.thisSelectsTheConversationModePromptStoredInThe")}
         </p>
@@ -2316,20 +2428,17 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
           <label htmlFor={roleplayConnectionSelectId} className={WIZARD_FIELD_LABEL}>
             {localizeUi("ui.chat.conversationquicksetup.connection")}
           </label>
-          <select
+          <WizardSelect
             id={roleplayConnectionSelectId}
             value={chat.connectionId ?? ""}
-            onChange={(e) => setConnection(e.target.value || null)}
-            className={WIZARD_INPUT_CLASS}
-          >
-            <option value="">{localizeUi("ui.game.gamesurfacecomponent.none")}</option>
-            <option value="random">{localizeUi("ui.game.gamesurfacecomponent.random")}</option>
-            {connectionOptions.map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.name}
-              </option>
-            ))}
-          </select>
+            ariaLabel={localizeUi("ui.chat.conversationquicksetup.connection")}
+            options={[
+              { value: "", label: localizeUi("ui.game.gamesurfacecomponent.none") },
+              { value: "random", label: localizeUi("ui.game.gamesurfacecomponent.random") },
+              ...connectionOptions.map((connection) => ({ value: connection.id, label: connection.name })),
+            ]}
+            onChange={(nextValue) => setConnection(nextValue || null)}
+          />
         </div>
         {connectionOptions.length === 0 && (
           <button
@@ -2356,18 +2465,18 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
 
   function renderPreset() {
     return (
-      <select
+      <WizardSelect
         value={chat.promptPresetId ?? ""}
-        onChange={(e) => setPreset(e.target.value || null)}
-        className={WIZARD_INPUT_CLASS}
-      >
-        <option value="">{localizeUi("ui.game.gamesurfacecomponent.none")}</option>
-        {((presets ?? []) as Array<{ id: string; name: string; isDefault?: boolean | string }>).map((p) => (
-          <option key={p.id} value={p.id}>
-            {p.name}
-          </option>
-        ))}
-      </select>
+        ariaLabel={localizeUi("chat.toolbar.preset")}
+        options={[
+          { value: "", label: localizeUi("ui.game.gamesurfacecomponent.none") },
+          ...((presets ?? []) as Array<{ id: string; name: string; isDefault?: boolean | string }>).map((preset) => ({
+            value: preset.id,
+            label: preset.name,
+          })),
+        ]}
+        onChange={(nextValue) => setPreset(nextValue || null)}
+      />
     );
   }
 

--- a/packages/client/src/lib/chat-attachment-images.ts
+++ b/packages/client/src/lib/chat-attachment-images.ts
@@ -178,11 +178,27 @@ export async function prepareImageAttachment(blob: Blob, displayName = "image"):
   try {
     const encodedDimensions = readEncodedImageDimensions(new Uint8Array(await blob.arrayBuffer()));
     if (encodedDimensions) assertSafeImageDimensions(encodedDimensions);
-    bitmap = await createImageBitmap(blob);
+    const decodeSize = encodedDimensions
+      ? fitWithinEdge(encodedDimensions.width, encodedDimensions.height, IMAGE_COMPRESSION_EDGE)
+      : null;
+    const shouldResizeWhileDecoding =
+      !!decodeSize &&
+      !!encodedDimensions &&
+      (decodeSize.width !== encodedDimensions.width || decodeSize.height !== encodedDimensions.height);
+    if (shouldResizeWhileDecoding && decodeSize) {
+      bitmap = await createImageBitmap(blob, {
+        resizeWidth: decodeSize.width,
+        resizeHeight: decodeSize.height,
+        resizeQuality: "high",
+      });
+    } else {
+      bitmap = await createImageBitmap(blob);
+    }
     assertSafeImageDimensions(bitmap);
     const shouldCompress =
       shouldAlwaysConvert ||
       blob.size > IMAGE_COMPRESSION_SOURCE_BYTES ||
+      shouldResizeWhileDecoding ||
       bitmap.width > IMAGE_COMPRESSION_EDGE ||
       bitmap.height > IMAGE_COMPRESSION_EDGE;
 

--- a/packages/shared/src/constants/image-generation-defaults.ts
+++ b/packages/shared/src/constants/image-generation-defaults.ts
@@ -173,8 +173,16 @@ export function normalizeImageGenerationProfile(
   rawProfile: unknown,
   service: ImageDefaultsService,
 ): NormalizeImageGenerationProfileResult {
+  const profile = normalizeImageGenerationProfileValue(rawProfile, service);
+  return { profile, changed: JSON.stringify(profile) !== JSON.stringify(rawProfile) };
+}
+
+function normalizeImageGenerationProfileValue(
+  rawProfile: unknown,
+  service: ImageDefaultsService,
+): ImageGenerationDefaultsProfile {
   if (!isRecord(rawProfile)) {
-    return { profile: createDefaultImageGenerationProfile(service), changed: true };
+    return createDefaultImageGenerationProfile(service);
   }
 
   const profile = createDefaultImageGenerationProfile(service);
@@ -189,15 +197,14 @@ export function normalizeImageGenerationProfile(
     profile.novelai = normalizeNovelAiDefaults(rawProfile.novelai);
   }
 
-  const changed = JSON.stringify(profile) !== JSON.stringify(rawProfile);
-  return { profile, changed };
+  return profile;
 }
 
 export function sanitizeImageGenerationProfile(
   profile: ImageGenerationDefaultsProfile,
   service: ImageDefaultsService,
 ): ImageGenerationDefaultsProfile {
-  return normalizeImageGenerationProfile(profile, service).profile;
+  return normalizeImageGenerationProfileValue(profile, service);
 }
 
 export function mergePromptPrefix(prefix: string, prompt: string): string {


### PR DESCRIPTION
## Linked issues

Closes #4748
Closes #4750

## Why this change

The prior fixes did not cover the actual failure modes. NovelAI style plates were still decoded into a full-resolution browser bitmap before resizing, and the editor sanitizer compared large encoded image strings by serializing them twice. On Windows Chromium, this could destabilize the center editor. The Connection and Preset menus were still native `<select>` popups, whose Windows rendering ignores the page option colors.

## What changed

- Downsample oversized uploaded images during `createImageBitmap` decoding instead of allocating a full-size browser bitmap first.
- Keep the fast editor sanitization path free of redundant JSON serialization of encoded style-plate data.
- Replace only the new Conversation/Roleplay Connection and Preset native popups with a compact themed, keyboard-accessible in-app listbox.
- Expand the focused browser regressions to use a 1784×3228 PNG and exercise both opened setup menus.
- Add Unreleased changelog entries for both follow-up issues.

## Validation

- [ ] `pnpm check`
- [ ] Full `pnpm smoke:ui`
- [ ] Manually verify the affected paths on Windows Chromium
- [ ] Manually verify light and dark themes
- [ ] Read and followed `CONTRIBUTING.md`

Automated evidence completed: `pnpm check` passed; the full browser suite passed with 202 tests and 100 intentional viewport skips; focused desktop and mobile Chromium runs passed. All boxes remain intentionally unchecked for human verification.

Manual verification still requested: upload the original reported style plate and open both new-chat selectors on a physical Windows Chrome or Edge installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added themed, keyboard-accessible selectors for connection and preset choices during Conversation and Roleplay setup.
  * Added safe preview support for oversized NovelAI V4.5 style-plate uploads.

* **Bug Fixes**
  * Large image uploads are automatically resized and compressed when needed, improving preview reliability while enforcing size and dimension limits.
  * Improved image-generation profile normalization and handling of invalid settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->