### PR TITLE
fix: accept valid pnpm output in Windows installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed the Windows installer falsely rejecting the required pnpm version when its version command emits LF-only output, while continuing to reject failed commands and mismatched versions (#4875).
 - Kept Random Model chats on a stable configured embedding source during Memory Recall refreshes instead of falling back to the local embedder (#4864).
 - Restored installed feature-only packages such as Noodle to the Agents management pane while keeping them out of ordinary chat-agent pickers (#4865).
 - Preserved bold formatting nested inside italic user messages (#4866).

--- a/scripts/check-windows-installer-layout.mjs
+++ b/scripts/check-windows-installer-layout.mjs
@@ -56,7 +56,7 @@ try {
     "npm config get prefix",
     '${StrTrimNewLines} $NPM_PREFIX "$NPM_PREFIX"',
     't "$NPM_PREFIX;$1"',
-    "cmd /c pnpm --version",
+    "cmd /d /c pnpm --version",
   ];
   let previousFallbackStep = -1;
   const npmFallbackIsOrdered = npmFallbackSequence.every((step) => {
@@ -74,6 +74,25 @@ try {
   if (npmFallback.includes('t "$APPDATA\\npm;$1"')) {
     failures.push({
       message: "The Windows installer must not assume the default npm prefix; custom global prefixes must work.",
+    });
+  }
+
+  const pnpmCheckStart = code.indexOf('DetailPrint "Ensuring pnpm ${PNPM_VERSION}..."');
+  const pnpmCheckEnd = code.indexOf('DetailPrint "pnpm ready."', pnpmCheckStart);
+  const pnpmChecks =
+    pnpmCheckStart >= 0 && pnpmCheckEnd > pnpmCheckStart ? code.slice(pnpmCheckStart, pnpmCheckEnd) : "";
+  const normalizedVersionChecks = pnpmChecks.match(
+    /\$\{StrTrimNewLines\} \$CURRENT_PNPM_VERSION "\$CURRENT_PNPM_VERSION"/g,
+  );
+  const exactVersionChecks = pnpmChecks.match(/\$\{If\} \$CURRENT_PNPM_VERSION == "\$\{PNPM_VERSION\}"/g);
+  if (pnpmChecks.toLowerCase().includes("findstr.exe")) {
+    failures.push({
+      message: "pnpm version checks must not use findstr; LF-only output can make exact-line matching fail.",
+    });
+  }
+  if (normalizedVersionChecks?.length !== 4 || exactVersionChecks?.length !== 4) {
+    failures.push({
+      message: "Every Windows installer pnpm runner must capture, trim, and compare its reported version exactly.",
     });
   }
 

--- a/scripts/check-windows-installer-layout.mjs
+++ b/scripts/check-windows-installer-layout.mjs
@@ -85,7 +85,7 @@ try {
     /\$\{StrTrimNewLines\} \$CURRENT_PNPM_VERSION "\$CURRENT_PNPM_VERSION"/g,
   );
   const exactVersionChecks = pnpmChecks.match(/\$\{If\} \$CURRENT_PNPM_VERSION == "\$\{PNPM_VERSION\}"/g);
-  if (pnpmChecks.toLowerCase().includes("findstr.exe")) {
+  if (/\bfindstr(?:\.exe)?\b/i.test(pnpmChecks)) {
     failures.push({
       message: "pnpm version checks must not use findstr; LF-only output can make exact-line matching fail.",
     });

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -112,6 +112,7 @@ Var GIT_OK
 Var NODE_OK
 Var PNPM_OK
 Var PNPM_RUNNER
+Var CURRENT_PNPM_VERSION
 Var NPM_PREFIX
 Var CLONE_DIR
 Var CLONE_DIR_CREATED
@@ -353,29 +354,41 @@ Please restart your computer and run this installer again."
   Pop $1
   ${If} $0 == 0
     DetailPrint "Trying pinned pnpm ${PNPM_VERSION} via Corepack..."
-    nsExec::ExecToStack 'cmd /c corepack pnpm@${PNPM_DESCRIPTOR} --version | %SystemRoot%\System32\findstr.exe /x /l /c:${PNPM_VERSION}'
+    StrCpy $CURRENT_PNPM_VERSION ""
+    nsExec::ExecToStack 'cmd /d /c corepack pnpm@${PNPM_DESCRIPTOR} --version 2>nul'
     Pop $PNPM_OK
-    Pop $1
+    Pop $CURRENT_PNPM_VERSION
     ${If} $PNPM_OK == 0
-      StrCpy $PNPM_RUNNER "corepack"
+      ${StrTrimNewLines} $CURRENT_PNPM_VERSION "$CURRENT_PNPM_VERSION"
+      ${If} $CURRENT_PNPM_VERSION == "${PNPM_VERSION}"
+        StrCpy $PNPM_RUNNER "corepack"
+      ${EndIf}
     ${EndIf}
   ${EndIf}
   ${If} $PNPM_RUNNER == ""
     DetailPrint "Corepack pnpm ${PNPM_VERSION} unavailable; trying installed pnpm..."
-    nsExec::ExecToStack 'cmd /c pnpm --version | %SystemRoot%\System32\findstr.exe /x /l /c:${PNPM_VERSION}'
+    StrCpy $CURRENT_PNPM_VERSION ""
+    nsExec::ExecToStack 'cmd /d /c pnpm --version 2>nul'
     Pop $PNPM_OK
-    Pop $1
+    Pop $CURRENT_PNPM_VERSION
     ${If} $PNPM_OK == 0
-      StrCpy $PNPM_RUNNER "pnpm"
+      ${StrTrimNewLines} $CURRENT_PNPM_VERSION "$CURRENT_PNPM_VERSION"
+      ${If} $CURRENT_PNPM_VERSION == "${PNPM_VERSION}"
+        StrCpy $PNPM_RUNNER "pnpm"
+      ${EndIf}
     ${EndIf}
   ${EndIf}
   ${If} $PNPM_RUNNER == ""
     DetailPrint "Installed pnpm unavailable; trying temporary pnpm ${PNPM_VERSION} via npx..."
-    nsExec::ExecToStack 'cmd /c npx --yes pnpm@${PNPM_VERSION} --version | %SystemRoot%\System32\findstr.exe /x /l /c:${PNPM_VERSION}'
+    StrCpy $CURRENT_PNPM_VERSION ""
+    nsExec::ExecToStack 'cmd /d /c npx --yes pnpm@${PNPM_VERSION} --version 2>nul'
     Pop $PNPM_OK
-    Pop $1
+    Pop $CURRENT_PNPM_VERSION
     ${If} $PNPM_OK == 0
-      StrCpy $PNPM_RUNNER "npx"
+      ${StrTrimNewLines} $CURRENT_PNPM_VERSION "$CURRENT_PNPM_VERSION"
+      ${If} $CURRENT_PNPM_VERSION == "${PNPM_VERSION}"
+        StrCpy $PNPM_RUNNER "npx"
+      ${EndIf}
     ${EndIf}
   ${EndIf}
   ${If} $PNPM_RUNNER == ""
@@ -393,11 +406,15 @@ Please restart your computer and run this installer again."
       ${If} $NPM_PREFIX != ""
         ReadEnvStr $1 "PATH"
         System::Call 'Kernel32::SetEnvironmentVariable(t "PATH", t "$NPM_PREFIX;$1")i'
-        nsExec::ExecToStack 'cmd /c pnpm --version | %SystemRoot%\System32\findstr.exe /x /l /c:${PNPM_VERSION}'
+        StrCpy $CURRENT_PNPM_VERSION ""
+        nsExec::ExecToStack 'cmd /d /c pnpm --version 2>nul'
         Pop $PNPM_OK
-        Pop $1
+        Pop $CURRENT_PNPM_VERSION
         ${If} $PNPM_OK == 0
-          StrCpy $PNPM_RUNNER "pnpm"
+          ${StrTrimNewLines} $CURRENT_PNPM_VERSION "$CURRENT_PNPM_VERSION"
+          ${If} $CURRENT_PNPM_VERSION == "${PNPM_VERSION}"
+            StrCpy $PNPM_RUNNER "pnpm"
+          ${EndIf}
         ${EndIf}
       ${EndIf}
     ${EndIf}


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository’s `staging` branch or a same-repository `hotfix/*` branch to `main`.

## Linked issue

Closes #4875

## Why this change

The Windows NSIS installer piped `pnpm --version` through `findstr /X`. On affected Windows systems pnpm emits an LF-only line ending, causing `findstr` to return failure even though the exact required pnpm version is available. This left every pnpm runner and the npm fallback falsely rejected.

## What changed

- Capture each pnpm runner’s version output directly, trim CR/LF, and compare it exactly with the pinned version.
- Preserve the Corepack → installed pnpm → npx → npm fallback order and command-exit checks.
- Guard all four NSIS checks against reintroducing line-ending-sensitive `findstr` validation.
- Document the user-facing installer fix in the changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated/local checks run:

- `pnpm check`
- `node scripts/check-windows-installer-layout.mjs`
- `pnpm version:check`
- `pnpm guard:installer-artifacts`
- `pnpm exec prettier --check scripts/check-windows-installer-layout.mjs`
- `makensis -V3 installer.nsi`
- `git diff --check`

### Manual verification notes

- Windows installer execution remains to be manually verified on an affected Windows host. The NSIS source compiles successfully on macOS with MakeNSIS 3.11.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

No user guide changes are needed; the existing pnpm troubleshooting commands remain correct. `CHANGELOG.md` records the fix.

## UI evidence (if applicable)

Not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Windows installer’s pnpm version detection for environments that return LF-only command output.
  * Added exact version validation across supported pnpm installation methods.
  * Preserved safeguards that reject failed commands and version mismatches.
  * Improved npm fallback command handling for more reliable installations.

* **Documentation**
  * Added an Unreleased changelog entry describing the Windows installer fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->