### PR TITLE
Fix connections, Professor Mari, Tracker, and lorebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept NovelAI V4.5 style-plate file selection inside the Connection editor across Chromium platforms (#4777).
+- Deactivated and revealed lorebooks that lose their final owner, replaced Lorebook Keeper entry bodies without stacking duplicates, and added sandbox-safe structured file copy, move, and removal tools for Android/Termux (#4775).
+- Let readers scroll through Professor Mari history while her response is still streaming (#4774).
+- Replaced the browser-native single-chat deletion prompt in Professor Mari with Marinara's confirmation dialog (#4773).
+- Preserved Tracker panel controls at their configured width, kept the panel aligned beside the right sidebar, and made closing its detached window close the panel (#4772).
+- Displayed the actual error output beneath failed Professor Mari workspace tool events (#4770).
+- Quarantined an automatic-generation connection for six hours after three consecutive provider failures while keeping foreground chats available (#4769).
+- Moved smart group responder selection to the default Agent connection with Agent fallback and the connection's saved generation parameters instead of a fixed 512-token chat-connection call (#4765).
 - Shared Professor Mari's robust JSON repair waterfall with structured agents so repairable malformed or truncated output no longer wastes retries (#4753).
 - Revalidated replaceable user backgrounds so re-importing a different image under a deleted filename no longer displays stale browser-cached pixels (#4757).
 - Kept NovelAI V4.5 style-plate uploads inside the Connection editor by decoding oversized images directly to a bounded preview and avoiding redundant copies of their encoded data (#4748).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -4573,8 +4573,8 @@ test("new Roleplay chats seed character Tracker custom-field defaults without re
   }
 });
 
-test("desktop Tracker stays in the Roleplay gutter without shifting the chat column", async ({ page }, testInfo) => {
-  test.skip(!testInfo.project.name.includes("desktop"), "Desktop Tracker gutter behavior is covered on desktop.");
+test("desktop Tracker preserves its controls without shifting the chat column", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Desktop Tracker overlap behavior is covered on desktop.");
 
   // Keep this device-local layout test isolated from the shared settings
   // record used by the parallel browser project.
@@ -4642,9 +4642,10 @@ test("desktop Tracker stays in the Roleplay gutter without shifting the chat col
     expect(Math.abs(chatColumnAfter!.x - chatColumnBefore!.x)).toBeLessThanOrEqual(1);
     expect(Math.abs(chatColumnAfter!.width - chatColumnBefore!.width)).toBeLessThanOrEqual(1);
 
-    const expectedWidth = Math.min(420, Math.floor(chatColumnAfter!.x - mainBox!.x - 8));
+    const expectedWidth = Math.min(420, Math.floor(mainBox!.width - 8));
     expect(Math.abs(trackerBox!.width - expectedWidth)).toBeLessThanOrEqual(1);
-    expect(trackerBox!.x + trackerBox!.width).toBeLessThanOrEqual(chatColumnAfter!.x - 7);
+    expect(trackerBox!.x).toBeGreaterThanOrEqual(mainBox!.x - 1);
+    expect(trackerBox!.x + trackerBox!.width).toBeGreaterThan(chatColumnAfter!.x);
 
     const trackerContent = tracker.locator(".mari-tracker-panel-scroll");
     const expectedScale = Math.max(0.65, expectedWidth / 420);

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -4645,6 +4645,7 @@ test("desktop Tracker preserves its controls without shifting the chat column", 
     const expectedWidth = Math.min(420, Math.floor(mainBox!.width - 8));
     expect(Math.abs(trackerBox!.width - expectedWidth)).toBeLessThanOrEqual(1);
     expect(trackerBox!.x).toBeGreaterThanOrEqual(mainBox!.x - 1);
+    expect(trackerBox!.x).toBeLessThanOrEqual(mainBox!.x + 1);
     expect(trackerBox!.x + trackerBox!.width).toBeGreaterThan(chatColumnAfter!.x);
 
     const trackerContent = tracker.locator(".mari-tracker-panel-scroll");

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -3486,6 +3486,7 @@ export function HomeProfessorMariChat({
             chatId: chat.id,
             message: text,
             connectionId: effectiveConnectionId,
+            debugMode: useUIStore.getState().debugMode,
             attachments,
             existingUserMessageId,
           },

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -78,7 +78,10 @@ import { useAgentStore } from "../../stores/agent.store";
 import { useSidecarStore } from "../../stores/sidecar.store";
 import { useUIStore } from "../../stores/ui.store";
 import { showLocalMessageNotification, showNativeMessageNotification } from "../../lib/local-notifications";
-import { scrollProfessorMariTranscriptToBottom } from "../../lib/professor-mari-transcript-scroll";
+import {
+  isProfessorMariTranscriptNearBottom,
+  scrollProfessorMariTranscriptToBottom,
+} from "../../lib/professor-mari-transcript-scroll";
 import {
   formatCompactTokenCount,
   resolveProfessorMariContextBudget,
@@ -1383,23 +1386,30 @@ function WorkspaceToolEvent({ tool }: { tool: WorkspaceToolCall }) {
         </span>
       }
     >
-      <div
-        className={cn(
-          "inline-flex max-w-full items-center gap-1.5 rounded-lg border px-2 py-1 text-[0.7rem] leading-5 shadow-sm",
-          toolToneClasses(presentation.tone),
-          isError && "border-[var(--destructive)]/35 bg-[var(--destructive)]/10",
-        )}
-        title={presentation.detail ?? presentation.title}
-      >
-        <span className="shrink-0 rounded-full bg-[var(--background)]/70 px-1.5 py-0.5 text-[0.56rem] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
-          {presentation.eyebrow}
-        </span>
-        <span className="min-w-0 truncate font-semibold text-[var(--foreground)]">{presentation.title}</span>
-        {presentation.detail && (
-          <span className="min-w-0 truncate text-[var(--muted-foreground)]">· {presentation.detail}</span>
-        )}
-        {isError && (
-          <span className="shrink-0 text-[0.65rem] font-semibold text-[var(--destructive)]">{localizeUi("ui.chat.workspacetoolevent.needsAttention")}</span>
+      <div className="min-w-0 space-y-1.5">
+        <div
+          className={cn(
+            "inline-flex max-w-full items-center gap-1.5 rounded-lg border px-2 py-1 text-[0.7rem] leading-5 shadow-sm",
+            toolToneClasses(presentation.tone),
+            isError && "border-[var(--destructive)]/35 bg-[var(--destructive)]/10",
+          )}
+          title={presentation.detail ?? presentation.title}
+        >
+          <span className="shrink-0 rounded-full bg-[var(--background)]/70 px-1.5 py-0.5 text-[0.56rem] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+            {presentation.eyebrow}
+          </span>
+          <span className="min-w-0 truncate font-semibold text-[var(--foreground)]">{presentation.title}</span>
+          {presentation.detail && (
+            <span className="min-w-0 truncate text-[var(--muted-foreground)]">· {presentation.detail}</span>
+          )}
+          {isError && (
+            <span className="shrink-0 text-[0.65rem] font-semibold text-[var(--destructive)]">{localizeUi("ui.chat.workspacetoolevent.needsAttention")}</span>
+          )}
+        </div>
+        {isError && tool.output?.trim() && (
+          <pre className="max-h-36 overflow-y-auto whitespace-pre-wrap break-words rounded-lg border border-[var(--destructive)]/30 bg-[var(--destructive)]/8 px-2.5 py-2 text-[0.6875rem] leading-relaxed text-[var(--destructive)]">
+            {tool.output.trim()}
+          </pre>
         )}
       </div>
     </TranscriptRow>
@@ -2339,6 +2349,7 @@ export function HomeProfessorMariChat({
   const messageLoadAbortRef = useRef<AbortController | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const transcriptScrollFrameRef = useRef<number | null>(null);
+  const transcriptFollowOutputRef = useRef(true);
   const floatingSurfaceRef = useRef<HTMLDivElement>(null);
   const floatingButtonRef = useRef<HTMLDivElement>(null);
   const floatingDragRef = useRef<FloatingDragState | null>(null);
@@ -2391,6 +2402,7 @@ export function HomeProfessorMariChat({
       }
       scrollRef.current = node;
       if (!node || loadingHistory || !chatId || loadedMessagesChatId !== chatId) return;
+      transcriptFollowOutputRef.current = true;
       transcriptScrollFrameRef.current = window.requestAnimationFrame(() => {
         transcriptScrollFrameRef.current = null;
         if (scrollRef.current === node) scrollProfessorMariTranscriptToBottom(node);
@@ -2758,9 +2770,14 @@ export function HomeProfessorMariChat({
 
   useEffect(() => {
     const node = scrollRef.current;
-    if (!node) return;
+    if (!node || !transcriptFollowOutputRef.current) return;
     scrollProfessorMariTranscriptToBottom(node);
   }, [messages, workspaceTimeline, workspaceActivity, visiblePendingChangeReviewKey, workspaceStatus?.error]);
+
+  const handleTranscriptScroll = useCallback(() => {
+    const node = scrollRef.current;
+    if (node) transcriptFollowOutputRef.current = isProfessorMariTranscriptNearBottom(node);
+  }, []);
 
   const displayMessages = useMemo(() => [createWelcomeMessage(chatId), ...messages], [chatId, messages]);
 
@@ -3296,7 +3313,15 @@ export function HomeProfessorMariChat({
     async (id: string) => {
       const item = chatHistory.find((chat) => chat.id === id);
       if (!item) return;
-      if (!window.confirm(localizeUi("ui.chat.homeprofessormarichat.deleteValue1", { value1: item.name ||localizeUi("ui.chat.homeprofessormarichat.thisProfessorMariChat") }))) return;
+      const confirmed = await showConfirmDialog({
+        title: localizeUi("ui.chat.homeprofessormarichat.deleteValue1", {
+          value1: item.name || localizeUi("ui.chat.homeprofessormarichat.thisProfessorMariChat"),
+        }),
+        message: localizeUi("ui.chat.homeprofessormarichat.deleteSelectedChatsConfirmation", { count: 1 }),
+        confirmLabel: localizeUi("lorebook.editor.batch.delete"),
+        tone: "destructive",
+      });
+      if (!confirmed) return;
       try {
         await api.delete(`/chats/internal/professor-mari/chats/${id}`);
         if (id === chatId) {
@@ -3799,6 +3824,7 @@ export function HomeProfessorMariChat({
     <>
       <div
         ref={setTranscriptScrollNode}
+        onScroll={handleTranscriptScroll}
         data-component="HomeProfessorMariChat.Transcript"
         className="min-h-0 flex-1 space-y-2.5 overflow-y-auto px-3 py-3 pb-4 text-left"
       >
@@ -4442,6 +4468,7 @@ export function HomeProfessorMariChat({
 
                       <div
                         ref={setTranscriptScrollNode}
+                        onScroll={handleTranscriptScroll}
                         data-component="HomeProfessorMariChat.Transcript"
                         className="min-h-0 flex-1 space-y-2.5 overflow-y-auto px-3 py-3 pb-4 text-left"
                       >

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -2832,6 +2832,7 @@ function ImageGenerationDefaultsPanel({
 }) {
   const { t: localizeUi } = useUiTranslation();
   const activeServiceRef = useRef(service);
+  const novelAiStylePlateInputRef = useRef<HTMLInputElement>(null);
   activeServiceRef.current = service;
   const updateSeed = (seed: number) => {
     onChange({ ...value, seed });
@@ -3204,16 +3205,22 @@ function ImageGenerationDefaultsPanel({
                       <p className="text-[0.55rem] text-[var(--muted-foreground)]">{localizeUi("ui.connections.imagegenerationdefaultspanel.aPersistentStyleOnlyReferenceAppliedFirstToEvery")}</p>
                     </div>
                     <div className="flex items-center gap-2">
-                      <label className="inline-flex cursor-pointer items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]">
+                      <button
+                        type="button"
+                        onClick={() => novelAiStylePlateInputRef.current?.click()}
+                        className="inline-flex cursor-pointer items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
+                      >
                         <Upload size="0.6875rem" />
                         {novelai.styleReferenceImage ?localizeUi("settings.notifications.customSound.actions.replace") :localizeUi("ui.connections.imagegenerationdefaultspanel.chooseImage")}
-                        <input
-                          type="file"
-                          accept="image/png,image/jpeg,image/webp"
-                          className="sr-only"
-                          onChange={handleNovelAiStylePlateUpload}
-                        />
-                      </label>
+                      </button>
+                      <input
+                        ref={novelAiStylePlateInputRef}
+                        type="file"
+                        accept="image/png,image/jpeg,image/webp"
+                        className="sr-only"
+                        tabIndex={-1}
+                        onChange={handleNovelAiStylePlateUpload}
+                      />
                       {novelai.styleReferenceImage && (
                         <button
                           type="button"

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -388,6 +388,8 @@ export function AppShell() {
   const trackerPanelWidth = getTrackerPanelWidthForProfile(trackerPanelSizeProfile);
   const [trackerPanelResolvedWidth, setTrackerPanelResolvedWidth] = useState(trackerPanelWidth);
   const [trackerPanelWindowTarget, setTrackerPanelWindowTarget] = useState<TrackerPanelWindowTarget | null>(null);
+  const trackerPanelWindowTargetRef = useRef<TrackerPanelWindowTarget | null>(null);
+  const trackerPanelDockingPopupRef = useRef<TrackerPanelWindowTarget["popup"] | null>(null);
   const detachTrackerPanelPendingRef = useRef(false);
   const [trackerPanelHost] = useState(() => {
     const host = document.createElement("div");
@@ -823,17 +825,20 @@ export function AppShell() {
     !hasDetailView &&
     (!shellOverlayMode || (!sidebarOpen && !rightPanelOpen && !trackerPanelVisible));
   const trackerWindowHost = trackerPanelWindowTarget?.popup ?? window;
-  const trackerPanelDockingRef = useRef(false);
 
   const dockTrackerPanel = useCallback(() => {
-    trackerPanelDockingRef.current = true;
-    if (trackerPanelWindowTarget) closeTrackerPanelWindow(trackerPanelWindowTarget);
+    const target = trackerPanelWindowTargetRef.current;
+    if (target) {
+      trackerPanelDockingPopupRef.current = target.popup;
+      closeTrackerPanelWindow(target);
+      trackerPanelWindowTargetRef.current = null;
+    }
     setTrackerPanelWindowTarget(null);
-  }, [trackerPanelWindowTarget]);
+  }, []);
 
   const detachTrackerPanel = useCallback(async () => {
     if (detachTrackerPanelPendingRef.current) return;
-    trackerPanelDockingRef.current = false;
+    trackerPanelDockingPopupRef.current = null;
     detachTrackerPanelPendingRef.current = true;
 
     try {
@@ -845,6 +850,7 @@ export function AppShell() {
         toast.error(localizeUi("ui.layout.appshell.trackerPanelPopupBlocked"));
         return;
       }
+      trackerPanelWindowTargetRef.current = target;
       setTrackerPanelWindowTarget(target);
     } catch {
       toast.error(localizeUi("ui.layout.appshell.trackerPanelWindowFailed"));
@@ -853,12 +859,14 @@ export function AppShell() {
     }
   }, [localizeUi, trackerPanelWidth]);
 
-  const handleTrackerPanelWindowClosed = useCallback(() => {
-    setTrackerPanelWindowTarget(null);
-    if (trackerPanelDockingRef.current) {
-      trackerPanelDockingRef.current = false;
+  const handleTrackerPanelWindowClosed = useCallback((closedTarget: TrackerPanelWindowTarget) => {
+    if (trackerPanelDockingPopupRef.current === closedTarget.popup) {
+      trackerPanelDockingPopupRef.current = null;
       return;
     }
+    if (trackerPanelWindowTargetRef.current?.popup !== closedTarget.popup) return;
+    trackerPanelWindowTargetRef.current = null;
+    setTrackerPanelWindowTarget(null);
     setTrackerPanelOpen(false, activeChatId);
   }, [activeChatId, setTrackerPanelOpen]);
 
@@ -874,6 +882,7 @@ export function AppShell() {
   useEffect(() => {
     if (!trackerPanelWindowTarget || (trackerPanelActive && trackerPanelModeAvailable)) return;
     closeTrackerPanelWindow(trackerPanelWindowTarget);
+    trackerPanelWindowTargetRef.current = null;
     setTrackerPanelWindowTarget(null);
   }, [trackerPanelActive, trackerPanelModeAvailable, trackerPanelWindowTarget]);
   useEffect(() => {

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -823,14 +823,17 @@ export function AppShell() {
     !hasDetailView &&
     (!shellOverlayMode || (!sidebarOpen && !rightPanelOpen && !trackerPanelVisible));
   const trackerWindowHost = trackerPanelWindowTarget?.popup ?? window;
+  const trackerPanelDockingRef = useRef(false);
 
   const dockTrackerPanel = useCallback(() => {
+    trackerPanelDockingRef.current = true;
     if (trackerPanelWindowTarget) closeTrackerPanelWindow(trackerPanelWindowTarget);
     setTrackerPanelWindowTarget(null);
   }, [trackerPanelWindowTarget]);
 
   const detachTrackerPanel = useCallback(async () => {
     if (detachTrackerPanelPendingRef.current) return;
+    trackerPanelDockingRef.current = false;
     detachTrackerPanelPendingRef.current = true;
 
     try {
@@ -852,7 +855,12 @@ export function AppShell() {
 
   const handleTrackerPanelWindowClosed = useCallback(() => {
     setTrackerPanelWindowTarget(null);
-  }, []);
+    if (trackerPanelDockingRef.current) {
+      trackerPanelDockingRef.current = false;
+      return;
+    }
+    setTrackerPanelOpen(false, activeChatId);
+  }, [activeChatId, setTrackerPanelOpen]);
 
   const professorMariFloatingActive = hasDetailView && hasProfessorMariFloatingFollowup();
 

--- a/packages/client/src/features/tracker-panel/components/TrackerPanelDetachedWindow.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerPanelDetachedWindow.tsx
@@ -159,7 +159,7 @@ export function TrackerPanelDetachedWindow({
   target,
 }: {
   host: HTMLElement;
-  onClosed: () => void;
+  onClosed: (target: TrackerPanelWindowTarget) => void;
   target: TrackerPanelWindowTarget;
 }) {
   useLayoutEffect(() => {
@@ -178,7 +178,7 @@ export function TrackerPanelDetachedWindow({
     const syncStyles = () => mirrorStyles(document, popupDocument, mirroredStyles);
     const handlePopupClose = () => {
       target.removeOpenerPageHideListener();
-      onClosed();
+      onClosed(target);
     };
 
     syncDocumentPresentation();

--- a/packages/client/src/lib/professor-mari-transcript-scroll.ts
+++ b/packages/client/src/lib/professor-mari-transcript-scroll.ts
@@ -1,7 +1,13 @@
 export type ProfessorMariTranscriptScrollContainer = {
+  clientHeight: number;
   scrollHeight: number;
   scrollTop: number;
 };
+
+/** Keep streaming output pinned only while the reader remains near the newest message. */
+export function isProfessorMariTranscriptNearBottom(container: ProfessorMariTranscriptScrollContainer, threshold = 72) {
+  return container.scrollHeight - container.clientHeight - container.scrollTop <= threshold;
+}
 
 /** Align a mounted Professor Mari transcript with its newest message. */
 export function scrollProfessorMariTranscriptToBottom(container: ProfessorMariTranscriptScrollContainer) {

--- a/packages/client/src/lib/tracker-panel-layout.ts
+++ b/packages/client/src/lib/tracker-panel-layout.ts
@@ -8,18 +8,14 @@ interface TrackerPanelDesktopWidthInput {
   gap?: number;
 }
 
-/** Keep the desktop Tracker inside the free gutter beside the centered Roleplay chat column. */
+/** Preserve the requested Tracker width, constraining it only to the main viewport. */
 export function resolveTrackerPanelDesktopWidth({
   preferredWidth,
   mainLeft,
   mainRight,
-  chatColumnLeft,
-  chatColumnRight,
-  side,
   gap = 0,
 }: TrackerPanelDesktopWidthInput) {
-  const gutterWidth = side === "left" ? chatColumnLeft - mainLeft : mainRight - chatColumnRight;
-  return Math.max(0, Math.min(preferredWidth, Math.floor(gutterWidth - gap)));
+  return Math.max(0, Math.min(preferredWidth, Math.floor(mainRight - mainLeft - gap)));
 }
 
 /** Scale constrained Tracker contents while retaining a readable lower bound and responsive reflow. */

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -37,6 +37,7 @@ import {
   customAgentHasCapability,
   CHAT_SUMMARY_PROMPT_SETTINGS_KEY,
   CUSTOM_GENERATION_PARAMETERS_SETTINGS_KEY,
+  DEFAULT_AGENT_MAX_TOKENS,
   DEFAULT_CONVERSATION_PROMPT,
   DEFAULT_GENERATION_PARAMS,
   unwrapConversationInstructions,
@@ -470,10 +471,14 @@ import {
   type GenerationPromptMessage,
 } from "../services/generation/prompt-message-scope.js";
 import {
-  applyProviderMaxTokensOverride,
   readChatCompletionsReasoningMetadata,
+  resolveStoredChatOptions,
+  resolveStoredMaxTokens,
   shouldReplayStoredChatCompletionsReasoning,
 } from "../services/generation/generation-parameters.js";
+import { clampGenerationMaxOutputTokens } from "../services/generation/output-token-limits.js";
+import { createLLMProvider } from "../services/llm/provider-registry.js";
+import { withConnectionFallbackProvider } from "../services/llm/connection-fallback-provider.js";
 import {
   fitMessagesForModelAccess,
   mergeModelContextLimit,
@@ -5108,23 +5113,59 @@ export async function generateRoutes(app: FastifyInstance) {
           ];
 
           try {
-            const selectorProvider = provider;
-            const selectorModel = conn.model;
-            const selectorMaxTokens = applyProviderMaxTokensOverride(selectorProvider, 512);
+            const selectorConnection = (await connections.getDefaultForAgents()) ?? conn;
+            const selectorFallbackConnection = await connections.getFallbackForAgents();
+            const selectorBaseUrl = resolveBaseUrl(selectorConnection);
+            if (!selectorBaseUrl) throw new Error("The group responder connection has no base URL");
+            const selectorProvider = withConnectionFallbackProvider({
+              primary: createLLMProvider(
+                selectorConnection.provider,
+                selectorBaseUrl,
+                selectorConnection.apiKey,
+                selectorConnection.maxContext,
+                selectorConnection.openrouterProvider,
+                selectorConnection.maxTokensOverride,
+                selectorConnection.claudeFastMode === "true",
+                selectorConnection.treatAsLocalEndpoint === "true",
+                selectorConnection.defaultParameters,
+              ),
+              primaryConnectionId: selectorConnection.id,
+              fallbackConnection: selectorFallbackConnection,
+              fallbackBaseUrl: selectorFallbackConnection ? resolveBaseUrl(selectorFallbackConnection) : "",
+              category: "agents",
+              onFallback,
+            });
+            const selectorModel = selectorConnection.model;
+            const selectorPolicy = resolveModelAccessPolicy({
+              provider: selectorConnection.provider,
+              model: selectorModel,
+              maxContext: selectorConnection.maxContext,
+            });
+            const selectorMaxTokens = clampGenerationMaxOutputTokens({
+              provider: selectorConnection.provider,
+              model: selectorModel,
+              maxTokens: resolveStoredMaxTokens(selectorConnection.defaultParameters, DEFAULT_AGENT_MAX_TOKENS),
+              maxTokensOverride: selectorConnection.maxTokensOverride,
+            });
+            const selectorDefaults = resolveStoredChatOptions(
+              selectorConnection.defaultParameters,
+              selectorConnection.provider,
+              selectorModel,
+            );
 
             const result = await withLlmRequestTimeout(chatGenerationTimeoutMs, () =>
               selectorProvider.chatComplete(selectionPrompt, {
                 model: selectorModel,
-                ...(suppressModelParameters
+                ...(selectorPolicy.suppressModelParameters
                   ? {}
                   : {
-                      temperature: 0.2,
+                      ...selectorDefaults,
+                      temperature: selectorDefaults.temperature ?? 0.2,
+                      topP: selectorDefaults.topP ?? 1,
                       maxTokens: selectorMaxTokens,
-                      maxContext: effectiveMaxContext,
-                      topP: 1,
-                      serviceTier,
+                      maxContext: selectorPolicy.effectiveMaxContext,
                     }),
-                suppressModelParameters,
+                suppressModelParameters: selectorPolicy.suppressModelParameters,
                 stream: false,
                 signal: abortController.signal,
               }),

--- a/packages/server/src/routes/generate/lorebook-keeper-utils.ts
+++ b/packages/server/src/routes/generate/lorebook-keeper-utils.ts
@@ -279,21 +279,10 @@ export function mergeLorebookKeeperUpdateContent(args: {
   const replacement =
     typeof args.replacementContent === "string" ? dedupeKeeperContentParagraphs(args.replacementContent) : "";
   const facts = normalizeKeeperFacts(args.newFacts);
-
-  if (facts.length === 0) {
-    if (!existing) return replacement;
-    if (!replacement) return existing;
-
-    const existingComparable = normalizeKeeperFactForComparison(existing);
-    const replacementComparable = normalizeKeeperFactForComparison(replacement);
-    if (replacementComparable.includes(existingComparable)) return replacement;
-    if (existingComparable.includes(replacementComparable)) return existing;
-
-    return dedupeKeeperContentParagraphs(`${existing}\n\n${replacement}`);
-  }
-
-  const baseContent =
-    existing && replacement ? dedupeKeeperContentParagraphs(`${existing}\n\n${replacement}`) : existing || replacement;
+  // A supplied content body is an update, not an appendix. Retain the old body only
+  // when Lorebook Keeper supplied facts without a replacement.
+  const baseContent = replacement || existing;
+  if (facts.length === 0) return baseContent;
   const existingComparable = normalizeKeeperFactForComparison(baseContent);
   const novelFacts = facts.filter((fact) => {
     const comparable = normalizeKeeperFactForComparison(fact);

--- a/packages/server/src/routes/professor-mari-workspace.routes.ts
+++ b/packages/server/src/routes/professor-mari-workspace.routes.ts
@@ -14,6 +14,7 @@ const promptSchema = z.object({
   chatId: z.string().min(1),
   message: z.string().min(1),
   connectionId: z.string().optional().nullable(),
+  debugMode: z.boolean().optional().default(false),
   existingUserMessageId: z.string().min(1).optional(),
   attachments: z
     .array(
@@ -138,6 +139,7 @@ export async function professorMariWorkspaceRoutes(app: FastifyInstance) {
         chatId: body.chatId,
         text: body.message,
         connectionId: body.connectionId ?? null,
+        debugMode: body.debugMode,
         attachments: body.attachments,
         existingUserMessageId: body.existingUserMessageId,
         onEvent: send,

--- a/packages/server/src/services/generation/connection-admission.ts
+++ b/packages/server/src/services/generation/connection-admission.ts
@@ -10,10 +10,14 @@ type ConnectionState = {
   foregroundActive: number;
   backgroundActive: boolean;
   lastForegroundFinishedAt: number;
+  consecutiveBackgroundFailures: number;
+  backgroundQuarantinedUntil: number;
 };
 
 const states = new Map<string, ConnectionState>();
 export const BACKGROUND_CONNECTION_IDLE_MS = 30_000;
+export const BACKGROUND_CONNECTION_FAILURE_THRESHOLD = 3;
+export const BACKGROUND_CONNECTION_FAILURE_COOLDOWN_MS = 6 * 60 * 60 * 1000;
 
 export type ConnectionAttemptOutcome = "completed" | "failed";
 export type ConnectionAttemptFinalizer = (outcome: ConnectionAttemptOutcome) => void | Promise<void>;
@@ -73,31 +77,52 @@ export function isConnectionAdmissionFailure(error: unknown): boolean {
 function stateFor(connectionId: string): ConnectionState {
   const existing = states.get(connectionId);
   if (existing) return existing;
-  const state = { foregroundActive: 0, backgroundActive: false, lastForegroundFinishedAt: 0 };
+  const state = {
+    foregroundActive: 0,
+    backgroundActive: false,
+    lastForegroundFinishedAt: 0,
+    consecutiveBackgroundFailures: 0,
+    backgroundQuarantinedUntil: 0,
+  };
   states.set(connectionId, state);
   return state;
 }
 
-export function beginForegroundConnection(connectionId: string): () => void {
+function recordConnectionOutcome(state: ConnectionState, outcome: ConnectionAttemptOutcome | undefined) {
+  if (outcome === "completed") {
+    state.consecutiveBackgroundFailures = 0;
+    state.backgroundQuarantinedUntil = 0;
+    return;
+  }
+  if (outcome !== "failed") return;
+  state.consecutiveBackgroundFailures += 1;
+  if (state.consecutiveBackgroundFailures >= BACKGROUND_CONNECTION_FAILURE_THRESHOLD) {
+    state.backgroundQuarantinedUntil = Date.now() + BACKGROUND_CONNECTION_FAILURE_COOLDOWN_MS;
+  }
+}
+
+export function beginForegroundConnection(connectionId: string): (outcome?: ConnectionAttemptOutcome) => void {
   const state = stateFor(connectionId);
   state.foregroundActive += 1;
   let released = false;
-  return () => {
+  return (outcome) => {
     if (released) return;
     released = true;
     state.foregroundActive -= 1;
     state.lastForegroundFinishedAt = Date.now();
+    if (outcome === "completed") recordConnectionOutcome(state, outcome);
   };
 }
 
 export function tryBackgroundConnection(
   connectionId: string,
   at: Date,
-): { acquired: false } | { acquired: true; release: () => void } {
+): { acquired: false } | { acquired: true; release: (outcome?: ConnectionAttemptOutcome) => void } {
   const state = stateFor(connectionId);
   if (
     state.backgroundActive ||
     state.foregroundActive > 0 ||
+    at.getTime() < state.backgroundQuarantinedUntil ||
     at.getTime() - state.lastForegroundFinishedAt < BACKGROUND_CONNECTION_IDLE_MS
   ) {
     return { acquired: false };
@@ -105,8 +130,9 @@ export function tryBackgroundConnection(
   state.backgroundActive = true;
   return {
     acquired: true,
-    release: () => {
+    release: (outcome) => {
       state.backgroundActive = false;
+      recordConnectionOutcome(state, outcome);
     },
   };
 }
@@ -118,7 +144,7 @@ export function resetConnectionAdmissionForTests(): void {
 async function beginConnectionAttempt(
   connectionId: string,
   mode: ConnectionAdmissionMode,
-): Promise<{ release: () => void; finalize?: ConnectionAttemptFinalizer }> {
+): Promise<{ release: (outcome?: ConnectionAttemptOutcome) => void; finalize?: ConnectionAttemptFinalizer }> {
   if (mode.kind === "none") return { release: () => undefined };
   if (mode.kind === "foreground") return { release: beginForegroundConnection(connectionId) };
 
@@ -138,7 +164,7 @@ async function beginConnectionAttempt(
  * see. A finalization failure only surfaces when the operation itself succeeded.
  */
 async function finalizeConnectionAttempt(
-  attempt: { release: () => void; finalize?: ConnectionAttemptFinalizer },
+  attempt: { release: (outcome?: ConnectionAttemptOutcome) => void; finalize?: ConnectionAttemptFinalizer },
   outcome: ConnectionAttemptOutcome,
 ): Promise<void> {
   try {
@@ -147,7 +173,7 @@ async function finalizeConnectionAttempt(
     if (outcome === "completed") throw new ConnectionAttemptFinalizationError(error);
     logger.error(error, "[connection-admission] Attempt accounting failed after a failed provider call");
   } finally {
-    attempt.release();
+    attempt.release(outcome);
   }
 }
 

--- a/packages/server/src/services/generation/connection-admission.ts
+++ b/packages/server/src/services/generation/connection-admission.ts
@@ -128,9 +128,12 @@ export function tryBackgroundConnection(
     return { acquired: false };
   }
   state.backgroundActive = true;
+  let released = false;
   return {
     acquired: true,
     release: (outcome) => {
+      if (released) return;
+      released = true;
       state.backgroundActive = false;
       recordConnectionOutcome(state, outcome);
     },

--- a/packages/server/src/services/noodle/noodle-fan-activity.operation.ts
+++ b/packages/server/src/services/noodle/noodle-fan-activity.operation.ts
@@ -199,6 +199,7 @@ export async function runNoodlerFanActivity(input: {
     if (!connection) return { status: "connection_not_found", created: 0 };
     const admission = tryBackgroundConnection(connection.id, at);
     if (!admission.acquired) return { status: "busy", created: 0 };
+    let admissionOutcome: "completed" | "failed" | undefined;
 
     try {
       let run: NoodleFanActivityDayPlanRun | null;
@@ -233,18 +234,20 @@ export async function runNoodlerFanActivity(input: {
           creators,
           debugMode: input.debugMode,
         });
+        admissionOutcome = "completed";
         plan = storeNoodleFanAcceptedActivities(plan, run.id, accepted);
         await writePlan(input.db, plan);
         const storedRun = plan.runs.find((candidate) => candidate.id === run!.id)!;
         const created = await applyAcceptedActivities(input.db, plan, storedRun, settings, at);
         return { status: "generated", created, runId: run.id };
       } catch (error) {
+        if (!admissionOutcome) admissionOutcome = "failed";
         plan = finishNoodleFanActivityRun(plan, run.id, "abandoned", at);
         await writePlan(input.db, plan);
         throw error;
       }
     } finally {
-      admission.release();
+      admission.release(admissionOutcome);
     }
   } finally {
     release();

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -1,8 +1,8 @@
 // ──────────────────────────────────────────────
 // Professor Mari native command workspace runtime
 // ──────────────────────────────────────────────
-import { existsSync, realpathSync } from "node:fs";
-import { copyFile, mkdir, readdir, readFile, rename, rmdir, stat, unlink, writeFile } from "node:fs/promises";
+import { constants, existsSync, realpathSync } from "node:fs";
+import { copyFile, mkdir, readdir, readFile, rmdir, stat, unlink, writeFile } from "node:fs/promises";
 import { delimiter, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { FastifyInstance } from "fastify";
@@ -2618,9 +2618,13 @@ ${sections.join("\n\n")}
     const source = this.ordinaryMutationPath(stringArg(args, "source"));
     const destination = this.ordinaryMutationPath(stringArg(args, "destination"), { allowMissing: true });
     if (!(await stat(source)).isFile()) throw new Error("copy source must be a file");
-    if (existsSync(destination)) throw new Error("copy destination already exists");
     await mkdir(dirname(destination), { recursive: true });
-    await copyFile(source, destination);
+    try {
+      await copyFile(source, destination, constants.COPYFILE_EXCL);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") throw new Error("copy destination already exists");
+      throw error;
+    }
     return `Copied ${this.displayPath(source)} to ${this.displayPath(destination)}.`;
   }
 
@@ -2628,9 +2632,14 @@ ${sections.join("\n\n")}
     const source = this.ordinaryMutationPath(stringArg(args, "source"));
     const destination = this.ordinaryMutationPath(stringArg(args, "destination"), { allowMissing: true });
     if (!(await stat(source)).isFile()) throw new Error("move source must be a file");
-    if (existsSync(destination)) throw new Error("move destination already exists");
     await mkdir(dirname(destination), { recursive: true });
-    await rename(source, destination);
+    try {
+      await copyFile(source, destination, constants.COPYFILE_EXCL);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") throw new Error("move destination already exists");
+      throw error;
+    }
+    await unlink(source);
     return `Moved ${this.displayPath(source)} to ${this.displayPath(destination)}.`;
   }
 

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -28,11 +28,17 @@ import {
 } from "../generation/prompt-attachments.js";
 import { resolveBaseUrl } from "../generation/connection-base-url.js";
 import { MARI_GUIDED_SEQUENCES } from "./guided-sequences.js";
-import { getFileStorageDir, getMonorepoRoot, getPort, getServerProtocol } from "../../config/runtime-config.js";
+import {
+  getFileStorageDir,
+  getMonorepoRoot,
+  getPort,
+  getServerProtocol,
+  isDebugAgentsEnabled,
+} from "../../config/runtime-config.js";
 import { apiConnections } from "../../db/schema/index.js";
 import { decryptApiKey } from "../../utils/crypto.js";
 import { DATA_DIR } from "../../utils/data-dir.js";
-import { logger } from "../../lib/logger.js";
+import { logger, logDebugOverride } from "../../lib/logger.js";
 import { tryParseJsonRecord } from "../../lib/json-repair.js";
 import { PROFESSOR_MARI_AGENT_CATALOG_KNOWLEDGE } from "./official-agent-knowledge.js";
 import {
@@ -568,7 +574,7 @@ Required schema:
 {
   "say": "visible text for the user, or empty string for silent work",
   "commands": [
-    { "name": "docs_search|docs_read|read|grep|find|ls|edit|write|bash|dependency|app_data", "arguments": {} }
+    { "name": "docs_search|docs_read|read|grep|find|ls|edit|write|copy|move|remove|bash|dependency|app_data", "arguments": {} }
   ],
   "suggestions": [
     { "label": "short button text", "prompt": "exact message to send if tapped", "entity": "characters|lorebooks|personas|presets|connections|agents|settings|chat", "tone": "danger|caution|success" }
@@ -1796,6 +1802,7 @@ export class ProfessorMariWorkspaceService {
     chatId: string;
     text: string;
     connectionId?: string | null;
+    debugMode?: boolean;
     attachments?: ProfessorMariPromptAttachment[];
     existingUserMessageId?: string;
     onEvent: PromptEventSink;
@@ -1895,10 +1902,14 @@ export class ProfessorMariWorkspaceService {
       const repeatedFailureCounts = new Map<string, number>();
       let protocolRepairRounds = 0;
       let verificationRepairRounds = 0;
+      const debugOverrideEnabled = args.debugMode === true || isDebugAgentsEnabled();
+      const debugLog = debugOverrideEnabled
+        ? (message: string, ...values: unknown[]) => logDebugOverride(true, message, ...values)
+        : undefined;
 
       for (let round = 0; round < MAX_COMMAND_ROUNDS; round += 1) {
         if (controller.signal.aborted) throw new Error("aborted");
-        const result = await this.chatCompleteWorkspace(provider, messages, baseOptions, () => {});
+        const result = await this.chatCompleteWorkspace(provider, messages, baseOptions, () => {}, debugLog);
         latestUsage = result.usage;
         latestFinishReason = result.finishReason ?? null;
         const usage = mapUsage(result.usage);
@@ -2063,7 +2074,7 @@ export class ProfessorMariWorkspaceService {
             content:
               "You reached the workspace command round limit. Do not issue more commands. Summarize what you learned or what remains blocked.",
           });
-          const finalResult = await this.chatCompleteWorkspace(provider, messages, baseOptions, () => {});
+          const finalResult = await this.chatCompleteWorkspace(provider, messages, baseOptions, () => {}, debugLog);
           latestUsage = finalResult.usage;
           latestFinishReason = finalResult.finishReason ?? null;
           const finalUsage = mapUsage(finalResult.usage);
@@ -2250,6 +2261,7 @@ ${sections.join("\n\n")}
     messages: ChatMessage[],
     baseOptions: ChatOptions,
     onToken?: (chunk: string) => void,
+    debugLog?: (message: string, ...values: unknown[]) => void,
   ): Promise<ChatCompletionResult> {
     const options: ChatOptions = onToken
       ? {
@@ -2268,6 +2280,7 @@ ${sections.join("\n\n")}
       options.enabledParameters?.verbosity === false ? "disabled" : (options.verbosity ?? "default"),
       Object.keys(options.customParameters ?? {}).join(",") || "none",
     );
+    debugLog?.("[debug/professor-mari] Final prompt messages:\n%s", JSON.stringify(messages, null, 2));
     return provider.chatComplete(messages, options);
   }
 

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -2,7 +2,7 @@
 // Professor Mari native command workspace runtime
 // ──────────────────────────────────────────────
 import { constants, existsSync, realpathSync } from "node:fs";
-import { copyFile, mkdir, readdir, readFile, rmdir, stat, unlink, writeFile } from "node:fs/promises";
+import { copyFile, link, mkdir, readdir, readFile, rmdir, stat, unlink, writeFile } from "node:fs/promises";
 import { delimiter, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { FastifyInstance } from "fastify";
@@ -1720,6 +1720,10 @@ export class ProfessorMariWorkspaceService {
   private lastError: string | null = null;
   private active = false;
   private abortController: AbortController | null = null;
+  // Professor Mari is the only untrusted workspace writer. Serialize all of
+  // her mutations so path validation and the operation cannot overlap another
+  // agent mutation; user and host processes remain outside this sandbox boundary.
+  private workspaceMutationTail: Promise<void> = Promise.resolve();
 
   constructor(private readonly app: FastifyInstance) {}
 
@@ -2314,9 +2318,13 @@ ${sections.join("\n\n")}
     });
     onEvent({ type: "tool_start", data: { id: command.id, name: command.name, input } });
     try {
-      const validationIssue = workspaceCommandValidationIssue(command);
-      if (validationIssue) throw new Error(validationIssue);
-      const output = await this.runWorkspaceCommand(command, signal);
+      const run = async () => {
+        signal.throwIfAborted();
+        const validationIssue = workspaceCommandValidationIssue(command);
+        if (validationIssue) throw new Error(validationIssue);
+        return this.runWorkspaceCommand(command, signal);
+      };
+      const output = isReadOnlyWorkspaceCommand(command) ? await run() : await this.serializeWorkspaceMutation(run);
       const compacted = compactOutput(output);
       upsertTraceTool(trace, {
         id: command.id,
@@ -2332,6 +2340,20 @@ ${sections.join("\n\n")}
       upsertTraceTool(trace, { id: command.id, name: command.name, status: "error", output, updatedAt: Date.now() });
       onEvent({ type: "tool_end", data: { id: command.id, name: command.name, isError: true, output } });
       return { id: command.id, name: command.name, input, output, success: false };
+    }
+  }
+
+  private async serializeWorkspaceMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.workspaceMutationTail;
+    let release!: () => void;
+    this.workspaceMutationTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
     }
   }
 
@@ -2634,12 +2656,19 @@ ${sections.join("\n\n")}
     if (!(await stat(source)).isFile()) throw new Error("move source must be a file");
     await mkdir(dirname(destination), { recursive: true });
     try {
-      await copyFile(source, destination, constants.COPYFILE_EXCL);
+      // A hard link is an atomic, no-replace claim on the destination and keeps
+      // it tied to the exact source inode until the source name is removed.
+      await link(source, destination);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "EEXIST") throw new Error("move destination already exists");
       throw error;
     }
-    await unlink(source);
+    try {
+      await unlink(source);
+    } catch (error) {
+      await unlink(destination).catch(() => undefined);
+      throw error;
+    }
     return `Moved ${this.displayPath(source)} to ${this.displayPath(destination)}.`;
   }
 

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -2,7 +2,7 @@
 // Professor Mari native command workspace runtime
 // ──────────────────────────────────────────────
 import { existsSync, realpathSync } from "node:fs";
-import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readdir, readFile, rename, rmdir, stat, unlink, writeFile } from "node:fs/promises";
 import { delimiter, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { FastifyInstance } from "fastify";
@@ -142,6 +142,9 @@ const WORKSPACE_TOOLS: MariWorkspaceToolName[] = [
   "ls",
   "edit",
   "write",
+  "copy",
+  "move",
+  "remove",
   "bash",
   "dependency",
   "app_data",
@@ -330,6 +333,33 @@ const WORKSPACE_TOOL_DEFINITIONS: WorkspaceToolDefinition[] = [
     },
   },
   {
+    name: "copy",
+    description: "Copy one ordinary workspace file without overwriting an existing destination.",
+    parameters: {
+      type: "object",
+      properties: { source: { type: "string" }, destination: { type: "string" } },
+      required: ["source", "destination"],
+    },
+  },
+  {
+    name: "move",
+    description: "Move one ordinary workspace file without overwriting an existing destination.",
+    parameters: {
+      type: "object",
+      properties: { source: { type: "string" }, destination: { type: "string" } },
+      required: ["source", "destination"],
+    },
+  },
+  {
+    name: "remove",
+    description: "Delete one ordinary workspace file or one empty directory.",
+    parameters: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    },
+  },
+  {
     name: "bash",
     description:
       "Run a simple shell command in an OS sandbox with network access denied and filesystem writes confined to the workspace. Prefer structured tools.",
@@ -485,7 +515,7 @@ Workspace defaults:
 - Use Mari CLI commands for images, wiki reads, code/workspace tasks, agents, tools, raw DB work, or anything \`app_data\` does not cover. Only write raw files when no CLI/helper path fits.
 - You may create and update Personal Extension drafts with \`personal_extension.create\` and \`personal_extension.update\`. These actions always disable changed code and clear its approval. Browser Extensions receive active chat and Character IDs through \`marinara.context\`; request \`read_active_characters\` or \`read_active_persona\` only when the extension truly needs bounded active-record fields. Never claim to approve, enable, or run an extension: only the user can review the exact code hash and requested permissions, then choose **Review and Run** in **Settings → Addons → Personal Extensions**.
 - For user-facing Browser Extension UI, use \`marinara.ui.registerContribution(...)\`. It can add a trusted Marinara-rendered top-bar button, Extensions menu item, right-side panel, or button in the Chats, Bots, Characters, Personas, Lorebooks, Presets, Connections, Agents, and Settings surfaces. For a side-panel \`button\`, set \`surface\` to the requested surface and choose \`position: "header"\`, \`"before-content"\`, or \`"after-content"\`; omit both fields for the top bar. The \`icon\` may be any kebab-case Lucide icon name supported by Marinara. Panels may contain headings, text, preformatted output, buttons, text inputs, selects, toggles, sliders, color controls, and spacers. Use \`onActivate\` and \`onEvent\` for behavior and update the returned handle when the view changes. Never write extension code that expects \`document\`, \`window\`, \`innerHTML\`, host CSS selectors, React internals, unrestricted \`fetch\`, or direct Marinara API access; those capabilities are deliberately absent.
-- Raw \`bash\` commands run in an OS sandbox with network access denied, inherited secrets removed, and filesystem writes confined to the workspace. If the sandbox is unavailable, raw shell fails closed; use structured workspace tools.
+- Raw \`bash\` commands run in an OS sandbox with network access denied, inherited secrets removed, and filesystem writes confined to the workspace. If the sandbox is unavailable, raw shell fails closed; use structured \`read\`, \`grep\`, \`find\`, \`ls\`, \`edit\`, \`write\`, \`copy\`, \`move\`, \`remove\`, and \`app_data\` tools instead.
 - Use the \`dependency\` tool when a source change needs a public npm package. Raw package-manager installs are blocked. The tool resolves an exact version and integrity, then waits for the user to approve installation with lifecycle scripts disabled.
 - Ordinary source files can still be edited directly. Dependency manifests, lockfiles, launchers, installers, and CI workflows are staged for a separate user review instead of being changed silently. Never bypass that review through \`bash\`.
 - Inspect before claiming facts. Verify after changing anything.
@@ -1431,8 +1461,9 @@ function isReadOnlyWorkspaceCommand(command: WorkspaceCommandCall): boolean {
     command.name === "grep" ||
     command.name === "find" ||
     command.name === "ls"
-  )
+  ) {
     return true;
+  }
   if (command.name !== "app_data") return false;
   return appDataActionLooksReadOnly(command.arguments.action);
 }
@@ -1470,7 +1501,15 @@ function bashLooksMutating(command: string): boolean {
 }
 
 function isMutatingWorkspaceCommand(command: WorkspaceCommandCall): boolean {
-  if (command.name === "edit" || command.name === "write" || command.name === "dependency") return true;
+  if (
+    command.name === "edit" ||
+    command.name === "write" ||
+    command.name === "copy" ||
+    command.name === "move" ||
+    command.name === "remove" ||
+    command.name === "dependency"
+  )
+    return true;
   if (command.name === "app_data") return !isReadOnlyWorkspaceCommand(command);
   if (command.name !== "bash") return false;
   const rawCommand = command.arguments.command;
@@ -1560,6 +1599,11 @@ function workspaceCommandValidationIssue(command: WorkspaceCommandCall): string 
     }
     case "write":
       return requireString("path") ?? (typeof args.content === "string" ? null : "write requires a content string");
+    case "copy":
+    case "move":
+      return requireString("source") ?? requireString("destination");
+    case "remove":
+      return requireString("path");
     case "bash":
       return requireString("command");
     case "app_data":
@@ -2319,6 +2363,12 @@ ${sections.join("\n\n")}
         return this.commandWrite(command.arguments);
       case "edit":
         return this.commandEdit(command.arguments);
+      case "copy":
+        return this.commandCopy(command.arguments);
+      case "move":
+        return this.commandMove(command.arguments);
+      case "remove":
+        return this.commandRemove(command.arguments);
       case "dependency":
         return this.commandDependency(command.arguments);
       case "app_data":
@@ -2332,7 +2382,7 @@ ${sections.join("\n\n")}
 
   private resolveWorkspacePath(
     inputPath: string,
-    options: { allowMissing?: boolean; forbidStorageMutation?: boolean } = {},
+    options: { allowMissing?: boolean; forbidStorageMutation?: boolean; requireOrdinaryMutationPath?: boolean } = {},
   ) {
     const rawPath = inputPath.trim() || ".";
     const absolute = resolve(this.workspaceRoot, rawPath);
@@ -2354,15 +2404,17 @@ ${sections.join("\n\n")}
     // or Git internals, and reads would follow it.
     const canonicalTarget =
       existingAncestor === absolute ? canonicalAncestor : join(canonicalAncestor, relative(existingAncestor, absolute));
-    if (
-      workspacePathAccessPolicy(workspaceRoot, absolute) === "forbidden" ||
-      workspacePathAccessPolicy(canonicalRoot, canonicalTarget) === "forbidden"
-    ) {
+    const requestedPolicy = workspacePathAccessPolicy(workspaceRoot, absolute);
+    const canonicalPolicy = workspacePathAccessPolicy(canonicalRoot, canonicalTarget);
+    if (requestedPolicy === "forbidden" || canonicalPolicy === "forbidden") {
       throw new Error("Professor Mari cannot access environment-secret files or Git internals.");
+    }
+    if (options.requireOrdinaryMutationPath && (requestedPolicy !== "normal" || canonicalPolicy !== "normal")) {
+      throw new Error("This path requires a dedicated reviewed tool and cannot be changed directly.");
     }
     if (options.forbidStorageMutation) {
       const storageRoot = resolve(getFileStorageDir());
-      if (isWithin(storageRoot, absolute)) {
+      if (isWithin(storageRoot, absolute) || isWithin(storageRoot, canonicalTarget)) {
         throw new Error("DATA_DIR/storage is managed by Marinara. Use mari db for table edits instead of file writes.");
       }
     }
@@ -2550,6 +2602,45 @@ ${sections.join("\n\n")}
     await mkdir(dirname(filePath), { recursive: true });
     await writeFile(filePath, content, "utf8");
     return `Wrote ${Buffer.byteLength(content, "utf8")} bytes to ${this.displayPath(filePath)}.`;
+  }
+
+  private ordinaryMutationPath(inputPath: string, options: { allowMissing?: boolean } = {}) {
+    const filePath = this.resolveWorkspacePath(inputPath, {
+      allowMissing: options.allowMissing,
+      forbidStorageMutation: true,
+      requireOrdinaryMutationPath: true,
+    });
+    if (resolve(filePath) === resolve(this.workspaceRoot)) throw new Error("The workspace root cannot be moved or removed.");
+    return filePath;
+  }
+
+  private async commandCopy(args: Record<string, unknown>): Promise<string> {
+    const source = this.ordinaryMutationPath(stringArg(args, "source"));
+    const destination = this.ordinaryMutationPath(stringArg(args, "destination"), { allowMissing: true });
+    if (!(await stat(source)).isFile()) throw new Error("copy source must be a file");
+    if (existsSync(destination)) throw new Error("copy destination already exists");
+    await mkdir(dirname(destination), { recursive: true });
+    await copyFile(source, destination);
+    return `Copied ${this.displayPath(source)} to ${this.displayPath(destination)}.`;
+  }
+
+  private async commandMove(args: Record<string, unknown>): Promise<string> {
+    const source = this.ordinaryMutationPath(stringArg(args, "source"));
+    const destination = this.ordinaryMutationPath(stringArg(args, "destination"), { allowMissing: true });
+    if (!(await stat(source)).isFile()) throw new Error("move source must be a file");
+    if (existsSync(destination)) throw new Error("move destination already exists");
+    await mkdir(dirname(destination), { recursive: true });
+    await rename(source, destination);
+    return `Moved ${this.displayPath(source)} to ${this.displayPath(destination)}.`;
+  }
+
+  private async commandRemove(args: Record<string, unknown>): Promise<string> {
+    const target = this.ordinaryMutationPath(stringArg(args, "path"));
+    const targetStat = await stat(target);
+    if (targetStat.isFile()) await unlink(target);
+    else if (targetStat.isDirectory()) await rmdir(target);
+    else throw new Error("remove path must be a file or empty directory");
+    return `Removed ${this.displayPath(target)}.`;
   }
 
   private async commandEdit(args: Record<string, unknown>): Promise<string> {

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -2673,8 +2673,17 @@ ${sections.join("\n\n")}
       // it tied to the exact source inode until the source name is removed.
       await link(source, destination);
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "EEXIST") throw new Error("move destination already exists");
-      throw error;
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "EEXIST") throw new Error("move destination already exists");
+      if (code !== "EXDEV" && code !== "EPERM") throw error;
+      try {
+        await copyFile(source, destination, constants.COPYFILE_EXCL);
+      } catch (copyError) {
+        if ((copyError as NodeJS.ErrnoException).code === "EEXIST") {
+          throw new Error("move destination already exists");
+        }
+        throw copyError;
+      }
     }
     try {
       await unlink(source);

--- a/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
+++ b/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
@@ -259,7 +259,7 @@ export async function spawnWorkspaceSandboxedShell(
   const status = getWorkspaceShellSandboxStatus();
   if (!status.available) {
     throw new Error(
-      `${status.reason} Use Professor Mari's structured read, grep, find, ls, edit, write, and app_data tools instead.`,
+      `${status.reason} Use Professor Mari's structured read, grep, find, ls, edit, write, copy, move, remove, and app_data tools instead.`,
     );
   }
 

--- a/packages/server/src/services/storage/characters.storage.ts
+++ b/packages/server/src/services/storage/characters.storage.ts
@@ -10,6 +10,8 @@ import {
   personaCardVersions,
   characterGroups,
   personaGroups,
+  lorebooks,
+  lorebookCharacterLinks,
 } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
 import {
@@ -633,6 +635,35 @@ export function createCharactersStorage(db: DB) {
 
     async remove(id: string) {
       await db.transaction(async (tx) => {
+        const affectedLorebookLinks = await tx
+          .select()
+          .from(lorebookCharacterLinks)
+          .where(eq(lorebookCharacterLinks.characterId, id));
+        const legacyLorebooks = await tx.select().from(lorebooks).where(eq(lorebooks.characterId, id));
+        await tx.delete(lorebookCharacterLinks).where(eq(lorebookCharacterLinks.characterId, id));
+        const affectedLorebookIds = new Set([
+          ...affectedLorebookLinks.map((link) => link.lorebookId),
+          ...legacyLorebooks.map((lorebook) => lorebook.id),
+        ]);
+        for (const lorebookId of affectedLorebookIds) {
+          const remainingLinks = await tx
+            .select()
+            .from(lorebookCharacterLinks)
+            .where(eq(lorebookCharacterLinks.lorebookId, lorebookId))
+            .orderBy(asc(lorebookCharacterLinks.createdAt));
+          const lorebookRows = await tx.select().from(lorebooks).where(eq(lorebooks.id, lorebookId));
+          const lorebook = lorebookRows[0];
+          const becameUnowned =
+            remainingLinks.length === 0 && !lorebook?.personaId && !lorebook?.chatId && lorebook?.isGlobal !== "true";
+          await tx
+            .update(lorebooks)
+            .set({
+              characterId: remainingLinks[0]?.characterId ?? null,
+              ...(becameUnowned ? { enabled: "false", hiddenFromLibrary: "false" } : {}),
+              updatedAt: now(),
+            })
+            .where(eq(lorebooks.id, lorebookId));
+        }
         await tx.delete(characters).where(eq(characters.id, id));
         const groups = await tx.select().from(characterGroups);
         for (const group of groups) {

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -561,6 +561,22 @@ export function createLorebooksStorage(db: DB) {
         : ((current?.personaIds as string[] | undefined) ?? []);
       if (shouldUpdateCharacterLinks) updates.characterId = nextCharacterIds[0] ?? null;
       if (shouldUpdatePersonaLinks) updates.personaId = nextPersonaIds[0] ?? null;
+      const nextChatId = input.chatId !== undefined ? input.chatId : current?.chatId;
+      const nextIsGlobal = input.isGlobal !== undefined ? input.isGlobal : current?.isGlobal === true;
+      const hadLinkedOwner =
+        ((current?.characterIds as string[] | undefined)?.length ?? 0) > 0 ||
+        ((current?.personaIds as string[] | undefined)?.length ?? 0) > 0;
+      const lostFinalOwner =
+        (shouldUpdateCharacterLinks || shouldUpdatePersonaLinks) &&
+        hadLinkedOwner &&
+        nextCharacterIds.length === 0 &&
+        nextPersonaIds.length === 0 &&
+        !nextChatId &&
+        !nextIsGlobal;
+      if (lostFinalOwner) {
+        if (input.enabled === undefined) updates.enabled = "false";
+        if (input.hiddenFromLibrary === undefined) updates.hiddenFromLibrary = "false";
+      }
       if (input.chatId !== undefined) updates.chatId = input.chatId;
       if (input.isGlobal !== undefined) updates.isGlobal = String(input.isGlobal);
       if (input.enabled !== undefined) updates.enabled = String(input.enabled);

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -551,32 +551,6 @@ export function createLorebooksStorage(db: DB) {
         updates.vectorMaxResults = normalizeLorebookVectorMaxResults(input.vectorMaxResults);
       const shouldUpdateCharacterLinks = input.characterIds !== undefined || input.characterId !== undefined;
       const shouldUpdatePersonaLinks = input.personaIds !== undefined || input.personaId !== undefined;
-      const current = shouldUpdateCharacterLinks || shouldUpdatePersonaLinks ? ((await this.getById(id)) as any) : null;
-      if ((shouldUpdateCharacterLinks || shouldUpdatePersonaLinks) && !current) return null;
-      const nextCharacterIds = shouldUpdateCharacterLinks
-        ? resolveLinkIds(input.characterIds, input.characterId)
-        : ((current?.characterIds as string[] | undefined) ?? []);
-      const nextPersonaIds = shouldUpdatePersonaLinks
-        ? resolveLinkIds(input.personaIds, input.personaId)
-        : ((current?.personaIds as string[] | undefined) ?? []);
-      if (shouldUpdateCharacterLinks) updates.characterId = nextCharacterIds[0] ?? null;
-      if (shouldUpdatePersonaLinks) updates.personaId = nextPersonaIds[0] ?? null;
-      const nextChatId = input.chatId !== undefined ? input.chatId : current?.chatId;
-      const nextIsGlobal = input.isGlobal !== undefined ? input.isGlobal : current?.isGlobal === true;
-      const hadLinkedOwner =
-        ((current?.characterIds as string[] | undefined)?.length ?? 0) > 0 ||
-        ((current?.personaIds as string[] | undefined)?.length ?? 0) > 0;
-      const lostFinalOwner =
-        (shouldUpdateCharacterLinks || shouldUpdatePersonaLinks) &&
-        hadLinkedOwner &&
-        nextCharacterIds.length === 0 &&
-        nextPersonaIds.length === 0 &&
-        !nextChatId &&
-        !nextIsGlobal;
-      if (lostFinalOwner) {
-        if (input.enabled === undefined) updates.enabled = "false";
-        if (input.hiddenFromLibrary === undefined) updates.hiddenFromLibrary = "false";
-      }
       if (input.chatId !== undefined) updates.chatId = input.chatId;
       if (input.isGlobal !== undefined) updates.isGlobal = String(input.isGlobal);
       if (input.enabled !== undefined) updates.enabled = String(input.enabled);
@@ -586,12 +560,60 @@ export function createLorebooksStorage(db: DB) {
       if (input.generatedBy !== undefined) updates.generatedBy = input.generatedBy;
       if (input.sourceAgentId !== undefined) updates.sourceAgentId = input.sourceAgentId;
 
-      await db.transaction(async (tx) => {
-        await tx.update(lorebooks).set(updates).where(eq(lorebooks.id, id));
+      const updated = await db.transaction(async (tx) => {
+        const transactionalUpdates = { ...updates };
+        let nextCharacterIds: string[] = [];
+        let nextPersonaIds: string[] = [];
+        if (shouldUpdateCharacterLinks || shouldUpdatePersonaLinks) {
+          const currentRows = await tx.select().from(lorebooks).where(eq(lorebooks.id, id));
+          const current = currentRows[0];
+          if (!current) return false;
+          const currentCharacterLinks = await tx
+            .select()
+            .from(lorebookCharacterLinks)
+            .where(eq(lorebookCharacterLinks.lorebookId, id));
+          const currentPersonaLinks = await tx
+            .select()
+            .from(lorebookPersonaLinks)
+            .where(eq(lorebookPersonaLinks.lorebookId, id));
+          const currentCharacterIds = resolveLinkIds(
+            currentCharacterLinks.map((link) => link.characterId),
+            current.characterId,
+          );
+          const currentPersonaIds = resolveLinkIds(
+            currentPersonaLinks.map((link) => link.personaId),
+            current.personaId,
+          );
+          nextCharacterIds = shouldUpdateCharacterLinks
+            ? resolveLinkIds(input.characterIds, input.characterId)
+            : currentCharacterIds;
+          nextPersonaIds = shouldUpdatePersonaLinks
+            ? resolveLinkIds(input.personaIds, input.personaId)
+            : currentPersonaIds;
+          if (shouldUpdateCharacterLinks) transactionalUpdates.characterId = nextCharacterIds[0] ?? null;
+          if (shouldUpdatePersonaLinks) transactionalUpdates.personaId = nextPersonaIds[0] ?? null;
+
+          const nextChatId = input.chatId !== undefined ? input.chatId : current.chatId;
+          const nextIsGlobal = input.isGlobal !== undefined ? input.isGlobal : current.isGlobal === "true";
+          const lostFinalOwner =
+            (currentCharacterIds.length > 0 || currentPersonaIds.length > 0) &&
+            nextCharacterIds.length === 0 &&
+            nextPersonaIds.length === 0 &&
+            !nextChatId &&
+            !nextIsGlobal;
+          if (lostFinalOwner) {
+            if (input.enabled === undefined) transactionalUpdates.enabled = "false";
+            if (input.hiddenFromLibrary === undefined) transactionalUpdates.hiddenFromLibrary = "false";
+          }
+        }
+
+        await tx.update(lorebooks).set(transactionalUpdates).where(eq(lorebooks.id, id));
         if (shouldUpdateCharacterLinks || shouldUpdatePersonaLinks) {
           await syncLorebookLinks(tx, id, nextCharacterIds, nextPersonaIds);
         }
+        return true;
       });
+      if (!updated) return null;
       return this.getById(id);
     },
 

--- a/packages/shared/src/types/professor-mari-workspace.ts
+++ b/packages/shared/src/types/professor-mari-workspace.ts
@@ -11,6 +11,9 @@ export type MariWorkspaceToolName =
   | "ls"
   | "edit"
   | "write"
+  | "copy"
+  | "move"
+  | "remove"
   | "bash"
   | "dependency"
   | "app_data";

--- a/scripts/regressions/noodle-autopost.regression.ts
+++ b/scripts/regressions/noodle-autopost.regression.ts
@@ -67,6 +67,23 @@ assert.equal(admitted.acquired, true);
 if (admitted.acquired) admitted.release();
 
 resetConnectionAdmissionForTests();
+const duplicateRelease = tryBackgroundConnection("duplicate-release-connection", new Date());
+assert.equal(duplicateRelease.acquired, true);
+if (duplicateRelease.acquired) {
+  duplicateRelease.release("failed");
+  duplicateRelease.release("failed");
+}
+await assert.rejects(
+  withConnectionAdmission("duplicate-release-connection", { kind: "background" }, async () => {
+    throw new Error("second provider failure");
+  }),
+  /second provider failure/u,
+);
+const beforeThreshold = tryBackgroundConnection("duplicate-release-connection", new Date());
+assert.equal(beforeThreshold.acquired, true, "Releasing one attempt twice must record only one provider failure");
+if (beforeThreshold.acquired) beforeThreshold.release("completed");
+
+resetConnectionAdmissionForTests();
 for (let attempt = 0; attempt < BACKGROUND_CONNECTION_FAILURE_THRESHOLD; attempt += 1) {
   await assert.rejects(
     withConnectionAdmission("failing-background-connection", { kind: "background" }, async () => {

--- a/scripts/regressions/noodle-autopost.regression.ts
+++ b/scripts/regressions/noodle-autopost.regression.ts
@@ -21,9 +21,12 @@ import {
 } from "../../packages/server/src/services/storage/noodle.storage.js";
 import { isNoodlerNightQuietTime } from "../../packages/server/src/services/noodle/noodle-noodler-reserve.operation.js";
 import {
+  BACKGROUND_CONNECTION_FAILURE_COOLDOWN_MS,
+  BACKGROUND_CONNECTION_FAILURE_THRESHOLD,
   beginForegroundConnection,
   resetConnectionAdmissionForTests,
   tryBackgroundConnection,
+  withConnectionAdmission,
 } from "../../packages/server/src/services/generation/connection-admission.js";
 
 assert.deepEqual(noodleAutoPostingSettingsSchema.parse({}), { enabled: false, imagesEnabled: false });
@@ -62,6 +65,27 @@ assert.equal(tryBackgroundConnection("connection-1", new Date(Date.now() + 29_99
 const admitted = tryBackgroundConnection("connection-1", new Date(Date.now() + 30_001));
 assert.equal(admitted.acquired, true);
 if (admitted.acquired) admitted.release();
+
+resetConnectionAdmissionForTests();
+for (let attempt = 0; attempt < BACKGROUND_CONNECTION_FAILURE_THRESHOLD; attempt += 1) {
+  await assert.rejects(
+    withConnectionAdmission("failing-background-connection", { kind: "background" }, async () => {
+      throw new Error("provider unavailable");
+    }),
+    /provider unavailable/u,
+  );
+}
+assert.equal(
+  tryBackgroundConnection("failing-background-connection", new Date()).acquired,
+  false,
+  "Repeated automatic provider failures must quarantine the connection",
+);
+const recoveredAdmission = tryBackgroundConnection(
+  "failing-background-connection",
+  new Date(Date.now() + BACKGROUND_CONNECTION_FAILURE_COOLDOWN_MS + 1),
+);
+assert.equal(recoveredAdmission.acquired, true, "The automatic connection must be probed again after its cooldown");
+if (recoveredAdmission.acquired) recoveredAdmission.release("completed");
 
 const storageDir = mkdtempSync(join(tmpdir(), "marinara-noodler-reserve-"));
 process.env.FILE_STORAGE_DIR = storageDir;

--- a/scripts/regressions/noodle-autopost.regression.ts
+++ b/scripts/regressions/noodle-autopost.regression.ts
@@ -23,6 +23,7 @@ import { isNoodlerNightQuietTime } from "../../packages/server/src/services/nood
 import {
   BACKGROUND_CONNECTION_FAILURE_COOLDOWN_MS,
   BACKGROUND_CONNECTION_FAILURE_THRESHOLD,
+  BACKGROUND_CONNECTION_IDLE_MS,
   beginForegroundConnection,
   resetConnectionAdmissionForTests,
   tryBackgroundConnection,
@@ -84,19 +85,41 @@ assert.equal(beforeThreshold.acquired, true, "Releasing one attempt twice must r
 if (beforeThreshold.acquired) beforeThreshold.release("completed");
 
 resetConnectionAdmissionForTests();
-for (let attempt = 0; attempt < BACKGROUND_CONNECTION_FAILURE_THRESHOLD; attempt += 1) {
-  await assert.rejects(
-    withConnectionAdmission("failing-background-connection", { kind: "background" }, async () => {
-      throw new Error("provider unavailable");
-    }),
-    /provider unavailable/u,
-  );
-}
+const recordBackgroundFailures = async (connectionId: string) => {
+  for (let attempt = 0; attempt < BACKGROUND_CONNECTION_FAILURE_THRESHOLD; attempt += 1) {
+    await assert.rejects(
+      withConnectionAdmission(connectionId, { kind: "background" }, async () => {
+        throw new Error("provider unavailable");
+      }),
+      /provider unavailable/u,
+    );
+  }
+};
+await recordBackgroundFailures("failing-background-connection");
 assert.equal(
   tryBackgroundConnection("failing-background-connection", new Date()).acquired,
   false,
   "Repeated automatic provider failures must quarantine the connection",
 );
+const foregroundResult = await withConnectionAdmission(
+  "failing-background-connection",
+  { kind: "foreground" },
+  async () => "foreground-ok",
+);
+assert.equal(foregroundResult, "foreground-ok", "Background quarantine must not reject foreground chats");
+const admittedAfterForegroundRecovery = tryBackgroundConnection(
+  "failing-background-connection",
+  new Date(Date.now() + BACKGROUND_CONNECTION_IDLE_MS + 1),
+);
+assert.equal(
+  admittedAfterForegroundRecovery.acquired,
+  true,
+  "A successful foreground chat must clear the longer background quarantine",
+);
+if (admittedAfterForegroundRecovery.acquired) admittedAfterForegroundRecovery.release("completed");
+
+resetConnectionAdmissionForTests();
+await recordBackgroundFailures("failing-background-connection");
 const recoveredAdmission = tryBackgroundConnection(
   "failing-background-connection",
   new Date(Date.now() + BACKGROUND_CONNECTION_FAILURE_COOLDOWN_MS + 1),

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -922,6 +922,32 @@ try {
   assert.equal(unlinked?.enabled, false, "Unlinking the final owner must deactivate the lorebook");
   assert.equal(unlinked?.hiddenFromLibrary, false, "An unlinked lorebook must return to the manageable library");
 
+  const concurrentCharacterOwner = await characterStorage.create(
+    characterDataSchema.parse({ name: "Concurrent owner" }),
+  );
+  const concurrentPersonaOwner = await characterStorage.createPersona("Concurrent persona", "Regression fixture");
+  const concurrentlyUnlinkedLorebook = await lorebookStorage.create(
+    createLorebookSchema.parse({
+      name: "Concurrently unlinked notes",
+      characterIds: [concurrentCharacterOwner.id],
+      personaIds: [concurrentPersonaOwner.id],
+      hiddenFromLibrary: true,
+    }),
+  );
+  await Promise.all([
+    lorebookStorage.update(concurrentlyUnlinkedLorebook.id, { characterIds: [] }),
+    lorebookStorage.update(concurrentlyUnlinkedLorebook.id, { personaIds: [] }),
+  ]);
+  const concurrentlyUnlinked = await lorebookStorage.getById(concurrentlyUnlinkedLorebook.id);
+  assert.deepEqual(concurrentlyUnlinked?.characterIds, [], "Concurrent unlinking must not restore a Character owner");
+  assert.deepEqual(concurrentlyUnlinked?.personaIds, [], "Concurrent unlinking must not restore a Persona owner");
+  assert.equal(concurrentlyUnlinked?.enabled, false, "Concurrent final-owner unlinking must deactivate the lorebook");
+  assert.equal(
+    concurrentlyUnlinked?.hiddenFromLibrary,
+    false,
+    "Concurrent final-owner unlinking must leave the lorebook manageable",
+  );
+
   const referencedContext = await buildReferencedCharacterContext({
     db,
     activeCharacterIds: [storageTrimFixture.id],
@@ -5454,7 +5480,7 @@ assert.equal(
 );
 assert.match(
   appShellSource,
-  /handleTrackerPanelWindowClosed[\s\S]{0,260}setTrackerPanelOpen\(false, activeChatId\)/u,
+  /handleTrackerPanelWindowClosed[\s\S]{0,500}trackerPanelWindowTargetRef\.current\?\.popup !== closedTarget\.popup[\s\S]{0,300}setTrackerPanelOpen\(false, activeChatId\)/u,
   "Closing a detached Tracker window must close the Tracker instead of silently docking it",
 );
 const backgroundSeedRoot = mkdtempSync(join(tmpdir(), "marinara-default-background-"));

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -20,6 +20,8 @@ import {
   characters,
   chatPresets,
   chats,
+  lorebookCharacterLinks,
+  lorebooks,
   messages,
 } from "../../packages/server/src/db/schema/index.js";
 import { eq } from "../../packages/server/src/db/file-query.js";
@@ -77,7 +79,10 @@ import {
   getPersonalExtensionTraffic,
   recordPersonalExtensionRequest,
 } from "../../packages/client/src/lib/personal-extension-traffic.js";
-import { scrollProfessorMariTranscriptToBottom } from "../../packages/client/src/lib/professor-mari-transcript-scroll.js";
+import {
+  isProfessorMariTranscriptNearBottom,
+  scrollProfessorMariTranscriptToBottom,
+} from "../../packages/client/src/lib/professor-mari-transcript-scroll.js";
 import {
   formatCompactTokenCount,
   resolveProfessorMariContextBudget,
@@ -185,6 +190,7 @@ import {
   formatLorebookWriteApprovalText,
   parseLorebookWriteApprovalText,
 } from "../../packages/server/src/routes/generate/agent-write-approval.js";
+import { mergeLorebookKeeperUpdateContent } from "../../packages/server/src/routes/generate/lorebook-keeper-utils.js";
 import { runImageGenerationRequest } from "../../packages/server/src/services/image/image-generation-queue.js";
 import {
   buildSwarmUiGenerationBody,
@@ -870,6 +876,51 @@ try {
     0,
     "Hidden embedded lorebooks must not appear in general library searches",
   );
+
+  const removedOwner = await characterStorage.create(characterDataSchema.parse({ name: "Removed owner" }));
+  const removedOwnerLorebook = await lorebookStorage.create(
+    createLorebookSchema.parse({
+      name: "Formerly private notes",
+      characterIds: [removedOwner.id],
+      hiddenFromLibrary: true,
+    }),
+  );
+  await characterStorage.remove(removedOwner.id);
+  assert.equal(
+    (
+      await db
+        .select()
+        .from(lorebookCharacterLinks)
+        .where(eq(lorebookCharacterLinks.lorebookId, removedOwnerLorebook.id))
+    ).length,
+    0,
+    "Deleting a Character must remove its lorebook ownership link",
+  );
+  const retainedOrphan = (await db.select().from(lorebooks).where(eq(lorebooks.id, removedOwnerLorebook.id)))[0];
+  assert.ok(retainedOrphan, "An orphaned lorebook must remain available for recovery and management");
+  assert.equal(retainedOrphan.enabled, "false");
+  assert.equal(retainedOrphan.hiddenFromLibrary, "false");
+
+  const legacyOwner = await characterStorage.create(characterDataSchema.parse({ name: "Legacy owner" }));
+  const legacyLorebook = await lorebookStorage.create(
+    createLorebookSchema.parse({ name: "Legacy notes", characterIds: [legacyOwner.id], hiddenFromLibrary: true }),
+  );
+  await db
+    .delete(lorebookCharacterLinks)
+    .where(eq(lorebookCharacterLinks.lorebookId, legacyLorebook.id));
+  await characterStorage.remove(legacyOwner.id);
+  const retainedLegacyOrphan = (await db.select().from(lorebooks).where(eq(lorebooks.id, legacyLorebook.id)))[0];
+  assert.equal(retainedLegacyOrphan.characterId, null, "Deleting a Character must clear legacy direct ownership");
+  assert.equal(retainedLegacyOrphan.enabled, "false", "Legacy orphaned lorebooks must be deactivated");
+  assert.equal(retainedLegacyOrphan.hiddenFromLibrary, "false", "Legacy orphaned lorebooks must be manageable");
+
+  const unlinkedOwner = await characterStorage.create(characterDataSchema.parse({ name: "Unlinked owner" }));
+  const unlinkedLorebook = await lorebookStorage.create(
+    createLorebookSchema.parse({ name: "Unlinked notes", characterIds: [unlinkedOwner.id], hiddenFromLibrary: true }),
+  );
+  const unlinked = await lorebookStorage.update(unlinkedLorebook.id, { characterIds: [] });
+  assert.equal(unlinked?.enabled, false, "Unlinking the final owner must deactivate the lorebook");
+  assert.equal(unlinked?.hiddenFromLibrary, false, "An unlinked lorebook must return to the manageable library");
 
   const referencedContext = await buildReferencedCharacterContext({
     db,
@@ -1989,6 +2040,25 @@ assert.deepEqual(generatedLorebookEntry.secondaryKeys, ["rain"]);
   );
 }
 
+assert.equal(
+  mergeLorebookKeeperUpdateContent({
+    existingContent: "Old timeline that must be replaced.",
+    replacementContent: "Corrected timeline.",
+    newFacts: [],
+  }),
+  "Corrected timeline.",
+  "Lorebook Keeper updates must replace an existing body instead of stacking another copy",
+);
+assert.equal(
+  mergeLorebookKeeperUpdateContent({
+    existingContent: "Stable scene state.",
+    replacementContent: "",
+    newFacts: ["A new clue appeared."],
+  }),
+  "Stable scene state.\n\n- A new clue appeared.",
+  "Fact-only Lorebook Keeper updates must preserve the current body",
+);
+
 const completeProfessorMariPersona = buildPersonaCreateRow(
   {
     name: "Complete helper persona",
@@ -2635,6 +2705,21 @@ const conversationGenerationSource = readFileSync(
   new URL("../../packages/server/src/routes/generate.routes.ts", import.meta.url),
   "utf8",
 );
+assert.match(
+  conversationGenerationSource,
+  /const selectorConnection = \(await connections\.getDefaultForAgents\(\)\) \?\? conn/u,
+  "Smart group responder selection must prefer the default Agent connection and fall back to the chat connection",
+);
+assert.match(
+  conversationGenerationSource,
+  /resolveStoredMaxTokens\(selectorConnection\.defaultParameters, DEFAULT_AGENT_MAX_TOKENS\)/u,
+  "Smart group responder selection must respect the Agent connection token default instead of a 512-token cap",
+);
+assert.match(
+  conversationGenerationSource,
+  /resolveStoredChatOptions\([\s\S]{0,180}selectorConnection\.defaultParameters/u,
+  "Smart group responder selection must inherit the Agent connection generation parameters",
+);
 const foregroundAutonomousSource = readFileSync(
   new URL("../../packages/client/src/hooks/use-autonomous-messaging.ts", import.meta.url),
   "utf8",
@@ -2688,12 +2773,29 @@ assert.equal(resolveProfessorMariContextBudget([], 128_000), null);
 assert.match(professorMariHomeSource, /chatHistorySelectionMode/u);
 assert.match(professorMariHomeSource, /toggleProfessorChatSelection/u);
 assert.match(professorMariHomeSource, /handleBulkDeleteProfessorChats/u);
-const professorMariTranscript = { scrollHeight: 720, scrollTop: 0 };
+assert.match(
+  professorMariHomeSource,
+  /handleDeleteProfessorChat[\s\S]{0,500}showConfirmDialog/u,
+  "Deleting one Professor Mari chat must use the app confirmation dialog",
+);
+assert.match(
+  professorMariHomeSource,
+  /isError && tool\.output\?\.trim\(\)[\s\S]{0,200}<pre/u,
+  "Failed workspace tools must reveal their provider output in the transcript",
+);
+const professorMariTranscript = { clientHeight: 240, scrollHeight: 720, scrollTop: 0 };
 scrollProfessorMariTranscriptToBottom(professorMariTranscript);
 assert.equal(
   professorMariTranscript.scrollTop,
   professorMariTranscript.scrollHeight,
   "Professor Mari transcript scrolling must align a mounted pane with its newest message",
+);
+assert.equal(isProfessorMariTranscriptNearBottom(professorMariTranscript), true);
+professorMariTranscript.scrollTop = 200;
+assert.equal(
+  isProfessorMariTranscriptNearBottom(professorMariTranscript),
+  false,
+  "Professor Mari streaming must stop following output after the reader scrolls away from the bottom",
 );
 assert.match(
   professorMariHomeSource,
@@ -5327,8 +5429,8 @@ assert.equal(
     side: "left",
     gap: 8,
   }),
-  128,
-  "The Tracker should shrink to the narrower left chat gutter",
+  420,
+  "The Tracker may overlap the chat instead of crushing its controls into a narrow gutter",
 );
 assert.equal(
   resolveTrackerPanelDesktopWidth({
@@ -5340,8 +5442,8 @@ assert.equal(
     side: "right",
     gap: 8,
   }),
-  128,
-  "The Tracker should use the matching right chat gutter",
+  340,
+  "The right-side Tracker should preserve its selected width when the main viewport can hold it",
 );
 assert.equal(resolveTrackerPanelContentScale(340, 340), 1);
 assert.equal(resolveTrackerPanelContentScale(340, 255), 0.75);
@@ -5349,6 +5451,11 @@ assert.equal(
   resolveTrackerPanelContentScale(420, 128),
   0.65,
   "Severely constrained Tracker contents should reflow before their text becomes unreadably small",
+);
+assert.match(
+  appShellSource,
+  /handleTrackerPanelWindowClosed[\s\S]{0,260}setTrackerPanelOpen\(false, activeChatId\)/u,
+  "Closing a detached Tracker window must close the Tracker instead of silently docking it",
 );
 const backgroundSeedRoot = mkdtempSync(join(tmpdir(), "marinara-default-background-"));
 const backgroundSeedDir = join(backgroundSeedRoot, "backgrounds");
@@ -5588,6 +5695,11 @@ try {
     "SwarmUI workflow validation must reject backend-local reference-image filenames before save",
   );
   assert.match(connectionEditorSource, /if \(swarmUiWorkflowError\) \{[\s\S]{0,180}throw new Error/u);
+  assert.match(
+    connectionEditorSource,
+    /type="button"[\s\S]{0,180}novelAiStylePlateInputRef\.current\?\.click\(\)[\s\S]{0,1000}type="file"/u,
+    "NovelAI style-plate selection must use an explicit non-submitting button instead of label navigation",
+  );
 
   const backgroundAutonomousSource = readFileSync(
     join(REPOSITORY_ROOT, "packages/client/src/hooks/use-background-autonomous.ts"),

--- a/scripts/regressions/professor-mari-shell-sandbox.regression.ts
+++ b/scripts/regressions/professor-mari-shell-sandbox.regression.ts
@@ -44,6 +44,7 @@ assert.match(workspaceSource, /Use the dependency tool/u);
 assert.match(workspaceSource, /name: "copy"/u);
 assert.match(workspaceSource, /name: "move"/u);
 assert.match(workspaceSource, /name: "remove"/u);
+assert.match(workspaceSource, /constants\.COPYFILE_EXCL/u);
 assert.match(sandboxSource, /copy, move, remove/u);
 assert.doesNotMatch(workspaceSource, /spawn\(shell,\s*shellArgs/u);
 

--- a/scripts/regressions/professor-mari-shell-sandbox.regression.ts
+++ b/scripts/regressions/professor-mari-shell-sandbox.regression.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -12,6 +12,7 @@ import {
   WorkspaceChangeReviewService,
   workspacePathAccessPolicy,
 } from "../../packages/server/src/services/professor-mari/workspace-change-review.service.js";
+import { ProfessorMariWorkspaceService } from "../../packages/server/src/services/professor-mari/workspace-agent.service.js";
 
 function shellQuote(value: string) {
   return `'${value.replace(/'/g, "'\\''")}'`;
@@ -44,9 +45,72 @@ assert.match(workspaceSource, /Use the dependency tool/u);
 assert.match(workspaceSource, /name: "copy"/u);
 assert.match(workspaceSource, /name: "move"/u);
 assert.match(workspaceSource, /name: "remove"/u);
-assert.match(workspaceSource, /constants\.COPYFILE_EXCL/u);
 assert.match(sandboxSource, /copy, move, remove/u);
 assert.doesNotMatch(workspaceSource, /spawn\(shell,\s*shellArgs/u);
+
+const structuredWorkspace = mkdtempSync(join(tmpdir(), "marinara-mari-structured-workspace-"));
+try {
+  const service = new ProfessorMariWorkspaceService({} as never);
+  service.setEnabled(true, structuredWorkspace);
+  const commandRunner = service as unknown as {
+    executeWorkspaceCommand(
+      command: {
+        id: string;
+        name: "copy" | "move" | "remove";
+        arguments: Record<string, unknown>;
+      },
+      signal: AbortSignal,
+      trace: unknown[],
+      onEvent: () => void,
+    ): Promise<{ output: string; success: boolean }>;
+  };
+  let commandId = 0;
+  const runFileCommand = (name: "copy" | "move" | "remove", args: Record<string, unknown>) =>
+    commandRunner.executeWorkspaceCommand(
+      { id: `structured-${commandId++}`, name, arguments: args },
+      new AbortController().signal,
+      [],
+      () => undefined,
+    );
+
+  writeFileSync(join(structuredWorkspace, "source.txt"), "source-content", "utf8");
+  writeFileSync(join(structuredWorkspace, "existing.txt"), "existing-content", "utf8");
+
+  const blockedCopy = await runFileCommand("copy", { source: "source.txt", destination: "existing.txt" });
+  assert.equal(blockedCopy.success, false);
+  assert.match(blockedCopy.output, /copy destination already exists/u);
+  assert.equal(readFileSync(join(structuredWorkspace, "source.txt"), "utf8"), "source-content");
+  assert.equal(readFileSync(join(structuredWorkspace, "existing.txt"), "utf8"), "existing-content");
+
+  const blockedMove = await runFileCommand("move", { source: "source.txt", destination: "existing.txt" });
+  assert.equal(blockedMove.success, false);
+  assert.match(blockedMove.output, /move destination already exists/u);
+  assert.equal(readFileSync(join(structuredWorkspace, "source.txt"), "utf8"), "source-content");
+  assert.equal(readFileSync(join(structuredWorkspace, "existing.txt"), "utf8"), "existing-content");
+
+  mkdirSync(join(structuredWorkspace, "non-empty"));
+  writeFileSync(join(structuredWorkspace, "non-empty", "child.txt"), "keep-me", "utf8");
+  const blockedDirectoryMove = await runFileCommand("move", {
+    source: "non-empty",
+    destination: "moved-directory",
+  });
+  assert.equal(blockedDirectoryMove.success, false);
+  assert.match(blockedDirectoryMove.output, /move source must be a file/u);
+  assert.equal(readFileSync(join(structuredWorkspace, "non-empty", "child.txt"), "utf8"), "keep-me");
+
+  await runFileCommand("copy", { source: "source.txt", destination: "copied.txt" });
+  assert.equal(readFileSync(join(structuredWorkspace, "copied.txt"), "utf8"), "source-content");
+  await runFileCommand("move", { source: "copied.txt", destination: "moved.txt" });
+  assert.equal(existsSync(join(structuredWorkspace, "copied.txt")), false);
+  assert.equal(readFileSync(join(structuredWorkspace, "moved.txt"), "utf8"), "source-content");
+  await runFileCommand("remove", { path: "moved.txt" });
+  assert.equal(existsSync(join(structuredWorkspace, "moved.txt")), false);
+  const blockedDirectoryRemove = await runFileCommand("remove", { path: "non-empty" });
+  assert.equal(blockedDirectoryRemove.success, false);
+  assert.match(blockedDirectoryRemove.output, /not empty|ENOTEMPTY/iu);
+} finally {
+  rmSync(structuredWorkspace, { recursive: true, force: true });
+}
 
 const reviewWorkspace = mkdtempSync(join(tmpdir(), "marinara-mari-review-workspace-"));
 const fakeIntegrity = "sha512-regression-integrity";

--- a/scripts/regressions/professor-mari-shell-sandbox.regression.ts
+++ b/scripts/regressions/professor-mari-shell-sandbox.regression.ts
@@ -45,6 +45,8 @@ assert.match(workspaceSource, /Use the dependency tool/u);
 assert.match(workspaceSource, /name: "copy"/u);
 assert.match(workspaceSource, /name: "move"/u);
 assert.match(workspaceSource, /name: "remove"/u);
+assert.match(workspaceSource, /write\|copy\|move\|remove\|bash/u);
+assert.match(workspaceSource, /Final prompt messages/u);
 assert.match(sandboxSource, /copy, move, remove/u);
 assert.doesNotMatch(workspaceSource, /spawn\(shell,\s*shellArgs/u);
 

--- a/scripts/regressions/professor-mari-shell-sandbox.regression.ts
+++ b/scripts/regressions/professor-mari-shell-sandbox.regression.ts
@@ -41,6 +41,10 @@ assert.match(sandboxSource, /--unshare-all/u);
 assert.match(sandboxSource, /throw new Error\(\s*`\$\{status\.reason\}/u);
 assert.match(workspaceSource, /spawnWorkspaceSandboxedShell/u);
 assert.match(workspaceSource, /Use the dependency tool/u);
+assert.match(workspaceSource, /name: "copy"/u);
+assert.match(workspaceSource, /name: "move"/u);
+assert.match(workspaceSource, /name: "remove"/u);
+assert.match(sandboxSource, /copy, move, remove/u);
 assert.doesNotMatch(workspaceSource, /spawn\(shell,\s*shellArgs/u);
 
 const reviewWorkspace = mkdtempSync(join(tmpdir(), "marinara-mari-review-workspace-"));


### PR DESCRIPTION
## Why

Eight assigned reports outside the Home rebuild were still affecting connection reliability, Professor Mari workflows, lorebook integrity, and Tracker usability. This sweep resolves them together while keeping the changes focused and keeping the Home rebuild PR entirely untouched.

## Summary

- Route smart Conversation group selection through the default Agent connection and Agent fallback, honoring saved model parameters instead of a fixed 512-token chat-connection request.
- Quarantine automatic generation on a connection for six hours after three consecutive failures, while preserving foreground chat access and resetting the quarantine after recovery.
- Keep Professor Mari history scrollable during streaming, use the Marinara confirmation dialog for individual chat deletion, and reveal failed workspace tool output in the transcript.
- Preserve Tracker controls at the configured width, snap beside an open side panel, allow overlap when space is tight, and fully close the Tracker when its detached window closes.
- Keep NovelAI V4.5 style-plate selection inside the Connection editor with an explicit non-submitting upload control.
- Deactivate and reveal lorebooks that lose their final Character/Persona owner, including legacy direct links; make Lorebook Keeper replacement bodies authoritative so repeated saves do not stack old content.
- Add reviewed structured copy, move, and remove tools for Android/Termux and other hosts without a supported raw-shell sandbox.

## Security boundary

Android/Termux raw shell remains fail-closed. It does not have a supported Seatbelt/Bubblewrap equivalent. Professor Mari now receives safe structured file operations instead; they are workspace-confined, deny storage/protected paths (including symlink routes), refuse overwrite, and only remove one file or an empty directory.

## Automated validation

- `pnpm check`
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts`
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/noodle-autopost.regression.ts`
- `pnpm regression:professor-mari-shell-sandbox`
- `pnpm regression:providers`
- Targeted Playwright coverage for NovelAI style-plate upload and desktop Tracker layout

The full local UI smoke run reached 203 passed and 100 skipped. The affected Tracker check was updated and passes in isolation; Secret Plot also passes in isolation. The unrelated existing mobile composer history-position check still hangs in isolation and is outside the files changed here.

## Manual test plan

- [ ] Manually verify NovelAI V4.5 style-plate selection in Chrome on Windows 10.
- [ ] Manually verify Professor Mari streaming scroll, native single-chat deletion, and visible workspace error details on desktop and mobile.
- [ ] Manually verify Tracker placement with the right panel resized and close behavior after detaching it.
- [ ] Manually verify orphaned lorebook recovery and Lorebook Keeper replacement behavior using a copied profile.
- [ ] Manually verify repeated Noodle provider failures cool down automatic requests while normal chats remain usable.
- [ ] Manually verify smart group selection uses the configured Agent connection and its token/thinking settings.
- [ ] Manually verify structured copy, move, and remove operations from Professor Mari on Termux.

Closes #4777
Closes #4775
Closes #4774
Closes #4773
Closes #4772
Closes #4770
Closes #4769
Closes #4765

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Professor Mari supports structured workspace copy, move, and remove actions with safer path handling.
  - Smart group responders select suitable connections and generation settings.
  - Background connections are temporarily quarantined after repeated failures.

- **Bug Fixes**
  - Improved Professor Mari transcript scrolling, tool error display, debug prompts, and chat deletion confirmation.
  - Fixed Tracker panel sizing and detached-window behavior.
  - Improved NovelAI style-plate uploads.
  - Corrected lorebook ownership, deletion, visibility, and content updates.
  - Fixed workspace file-operation error guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->