### PR TITLE
fix: normalize legacy Universal Preset names before reconciliation

### DIFF
--- a/packages/server/src/db/seed.ts
+++ b/packages/server/src/db/seed.ts
@@ -380,6 +380,16 @@ export async function seedDefaultPreset(db: DB) {
     }
   }
 
+  // Normalize the old display name before any reconciliation branch can
+  // return, including profiles without a prior snapshot marker.
+  if (existingMarinaraPreset?.name === LEGACY_MARINARA_PRESET_NAME) {
+    const renamedPreset = await storage.update(existingMarinaraPreset.id, {
+      name: MARINARA_UNIVERSAL_PRESET_NAME,
+      description: bundledPresetDescription(bundled.envelope),
+    });
+    if (renamedPreset) existingMarinaraPreset = renamedPreset;
+  }
+
   const bundledConversationPromptValue = bundledConversationPrompt(bundled.envelope.data.preset);
   if (existingMarinaraPreset && appliedSnapshotHash) {
     const currentSnapshotHash = await computePresetSnapshotHash(storage, existingMarinaraPreset.id);
@@ -441,17 +451,6 @@ export async function seedDefaultPreset(db: DB) {
 
   if (existingMarinaraPreset && !appliedSnapshotHash) {
     await appSettings.set(MARINARA_PRESET_SNAPSHOT_KEY, computeBundledPresetSnapshotHash(bundled.envelope));
-  }
-
-  // Older builds named the bundled preset "Default"; keep the display name tidy
-  // even when its bundled body already matches the current seed hash.
-  const legacyMarinaraPreset =
-    existingMarinaraPreset?.name === LEGACY_MARINARA_PRESET_NAME ? existingMarinaraPreset : null;
-  if (legacyMarinaraPreset) {
-    await storage.update(legacyMarinaraPreset.id, {
-      name: MARINARA_UNIVERSAL_PRESET_NAME,
-      description: bundledPresetDescription(bundled.envelope),
-    });
   }
 
   if (existingMarinaraPreset) return;

--- a/scripts/regressions/stock-preset-protection.regression.ts
+++ b/scripts/regressions/stock-preset-protection.regression.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { seedDefaultPreset } from "../../packages/server/src/db/seed.js";
 import { createFileNativeDB } from "../../packages/server/src/db/file-backed-store.js";
+import { createAppSettingsStorage } from "../../packages/server/src/services/storage/app-settings.storage.js";
 import { createPromptsStorage } from "../../packages/server/src/services/storage/prompts.storage.js";
 import { isStockMarinaraUniversalPreset } from "../../packages/shared/src/types/prompt.js";
 
@@ -13,6 +14,7 @@ const db = await createFileNativeDB();
 
 try {
   const storage = createPromptsStorage(db);
+  const appSettings = createAppSettingsStorage(db);
   await seedDefaultPreset(db);
   const original = (await storage.list()).find(isStockMarinaraUniversalPreset);
   assert.ok(original, "a fresh profile receives the stock Marinara universal preset");
@@ -23,6 +25,16 @@ try {
     (await storage.list()).find(isStockMarinaraUniversalPreset)?.id,
     original.id,
     "snapshot evidence migrates a genuine legacy stock preset to the reserved identity",
+  );
+
+  await storage.update(original.id, { name: "Default" });
+  await appSettings.remove("seed:marinara-universal-preset:snapshot-sha256");
+  await appSettings.set("seed:marinara-universal-preset:sha256", "outdated-seed-hash");
+  await seedDefaultPreset(db);
+  assert.equal(
+    (await storage.getById(original.id))?.name,
+    "Marinara's Universal Preset",
+    "legacy display names are normalized before no-snapshot reconciliation returns",
   );
 
   const originalDescription = original.description;


### PR DESCRIPTION
## Why

Follow-up to #4873: CodeRabbit identified that the legacy `Default` display-name migration ran after reconciliation branches that can return early. Profiles on the no-snapshot upgrade path could therefore retain the old name for one extra startup.

Refs #4871

## What changed

- Move the existing legacy display-name normalization before all preset reconciliation branches.
- Add regression coverage for an outdated seed hash with no snapshot marker.

## Automated verification

- `pnpm check`
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/stock-preset-protection.regression.ts`

## Manual verification

- [ ] Start from a legacy stock preset named `Default` with an outdated seed hash and no snapshot marker, then confirm startup renames it immediately.