### PR TITLE
Fix Game persisted settings and Session Log metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Preserved Game Send-on-Enter and tutorial-dismissal preferences across their sync and local-storage boundaries, and made Session Logs honor persisted token counts and current-session markers after message metadata hydration (#4869).
 - Kept Recent Chats previews separate on narrow desktop windows by limiting the constrained two-column layout to the four newest chats while preserving the existing mobile and wide-screen counts (#4858).
 - Scoped image-connection prompt instructions to image-producing agents, bounded stored instructions to 20,000 characters, and kept each retry agent on its own configured image connection.
 - Kept chat settings profiles within their saved chat mode, migrated legacy Visual Novel profiles to Roleplay on import, and prevented reusable profiles from overwriting branch identity (#4849).

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -74,6 +74,7 @@ import { getDefaultChatTextColor, useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { parseChatMetadata } from "../../lib/chat-display";
 import { parseMessageExtraRecord } from "../../lib/chat-message-extra";
+import { estimateGameSessionHistoryTokens } from "../../lib/game-session-history";
 import { createMessageMacroResolver, findCharacterByName } from "../../lib/chat-macros";
 import { animateTextHtml } from "./AnimatedText";
 import { ttsService } from "../../lib/tts-service";
@@ -214,33 +215,6 @@ type NarrationMessage = Pick<Message, "id" | "chatId" | "role" | "content" | "ch
   characterName?: string;
 };
 
-const APPROX_MESSAGE_TOKEN_OVERHEAD = 4;
-
-function estimateTextTokenCount(text: string): number {
-  const trimmed = text.trim();
-  if (!trimmed) return 0;
-  const wordEstimate = trimmed.split(/\s+/).filter(Boolean).length * 1.3;
-  const charEstimate = trimmed.length / 4;
-  return Math.ceil(Math.max(wordEstimate, charEstimate));
-}
-
-function estimateMessageTokenCount(message: NarrationMessage): number {
-  const stored = message.extra?.tokenCount;
-  if (typeof stored === "number" && Number.isFinite(stored) && stored > 0) return stored;
-  const textTokens = estimateTextTokenCount(message.content);
-  return textTokens > 0 ? textTokens + APPROX_MESSAGE_TOKEN_OVERHEAD : 0;
-}
-
-function estimateSessionHistoryTokens(messages: NarrationMessage[]): number {
-  let startIndex = 0;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i]?.extra?.isConversationStart) {
-      startIndex = i;
-      break;
-    }
-  }
-  return messages.slice(startIndex).reduce((total, message) => total + estimateMessageTokenCount(message), 0);
-}
 
 function formatTokenEstimate(tokens: number): string {
   if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(tokens >= 10_000_000 ? 0 : 1).replace(/\.0$/, "")}m`;
@@ -2711,7 +2685,7 @@ export function GameNarration({
           }
         : { key: "", offsetTop: 0, scrollTop: container.scrollTop };
   }, []);
-  const sessionHistoryTokens = useMemo(() => estimateSessionHistoryTokens(messages), [messages]);
+  const sessionHistoryTokens = useMemo(() => estimateGameSessionHistoryTokens(messages), [messages]);
   const loadOlderLogs = useCallback(() => {
     setVisibleLogCount((current) => Math.min(logEntries.length, current + logPageSize));
   }, [logEntries.length, logPageSize]);

--- a/packages/client/src/lib/game-session-history.ts
+++ b/packages/client/src/lib/game-session-history.ts
@@ -26,7 +26,7 @@ function estimateMessageTokenCount(message: GameSessionHistoryMessage): number {
 export function estimateGameSessionHistoryTokens(messages: GameSessionHistoryMessage[]): number {
   let startIndex = 0;
   for (let i = messages.length - 1; i >= 0; i--) {
-    if (parseMessageExtraRecord(messages[i]?.extra).isConversationStart) {
+    if (parseMessageExtraRecord(messages[i]?.extra).isConversationStart === true) {
       startIndex = i;
       break;
     }

--- a/packages/client/src/lib/game-session-history.ts
+++ b/packages/client/src/lib/game-session-history.ts
@@ -1,0 +1,35 @@
+import { parseMessageExtraRecord } from "./chat-message-extra";
+
+type GameSessionHistoryMessage = {
+  content: string;
+  extra?: unknown;
+};
+
+const APPROX_MESSAGE_TOKEN_OVERHEAD = 4;
+
+function estimateTextTokenCount(text: string): number {
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  const wordEstimate = trimmed.split(/\s+/).filter(Boolean).length * 1.3;
+  const charEstimate = trimmed.length / 4;
+  return Math.ceil(Math.max(wordEstimate, charEstimate));
+}
+
+function estimateMessageTokenCount(message: GameSessionHistoryMessage): number {
+  const stored = parseMessageExtraRecord(message.extra).tokenCount;
+  if (typeof stored === "number" && Number.isFinite(stored) && stored > 0) return stored;
+  const textTokens = estimateTextTokenCount(message.content);
+  return textTokens > 0 ? textTokens + APPROX_MESSAGE_TOKEN_OVERHEAD : 0;
+}
+
+/** Estimates the active Game session history, beginning at its latest start marker. */
+export function estimateGameSessionHistoryTokens(messages: GameSessionHistoryMessage[]): number {
+  let startIndex = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (parseMessageExtraRecord(messages[i]?.extra).isConversationStart) {
+      startIndex = i;
+      break;
+    }
+  }
+  return messages.slice(startIndex).reduce((total, message) => total + estimateMessageTokenCount(message), 0);
+}

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -1279,6 +1279,7 @@ export function pickSyncedSettings(state: UIState) {
     convoGradient: state.convoGradient,
     enterToSendRP: state.enterToSendRP,
     enterToSendConvo: state.enterToSendConvo,
+    enterToSendGame: state.enterToSendGame,
     weatherEffects: state.weatherEffects,
     hasCompletedOnboarding: state.hasCompletedOnboarding,
     gameTutorialDisabled: state.gameTutorialDisabled,
@@ -2670,25 +2671,11 @@ export const useUIStore = create<UIState>()(
         if (version <= 22) {
           persisted.trackerPanelWidth = clampTrackerPanelWidth(persisted.trackerPanelWidth);
         }
-        // v23 -> v24: remember collapsed tracker data panels.
-        if (version <= 23) {
-          persisted.trackerPanelCollapsedSections = normalizeTrackerPanelCollapsedSections(
-            persisted.trackerPanelCollapsedSections,
-          );
-        }
         persisted.trackerPanelCollapsedSections = normalizeTrackerPanelCollapsedSections(
           persisted.trackerPanelCollapsedSections,
         );
-        // v24 -> v25: require an explicit tracker-panel opt-in before expression sprites replace portraits.
-        if (version <= 24 && persisted.trackerPanelUseExpressionSprites === undefined) {
-          persisted.trackerPanelUseExpressionSprites = false;
-        }
         if (persisted.trackerPanelUseExpressionSprites === undefined) {
           persisted.trackerPanelUseExpressionSprites = false;
-        }
-        // v25 -> v26: allow users to reorder tracker panel cards.
-        if (version <= 25) {
-          persisted.trackerPanelSectionOrder = normalizeTrackerPanelSectionOrder(persisted.trackerPanelSectionOrder);
         }
         persisted.trackerPanelSectionOrder = normalizeTrackerPanelSectionOrder(persisted.trackerPanelSectionOrder);
         // v26 -> v27: add Roleplay avatar and default sprite scale controls.
@@ -2722,50 +2709,21 @@ export const useUIStore = create<UIState>()(
         if (version <= 29 && persisted.chibiProfessorMariEnabled === undefined) {
           persisted.chibiProfessorMariEnabled = true;
         }
-        // v30 -> v31: persist Chat Summary popover source and display controls.
-        if (version <= 30) {
-          persisted.summaryPopoverSettings = normalizeSummaryPopoverSettings(persisted.summaryPopoverSettings);
-        }
         persisted.summaryPopoverSettings = normalizeSummaryPopoverSettings(persisted.summaryPopoverSettings);
         // v31 -> v32: add native chat/game background blur.
         if (version <= 31 && persisted.chatBackgroundBlur === undefined) {
           persisted.chatBackgroundBlur = 0;
         }
-        // v32 -> v33: make tracker character thought placement an explicit user preference.
-        if (version <= 32) {
-          persisted.trackerPanelThoughtBubbleDisplay = normalizeTrackerThoughtBubbleDisplay(
-            persisted.trackerPanelThoughtBubbleDisplay,
-          );
-        }
         persisted.trackerPanelThoughtBubbleDisplay = normalizeTrackerThoughtBubbleDisplay(
           persisted.trackerPanelThoughtBubbleDisplay,
         );
-        // v33 -> v34: replace arbitrary tracker desktop widths with curated size profiles.
-        if (version <= 33) {
-          persisted.trackerPanelSizeProfile = normalizeTrackerPanelSizeProfile(
-            persisted.trackerPanelSizeProfile,
-            persisted.trackerPanelWidth,
-          );
-        }
         persisted.trackerPanelSizeProfile = normalizeTrackerPanelSizeProfile(
           persisted.trackerPanelSizeProfile,
           persisted.trackerPanelWidth,
         );
-        // v34 -> v35: tracker-only temperature display unit.
-        if (version <= 34) {
-          persisted.trackerTemperatureUnit = normalizeTrackerTemperatureUnit(persisted.trackerTemperatureUnit);
-        }
         persisted.trackerTemperatureUnit = normalizeTrackerTemperatureUnit(persisted.trackerTemperatureUnit);
-        // v35 -> v36: optional always-visible docked tracker thoughts.
-        if (version <= 35 && persisted.trackerPanelDockedThoughtsAlwaysVisible === undefined) {
-          persisted.trackerPanelDockedThoughtsAlwaysVisible = false;
-        }
         if (persisted.trackerPanelDockedThoughtsAlwaysVisible === undefined) {
           persisted.trackerPanelDockedThoughtsAlwaysVisible = false;
-        }
-        // v36 -> v37: user-selectable straight or typographic quote formatting.
-        if (version <= 36) {
-          persisted.quoteFormat = normalizeQuoteFormat(persisted.quoteFormat);
         }
         persisted.quoteFormat = normalizeQuoteFormat(persisted.quoteFormat);
         // v37 -> v38: customizable image style profiles.
@@ -2841,12 +2799,6 @@ export const useUIStore = create<UIState>()(
         persisted.ttsLineVolume = Math.max(0, Math.min(100, Math.round(persisted.ttsLineVolume)));
         // v69 -> v70: remember scene prompt setup choices.
         persisted.scenePromptPreferences = normalizeScenePromptPreferences(persisted.scenePromptPreferences);
-        // v42 -> v44: reconcile parallel v43 UI preference additions.
-        if (version <= 43) {
-          persisted.trackerPanelBackgroundColor = normalizeTrackerPanelBackgroundColor(
-            persisted.trackerPanelBackgroundColor,
-          );
-        }
         persisted.trackerPanelBackgroundColor = normalizeTrackerPanelBackgroundColor(
           persisted.trackerPanelBackgroundColor,
         );
@@ -3231,6 +3183,7 @@ export const useUIStore = create<UIState>()(
         activeCustomTheme: state.activeCustomTheme,
         customThemes: state.customThemes,
         hasCompletedOnboarding: state.hasCompletedOnboarding,
+        gameTutorialDisabled: state.gameTutorialDisabled,
         linkApiBannerDismissed: state.linkApiBannerDismissed,
         echoChamberOpen: state.echoChamberOpen,
         echoChamberSide: state.echoChamberSide,

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -27,6 +27,7 @@ import {
 import { eq } from "../../packages/server/src/db/file-query.js";
 import { parseBuildMeta, resolveBuildBranch } from "../../packages/server/src/config/build-info.js";
 import { createSerializedMutationQueue } from "../../packages/client/src/lib/serialized-mutation-queue.js";
+import { estimateGameSessionHistoryTokens } from "../../packages/client/src/lib/game-session-history.js";
 
 const REPOSITORY_ROOT = fileURLToPath(new URL("../../", import.meta.url));
 import {
@@ -4939,6 +4940,148 @@ assert.match(
   /hadMissingSyncedSettings[\s\S]*pickSyncedSettings\(useUIStore\.getState\(\)\)/u,
   "Incomplete server settings blobs must be rewritten with newly synced preferences",
 );
+
+const gameHistoryMessage = (content: string, extra?: unknown) => ({ content, extra });
+const objectGameHistoryMetadata = [gameHistoryMessage("ignored", { tokenCount: 37 })];
+const jsonGameHistoryMetadata = [gameHistoryMessage("ignored", '{"tokenCount":37}')];
+assert.equal(estimateGameSessionHistoryTokens(objectGameHistoryMetadata), 37);
+assert.equal(
+  estimateGameSessionHistoryTokens(jsonGameHistoryMetadata),
+  estimateGameSessionHistoryTokens(objectGameHistoryMetadata),
+  "JSON-string metadata must use the same valid token count as object metadata",
+);
+
+const latestObjectGameHistoryMarker = [
+  gameHistoryMessage("ignored", { tokenCount: 101 }),
+  gameHistoryMessage("ignored", { tokenCount: 23, isConversationStart: true }),
+  gameHistoryMessage("ignored", { tokenCount: 19 }),
+  gameHistoryMessage("ignored", { tokenCount: 7, isConversationStart: true }),
+];
+const latestJsonGameHistoryMarker = [
+  gameHistoryMessage("ignored", '{"tokenCount":101}'),
+  gameHistoryMessage("ignored", '{"tokenCount":23,"isConversationStart":true}'),
+  gameHistoryMessage("ignored", '{"tokenCount":19}'),
+  gameHistoryMessage("ignored", '{"tokenCount":7,"isConversationStart":true}'),
+];
+assert.equal(estimateGameSessionHistoryTokens(latestObjectGameHistoryMarker), 7);
+assert.equal(
+  estimateGameSessionHistoryTokens(latestJsonGameHistoryMarker),
+  estimateGameSessionHistoryTokens(latestObjectGameHistoryMarker),
+  "the latest JSON-string conversation-start marker must determine session history",
+);
+
+const fallbackGameHistoryMessages = [
+  gameHistoryMessage("one two", "{not valid JSON"),
+  gameHistoryMessage("three four"),
+];
+assert.equal(
+  estimateGameSessionHistoryTokens(fallbackGameHistoryMessages),
+  14,
+  "malformed and absent metadata must retain the full history with text estimates",
+);
+
+// The UI store needs browser storage while Zustand initializes its persisted state.
+// Supply an isolated in-memory implementation so these checks exercise its real
+// migration and projection functions in this Node-based regression lane.
+const uiStorage = new Map<string, string>();
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: {
+    getItem: (key: string) => uiStorage.get(key) ?? null,
+    setItem: (key: string, value: string) => uiStorage.set(key, value),
+    removeItem: (key: string) => uiStorage.delete(key),
+  },
+});
+const { pickSyncedSettings, useUIStore } = await import("../../packages/client/src/stores/ui.store.js");
+const migrateUiSettings = useUIStore.persist.getOptions().migrate;
+assert.ok(migrateUiSettings, "The UI store must retain its persisted-state migration");
+
+const representativeTrackerSettings = {
+  trackerPanelCollapsedSections: { world: true, invalid: true },
+  trackerPanelUseExpressionSprites: undefined,
+  trackerPanelSectionOrder: ["quests", "world", "world", "invalid"],
+  summaryPopoverSettings: {
+    sourceMode: "range",
+    contextSize: 11.8,
+    rangeStart: 4.2,
+    rangeEnd: 9.7,
+    hideSummarisedMessages: true,
+    collapseHiddenMessages: false,
+  },
+  trackerPanelThoughtBubbleDisplay: "floating",
+  trackerPanelSizeProfile: "invalid",
+  trackerPanelWidth: 280,
+  trackerTemperatureUnit: "kelvin",
+  trackerPanelDockedThoughtsAlwaysVisible: undefined,
+  quoteFormat: "invalid",
+  trackerPanelBackgroundColor: "  #123456  ",
+};
+const migrateRepresentativeTrackerSettings = async (version: number) =>
+  (await migrateUiSettings(structuredClone(representativeTrackerSettings), version)) as Record<string, unknown>;
+const oldTrackerSettings = await migrateRepresentativeTrackerSettings(0);
+const currentTrackerSettings = await migrateRepresentativeTrackerSettings(92);
+const trackerMigrationProjection = (settings: Record<string, unknown>) => ({
+  trackerPanelCollapsedSections: settings.trackerPanelCollapsedSections,
+  trackerPanelUseExpressionSprites: settings.trackerPanelUseExpressionSprites,
+  trackerPanelSectionOrder: settings.trackerPanelSectionOrder,
+  summaryPopoverSettings: settings.summaryPopoverSettings,
+  trackerPanelThoughtBubbleDisplay: settings.trackerPanelThoughtBubbleDisplay,
+  trackerPanelSizeProfile: settings.trackerPanelSizeProfile,
+  trackerTemperatureUnit: settings.trackerTemperatureUnit,
+  trackerPanelDockedThoughtsAlwaysVisible: settings.trackerPanelDockedThoughtsAlwaysVisible,
+  quoteFormat: settings.quoteFormat,
+  trackerPanelBackgroundColor: settings.trackerPanelBackgroundColor,
+});
+assert.deepEqual(
+  trackerMigrationProjection(oldTrackerSettings),
+  trackerMigrationProjection(currentTrackerSettings),
+  "Old and current persisted tracker settings must share the unconditional canonicalizers",
+);
+assert.deepEqual(trackerMigrationProjection(currentTrackerSettings), {
+  trackerPanelCollapsedSections: { world: true },
+  trackerPanelUseExpressionSprites: false,
+  trackerPanelSectionOrder: ["quests", "world", "persona", "characters", "custom"],
+  summaryPopoverSettings: {
+    sourceMode: "range",
+    contextSize: 12,
+    rangeStart: 4,
+    rangeEnd: 10,
+    hideSummarisedMessages: true,
+    collapseHiddenMessages: false,
+  },
+  trackerPanelThoughtBubbleDisplay: "floating",
+  trackerPanelSizeProfile: "compact",
+  trackerTemperatureUnit: "celsius",
+  trackerPanelDockedThoughtsAlwaysVisible: false,
+  quoteFormat: "straight",
+  trackerPanelBackgroundColor: "#123456",
+});
+assert.match(
+  uiStoreSource,
+  /if \(version <= 37\) \{[\s\S]*IMAGE_STYLE_PROFILES_STORAGE_KEY\] \?\? persisted\.imageStyleProfiles/u,
+  "The image-style legacy-key fallback must remain version-specific",
+);
+const projectionState = { ...useUIStore.getState(), enterToSendGame: false, gameTutorialDisabled: true };
+assert.equal(
+  pickSyncedSettings(projectionState).enterToSendGame,
+  false,
+  "Game's Send on Enter preference must be server-synced",
+);
+assert.equal(
+  pickSyncedSettings(projectionState).gameTutorialDisabled,
+  true,
+  "The tutorial dismissal must be server-synced",
+);
+const localProjection = useUIStore.persist.getOptions().partialize(projectionState) as Record<string, unknown>;
+const syncedSettingsMissingFromLocalPersistence = Object.keys(pickSyncedSettings(projectionState)).filter(
+  (key) => !Object.prototype.hasOwnProperty.call(localProjection, key),
+);
+assert.deepEqual(
+  syncedSettingsMissingFromLocalPersistence,
+  [],
+  "Every server-synced setting must also be browser-local persisted",
+);
+assert.equal(localProjection.gameTutorialDisabled, true, "The tutorial dismissal must be browser-local persisted");
 assert.match(chatAreaPromptReviewSource, /MEDIA_PROMPT_PREVIEW_TIMEOUT_MS/);
 assert.match(chatAreaPromptReviewSource, /confirmRoleplayVideoPromptReview/);
 assert.match(chatAreaPromptReviewSource, /confirmConversationSelfiePromptReview/);

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -4970,6 +4970,27 @@ assert.equal(
   "the latest JSON-string conversation-start marker must determine session history",
 );
 
+const falseStringObjectGameHistoryMarker = [
+  gameHistoryMessage("ignored", { tokenCount: 23, isConversationStart: true }),
+  gameHistoryMessage("ignored", { tokenCount: 19 }),
+  gameHistoryMessage("ignored", { tokenCount: 7, isConversationStart: "false" }),
+];
+const falseStringJsonGameHistoryMarker = [
+  gameHistoryMessage("ignored", '{"tokenCount":23,"isConversationStart":true}'),
+  gameHistoryMessage("ignored", '{"tokenCount":19}'),
+  gameHistoryMessage("ignored", '{"tokenCount":7,"isConversationStart":"false"}'),
+];
+assert.equal(
+  estimateGameSessionHistoryTokens(falseStringObjectGameHistoryMarker),
+  49,
+  "a string false-valued object marker must not start a Game session",
+);
+assert.equal(
+  estimateGameSessionHistoryTokens(falseStringJsonGameHistoryMarker),
+  49,
+  "a string false-valued JSON marker must not start a Game session",
+);
+
 const fallbackGameHistoryMessages = [
   gameHistoryMessage("one two", "{not valid JSON"),
   gameHistoryMessage("three four"),


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #4869

## Why this change

Game preferences and persisted narration metadata currently cross browser-local, server-sync, and JSON transport boundaries inconsistently. That can make Game's Send-on-Enter choice fail to follow the user's settings profile, let an offline restart resurrect the Game tutorial, and make Session Logs ignore stored token counts or the current-session marker.

The nearby UI-store migration also retains ten version gates whose work is repeated immediately by unconditional canonicalizers.

## What changed

- Added `enterToSendGame` to the synchronized UI settings projection.
- Added `gameTutorialDisabled` to browser-local persistence while retaining its existing server sync.
- Added a regression invariant requiring every server-synced UI setting to also be browser-local persisted.
- Reused `parseMessageExtraRecord` when Session Logs estimate the current Game session, including JSON-string metadata, the latest `isConversationStart` marker, valid finite positive token counts, and malformed/absent fallback.
- Removed only the ten redundant UI migration gates while preserving their unconditional canonicalizers and the real image-style-profile legacy fallback.
- Added focused coverage to the existing open-issues regression lane and documented the user-facing fixes in the changelog.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran `pnpm check` against the final committed tree.
- Ran the complete `pnpm regression:issues` aggregate; expected negative-fixture WARN/ERROR logs were emitted and the aggregate passed.
- Ran `git diff --check`.
- In a disposable headed Edge session, seeded an active Game chat through existing APIs with:
  - a 999-token message before the latest session marker;
  - current-session persisted token counts of 40, 80, and 120 returned through the ordinary JSON-string `extra` transport shape.
- Opened Game **Session Logs** and confirmed all four log entries rendered while the current-session estimate displayed `~240 tokens`, excluding the pre-marker 999-token message.
- Repeated the visible Session Logs check at a 390×844 mobile viewport.
- No visual styling or layout changed, so theme-specific before/after screenshots were not required. The disposable proof session was removed after verification.
- Container validation was not run because this change is limited to client state projection, hydration, and deterministic regression coverage.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

The `[Unreleased]` changelog is updated. No user documentation, translated documentation, or version files require changes.

## UI evidence (if applicable)

The affected UI is an existing Session Logs text estimate rather than a layout/style change. Headed desktop and mobile proof is described above; no repository image assets were added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Game “Send on Enter” and tutorial-dismissal preferences now persist correctly across local storage and synchronization.
  * Session Logs now restore token counts and current-session markers reliably.
  * Active game-session token estimates now handle stored metadata and fallback calculations more accurately.

* **Tests**
  * Added regression coverage for session history estimation, settings migration, synchronization, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->