### PR TITLE
fix: polish assigned Home and Appearance regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
-- Corrected Home and Appearance presentation regressions affecting semantic chat-mode colors, the Square avatar preview, Noodle notification placement, compact mobile Achievements, Discovery Desk spacing, and mobile Bookmarks motion (#4809, #4817, #4818, #4819, #4820, #4821).
+- Corrected Home and Appearance presentation regressions affecting semantic chat-mode colors, the Square avatar preview, Noodle notification placement, compact mobile Achievements, Discovery Desk spacing, mobile Bookmarks motion, and consistent widget-manager labels (#4809, #4817, #4818, #4819, #4820, #4821, #4823).
 - Restored Game party portrait file selection for Character, Persona, and NPC sheets whether or not the sheet editor is active (#4793).
 - Kept legacy reaction payloads out of rendered message content, accepted `/title <name>` in Professor Mari chats, and let her navigator open an exact saved chat title (#4782, #4794, #4800).
 - Standardized gradient-stop editing on Marinara's owned color controls and tightened Home responsiveness, including Guide overflow, deleted Recent Chats, semantic mode colors, decorative browser refresh behavior, larger Mari drag targeting, and pausing Home animations while the app is unfocused (#4797, #4799, #4802, #4804, #4807, #4808, #4809).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Corrected Home and Appearance presentation regressions affecting semantic chat-mode colors, the Square avatar preview, Noodle notification placement, compact mobile Achievements, Discovery Desk spacing, and mobile Bookmarks motion (#4809, #4817, #4818, #4819, #4820, #4821).
 - Restored Game party portrait file selection for Character, Persona, and NPC sheets whether or not the sheet editor is active (#4793).
 - Kept legacy reaction payloads out of rendered message content, accepted `/title <name>` in Professor Mari chats, and let her navigator open an exact saved chat title (#4782, #4794, #4800).
 - Standardized gradient-stop editing on Marinara's owned color controls and tightened Home responsiveness, including Guide overflow, deleted Recent Chats, semantic mode colors, decorative browser refresh behavior, larger Mari drag targeting, and pausing Home animations while the app is unfocused (#4797, #4799, #4802, #4804, #4807, #4808, #4809).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -297,6 +297,28 @@ test("turning off the custom mouse pointer persists immediately and after reload
     .toBeNull();
 });
 
+test("Appearance distinguishes the square avatar-shape preview from the circular option", async ({
+  page,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "One visual shape proof is sufficient.");
+
+  await page.goto("/");
+  await page.locator('[data-tour="panel-settings"]').click();
+  await page.getByRole("tab", { name: "Appearance" }).click();
+
+  const circle = page.locator('[data-avatar-shape-preview="circle"]');
+  const square = page.locator('[data-avatar-shape-preview="square"]');
+  await expect(circle).toBeVisible();
+  await expect(square).toBeVisible();
+  const [circleRadius, squareRadius, squareWidth] = await Promise.all([
+    circle.evaluate((element) => Number.parseFloat(getComputedStyle(element).borderTopLeftRadius)),
+    square.evaluate((element) => Number.parseFloat(getComputedStyle(element).borderTopLeftRadius)),
+    square.evaluate((element) => element.getBoundingClientRect().width),
+  ]);
+  expect(circleRadius).toBeGreaterThanOrEqual(squareWidth / 2);
+  expect(squareRadius).toBeLessThan(squareWidth / 3);
+});
+
 test("custom theme live preview batches stylesheet updates while typing", async ({ page }) => {
   await page.goto("/");
   await page.locator('[data-tour="panel-settings"]').click();
@@ -512,7 +534,7 @@ test("default dialogue color fills only cards without their own dialogue color",
     await chatTextColorControl.scrollIntoViewIfNeeded();
     await chatTextColorControl.getByRole("button", { name: /Scheme default/ }).click();
     await chatTextColorControl.getByRole("button", { name: "Gradient", exact: true }).click();
-    const firstGradientStop = chatTextColorControl.locator('input:not([type])').first();
+    const firstGradientStop = chatTextColorControl.locator("input:not([type])").first();
     await firstGradientStop.fill("red 20%");
     await firstGradientStop.fill("blue 35%");
     const positionedStopSliders = chatTextColorControl
@@ -3578,7 +3600,7 @@ test("stopped and refused generations keep sent text cleared and accept the firs
           (await readMessages()).filter(
             (message) =>
               message.role === "user" && message.content === "Provider refusal must not duplicate this sent message",
-        ).length,
+          ).length,
       )
       .toBe(1);
 
@@ -7295,11 +7317,11 @@ test("home shell and primary topbar panels open without client errors", async ({
       buttons
         .map((button) => {
           const icon = button.querySelector("svg");
-            const box = icon?.getBoundingClientRect();
-            return box ? box.x + box.width / 2 : null;
-          })
-          .filter((center): center is number => center !== null),
-      );
+          const box = icon?.getBoundingClientRect();
+          return box ? box.x + box.width / 2 : null;
+        })
+        .filter((center): center is number => center !== null),
+    );
     const spacings = iconCenters.slice(1).map((center, index) => center - iconCenters[index]);
     expect(iconCenters.length).toBeGreaterThan(2);
     expect(Math.max(...spacings) - Math.min(...spacings)).toBeLessThanOrEqual(2);
@@ -7332,7 +7354,9 @@ test("home shell and primary topbar panels open without client errors", async ({
   expect(errors).toEqual([]);
 });
 
-test("installed Home destinations appear as browser tabs without returning to the topbar", async ({ page }, testInfo) => {
+test("installed Home destinations appear as browser tabs without returning to the topbar", async ({
+  page,
+}, testInfo) => {
   const errors = collectUnexpectedErrors(page);
   const mobile = testInfo.project.name.includes("mobile");
   const refreshMarker = "refresh-fixture:2026-08-09T16:00:00.000Z";
@@ -7412,6 +7436,16 @@ test("installed Home destinations appear as browser tabs without returning to th
   await expect(noodleTab.locator("img").last()).toHaveAttribute("src", /noodler-klusek\.png/u);
   const refreshBadge = noodleTab.locator('[data-component="HomeBrowserHub.NoodleRefreshBadge"]');
   await expect(refreshBadge).toHaveText("1");
+  const [noodleTabBounds, refreshBadgeBounds] = await Promise.all([
+    noodleTab.boundingBox(),
+    refreshBadge.boundingBox(),
+  ]);
+  expect(noodleTabBounds).not.toBeNull();
+  expect(refreshBadgeBounds).not.toBeNull();
+  expect(refreshBadgeBounds!.y).toBeGreaterThanOrEqual(noodleTabBounds!.y);
+  expect(refreshBadgeBounds!.y + refreshBadgeBounds!.height).toBeLessThanOrEqual(
+    noodleTabBounds!.y + noodleTabBounds!.height + 1,
+  );
   if (mobile) {
     const tabList = page.locator('[data-component="HomeBrowserHub.TabList"]');
     await expect(tabList.getByRole("tab")).toHaveCount(3);
@@ -7544,6 +7578,24 @@ test("Home recent chats use mode colors and show character sprites", async ({ pa
 
   await page.goto("/");
   await expect(page.getByRole("heading", { name: "What shall we cook tonight?" })).toBeVisible({ timeout: 30_000 });
+  for (const mode of ["conversation", "roleplay", "game"] as const) {
+    const launcher = page.locator(`[data-home-chat-mode="${mode}"]`);
+    const icon = launcher.locator(`[data-chat-mode-icon="${mode}"]`);
+    const colors = await launcher.evaluate((element, currentMode) => {
+      const modeIcon = element.querySelector<SVGElement>(`[data-chat-mode-icon="${currentMode}"]`);
+      const probe = document.createElement("span");
+      probe.style.color = "var(--home-chat-mode-accent)";
+      element.append(probe);
+      const result = {
+        icon: modeIcon ? getComputedStyle(modeIcon).color : null,
+        accent: getComputedStyle(probe).color,
+      };
+      probe.remove();
+      return result;
+    }, mode);
+    expect(colors.icon).toBe(colors.accent);
+    await expect(icon).toHaveClass(/mari-rgb-static-icon/u);
+  }
   const expectedAccents = [
     ["Cyan chat", "oklch(0.79 0.16 205)"],
     ["Orange story", "oklch(0.76 0.19 52)"],
@@ -7565,6 +7617,19 @@ test("Home recent chats use mode colors and show character sprites", async ({ pa
     expect(
       await card.evaluate((element) => getComputedStyle(element).getPropertyValue("--recent-chat-accent").trim()),
     ).toBe(accent);
+    const iconColors = await card.evaluate((element) => {
+      const icon = element.querySelector<SVGElement>("[data-chat-mode-icon]");
+      const probe = document.createElement("span");
+      probe.style.color = "var(--recent-chat-accent)";
+      element.append(probe);
+      const result = {
+        icon: icon ? getComputedStyle(icon).color : null,
+        accent: getComputedStyle(probe).color,
+      };
+      probe.remove();
+      return result;
+    });
+    expect(iconColors.icon).toBe(iconColors.accent);
   }
   const gameCard = page.getByRole("button", { name: /Pink game/ });
   await expect(gameCard.locator('img[src*="moonlit-kitchen.svg"]')).toBeVisible();
@@ -8583,7 +8648,7 @@ test("Character and Persona panels launch card downloads and their local librari
   await expect(searchError).toHaveClass(/marinara-chat-chrome-panel-title/);
   const sourceButton = cardLibrary.getByRole("button", { name: /ChubAI/u });
   await sourceButton.evaluate((button: HTMLButtonElement) => button.click());
-  const sourceMenu = page.locator('.mari-chrome-selection-bar--opaque').filter({ hasText: "JannyAI" });
+  const sourceMenu = page.locator(".mari-chrome-selection-bar--opaque").filter({ hasText: "JannyAI" });
   await expect(sourceMenu).toBeVisible();
   const [sourceButtonBox, sourceMenuBox, browserBox] = await Promise.all([
     sourceButton.boundingBox(),
@@ -8593,7 +8658,9 @@ test("Character and Persona panels launch card downloads and their local librari
   expect(sourceButtonBox).not.toBeNull();
   expect(sourceMenuBox).not.toBeNull();
   expect(browserBox).not.toBeNull();
-  expect(Math.abs(sourceMenuBox!.x + sourceMenuBox!.width - (sourceButtonBox!.x + sourceButtonBox!.width))).toBeLessThanOrEqual(1);
+  expect(
+    Math.abs(sourceMenuBox!.x + sourceMenuBox!.width - (sourceButtonBox!.x + sourceButtonBox!.width)),
+  ).toBeLessThanOrEqual(1);
   expect(sourceMenuBox!.x + sourceMenuBox!.width).toBeLessThanOrEqual(browserBox!.x + browserBox!.width);
   await page.getByRole("button", { name: "Close provider menu" }).click();
   const closeCardLibrary = cardLibrary.getByRole("button", { name: "Close library" });
@@ -12480,8 +12547,21 @@ test("Home Community and clock widgets are useful, timezone-aware, and optional"
   await openHomeBookmark(page, "Widgets");
   const widgetManager = page.getByRole("dialog", { name: "Home Widgets" });
   await expect(widgetManager.getByRole("switch")).toHaveCount(9);
-  await widgetManager.getByRole("switch", { name: "Hide Community" }).click();
-  await widgetManager.getByRole("switch", { name: "Hide Clock & Calendar" }).click();
+  for (const label of [
+    "Your guide — Professor Mari",
+    "Continue chatting — Recent chats",
+    "From the kitchen — What's New",
+    "Discovery desk — Something new for your engine",
+    "Daily encounter — Character of the Day",
+    "Field notes — Learn the engine",
+    "Community — Around the table",
+    "Clock & calendar — Right now",
+    "Your shelf — Achievements",
+  ]) {
+    await expect(widgetManager.getByText(label, { exact: true })).toBeVisible();
+  }
+  await widgetManager.getByRole("switch", { name: "Hide Community — Around the table" }).click();
+  await widgetManager.getByRole("switch", { name: "Hide Clock & calendar — Right now" }).click();
   await expect(page.locator('[data-home-widget-id="community"]')).toHaveCount(0);
   await expect(page.locator('[data-home-widget-id="clock"]')).toHaveCount(0);
   await page.keyboard.press("Escape");
@@ -12516,6 +12596,7 @@ test("mobile Home collects its bookmarks into a Marinara-colored menu", async ({
   await trigger.click();
   await expect(trigger).toHaveAttribute("aria-expanded", "true");
   await expect(menu).toBeVisible();
+  await expect(menu).toHaveAttribute("data-bookmarks-motion", "slide");
   await expect(menu.locator(":scope > a, :scope > button")).toHaveCount(8);
   await expect(menu.locator(":scope > a img, :scope > button img")).toHaveCount(8);
   expect(await menu.evaluate((element) => element.scrollHeight <= element.clientHeight + 1)).toBe(true);
@@ -12532,7 +12613,11 @@ test("mobile Home collects its bookmarks into a Marinara-colored menu", async ({
     await expect(menu.getByText(label, { exact: true })).toBeVisible();
   }
 
-  await menu.getByRole("button", { name: "FAQ", exact: true }).click();
+  const menuStayedMountedForExit = await menu.getByRole("button", { name: "FAQ", exact: true }).evaluate((button) => {
+    button.click();
+    return Boolean(document.querySelector('[data-component="HomeBrowserHub.MobileBookmarksMenu"]'));
+  });
+  expect(menuStayedMountedForExit).toBe(true);
   await expect(menu).toHaveCount(0);
   await expect(page.getByRole("dialog", { name: "Professor Mari's FAQ" })).toBeVisible();
 });
@@ -12554,7 +12639,7 @@ test("enabling Recent Chats anchors its 2 by 2 footprint and repacks smaller wid
 
   await openHomeBookmark(page, "Widgets");
   const widgetManager = page.getByRole("dialog", { name: "Home Widgets" });
-  await widgetManager.getByRole("switch", { name: "Show Recent Chats" }).click();
+  await widgetManager.getByRole("switch", { name: "Show Continue chatting — Recent chats" }).click();
   const recent = page.locator('[data-home-widget-id="recent"]');
   await expect(recent).toBeVisible();
   await expect
@@ -12620,7 +12705,12 @@ test("enabling Recent Chats anchors its 2 by 2 footprint and repacks smaller wid
   }
 
   await openHomeBookmark(page, "Widgets");
-  for (const widget of ["Discovery Desk", "Character of the Day", "Clock & Calendar", "Achievements"]) {
+  for (const widget of [
+    "Discovery desk — Something new for your engine",
+    "Daily encounter — Character of the Day",
+    "Clock & calendar — Right now",
+    "Your shelf — Achievements",
+  ]) {
     await widgetManager.getByRole("switch", { name: `Show ${widget}` }).click();
   }
   await page.keyboard.press("Escape");
@@ -12721,7 +12811,9 @@ test("Home achievements preview the latest unlock and nearest measurable goal", 
   ).toBeVisible();
   await expect(achievementsWidget.getByText("Gotta catch them all!", { exact: true })).toHaveCount(1);
   const achievementsLauncher = achievementsWidget.getByRole("button", { name: "Open Achievements" });
-  const launcherBackground = await achievementsLauncher.evaluate((element) => getComputedStyle(element).backgroundColor);
+  const launcherBackground = await achievementsLauncher.evaluate(
+    (element) => getComputedStyle(element).backgroundColor,
+  );
   await achievementsLauncher.hover();
   await expect
     .poll(() => achievementsLauncher.evaluate((element) => getComputedStyle(element).backgroundColor))
@@ -12754,9 +12846,10 @@ test("Home achievements preview the latest unlock and nearest measurable goal", 
   expect(widgetsIndex).toBeGreaterThanOrEqual(0);
   expect(faqIndex).toBeLessThan(achievementsIndex);
   expect(achievementsIndex).toBeLessThan(widgetsIndex);
-  await expect(
-    bookmarks.getByRole("button", { name: "Achievements", exact: true }).locator("img"),
-  ).toHaveAttribute("src", "/home/tab-icons/achievements.png");
+  await expect(bookmarks.getByRole("button", { name: "Achievements", exact: true }).locator("img")).toHaveAttribute(
+    "src",
+    "/home/tab-icons/achievements.png",
+  );
   await bookmarks.getByRole("button", { name: "Achievements", exact: true }).click();
   await expect(achievementsDialog).toBeVisible();
   await page.keyboard.press("Escape");
@@ -12775,6 +12868,63 @@ test("Home achievements preview the latest unlock and nearest measurable goal", 
   const widgetManager = page.getByRole("dialog", { name: "Home Widgets" });
   await expect(widgetManager.getByText("Achievements", { exact: true })).toHaveCount(0);
   await page.keyboard.press("Escape");
+});
+
+test("mobile Achievements stays compact and preserves the gap before Discovery Desk", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("mobile"), "Mobile-only compact widget proof.");
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.addInitScript(() => {
+    const order = [
+      "professor",
+      "whats-new",
+      "recent",
+      "learn",
+      "community",
+      "character",
+      "clock",
+      "achievements",
+      "discovery",
+    ];
+    localStorage.setItem("marinara:home:widget-visibility:v2", JSON.stringify(order));
+    localStorage.setItem("marinara:home:widget-order:v1", JSON.stringify(order));
+    localStorage.setItem("marinara:home:widget-layout:v2", JSON.stringify({ 1: order }));
+  });
+
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "What shall we cook tonight?" })).toBeVisible({ timeout: 30_000 });
+  const achievements = page.locator('[data-home-widget-id="achievements"]');
+  const discovery = page.locator('[data-home-widget-id="discovery"]');
+  const achievementsSurface = achievements.locator(":scope > section");
+  const discoverySurface = discovery.locator(":scope > section");
+  const launcher = achievements.getByRole("button", { name: "Open Achievements" });
+  const closest = achievements.locator('[data-achievement-highlight="closest"]');
+  await expect(achievements).toBeVisible();
+  await expect(discovery).toBeVisible();
+
+  const layout = await page.locator('[data-component="HomeBrowserHub.Feed"]').evaluate((feed) => {
+    const bounds = (selector: string) => {
+      const element = document.querySelector<HTMLElement>(selector);
+      if (!element) throw new Error(`Missing ${selector}`);
+      const rect = element.getBoundingClientRect();
+      return { top: rect.top, bottom: rect.bottom, height: rect.height };
+    };
+    return {
+      rowGap: Number.parseFloat(getComputedStyle(feed).rowGap),
+      achievements: bounds('[data-home-widget-id="achievements"]'),
+      achievementsSurface: bounds('[data-home-widget-id="achievements"] > section'),
+      launcher: bounds('[data-home-widget-id="achievements"] button[aria-label="Open Achievements"]'),
+      closest: bounds('[data-home-widget-id="achievements"] [data-achievement-highlight="closest"]'),
+      discoverySurface: bounds('[data-home-widget-id="discovery"] > section'),
+    };
+  });
+  expect(layout.achievementsSurface.bottom).toBeLessThanOrEqual(layout.achievements.bottom + 1);
+  expect(layout.launcher.bottom).toBeLessThanOrEqual(layout.achievementsSurface.bottom + 1);
+  expect(layout.closest.bottom).toBeLessThanOrEqual(layout.achievementsSurface.bottom + 1);
+  expect(layout.discoverySurface.top - layout.achievementsSurface.bottom).toBeGreaterThanOrEqual(layout.rowGap - 1);
+  await expect(achievementsSurface).toHaveClass(/min-h-0/u);
+  await expect(discoverySurface).toBeVisible();
+  await expect(launcher).toBeVisible();
+  await expect(closest).toBeVisible();
 });
 
 test("Character of the Day stays vertically centered inside its mobile widget", async ({ page }, testInfo) => {
@@ -12803,15 +12953,9 @@ test("Character of the Day stays vertically centered inside its mobile widget", 
     const characterWidget = page.locator('[data-home-widget-id="character"]');
     await expect(characterWidget).toBeVisible({ timeout: 30_000 });
     const characterLayout = await characterWidget.evaluate((element) => {
-      const content = element.querySelector<HTMLElement>(
-        '[data-component="HomeBrowserHub.CharacterOfDayContent"]',
-      );
-      const avatar = element.querySelector<HTMLElement>(
-        '[data-component="HomeBrowserHub.CharacterOfDayAvatar"]',
-      );
-      const details = element.querySelector<HTMLElement>(
-        '[data-component="HomeBrowserHub.CharacterOfDayDetails"]',
-      );
+      const content = element.querySelector<HTMLElement>('[data-component="HomeBrowserHub.CharacterOfDayContent"]');
+      const avatar = element.querySelector<HTMLElement>('[data-component="HomeBrowserHub.CharacterOfDayAvatar"]');
+      const details = element.querySelector<HTMLElement>('[data-component="HomeBrowserHub.CharacterOfDayDetails"]');
       if (!content || !avatar || !details) return null;
       const contentBounds = content.getBoundingClientRect();
       const avatarBounds = avatar.getBoundingClientRect();
@@ -12906,7 +13050,7 @@ test("home browser hub scales cleanly and opens FAQ as a bookmark window", async
   const widgetManager = page.getByRole("dialog", { name: "Home Widgets" });
   await expect(widgetManager).toBeVisible();
   await expect(widgetManager.getByRole("switch")).toHaveCount(9);
-  await widgetManager.getByRole("switch", { name: "Hide Achievements" }).click();
+  await widgetManager.getByRole("switch", { name: "Hide Your shelf — Achievements" }).click();
   await expect(page.locator('[data-home-widget-id="achievements"]')).toHaveCount(0);
   await expect
     .poll(() =>
@@ -12926,7 +13070,7 @@ test("home browser hub scales cleanly and opens FAQ as a bookmark window", async
   await page.keyboard.press("Escape");
   await expect(achievementsWindow).toBeHidden();
   await openHomeBookmark(page, "Widgets");
-  await widgetManager.getByRole("switch", { name: "Show Achievements" }).click();
+  await widgetManager.getByRole("switch", { name: "Show Your shelf — Achievements" }).click();
   const restoredAchievements = page.locator('[data-home-widget-id="achievements"]');
   await expect(restoredAchievements).toBeVisible();
   await expect
@@ -12942,41 +13086,45 @@ test("home browser hub scales cleanly and opens FAQ as a bookmark window", async
   const baselineCompactHeight = await page
     .locator('[data-home-widget-id="professor"]')
     .evaluate((element) => element.getBoundingClientRect().height);
-  for (const widget of ["Recent Chats", "What's New", "Discovery Desk"]) {
+  for (const widget of [
+    "Continue chatting — Recent chats",
+    "From the kitchen — What's New",
+    "Discovery desk — Something new for your engine",
+  ]) {
     await widgetManager.getByRole("switch", { name: `Hide ${widget}` }).click();
   }
   await expect(page.locator("[data-home-widget-id]")).toHaveCount(6);
   await expectHomeWidgetHeightsMatch(page, baselineCompactHeight);
 
-  await widgetManager.getByRole("switch", { name: "Hide Achievements" }).click();
+  await widgetManager.getByRole("switch", { name: "Hide Your shelf — Achievements" }).click();
   await expect(page.locator("[data-home-widget-id]")).toHaveCount(5);
   await expectHomeWidgetHeightsMatch(page, baselineCompactHeight);
 
-  await widgetManager.getByRole("switch", { name: "Hide Professor Mari" }).click();
+  await widgetManager.getByRole("switch", { name: "Hide Your guide — Professor Mari" }).click();
   await expect(page.locator("[data-home-widget-id]")).toHaveCount(4);
   await expectHomeWidgetHeightsMatch(page, baselineCompactHeight);
 
-  await widgetManager.getByRole("switch", { name: "Hide Character of the Day" }).click();
+  await widgetManager.getByRole("switch", { name: "Hide Daily encounter — Character of the Day" }).click();
   await expect(page.locator("[data-home-widget-id]")).toHaveCount(3);
   await expectHomeWidgetHeightsMatch(page, baselineCompactHeight);
 
-  await widgetManager.getByRole("switch", { name: "Hide Community" }).click();
+  await widgetManager.getByRole("switch", { name: "Hide Community — Around the table" }).click();
   await expect(page.locator("[data-home-widget-id]")).toHaveCount(2);
   await expectHomeWidgetHeightsMatch(page, baselineCompactHeight);
 
-  await widgetManager.getByRole("switch", { name: "Hide Clock & Calendar" }).click();
+  await widgetManager.getByRole("switch", { name: "Hide Clock & calendar — Right now" }).click();
   await expect(page.locator("[data-home-widget-id]")).toHaveCount(1);
   await expectHomeWidgetHeightsMatch(page, baselineCompactHeight);
 
   for (const widget of [
-    "Recent Chats",
-    "What's New",
-    "Discovery Desk",
-    "Achievements",
-    "Professor Mari",
-    "Character of the Day",
-    "Community",
-    "Clock & Calendar",
+    "Continue chatting — Recent chats",
+    "From the kitchen — What's New",
+    "Discovery desk — Something new for your engine",
+    "Your shelf — Achievements",
+    "Your guide — Professor Mari",
+    "Daily encounter — Character of the Day",
+    "Community — Around the table",
+    "Clock & calendar — Right now",
   ]) {
     await widgetManager.getByRole("switch", { name: `Show ${widget}` }).click();
   }
@@ -13212,8 +13360,7 @@ test("Professor Mari navigation can be repositioned within Home on desktop", asy
   expect(dragScaleX / dragScaleY).toBeGreaterThan(1.03);
   expect(dragScaleX / dragScaleY).toBeLessThan(1.08);
 
-  const rightEdgeGrabX =
-    contentBounds!.x + contentBounds!.width - 16 - initialSpriteBounds!.width * (1 - 0.45);
+  const rightEdgeGrabX = contentBounds!.x + contentBounds!.width - 16 - initialSpriteBounds!.width * (1 - 0.45);
   await page.mouse.move(rightEdgeGrabX, contentBounds!.y + 220, { steps: 6 });
   await expect(bubble).toHaveAttribute("data-tail-side", "right");
   const movedDragTimeline = await dragAnimation.evaluate((element) => ({
@@ -13253,7 +13400,9 @@ test("Professor Mari navigation can be repositioned within Home on desktop", asy
   await expect(assistant).toHaveAttribute("data-dragging", "true");
   await expect(dragAnimation).toBeVisible();
   expect(
-    await dragAnimation.evaluate((element) => Number(element.getAnimations()[0]?.currentTime ?? Number.POSITIVE_INFINITY)),
+    await dragAnimation.evaluate((element) =>
+      Number(element.getAnimations()[0]?.currentTime ?? Number.POSITIVE_INFINITY),
+    ),
   ).toBeLessThan(150);
 
   const dragTarget = {
@@ -13472,105 +13621,105 @@ test("Home lifecycle stays bounded across repeated tab and chat navigation", asy
   const auditChat = (await auditChatResponse.json()) as { id: string };
   try {
     await page.goto("/");
-  await expect(page.locator('[data-component="HomeBrowserHub.HomePage"]')).toBeVisible({ timeout: 30_000 });
-  await page.waitForTimeout(3_000);
+    await expect(page.locator('[data-component="HomeBrowserHub.HomePage"]')).toBeVisible({ timeout: 30_000 });
+    await page.waitForTimeout(3_000);
 
-  const cdp = await page.context().newCDPSession(page);
-  const collect = async () => {
-    await cdp.send("HeapProfiler.collectGarbage");
-    await page.waitForTimeout(150);
-    const [dom, heap, runtime] = await Promise.all([
-      cdp.send("Memory.getDOMCounters"),
-      cdp.send("Runtime.getHeapUsage"),
-      page.evaluate(() => ({
-        animations: document.getAnimations().filter((animation) => animation.playState === "running").length,
-        homePages: document.querySelectorAll('[data-component="HomeBrowserHub.HomePage"]').length,
-        professorPages: document.querySelectorAll('[data-component="HomeProfessorMariChat"]').length,
-        lifecycle: (
-          window as unknown as {
-            __homeLifecycleAudit: {
-              snapshot: () => {
-                intervals: number;
-                timeouts: number;
-                homeSurfaceTimeouts: number;
-                timeoutDelays: Record<string, number>;
-                animationFrames: number;
-                resizeObservers: number;
+    const cdp = await page.context().newCDPSession(page);
+    const collect = async () => {
+      await cdp.send("HeapProfiler.collectGarbage");
+      await page.waitForTimeout(150);
+      const [dom, heap, runtime] = await Promise.all([
+        cdp.send("Memory.getDOMCounters"),
+        cdp.send("Runtime.getHeapUsage"),
+        page.evaluate(() => ({
+          animations: document.getAnimations().filter((animation) => animation.playState === "running").length,
+          homePages: document.querySelectorAll('[data-component="HomeBrowserHub.HomePage"]').length,
+          professorPages: document.querySelectorAll('[data-component="HomeProfessorMariChat"]').length,
+          lifecycle: (
+            window as unknown as {
+              __homeLifecycleAudit: {
+                snapshot: () => {
+                  intervals: number;
+                  timeouts: number;
+                  homeSurfaceTimeouts: number;
+                  timeoutDelays: Record<string, number>;
+                  animationFrames: number;
+                  resizeObservers: number;
+                };
               };
-            };
-          }
-        ).__homeLifecycleAudit.snapshot(),
-      })),
-    ]);
-    return {
-      documents: dom.documents,
-      nodes: dom.nodes,
-      listeners: dom.jsEventListeners,
-      heap: heap.usedSize,
-      ...runtime,
+            }
+          ).__homeLifecycleAudit.snapshot(),
+        })),
+      ]);
+      return {
+        documents: dom.documents,
+        nodes: dom.nodes,
+        listeners: dom.jsEventListeners,
+        heap: heap.usedSize,
+        ...runtime,
+      };
     };
-  };
 
-  const cycleInternalTabs = async (count: number) => {
-    for (let index = 0; index < count; index += 1) {
-      await page.getByRole("tab", { name: "Professor", exact: true }).click();
-      await expect(page.locator('[data-component="HomeBrowserHub.Address"]')).toContainText("marinara/professor");
-      await page.getByRole("tab", { name: "Home", exact: true }).click();
-      await expect(page.locator('[data-component="HomeBrowserHub.HomePage"]')).toBeVisible();
-    }
-  };
-  const cycleHomeMount = async (count: number) => {
-    for (let index = 0; index < count; index += 1) {
-      await page.evaluate(async (chatId) => {
-        const module = await import("/src/stores/chat.store.ts");
-        module.useChatStore.getState().setActiveChatId(chatId);
-      }, auditChat.id);
-      await expect(page.locator('[data-component="HomeBrowserHub.HomePage"]')).toHaveCount(0);
-      await page.evaluate(async () => {
-        const module = await import("/src/stores/chat.store.ts");
-        module.useChatStore.getState().setActiveChatId(null);
-      });
-      await expect(page.locator('[data-component="HomeBrowserHub.HomePage"]')).toBeVisible();
-    }
-  };
+    const cycleInternalTabs = async (count: number) => {
+      for (let index = 0; index < count; index += 1) {
+        await page.getByRole("tab", { name: "Professor", exact: true }).click();
+        await expect(page.locator('[data-component="HomeBrowserHub.Address"]')).toContainText("marinara/professor");
+        await page.getByRole("tab", { name: "Home", exact: true }).click();
+        await expect(page.locator('[data-component="HomeBrowserHub.HomePage"]')).toBeVisible();
+      }
+    };
+    const cycleHomeMount = async (count: number) => {
+      for (let index = 0; index < count; index += 1) {
+        await page.evaluate(async (chatId) => {
+          const module = await import("/src/stores/chat.store.ts");
+          module.useChatStore.getState().setActiveChatId(chatId);
+        }, auditChat.id);
+        await expect(page.locator('[data-component="HomeBrowserHub.HomePage"]')).toHaveCount(0);
+        await page.evaluate(async () => {
+          const module = await import("/src/stores/chat.store.ts");
+          module.useChatStore.getState().setActiveChatId(null);
+        });
+        await expect(page.locator('[data-component="HomeBrowserHub.HomePage"]')).toBeVisible();
+      }
+    };
 
-  await cycleInternalTabs(2);
-  await cycleHomeMount(2);
-  await page.waitForTimeout(1_750);
-  const baseline = await collect();
+    await cycleInternalTabs(2);
+    await cycleHomeMount(2);
+    await page.waitForTimeout(1_750);
+    const baseline = await collect();
 
-  await page.getByRole("tab", { name: "Professor", exact: true }).click();
-  await expect(page.locator('[data-component="HomeBrowserHub.Address"]')).toContainText("marinara/professor");
-  const professorTabIntervals = await page.evaluate(
-    () =>
-      (
-        window as unknown as {
-          __homeLifecycleAudit: { snapshot: () => { intervals: number } };
-        }
-      ).__homeLifecycleAudit.snapshot().intervals,
-  );
-  expect(professorTabIntervals).toBeLessThan(baseline.lifecycle.intervals);
-  await page.getByRole("tab", { name: "Home", exact: true }).click();
-  await expect(page.locator('[data-component="HomeBrowserHub.HomePage"]')).toBeVisible();
+    await page.getByRole("tab", { name: "Professor", exact: true }).click();
+    await expect(page.locator('[data-component="HomeBrowserHub.Address"]')).toContainText("marinara/professor");
+    const professorTabIntervals = await page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __homeLifecycleAudit: { snapshot: () => { intervals: number } };
+          }
+        ).__homeLifecycleAudit.snapshot().intervals,
+    );
+    expect(professorTabIntervals).toBeLessThan(baseline.lifecycle.intervals);
+    await page.getByRole("tab", { name: "Home", exact: true }).click();
+    await expect(page.locator('[data-component="HomeBrowserHub.HomePage"]')).toBeVisible();
 
-  await cycleInternalTabs(10);
-  await cycleHomeMount(10);
-  await page.waitForTimeout(1_750);
-  const after = await collect();
+    await cycleInternalTabs(10);
+    await cycleHomeMount(10);
+    await page.waitForTimeout(1_750);
+    const after = await collect();
 
-  await testInfo.attach("home-lifecycle-counters", {
-    body: JSON.stringify({ baseline, after }, null, 2),
-    contentType: "application/json",
-  });
-  expect(after.documents).toBeLessThanOrEqual(baseline.documents + 1);
-  expect(after.nodes).toBeLessThanOrEqual(baseline.nodes + 80);
-  expect(after.listeners).toBeLessThanOrEqual(baseline.listeners + 8);
-  expect(after.heap).toBeLessThanOrEqual(baseline.heap + 3 * 1024 * 1024);
-  expect(after.animations).toBeLessThanOrEqual(baseline.animations + 2);
-  expect(after.lifecycle.intervals).toBe(baseline.lifecycle.intervals);
-  expect(after.lifecycle.resizeObservers).toBe(baseline.lifecycle.resizeObservers);
-  expect(after.lifecycle.homeSurfaceTimeouts).toBe(baseline.lifecycle.homeSurfaceTimeouts);
-  expect(after.lifecycle.animationFrames).toBeLessThanOrEqual(baseline.lifecycle.animationFrames + 1);
+    await testInfo.attach("home-lifecycle-counters", {
+      body: JSON.stringify({ baseline, after }, null, 2),
+      contentType: "application/json",
+    });
+    expect(after.documents).toBeLessThanOrEqual(baseline.documents + 1);
+    expect(after.nodes).toBeLessThanOrEqual(baseline.nodes + 80);
+    expect(after.listeners).toBeLessThanOrEqual(baseline.listeners + 8);
+    expect(after.heap).toBeLessThanOrEqual(baseline.heap + 3 * 1024 * 1024);
+    expect(after.animations).toBeLessThanOrEqual(baseline.animations + 2);
+    expect(after.lifecycle.intervals).toBe(baseline.lifecycle.intervals);
+    expect(after.lifecycle.resizeObservers).toBe(baseline.lifecycle.resizeObservers);
+    expect(after.lifecycle.homeSurfaceTimeouts).toBe(baseline.lifecycle.homeSurfaceTimeouts);
+    expect(after.lifecycle.animationFrames).toBeLessThanOrEqual(baseline.lifecycle.animationFrames + 1);
     expect(after.homePages).toBe(1);
     expect(after.professorPages).toBe(0);
   } finally {
@@ -13603,7 +13752,7 @@ test("Home widget order can be dragged and persists across reloads", async ({ pa
   await expect(page.locator('[data-component="HomeBrowserHub.Feed"]')).toBeVisible();
   await page.getByRole("navigation", { name: "Home bookmarks" }).getByRole("button", { name: "Widgets" }).click();
   const widgetManager = page.getByRole("dialog", { name: "Home Widgets" });
-  await widgetManager.getByRole("switch", { name: "Hide Clock & Calendar" }).click();
+  await widgetManager.getByRole("switch", { name: "Hide Clock & calendar — Right now" }).click();
   await page.keyboard.press("Escape");
   await expect(page.locator('[data-home-widget-id="clock"]')).toHaveCount(0);
   await expect(page.locator("[data-home-empty-slot]")).toHaveCount(1);
@@ -13726,9 +13875,7 @@ test("chat mode tabs and new-chat actions stay reachable", async ({ page }) => {
 
     expect(errors).toEqual([]);
   } finally {
-    await Promise.allSettled(
-      characterlessChats.map((chat) => page.request.delete(`/api/chats/${chat.id}?force=true`)),
-    );
+    await Promise.allSettled(characterlessChats.map((chat) => page.request.delete(`/api/chats/${chat.id}?force=true`)));
   }
 });
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -12613,13 +12613,12 @@ test("mobile Home collects its bookmarks into a Marinara-colored menu", async ({
     await expect(menu.getByText(label, { exact: true })).toBeVisible();
   }
 
-  const menuStayedMountedForExit = await menu.getByRole("button", { name: "FAQ", exact: true }).evaluate((button) => {
-    button.click();
-    return Boolean(document.querySelector('[data-component="HomeBrowserHub.MobileBookmarksMenu"]'));
-  });
-  expect(menuStayedMountedForExit).toBe(true);
-  await expect(menu).toHaveCount(0);
+  await menu.getByRole("button", { name: "FAQ", exact: true }).click();
   await expect(page.getByRole("dialog", { name: "Professor Mari's FAQ" })).toBeVisible();
+  await expect(menu).toBeAttached();
+  await page.waitForTimeout(50);
+  await expect(menu).toBeAttached();
+  await expect(menu).toHaveCount(0);
 });
 
 test("enabling Recent Chats anchors its 2 by 2 footprint and repacks smaller widgets", async ({ page }, testInfo) => {

--- a/packages/client/src/components/chat/HomeAchievements.tsx
+++ b/packages/client/src/components/chat/HomeAchievements.tsx
@@ -115,21 +115,21 @@ function CompactAchievementHighlight({
       : "oklch(0.79 0.16 205)";
 
   return (
-    <span data-achievement-highlight={kind} className="flex min-w-0 items-center gap-2 py-0.5">
+    <span data-achievement-highlight={kind} className="flex min-w-0 items-center gap-1.5 py-0 sm:gap-2 sm:py-0.5">
       <span
-        className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-[color-mix(in_srgb,var(--achievement-tone)_44%,var(--border))] bg-[color-mix(in_srgb,var(--achievement-tone)_15%,var(--card))] text-[var(--achievement-tone)]"
+        className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-[color-mix(in_srgb,var(--achievement-tone)_44%,var(--border))] bg-[color-mix(in_srgb,var(--achievement-tone)_15%,var(--card))] text-[var(--achievement-tone)] sm:h-6 sm:w-6"
         style={{ "--achievement-tone": tone } as CSSProperties}
         data-achievement-icon={achievement?.icon ?? "trophy"}
         data-achievement-rank={achievement?.rank ?? "unranked"}
         aria-hidden="true"
       >
-        <Icon size="0.72rem" strokeWidth={2.35} />
+        <Icon size="0.68rem" strokeWidth={2.35} />
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block text-[0.52rem] font-extrabold uppercase leading-none tracking-[0.11em] text-[var(--muted-foreground)]">
+        <span className="block text-[0.48rem] font-extrabold uppercase leading-none tracking-[0.09em] text-[var(--muted-foreground)] sm:text-[0.52rem] sm:tracking-[0.11em]">
           {label}
         </span>
-        <span className="mt-0.5 block truncate text-[0.65rem] font-bold leading-tight text-[var(--foreground)]">
+        <span className="mt-0.5 block truncate text-[0.6rem] font-bold leading-tight text-[var(--foreground)] sm:text-[0.65rem]">
           {achievement ? localizeAchievementTitle(t, achievement) : fallback}
         </span>
       </span>
@@ -283,7 +283,7 @@ export function HomeAchievements({
           className={cn(
             "group text-left",
             compact
-              ? "w-full max-w-full rounded-xl px-2 py-0 transition-colors hover:bg-[color-mix(in_srgb,var(--home-module-accent)_10%,var(--accent))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-module-accent)]"
+              ? "w-full max-w-full rounded-xl px-1.5 py-0 transition-colors hover:bg-[color-mix(in_srgb,var(--home-module-accent)_10%,var(--accent))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-module-accent)] sm:px-2"
               : "mari-chrome-control flex w-full max-w-5xl items-center justify-start gap-2 px-3 py-2.5 shadow-lg shadow-black/10 sm:gap-3 sm:px-4 sm:py-3",
             attached ? "-mt-px !rounded-b-xl !rounded-t-none !border-t-0" : "!rounded-xl",
             className,
@@ -309,27 +309,29 @@ export function HomeAchievements({
               ) : null}
               {compact ? (
                 <span className="block w-full">
-                  <span className="flex min-h-10 w-full items-center gap-2.5 text-left">
+                  <span className="flex min-h-8 w-full items-center gap-1.5 text-left sm:min-h-10 sm:gap-2.5">
                     <img
                       src="/home/tab-icons/achievements.png"
                       alt=""
-                      className="h-7 w-7 shrink-0 object-contain"
+                      className="h-5 w-5 shrink-0 object-contain sm:h-7 sm:w-7"
                       aria-hidden="true"
                     />
                     <span className="min-w-0 flex-1">
                       <span
                         data-achievement-open-label
-                        className="block truncate text-xs font-bold text-[var(--foreground)]"
+                        className="block truncate text-[0.68rem] font-bold text-[var(--foreground)] sm:text-xs"
                       >
                         {t("home.achievements.title")}
                       </span>
                       <span
                         data-achievement-open-description
-                        className="block truncate text-[0.62rem] text-[var(--muted-foreground)]"
+                        className="block truncate text-[0.56rem] text-[var(--muted-foreground)] sm:text-[0.62rem]"
                       >
                         {t("home.achievements.launcherDescription")}
                       </span>
-                      <span className="mari-chrome-text-muted block truncate text-[0.56rem]">{summary}</span>
+                      <span className="mari-chrome-text-muted block truncate text-[0.52rem] sm:text-[0.56rem]">
+                        {summary}
+                      </span>
                     </span>
                   </span>
                   <span className="mt-0.5 block border-t border-[var(--border)]/55 pt-1">

--- a/packages/client/src/components/chat/HomeBrowserHub.tsx
+++ b/packages/client/src/components/chat/HomeBrowserHub.tsx
@@ -13,6 +13,7 @@ import {
   type ReactNode,
 } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AnimatePresence, motion } from "framer-motion";
 import { flushSync } from "react-dom";
 import {
   ArrowLeft,
@@ -314,6 +315,17 @@ const HOME_WIDGET_LABEL_KEYS: Record<BuiltInHomeWidgetId, string> = {
   community: "home.widgets.community",
   clock: "home.widgets.clock",
   achievements: "home.widgets.achievements",
+};
+const HOME_WIDGET_MANAGER_LABEL_KEYS: Record<BuiltInHomeWidgetId, { name: string; purpose: string }> = {
+  professor: { name: "home.professorMari.eyebrow", purpose: "home.widgets.professor" },
+  recent: { name: "home.recentChats.eyebrow", purpose: "home.recentChats.title" },
+  "whats-new": { name: "home.whatsNew.eyebrow", purpose: "home.widgets.whatsNew" },
+  discovery: { name: "home.discovery.eyebrow", purpose: "home.discovery.title" },
+  character: { name: "home.characterOfDay.eyebrow", purpose: "home.characterOfDay.title" },
+  learn: { name: "home.learn.eyebrow", purpose: "home.learn.title" },
+  community: { name: "home.community.eyebrow", purpose: "home.community.title" },
+  clock: { name: "home.clock.eyebrow", purpose: "home.clock.title" },
+  achievements: { name: "home.achievements.eyebrow", purpose: "home.achievements.title" },
 };
 const HOME_WIDGET_MIN_ROW_HEIGHT = 208;
 const HOME_WIDGET_MAX_ROW_HEIGHT = 640;
@@ -1525,9 +1537,7 @@ export function HomeBrowserHub({
   const deleteCustomWidgetMutation = useMutation({
     mutationFn: async (widgetId: string) => {
       for (let attempt = 0; attempt < 2; attempt += 1) {
-        const catalog = await api.get<HomeCustomWidgetCatalog>(
-          `/app-settings/${HOME_CUSTOM_WIDGETS_SETTINGS_KEY}`,
-        );
+        const catalog = await api.get<HomeCustomWidgetCatalog>(`/app-settings/${HOME_CUSTOM_WIDGETS_SETTINGS_KEY}`);
         if (!catalog.widgets.some((widget) => widget.id === widgetId)) return catalog;
         try {
           return await api.put<HomeCustomWidgetCatalog>(`/app-settings/${HOME_CUSTOM_WIDGETS_SETTINGS_KEY}`, {
@@ -1993,6 +2003,20 @@ export function HomeBrowserHub({
     const customWidget = customWidgetsById.get(id);
     return customWidget?.title ?? t(HOME_WIDGET_LABEL_KEYS[id as BuiltInHomeWidgetId]);
   };
+  const widgetManagerLabel = (id: HomeWidgetId) => {
+    const customWidget = customWidgetsById.get(id);
+    if (customWidget) {
+      return t("home.widgets.managerLabel", {
+        name: t("home.widgets.customEyebrow"),
+        purpose: customWidget.title,
+      });
+    }
+    const labelKeys = HOME_WIDGET_MANAGER_LABEL_KEYS[id as BuiltInHomeWidgetId];
+    return t("home.widgets.managerLabel", {
+      name: t(labelKeys.name),
+      purpose: t(labelKeys.purpose),
+    });
+  };
   const widgetFrameProps = (id: HomeWidgetId) => ({
     id,
     order: activeWidgetSlots.indexOf(id),
@@ -2207,7 +2231,7 @@ export function HomeBrowserHub({
                         id={activityDescriptionId}
                         aria-label={t("home.browser.newTimelineRefresh")}
                         data-component="HomeBrowserHub.NoodleRefreshBadge"
-                        className="absolute right-0.5 top-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-[#FF7EC1] px-1 text-[0.58rem] font-black leading-none text-[#1a1025] ring-1 ring-[#7EA7FF] sm:-right-1 sm:-top-1"
+                        className="absolute right-1 top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-[#FF7EC1] px-1 text-[0.58rem] font-black leading-none text-[#1a1025] ring-1 ring-[#7EA7FF]"
                       >
                         <span aria-hidden="true">1</span>
                       </span>
@@ -2370,99 +2394,106 @@ export function HomeBrowserHub({
               {t("home.browser.bookmarks")}
             </button>
 
-            {mobileBookmarksOpen ? (
-              <div
-                id="marinara-mobile-bookmarks"
-                className="absolute left-2 right-2 top-[calc(100%+0.35rem)] grid max-h-[calc(100dvh-8rem)] gap-1 overflow-y-auto rounded-xl border border-[var(--border)] bg-[color-mix(in_srgb,var(--card)_96%,var(--background))] p-1.5 shadow-[0_22px_60px_-24px_rgba(0,0,0,0.72)] ring-1 ring-[color-mix(in_srgb,var(--foreground)_7%,transparent)] sm:hidden"
-                data-component="HomeBrowserHub.MobileBookmarksMenu"
-              >
-                <MobileBrowserBookmark
-                  href="https://discord.com/invite/KdAkTg94ME"
-                  onClick={() => {
-                    setMobileBookmarksOpen(false);
-                    trackHomeAction("discord_clicked");
-                  }}
-                  icon={<img src="/home/tab-icons/discord.svg" alt="" className="h-4 w-4 object-contain" />}
-                  tone="#5865F2"
+            <AnimatePresence initial={false}>
+              {mobileBookmarksOpen ? (
+                <motion.div
+                  id="marinara-mobile-bookmarks"
+                  initial={reduceMotion ? false : { opacity: 0, y: -8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
+                  transition={{ duration: reduceMotion ? 0 : 0.18, ease: [0.16, 1, 0.3, 1] }}
+                  className="absolute left-2 right-2 top-[calc(100%+0.35rem)] grid max-h-[calc(100dvh-8rem)] gap-1 overflow-y-auto rounded-xl border border-[var(--border)] bg-[color-mix(in_srgb,var(--card)_96%,var(--background))] p-1.5 shadow-[0_22px_60px_-24px_rgba(0,0,0,0.72)] ring-1 ring-[color-mix(in_srgb,var(--foreground)_7%,transparent)] sm:hidden"
+                  data-component="HomeBrowserHub.MobileBookmarksMenu"
+                  data-bookmarks-motion="slide"
                 >
-                  {t("home.browser.bookmarks.discord")}
-                </MobileBrowserBookmark>
-                <MobileBrowserBookmark
-                  href="https://ko-fi.com/marinara_spaghetti"
-                  onClick={() => {
-                    setMobileBookmarksOpen(false);
-                    trackHomeAction("kofi_clicked");
-                  }}
-                  icon={<img src="/home/tab-icons/kofi.png" alt="" className="h-4 w-4 object-contain" />}
-                  tone="#ff6433"
-                >
-                  {t("home.actions.support")}
-                </MobileBrowserBookmark>
-                <MobileBrowserBookmark
-                  onClick={() => {
-                    setMobileBookmarksOpen(false);
-                    trackHomeAction("credits_viewed");
-                    onOpenCredits();
-                  }}
-                  icon={<img src="/home/tab-icons/credits.png" alt="" className="h-4 w-4 object-contain" />}
-                  tone={HOME_MODULE_ACCENTS.orange}
-                >
-                  {t("home.actions.credits")}
-                </MobileBrowserBookmark>
-                <MobileBrowserBookmark
-                  onClick={() => {
-                    setMobileBookmarksOpen(false);
-                    useUIStore.getState().openModal("docs-viewer");
-                  }}
-                  icon={<img src="/home/tab-icons/documentation.png" alt="" className="h-4 w-4 object-contain" />}
-                  tone={HOME_MODULE_ACCENTS.cyan}
-                >
-                  {t("home.actions.documentation")}
-                </MobileBrowserBookmark>
-                <MobileBrowserBookmark
-                  onClick={() => {
-                    setMobileBookmarksOpen(false);
-                    useUIStore.getState().setHasCompletedOnboarding(false);
-                  }}
-                  icon={<img src="/home/tab-icons/tutorial.png" alt="" className="h-4 w-4 object-contain" />}
-                  tone={HOME_MODULE_ACCENTS.orange}
-                >
-                  {t("home.browser.bookmarks.tutorial")}
-                </MobileBrowserBookmark>
-                <MobileBrowserBookmark
-                  onClick={() => {
-                    setMobileBookmarksOpen(false);
-                    setFaqOpen(true);
-                  }}
-                  icon={<img src="/home/tab-icons/faq.png" alt="" className="h-4 w-4 object-contain" />}
-                  tone={HOME_MODULE_ACCENTS.pink}
-                >
-                  {t("home.browser.faqTab")}
-                </MobileBrowserBookmark>
-                {achievementsEnabled ? (
+                  <MobileBrowserBookmark
+                    href="https://discord.com/invite/KdAkTg94ME"
+                    onClick={() => {
+                      setMobileBookmarksOpen(false);
+                      trackHomeAction("discord_clicked");
+                    }}
+                    icon={<img src="/home/tab-icons/discord.svg" alt="" className="h-4 w-4 object-contain" />}
+                    tone="#5865F2"
+                  >
+                    {t("home.browser.bookmarks.discord")}
+                  </MobileBrowserBookmark>
+                  <MobileBrowserBookmark
+                    href="https://ko-fi.com/marinara_spaghetti"
+                    onClick={() => {
+                      setMobileBookmarksOpen(false);
+                      trackHomeAction("kofi_clicked");
+                    }}
+                    icon={<img src="/home/tab-icons/kofi.png" alt="" className="h-4 w-4 object-contain" />}
+                    tone="#ff6433"
+                  >
+                    {t("home.actions.support")}
+                  </MobileBrowserBookmark>
                   <MobileBrowserBookmark
                     onClick={() => {
                       setMobileBookmarksOpen(false);
-                      setAchievementsOpen(true);
+                      trackHomeAction("credits_viewed");
+                      onOpenCredits();
                     }}
-                    icon={<img src="/home/tab-icons/achievements.png" alt="" className="h-4 w-4 object-contain" />}
+                    icon={<img src="/home/tab-icons/credits.png" alt="" className="h-4 w-4 object-contain" />}
                     tone={HOME_MODULE_ACCENTS.orange}
                   >
-                    {t("home.browser.achievements")}
+                    {t("home.actions.credits")}
                   </MobileBrowserBookmark>
-                ) : null}
-                <MobileBrowserBookmark
-                  onClick={() => {
-                    setMobileBookmarksOpen(false);
-                    setWidgetManagerOpen(true);
-                  }}
-                  icon={<img src="/home/tab-icons/widgets.svg" alt="" className="h-4 w-4 object-contain" />}
-                  tone={HOME_MODULE_ACCENTS.violet}
-                >
-                  {t("home.browser.widgets")}
-                </MobileBrowserBookmark>
-              </div>
-            ) : null}
+                  <MobileBrowserBookmark
+                    onClick={() => {
+                      setMobileBookmarksOpen(false);
+                      useUIStore.getState().openModal("docs-viewer");
+                    }}
+                    icon={<img src="/home/tab-icons/documentation.png" alt="" className="h-4 w-4 object-contain" />}
+                    tone={HOME_MODULE_ACCENTS.cyan}
+                  >
+                    {t("home.actions.documentation")}
+                  </MobileBrowserBookmark>
+                  <MobileBrowserBookmark
+                    onClick={() => {
+                      setMobileBookmarksOpen(false);
+                      useUIStore.getState().setHasCompletedOnboarding(false);
+                    }}
+                    icon={<img src="/home/tab-icons/tutorial.png" alt="" className="h-4 w-4 object-contain" />}
+                    tone={HOME_MODULE_ACCENTS.orange}
+                  >
+                    {t("home.browser.bookmarks.tutorial")}
+                  </MobileBrowserBookmark>
+                  <MobileBrowserBookmark
+                    onClick={() => {
+                      setMobileBookmarksOpen(false);
+                      setFaqOpen(true);
+                    }}
+                    icon={<img src="/home/tab-icons/faq.png" alt="" className="h-4 w-4 object-contain" />}
+                    tone={HOME_MODULE_ACCENTS.pink}
+                  >
+                    {t("home.browser.faqTab")}
+                  </MobileBrowserBookmark>
+                  {achievementsEnabled ? (
+                    <MobileBrowserBookmark
+                      onClick={() => {
+                        setMobileBookmarksOpen(false);
+                        setAchievementsOpen(true);
+                      }}
+                      icon={<img src="/home/tab-icons/achievements.png" alt="" className="h-4 w-4 object-contain" />}
+                      tone={HOME_MODULE_ACCENTS.orange}
+                    >
+                      {t("home.browser.achievements")}
+                    </MobileBrowserBookmark>
+                  ) : null}
+                  <MobileBrowserBookmark
+                    onClick={() => {
+                      setMobileBookmarksOpen(false);
+                      setWidgetManagerOpen(true);
+                    }}
+                    icon={<img src="/home/tab-icons/widgets.svg" alt="" className="h-4 w-4 object-contain" />}
+                    tone={HOME_MODULE_ACCENTS.violet}
+                  >
+                    {t("home.browser.widgets")}
+                  </MobileBrowserBookmark>
+                </motion.div>
+              ) : null}
+            </AnimatePresence>
           </nav>
         </header>
 
@@ -2543,7 +2574,7 @@ export function HomeBrowserHub({
                       ariaLabel={t("home.shortcuts.newConversation")}
                     >
                       <ShortcutIcon tone={HOME_CHAT_MODE_ACCENTS.conversation}>
-                        <ChatModeIcon mode="conversation" size="1rem" />
+                        <ChatModeIcon mode="conversation" size="1rem" className="mari-rgb-static-icon" />
                       </ShortcutIcon>
                       <span className="text-[0.65rem] font-bold text-[var(--foreground)] sm:text-xs">
                         {t("home.recentChats.mode.conversation")}
@@ -2555,7 +2586,7 @@ export function HomeBrowserHub({
                       ariaLabel={t("home.shortcuts.newRoleplay")}
                     >
                       <ShortcutIcon tone={HOME_CHAT_MODE_ACCENTS.roleplay}>
-                        <ChatModeIcon mode="roleplay" size="1rem" />
+                        <ChatModeIcon mode="roleplay" size="1rem" className="mari-rgb-static-icon" />
                       </ShortcutIcon>
                       <span className="text-[0.65rem] font-bold text-[var(--foreground)] sm:text-xs">
                         {t("home.recentChats.mode.roleplay")}
@@ -2567,7 +2598,7 @@ export function HomeBrowserHub({
                       ariaLabel={t("home.shortcuts.newGame")}
                     >
                       <ShortcutIcon tone={HOME_CHAT_MODE_ACCENTS.game}>
-                        <ChatModeIcon mode="game" size="1rem" />
+                        <ChatModeIcon mode="game" size="1rem" className="mari-rgb-static-icon" />
                       </ShortcutIcon>
                       <span className="text-[0.65rem] font-bold text-[var(--foreground)] sm:text-xs">
                         {t("home.recentChats.mode.game")}
@@ -2910,7 +2941,7 @@ export function HomeBrowserHub({
                         accent={HOME_MODULE_ACCENTS.orange}
                         art="/home/achievement-trophy.png"
                         artClassName={HOME_CARD_ART_CLASS}
-                        className="h-full min-h-52"
+                        className="h-full min-h-0"
                       >
                         <HomeAchievements
                           compact
@@ -2998,7 +3029,7 @@ export function HomeBrowserHub({
           <div className="grid gap-2">
             {availableWidgetIds.map((id, index) => {
               const enabled = visibleWidgets.includes(id);
-              const label = widgetLabel(id);
+              const label = widgetManagerLabel(id);
               const customWidget = customWidgetsById.get(id);
               const tones = [
                 HOME_MODULE_ACCENTS.pink,
@@ -3022,7 +3053,7 @@ export function HomeBrowserHub({
                     <i className="rounded-[0.12rem] bg-[oklch(0.73_0.21_345)]" />
                     <i className="rounded-[0.12rem] bg-[var(--widget-tone)]" />
                   </span>
-                  <span className="min-w-0 flex-1 truncate text-sm font-semibold text-[var(--foreground)]">
+                  <span className="min-w-0 flex-1 text-sm font-semibold leading-snug text-[var(--foreground)]">
                     {label}
                   </span>
                   {customWidget ? (

--- a/packages/client/src/components/chat/RecentChats.tsx
+++ b/packages/client/src/components/chat/RecentChats.tsx
@@ -266,7 +266,7 @@ export function RecentChats() {
               <ChatModeIcon
                 mode={chatMode}
                 size="3rem"
-                className="absolute -bottom-1 right-1 text-[var(--recent-chat-accent)] opacity-15 md:-bottom-2 md:[width:4.5rem] md:[height:4.5rem]"
+                className="mari-rgb-static-icon absolute -bottom-1 right-1 text-[var(--recent-chat-accent)] opacity-15 md:-bottom-2 md:[width:4.5rem] md:[height:4.5rem]"
                 aria-hidden="true"
               />
             )}
@@ -278,7 +278,8 @@ export function RecentChats() {
               )}
             >
               <span className="inline-flex items-center gap-1 rounded-full border border-[color-mix(in_srgb,var(--recent-chat-accent)_48%,transparent)] bg-[color-mix(in_srgb,var(--recent-chat-accent)_14%,var(--card))] px-1.5 py-0.5 text-[0.52rem] font-bold uppercase tracking-[0.1em] text-[var(--recent-chat-accent)] md:gap-1.5 md:px-2 md:py-1 md:text-[0.625rem] md:tracking-[0.12em]">
-                <ChatModeIcon mode={chatMode} size="0.7rem" aria-hidden="true" /> {t(mode.labelKey)}
+                <ChatModeIcon mode={chatMode} size="0.7rem" className="mari-rgb-static-icon" aria-hidden="true" />{" "}
+                {t(mode.labelKey)}
               </span>
               <span className="mt-1 block truncate text-xs font-semibold leading-tight text-[var(--foreground)] md:mt-2 md:line-clamp-2 md:whitespace-normal md:text-sm">
                 {chat.name}

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -4993,7 +4993,7 @@ function AppearanceSettings() {
                     <div
                       className={cn(
                         "h-5 w-5 shrink-0 bg-[var(--accent)]",
-                        conversationAvatarShape === "square" ? "rounded-md" : "rounded-full",
+                        conversationAvatarShape === "square" ? "rounded-[0.2rem]" : "rounded-full",
                       )}
                     />
                     <div className="mari-message-bubble texting-bubble texting-bubble-other max-w-[78%] rounded-2xl px-3 py-1.5 text-xs shadow-sm">
@@ -5006,7 +5006,7 @@ function AppearanceSettings() {
                   <div
                     className={cn(
                       "h-6 w-6 shrink-0 bg-[var(--accent)]",
-                      conversationAvatarShape === "square" ? "rounded-md" : "rounded-full",
+                      conversationAvatarShape === "square" ? "rounded-[0.2rem]" : "rounded-full",
                     )}
                   />
                   <div className="min-w-0 flex-1">
@@ -5046,7 +5046,7 @@ function AppearanceSettings() {
                   {
                     id: "square" as ConversationAvatarShape,
                     label: localizeUi("ui.panels.appearancesettings.squareAvatars"),
-                    cornerClass: "rounded-md",
+                    cornerClass: "rounded-[0.2rem]",
                   },
                 ] as const
               ).map((option) => (
@@ -5062,7 +5062,10 @@ function AppearanceSettings() {
                   )}
                   aria-pressed={conversationAvatarShape === option.id}
                 >
-                  <span className={cn("h-5 w-5 border border-current bg-[var(--accent)]", option.cornerClass)} />
+                  <span
+                    className={cn("h-5 w-5 border border-current bg-[var(--accent)]", option.cornerClass)}
+                    data-avatar-shape-preview={option.id}
+                  />
                   {option.label}
                 </button>
               ))}

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -523,6 +523,7 @@
   "home.widgets.drag": "Drag {{widget}} to rearrange",
   "home.widgets.hide": "Hide {{widget}}",
   "home.widgets.learn": "Learn the Engine",
+  "home.widgets.managerLabel": "{{name}} — {{purpose}}",
   "home.widgets.professor": "Professor Mari",
   "home.widgets.recent": "Recent Chats",
   "home.widgets.show": "Show {{widget}}",


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.

## Linked issues

Closes #4809
Closes #4817
Closes #4818
Closes #4819
Closes #4820
Closes #4821
Closes #4823

## Why this change

Several small Home and Appearance regressions remained after the Home rebuild: semantic chat-mode colors were overridden by the global animated accent, the Square avatar preview still read as circular, and responsive Home chrome/widgets had clipping, spacing, positioning, naming, and motion defects.

## What changed

- preserve the cyan/orange/pink semantic colors on Home launchers and Recent Chats mode icons
- make the Square avatar samples visibly square in both the option and conversation preview
- contain the Noodle refresh badge inside its browser tab instead of letting it overlap the topbar
- compact the mobile Achievements controls and remove their overflowing minimum height so the following Discovery Desk row keeps its grid gap
- animate the mobile Bookmarks menu in and out while respecting reduced-motion preferences
- label every Widgets entry as its section name and purpose, including custom widgets, through localization
- add focused desktop/mobile browser coverage for rendered icon colors, bounds, spacing, motion, shape, and manager labels

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` completed successfully (localization, lint, TypeScript, and production builds).
- Focused Playwright coverage completed with 14 passing and 4 intentionally skipped project variants.
- A broad smoke attempt exposed existing Character-library tests that still wait for the removed `Open Characters Library` accessible name on current `staging`; isolated reruns reproduce that unrelated baseline failure.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence

Focused browser assertions compare rendered semantic icon colors, keep the Noodle badge and compact Achievements controls within their bounds, preserve the Discovery Desk grid gap, distinguish Square from Circle, verify the Bookmarks exit lifecycle, and confirm all nine built-in widget name/purpose pairs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Home and Appearance presentation across responsive layouts.
  * Fixed semantic chat-mode colors and square avatar preview styling.
  * Refined Noodle notification placement and mobile Achievements display.
  * Improved Discovery Desk spacing, bookmark menu transitions, and widget-manager labels.

* **Tests**
  * Expanded end-to-end coverage for avatar previews, Home widgets, bookmarks, achievements, cleanup, and chat-mode icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->