### PR TITLE
Fix assigned generation, game, and chat regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Recorded the fallback provider and model on messages it actually generated instead of displaying the failed primary model (#4879).
 - Remembered the Echo Chamber corner independently for each chat and flushes position changes immediately so they survive tab changes and app restarts (#4882).
 - Made chat generation-parameter send toggles authoritative, so disabling Verbosity omits it from provider requests even when a preset still has a selected verbosity value (#4883).
 - Fixed the Windows installer falsely rejecting the required pnpm version when its version command emits LF-only output, while continuing to reject failed commands and mismatched versions (#4875).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Made chat generation-parameter send toggles authoritative, so disabling Verbosity omits it from provider requests even when a preset still has a selected verbosity value (#4883).
 - Fixed the Windows installer falsely rejecting the required pnpm version when its version command emits LF-only output, while continuing to reject failed commands and mismatched versions (#4875).
 - Kept Random Model chats on a stable configured embedding source during Memory Recall refreshes instead of falling back to the local embedder (#4864).
 - Restored installed feature-only packages such as Noodle to the Agents management pane while keeping them out of ordinary chat-agent pickers (#4865).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Remembered the Echo Chamber corner independently for each chat and flushes position changes immediately so they survive tab changes and app restarts (#4882).
 - Made chat generation-parameter send toggles authoritative, so disabling Verbosity omits it from provider requests even when a preset still has a selected verbosity value (#4883).
 - Fixed the Windows installer falsely rejecting the required pnpm version when its version command emits LF-only output, while continuing to reject failed commands and mismatched versions (#4875).
 - Kept Random Model chats on a stable configured embedding source during Memory Recall refreshes instead of falling back to the local embedder (#4864).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
-- Applied Game image prompt overrides and the selected Illustrator prompt template to Game prompt-director requests, including manual portraits that use the Illustrator agent's image connection (#4880).
+- Applied Game image prompt overrides and the selected Illustrator prompt template to Game prompt-director requests, including manual portraits that use the Illustrator agent's image connection and explicitly customized prompt settings when the general dynamic-prompt toggle is off (#4880).
 - Made Game combat use character-sheet levels, resource pools, and typed abilities instead of deriving levels from HP and treating every ability as an attack (#4881).
 - Recorded the fallback provider and model on messages it actually generated instead of displaying the failed primary model (#4879).
 - Remembered the Echo Chamber corner independently for each chat and flushes position changes immediately so they survive tab changes and app restarts (#4882).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Made Game combat use character-sheet levels, resource pools, and typed abilities instead of deriving levels from HP and treating every ability as an attack (#4881).
 - Recorded the fallback provider and model on messages it actually generated instead of displaying the failed primary model (#4879).
 - Remembered the Echo Chamber corner independently for each chat and flushes position changes immediately so they survive tab changes and app restarts (#4882).
 - Made chat generation-parameter send toggles authoritative, so disabling Verbosity omits it from provider requests even when a preset still has a selected verbosity value (#4883).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Applied Game image prompt overrides and the selected Illustrator prompt template to Game prompt-director requests, including manual portraits that use the Illustrator agent's image connection (#4880).
 - Made Game combat use character-sheet levels, resource pools, and typed abilities instead of deriving levels from HP and treating every ability as an attack (#4881).
 - Recorded the fallback provider and model on messages it actually generated instead of displaying the failed primary model (#4879).
 - Remembered the Echo Chamber corner independently for each chat and flushes position changes immediately so they survive tab changes and app restarts (#4882).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -6975,6 +6975,82 @@ test("game widget edits preserve their live numeric values", async ({ request },
   }
 });
 
+test("Game combat sheet helpers preserve ability types, card matches, and zero HP", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Pure Game combat hydration coverage only needs one browser.");
+
+  await page.goto("/");
+  const result = await page.evaluate(async () => {
+    const module = (await import("/src/components/game/GameSurface.tsx")) as unknown as {
+      combatSkillsFromSheet(value: unknown):
+        | Array<{ name: string; type: string; description?: string }>
+        | undefined;
+      findGameCombatCard(
+        cards: Array<{ name?: string }>,
+        targetName: string,
+      ): { name?: string } | undefined;
+      generatedPartyMemberToCombatant(
+        member: Record<string, unknown>,
+        index: number,
+        avatarCandidates: unknown[],
+        fallbackLevel: number,
+      ): { hp: number; maxHp: number };
+      generatedEnemyToCombatant(
+        enemy: Record<string, unknown>,
+        index: number,
+        fallbackLevel: number,
+      ): { hp: number; maxHp: number };
+    };
+    const skills = module.combatSkillsFromSheet([
+      "[attack] Solar Slash: A searing arc.",
+      "[heal] Gentle Mend — Restores HP.",
+      "[buff] Healing Aura - Raises defense.",
+      "[debuff] Slow: Reduces speed.",
+      "Shield Wall: Protects allies.",
+      "Field Cure: Restores an ally.",
+      "Quick Jab: A fast strike.",
+      "solar slash: Duplicate should be ignored.",
+      null,
+      false,
+      {},
+    ]);
+    const cards = [{ name: "Mika" }, { name: "Éowyn" }];
+    return {
+      skills: skills?.map(({ name, type, description }) => ({ name, type, description })),
+      empty: module.combatSkillsFromSheet([]),
+      invalid: module.combatSkillsFromSheet([null, false, {}]),
+      suffixMatch: module.findGameCombatCard(cards, "Mika (Mage)")?.name,
+      diacriticMatch: module.findGameCombatCard(cards, "Eowyn")?.name,
+      party: module.generatedPartyMemberToCombatant(
+        { name: "Mika", hp: 0, maxHp: 12, attacks: [], statuses: [] },
+        0,
+        [],
+        1,
+      ),
+      enemy: module.generatedEnemyToCombatant(
+        { name: "Slime", hp: 0, maxHp: 9, attacks: [], statuses: [] },
+        0,
+        1,
+      ),
+    };
+  });
+
+  expect(result.skills).toEqual([
+    { name: "Solar Slash", type: "attack", description: "A searing arc." },
+    { name: "Gentle Mend", type: "heal", description: "Restores HP." },
+    { name: "Healing Aura", type: "buff", description: "Raises defense." },
+    { name: "Slow", type: "debuff", description: "Reduces speed." },
+    { name: "Shield Wall", type: "buff", description: "Protects allies." },
+    { name: "Field Cure", type: "heal", description: "Restores an ally." },
+    { name: "Quick Jab", type: "attack", description: "A fast strike." },
+  ]);
+  expect(result.empty).toBeUndefined();
+  expect(result.invalid).toBeUndefined();
+  expect(result.suffixMatch).toBe("Mika");
+  expect(result.diacriticMatch).toBe("Éowyn");
+  expect(result.party).toMatchObject({ hp: 0, maxHp: 12 });
+  expect(result.enemy).toMatchObject({ hp: 0, maxHp: 9 });
+});
+
 test("Game character sheet Retry remains a draft until Save", async ({ page, request }, testInfo) => {
   const suffix = Date.now().toString(36);
   const characterName = `Retry Sheet Character ${suffix}`;

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -4348,7 +4348,7 @@ test("desktop Roleplay composition keeps ambient work off the input path and gro
   }
 });
 
-test("desktop Echo Chamber commits its resized dimensions before reload", async ({ page }, testInfo) => {
+test("desktop Echo Chamber commits its per-chat size and corner before reload", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Desktop Echo Chamber resizing is covered on desktop.");
 
   await page.route("**/api/app-settings/ui", async (route) => {
@@ -4394,15 +4394,22 @@ test("desktop Echo Chamber commits its resized dimensions before reload", async 
 
     await resizeHandle.press("ArrowRight");
     await resizeHandle.press("ArrowDown");
+    await page.getByTitle("top left").click();
 
-    const savedSize = await page.evaluate((chatId) => {
+    const savedLayout = await page.evaluate((chatId) => {
       const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui") ?? '{"state":{}}') as {
         state?: {
+          echoChamberSideByChatId?: Record<string, string>;
           echoChamberSizeByChatId?: Record<string, { width?: unknown; height?: unknown }>;
         };
       };
-      return persisted.state?.echoChamberSizeByChatId?.[chatId] ?? null;
+      return {
+        side: persisted.state?.echoChamberSideByChatId?.[chatId] ?? null,
+        size: persisted.state?.echoChamberSizeByChatId?.[chatId] ?? null,
+      };
     }, chat.id);
+    const savedSize = savedLayout.size;
+    expect(savedLayout.side).toBe("top-left");
     expect(savedSize).not.toBeNull();
     expect(savedSize?.width).toBeGreaterThan(Math.round(initialBox!.width));
     expect(savedSize?.height).toBeGreaterThan(Math.round(initialBox!.height));
@@ -5364,7 +5371,7 @@ test("legacy browser records are cleaned while extension imports stay locked", a
         };
       }),
     )
-    .toEqual({ version: 90, hasExtensionRecords: false, hasCleanupFlag: false });
+    .toEqual({ version: 93, hasExtensionRecords: false, hasCleanupFlag: false });
 
   expect(
     await page.evaluate(
@@ -7074,7 +7081,7 @@ test("Game character sheet Retry remains a draft until Save", async ({ page, req
       data: {
         name: personaName,
         description: "A memory-weaver who maps the drowned city's forgotten roads.",
-        personaStats: JSON.stringify({ rpgStats: personaRpgStats }),
+        personaStats: JSON.stringify({ enabled: true, bars: [], rpgStats: personaRpgStats }),
       },
     });
     expect(personaResponse.ok()).toBeTruthy();

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -7031,6 +7031,17 @@ test("Game combat sheet helpers preserve ability types, card matches, and zero H
         0,
         1,
       ),
+      invalidPartyHp: module.generatedPartyMemberToCombatant(
+        { name: "Mika", hp: false, maxHp: 12, attacks: [], statuses: [] },
+        0,
+        [],
+        1,
+      ).hp,
+      invalidEnemyHp: module.generatedEnemyToCombatant(
+        { name: "Slime", hp: false, maxHp: 9, attacks: [], statuses: [] },
+        0,
+        1,
+      ).hp,
     };
   });
 
@@ -7049,6 +7060,8 @@ test("Game combat sheet helpers preserve ability types, card matches, and zero H
   expect(result.diacriticMatch).toBe("Éowyn");
   expect(result.party).toMatchObject({ hp: 0, maxHp: 12 });
   expect(result.enemy).toMatchObject({ hp: 0, maxHp: 9 });
+  expect(result.invalidPartyHp).toBe(12);
+  expect(result.invalidEnemyHp).toBe(9);
 });
 
 test("Game character sheet Retry remains a draft until Save", async ({ page, request }, testInfo) => {

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -170,14 +170,22 @@ function CornerPicker({ current, onChange }: { current: EchoChamberSide; onChang
 export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelProps) {
   const { t: localizeUi } = useUiTranslation();
   const activeChatId = useChatStore((s) => s.activeChatId);
-  const echoChamberSide = useUIStore((s) => s.echoChamberSide);
-  const setEchoChamberSide = useUIStore((s) => s.setEchoChamberSide);
+  const echoChamberSide = useUIStore((s) =>
+    activeChatId ? (s.echoChamberSideByChatId[activeChatId] ?? s.echoChamberSide) : s.echoChamberSide,
+  );
+  const setEchoChamberSideForChat = useUIStore((s) => s.setEchoChamberSideForChat);
   const echoChamberOpen = useUIStore((s) => s.echoChamberOpen);
   const toggleEchoChamber = useUIStore((s) => s.toggleEchoChamber);
   const rememberedPanelSize = useUIStore((s) =>
     activeChatId ? (s.echoChamberSizeByChatId[activeChatId] ?? null) : null,
   );
   const setEchoChamberSizeForChat = useUIStore((s) => s.setEchoChamberSizeForChat);
+  const setEchoChamberSide = useCallback(
+    (side: EchoChamberSide) => {
+      if (activeChatId) setEchoChamberSideForChat(activeChatId, side);
+    },
+    [activeChatId, setEchoChamberSideForChat],
+  );
   const trackerPanelEnabled = useUIStore((s) => s.trackerPanelEnabled);
   const trackerPanelOpen = useUIStore((s) => s.trackerPanelOpen);
   const trackerPanelSide = useUIStore((s) => s.trackerPanelSide);

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -741,6 +741,7 @@ type StoredGameCombatCard = {
 };
 
 function readCombatNumber(value: unknown): number | null {
+  if (value == null || (typeof value === "string" && !value.trim())) return null;
   const numericValue = Number(value);
   return Number.isFinite(numericValue) ? numericValue : null;
 }
@@ -794,13 +795,14 @@ function inferCombatSkillType(value: string): NonNullable<Combatant["skills"]>[n
   return "attack";
 }
 
-function combatSkillsFromSheet(value: unknown): Combatant["skills"] {
+export function combatSkillsFromSheet(value: unknown): Combatant["skills"] {
   if (!Array.isArray(value)) return undefined;
   const seen = new Set<string>();
   const skills: NonNullable<Combatant["skills"]> = [];
 
   for (const [index, entry] of value.entries()) {
-    const raw = String(entry).trim();
+    if (typeof entry !== "string") continue;
+    const raw = entry.trim();
     if (!raw) continue;
     const declaredType = raw.match(/^\s*\[?(attack|heal(?:ing)?|buff|debuff)\]?/i)?.[1]?.toLowerCase();
     const withoutTypePrefix = raw
@@ -832,6 +834,13 @@ function combatSkillsFromSheet(value: unknown): Combatant["skills"] {
   }
 
   return skills.length > 0 ? skills : undefined;
+}
+
+export function findGameCombatCard(
+  cards: StoredGameCombatCard[],
+  targetName: string,
+): StoredGameCombatCard | undefined {
+  return findNamedEntry(cards, targetName, (card) => (typeof card.name === "string" ? card.name : null));
 }
 
 function combatStatusEffectsFromGenerated(
@@ -915,7 +924,7 @@ function isValidCombatant(value: unknown): value is Combatant {
   );
 }
 
-function generatedPartyMemberToCombatant(
+export function generatedPartyMemberToCombatant(
   member: CombatPartyMember,
   index: number,
   avatarCandidates: GamePartyMemberInfo[],
@@ -924,9 +933,9 @@ function generatedPartyMemberToCombatant(
 ): Combatant {
   const matchedAvatar = findNamedEntry(avatarCandidates, member.name, (entry) => entry.name);
   const cardHp = gameCard?.rpgStats?.hp;
-  const generatedMaxHp = Number(member.maxHp) || Number(member.hp) || 1;
+  const generatedMaxHp = readCombatNumber(member.maxHp) ?? readCombatNumber(member.hp) ?? 1;
   const maxHp = Math.max(1, readCombatNumber(cardHp?.max) ?? generatedMaxHp);
-  const generatedHp = Number(member.hp) || maxHp;
+  const generatedHp = readCombatNumber(member.hp) ?? maxHp;
   const hp = Math.max(0, Math.min(maxHp, readCombatNumber(cardHp?.value) ?? generatedHp));
   const level = Math.max(
     1,
@@ -971,9 +980,9 @@ function hydrateCombatPartyAvatars(party: Combatant[], avatarCandidates: GamePar
   return changed ? nextParty : party;
 }
 
-function generatedEnemyToCombatant(enemy: CombatEnemy, index: number, fallbackLevel: number): Combatant {
-  const maxHp = Math.max(1, Number(enemy.maxHp) || Number(enemy.hp) || 1);
-  const hp = Math.max(0, Math.min(maxHp, Number(enemy.hp) || maxHp));
+export function generatedEnemyToCombatant(enemy: CombatEnemy, index: number, fallbackLevel: number): Combatant {
+  const maxHp = Math.max(1, readCombatNumber(enemy.maxHp) ?? readCombatNumber(enemy.hp) ?? 1);
+  const hp = Math.max(0, Math.min(maxHp, readCombatNumber(enemy.hp) ?? maxHp));
   const level = combatLevelFromHp(maxHp, fallbackLevel);
   const element = enemy.attacks?.find((attack) => attack.element)?.element;
   const combatClass = typeof enemy.class === "string" && enemy.class.trim() ? enemy.class.trim() : undefined;
@@ -8087,9 +8096,7 @@ function GameSurfaceComponent({
               index,
               combatAvatarCandidates,
               fallbackLevel,
-              findNamedEntry(gameCharacterCards, member.name, (card) =>
-                typeof card.name === "string" ? card.name : null,
-              ),
+              findGameCombatCard(gameCharacterCards, member.name),
             ),
           )
         : [];
@@ -8558,15 +8565,9 @@ function GameSurfaceComponent({
       const numericValue = Number(value);
       return Number.isFinite(numericValue) ? numericValue : null;
     };
-    const gameCardByName = new Map<string, StoredGameCombatCard>();
     const gameCharacterCards = Array.isArray(chatMeta.gameCharacterCards)
       ? (chatMeta.gameCharacterCards as Array<Record<string, unknown>>)
       : [];
-    for (const card of gameCharacterCards as StoredGameCombatCard[]) {
-      if (typeof card?.name === "string" && card.name.trim()) {
-        gameCardByName.set(normalizeTextForMatch(card.name), card);
-      }
-    }
 
     const playerBarStats = [
       ...((gameSnapshot?.playerStats?.stats ?? []) as CombatStatLike[]),
@@ -8670,7 +8671,7 @@ function GameSurfaceComponent({
               (pc) => pc.characterId === m.id || normalizeTextForMatch(pc.name) === normalizeTextForMatch(m.name),
             );
         const stats = (isPlayerMember ? playerBarStats : (snap?.stats ?? [])) as CombatStatLike[];
-        const gameCard = gameCardByName.get(normalizeTextForMatch(m.name));
+        const gameCard = findGameCombatCard(gameCharacterCards as StoredGameCombatCard[], m.name);
         const cardRpgStats = gameCard?.rpgStats ?? null;
         const cardAttributes = new Map(
           Array.isArray(cardRpgStats?.attributes)

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -741,7 +741,8 @@ type StoredGameCombatCard = {
 };
 
 function readCombatNumber(value: unknown): number | null {
-  if (value == null || (typeof value === "string" && !value.trim())) return null;
+  if (value == null || (typeof value !== "number" && typeof value !== "string")) return null;
+  if (typeof value === "string" && !value.trim()) return null;
   const numericValue = Number(value);
   return Number.isFinite(numericValue) ? numericValue : null;
 }

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -729,6 +729,103 @@ function combatLevelFromHp(maxHp: number, fallbackLevel: number): number {
   return Math.max(1, Math.round(maxHp / 20));
 }
 
+type StoredGameCombatCard = {
+  name?: unknown;
+  abilities?: unknown;
+  rpgStats?: {
+    attributes?: Array<{ name?: unknown; value?: unknown }>;
+    hp?: { value?: unknown; max?: unknown };
+    pools?: Array<{ name?: unknown; value?: unknown; max?: unknown }>;
+  } | null;
+};
+
+function readCombatNumber(value: unknown): number | null {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : null;
+}
+
+function normalizeCombatStatName(value: unknown): string {
+  return typeof value === "string"
+    ? value
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, " ")
+        .trim()
+    : "";
+}
+
+function readGameCardAttribute(card: StoredGameCombatCard | undefined, ...aliases: string[]): number | null {
+  const accepted = new Set(aliases.map(normalizeCombatStatName));
+  for (const attribute of card?.rpgStats?.attributes ?? []) {
+    if (!accepted.has(normalizeCombatStatName(attribute?.name))) continue;
+    const value = readCombatNumber(attribute?.value);
+    if (value != null) return value;
+  }
+  return null;
+}
+
+function readGameCardPool(
+  card: StoredGameCombatCard | undefined,
+  ...aliases: string[]
+): { value: number; max: number } | null {
+  const accepted = new Set(aliases.map(normalizeCombatStatName));
+  for (const pool of card?.rpgStats?.pools ?? []) {
+    if (!accepted.has(normalizeCombatStatName(pool?.name))) continue;
+    const value = readCombatNumber(pool?.value);
+    const max = readCombatNumber(pool?.max);
+    if (value == null && max == null) continue;
+    const safeMax = Math.max(1, max ?? value ?? 1);
+    return { value: Math.max(0, Math.min(safeMax, value ?? safeMax)), max: safeMax };
+  }
+  return null;
+}
+
+function inferCombatSkillType(value: string): NonNullable<Combatant["skills"]>[number]["type"] {
+  if (/(?:^|\W)(heal|healing|cure|mend|recover|restore|regen(?:eration)?|revive)(?:\W|$)/i.test(value)) {
+    return "heal";
+  }
+  if (/(?:^|\W)(debuff|weaken|poison|stun|slow|curse|blind|silence|drain|cripple)(?:\W|$)/i.test(value)) {
+    return "debuff";
+  }
+  if (/(?:^|\W)(buff|boost|empower|inspire|shield|guard|haste|strengthen|enhance)(?:\W|$)/i.test(value)) {
+    return "buff";
+  }
+  return "attack";
+}
+
+function combatSkillsFromSheet(value: unknown): Combatant["skills"] {
+  if (!Array.isArray(value)) return undefined;
+  const seen = new Set<string>();
+  const skills: NonNullable<Combatant["skills"]> = [];
+
+  for (const [index, entry] of value.entries()) {
+    const raw = String(entry).trim();
+    if (!raw) continue;
+    const withoutTypePrefix = raw
+      .replace(/^\s*\[(?:attack|heal|healing|buff|debuff)]\s*/i, "")
+      .replace(/^\s*(?:attack|heal|healing|buff|debuff)\s*[:|-]\s*/i, "");
+    const separator = withoutTypePrefix.match(/\s*(?::|\s[—–-]\s)\s*/);
+    const name = (separator ? withoutTypePrefix.slice(0, separator.index) : withoutTypePrefix).trim() || raw;
+    const description = separator
+      ? withoutTypePrefix.slice((separator.index ?? 0) + separator[0].length).trim()
+      : withoutTypePrefix;
+    const id = slugifyCombatantId(`${name}-${index}`);
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    const type = inferCombatSkillType(raw);
+    skills.push({
+      id,
+      name,
+      type,
+      mpCost: type === "heal" ? 10 : 8,
+      power: type === "attack" ? 1.35 : type === "heal" ? 1.15 : 1,
+      description,
+    });
+  }
+
+  return skills.length > 0 ? skills : undefined;
+}
+
 function combatStatusEffectsFromGenerated(
   statuses: CombatPartyMember["statuses"] | CombatEnemy["statuses"] | undefined,
 ): Combatant["statusEffects"] {
@@ -757,18 +854,24 @@ function combatSkillsFromGeneratedAttacks(
     const id = slugifyCombatantId(`${name}-${index}`);
     if (!id || seen.has(id)) continue;
     seen.add(id);
+    const description = attack.description || (attack.type === "AoE" ? "Area combat ability" : "Combat ability");
+    const type = inferCombatSkillType(`${name} ${description} ${attack.statusEffect ?? ""}`);
     skills.push({
       id,
       name,
-      type: "attack",
+      type,
       mpCost: Math.max(4, Math.min(18, 5 + level)),
       power:
         typeof attack.power === "number" && Number.isFinite(attack.power)
           ? Math.max(0.5, Math.min(3, attack.power))
-          : attack.type === "AoE"
-            ? 1.15
-            : 1.35,
-      description: attack.description || (attack.type === "AoE" ? "Area combat ability" : "Combat ability"),
+          : type !== "attack"
+            ? type === "heal"
+              ? 1.15
+              : 1
+            : attack.type === "AoE"
+              ? 1.15
+              : 1.35,
+      description,
       cooldown: typeof attack.cooldown === "number" ? attack.cooldown : undefined,
       element: typeof attack.element === "string" ? attack.element : undefined,
       statusEffect: typeof attack.statusEffect === "string" ? attack.statusEffect : undefined,
@@ -809,11 +912,19 @@ function generatedPartyMemberToCombatant(
   index: number,
   avatarCandidates: GamePartyMemberInfo[],
   fallbackLevel: number,
+  gameCard?: StoredGameCombatCard,
 ): Combatant {
   const matchedAvatar = findNamedEntry(avatarCandidates, member.name, (entry) => entry.name);
-  const maxHp = Math.max(1, Number(member.maxHp) || Number(member.hp) || 1);
-  const hp = Math.max(0, Math.min(maxHp, Number(member.hp) || maxHp));
-  const level = combatLevelFromHp(maxHp, fallbackLevel);
+  const cardHp = gameCard?.rpgStats?.hp;
+  const generatedMaxHp = Number(member.maxHp) || Number(member.hp) || 1;
+  const maxHp = Math.max(1, readCombatNumber(cardHp?.max) ?? generatedMaxHp);
+  const generatedHp = Number(member.hp) || maxHp;
+  const hp = Math.max(0, Math.min(maxHp, readCombatNumber(cardHp?.value) ?? generatedHp));
+  const level = Math.max(
+    1,
+    Math.round(readGameCardAttribute(gameCard, "level", "lvl") ?? combatLevelFromHp(maxHp, fallbackLevel)),
+  );
+  const mana = readGameCardPool(gameCard, "mp", "mana", "magic points", "energy");
   const element = member.attacks?.find((attack) => attack.element)?.element;
   const combatClass = typeof member.class === "string" && member.class.trim() ? member.class.trim() : undefined;
   return {
@@ -821,16 +932,16 @@ function generatedPartyMemberToCombatant(
     name: member.name || `Ally ${index + 1}`,
     hp,
     maxHp,
-    mp: 20 + level * 3,
-    maxMp: 20 + level * 3,
-    attack: 8 + level * 2,
-    defense: 5 + level,
-    speed: 6 + level,
+    mp: mana?.value ?? 20 + level * 3,
+    maxMp: mana?.max ?? 20 + level * 3,
+    attack: readGameCardAttribute(gameCard, "attack", "atk", "strength", "str") ?? 8 + level * 2,
+    defense: readGameCardAttribute(gameCard, "defense", "def", "constitution", "con") ?? 5 + level,
+    speed: readGameCardAttribute(gameCard, "speed", "spd", "dexterity", "dex", "agility") ?? 6 + level,
     level,
     side: "player",
     sprite: matchedAvatar?.avatarUrl ?? undefined,
     statusEffects: combatStatusEffectsFromGenerated(member.statuses),
-    skills: combatSkillsFromGeneratedAttacks(member.attacks, level),
+    skills: combatSkillsFromSheet(gameCard?.abilities) ?? combatSkillsFromGeneratedAttacks(member.attacks, level),
     element,
     combatClass,
   };
@@ -2209,8 +2320,7 @@ function GameSurfaceComponent({
   const useJsonMusicDjGameMusic = useYoutubeGameMusic || useCustomGameMusic;
   const useMusicDjPlayerMusic = useSpotifyGameMusic || useJsonMusicDjGameMusic;
   const { data: ttsConfig } = useTTSConfig();
-  const generateGameSoundEffects =
-    ttsConfig?.source === "elevenlabs" && ttsConfig.elevenLabsGameSoundEffects === true;
+  const generateGameSoundEffects = ttsConfig?.source === "elevenlabs" && ttsConfig.elevenLabsGameSoundEffects === true;
   const generateGameMusic =
     ttsConfig?.source === "elevenlabs" && ttsConfig.elevenLabsGameMusic === true && !useMusicDjPlayerMusic;
   const activeGameMetaId = typeof chatMeta.gameId === "string" ? chatMeta.gameId : "";
@@ -2391,31 +2501,28 @@ function GameSurfaceComponent({
       ...generatedAudioAssetsRef.current,
     };
   }, [gameAssetExcludedFolders, queryClient]);
-  const generateGameAudioAsset = useCallback(
-    async (kind: "sfx" | "music", prompt: string): Promise<string | null> => {
-      const category = kind === "sfx" ? "sfx" : "music";
-      if (prompt.startsWith(`${category}:generated:`)) return prompt;
-      try {
-        const generated = await withTimeout(
-          (signal) => api.post<{ tag: string; path: string }>("/tts/game-audio", { kind, prompt }, { signal }),
-          GAME_AUDIO_GENERATION_TIMEOUT_MS,
-        );
-        generatedAudioAssetsRef.current[generated.tag] = {
-          tag: generated.tag,
-          category,
-          subcategory: "generated",
-          name: generated.tag.split(":").at(-1) ?? generated.tag,
-          path: generated.path,
-          ext: ".mp3",
-        };
-        return generated.tag;
-      } catch (error) {
-        console.warn(`[game-audio] Failed to generate ${kind}:`, error);
-        return null;
-      }
-    },
-    [],
-  );
+  const generateGameAudioAsset = useCallback(async (kind: "sfx" | "music", prompt: string): Promise<string | null> => {
+    const category = kind === "sfx" ? "sfx" : "music";
+    if (prompt.startsWith(`${category}:generated:`)) return prompt;
+    try {
+      const generated = await withTimeout(
+        (signal) => api.post<{ tag: string; path: string }>("/tts/game-audio", { kind, prompt }, { signal }),
+        GAME_AUDIO_GENERATION_TIMEOUT_MS,
+      );
+      generatedAudioAssetsRef.current[generated.tag] = {
+        tag: generated.tag,
+        category,
+        subcategory: "generated",
+        name: generated.tag.split(":").at(-1) ?? generated.tag,
+        path: generated.path,
+        ext: ".mp3",
+      };
+      return generated.tag;
+    } catch (error) {
+      console.warn(`[game-audio] Failed to generate ${kind}:`, error);
+      return null;
+    }
+  }, []);
   const materializeGeneratedGameAudio = useCallback(
     async (input: SceneAnalysis): Promise<SceneAnalysis> => {
       if (!generateGameSoundEffects && !generateGameMusic) return input;
@@ -2437,9 +2544,7 @@ function GameSurfaceComponent({
               next.music = (await generateGameAudioAsset("music", next.music)) ?? undefined;
             }
             if (generateGameSoundEffects && next.sfx?.length) {
-              const generated = await Promise.all(
-                next.sfx.map((prompt) => generateGameAudioAsset("sfx", prompt)),
-              );
+              const generated = await Promise.all(next.sfx.map((prompt) => generateGameAudioAsset("sfx", prompt)));
               next.sfx = generated.filter((tag): tag is string => !!tag);
             }
             return next;
@@ -5068,8 +5173,7 @@ function GameSurfaceComponent({
         let preview: GameAssetGenerationPreview | undefined;
         try {
           preview = await withTimeout(
-            (signal) =>
-              api.post<GameAssetGenerationPreview>("/game/generate-assets/preview", payload, { signal }),
+            (signal) => api.post<GameAssetGenerationPreview>("/game/generate-assets/preview", payload, { signal }),
             GAME_ASSET_PREVIEW_TIMEOUT_MS,
             () => {
               toast.error(
@@ -5159,10 +5263,7 @@ function GameSurfaceComponent({
     [clearFailedNpcAvatars, fetchManifest, installGeneratedIllustration],
   );
 
-  async function applySceneResult(
-    incomingResult: SceneAnalysis,
-    msg: { id: string; content?: string | null },
-  ) {
+  async function applySceneResult(incomingResult: SceneAnalysis, msg: { id: string; content?: string | null }) {
     const result = await materializeGeneratedGameAudio(incomingResult);
     setSceneAnalysisFailed(false);
     // NOTE: Game state transitions are owned exclusively by the GM model via [state: ...] tags.
@@ -6458,33 +6559,59 @@ function GameSurfaceComponent({
   // Engine state handed to the slot, recomputed per turn so the surface tracks streaming and new
   // messages. Builds nothing unless the surface is mounted, so a Classic game never pays for it.
   const experienceSurfaceProps = useMemo(
-    () => (!experienceSurfaceActive ? undefined : {
-      chatId: activeChatId,
+    () =>
+      !experienceSurfaceActive
+        ? undefined
+        : {
+            chatId: activeChatId,
+            chatMeta,
+            messages,
+            latestAssistant: latestAssistantMsg,
+            isStreaming,
+            scopedAssetMap,
+            sendMessage: sendExperienceMessage,
+            setExperienceBackgroundTag: pushExperienceBackground,
+            setExperienceSpeakerAvatars,
+            setExperienceChrome,
+            // Who is speaking RIGHT NOW, as the narration plays. Deriving it from the turn text instead yields
+            // only the LAST speaker of the turn, which leaves a VN sprite stuck on whoever spoke last.
+            activeSpeaker: activeSpeaker
+              ? { name: activeSpeaker.name, expression: activeSpeaker.expression ?? null }
+              : null,
+            experienceChoiceSlotEl,
+            // Per-turn state, so the surface can hold its menu until the narration finishes.
+            narrationDone,
+            latestNarrationText,
+            scenePreparing,
+            directionsPlaying,
+            assetGenerationBlocksScene,
+            replayActive,
+            sessionInteractive: (chatMeta.gameSessionStatus as string) !== "concluded",
+            // The host's sprite-size setting, so the player's slider keeps working in this mode.
+            spriteScale: gameFullBodySpriteScale,
+          },
+    [
+      experienceSurfaceActive,
+      activeChatId,
       chatMeta,
       messages,
-      latestAssistant: latestAssistantMsg,
+      latestAssistantMsg,
       isStreaming,
       scopedAssetMap,
-      sendMessage: sendExperienceMessage,
-      setExperienceBackgroundTag: pushExperienceBackground,
+      sendExperienceMessage,
+      pushExperienceBackground,
       setExperienceSpeakerAvatars,
       setExperienceChrome,
-      // Who is speaking RIGHT NOW, as the narration plays. Deriving it from the turn text instead yields
-      // only the LAST speaker of the turn, which leaves a VN sprite stuck on whoever spoke last.
-      activeSpeaker: activeSpeaker ? { name: activeSpeaker.name, expression: activeSpeaker.expression ?? null } : null,
+      activeSpeaker,
       experienceChoiceSlotEl,
-      // Per-turn state, so the surface can hold its menu until the narration finishes.
       narrationDone,
       latestNarrationText,
       scenePreparing,
       directionsPlaying,
       assetGenerationBlocksScene,
       replayActive,
-      sessionInteractive: (chatMeta.gameSessionStatus as string) !== "concluded",
-      // The host's sprite-size setting, so the player's slider keeps working in this mode.
-      spriteScale: gameFullBodySpriteScale,
-    }),
-    [experienceSurfaceActive, activeChatId, chatMeta, messages, latestAssistantMsg, isStreaming, scopedAssetMap, sendExperienceMessage, pushExperienceBackground, setExperienceSpeakerAvatars, setExperienceChrome, activeSpeaker, experienceChoiceSlotEl, narrationDone, latestNarrationText, scenePreparing, directionsPlaying, assetGenerationBlocksScene, replayActive, gameFullBodySpriteScale],
+      gameFullBodySpriteScale,
+    ],
   );
 
   // Game mutations
@@ -6518,8 +6645,9 @@ function GameSurfaceComponent({
     selection: unknown;
     attempt: number;
   };
-  const [pendingSharedWorldSetupApply, setPendingSharedWorldSetupApply] =
-    useState<PendingSharedWorldSetupApply | null>(null);
+  const [pendingSharedWorldSetupApply, setPendingSharedWorldSetupApply] = useState<PendingSharedWorldSetupApply | null>(
+    null,
+  );
   const pendingSharedWorldSetupApplyRef = useRef<PendingSharedWorldSetupApply | null>(null);
   const updatePendingSharedWorldSetupApply = useCallback((pending: PendingSharedWorldSetupApply | null) => {
     pendingSharedWorldSetupApplyRef.current = pending;
@@ -6529,12 +6657,7 @@ function GameSurfaceComponent({
   activeChatIdRef.current = activeChatId;
   const clearPendingSharedWorldSetupApply = useCallback((chatId: string, attempt: number) => {
     const pending = pendingSharedWorldSetupApplyRef.current;
-    if (
-      activeChatIdRef.current !== chatId ||
-      !pending ||
-      pending.chatId !== chatId ||
-      pending.attempt !== attempt
-    ) {
+    if (activeChatIdRef.current !== chatId || !pending || pending.chatId !== chatId || pending.attempt !== attempt) {
       return false;
     }
     pendingSharedWorldSetupApplyRef.current = null;
@@ -7942,9 +8065,20 @@ function GameSurfaceComponent({
   const hydrateGeneratedCombatState = useCallback(
     (combatState: CombatInitState): { party: Combatant[]; enemies: Combatant[] } | null => {
       const fallbackLevel = sessionNumber ?? 5;
+      const gameCharacterCards = Array.isArray(chatMeta.gameCharacterCards)
+        ? (chatMeta.gameCharacterCards as StoredGameCombatCard[])
+        : [];
       const partyCombatants = Array.isArray(combatState.party)
         ? combatState.party.map((member, index) =>
-            generatedPartyMemberToCombatant(member, index, combatAvatarCandidates, fallbackLevel),
+            generatedPartyMemberToCombatant(
+              member,
+              index,
+              combatAvatarCandidates,
+              fallbackLevel,
+              findNamedEntry(gameCharacterCards, member.name, (card) =>
+                typeof card.name === "string" ? card.name : null,
+              ),
+            ),
           )
         : [];
       const enemyCombatants = Array.isArray(combatState.enemies)
@@ -7954,7 +8088,7 @@ function GameSurfaceComponent({
       if (partyCombatants.length === 0 || enemyCombatants.length === 0) return null;
       return { party: partyCombatants, enemies: enemyCombatants };
     },
-    [combatAvatarCandidates, sessionNumber],
+    [chatMeta.gameCharacterCards, combatAvatarCandidates, sessionNumber],
   );
 
   useEffect(() => {
@@ -8398,14 +8532,6 @@ function GameSurfaceComponent({
     setPendingEncounter(null);
 
     type CombatStatLike = { name: string; value: number; max?: number };
-    type StoredGameCard = {
-      name?: unknown;
-      abilities?: unknown;
-      rpgStats?: {
-        attributes?: Array<{ name?: unknown; value?: unknown }>;
-        hp?: { value?: unknown; max?: unknown };
-      } | null;
-    };
 
     const normalizeKey = (value: string) =>
       value
@@ -8413,12 +8539,6 @@ function GameSurfaceComponent({
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, " ")
         .trim();
-    const skillIdFromName = (value: string) =>
-      value
-        .trim()
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, "-")
-        .replace(/^-+|-+$/g, "");
     const aliasMatches = (value: string, aliases: string[]) => aliases.some((alias) => value === normalizeKey(alias));
     const findStat = (stats: CombatStatLike[], aliases: string[]) =>
       stats.find((stat) => aliasMatches(normalizeKey(stat.name), aliases));
@@ -8426,42 +8546,11 @@ function GameSurfaceComponent({
       const numericValue = Number(value);
       return Number.isFinite(numericValue) ? numericValue : null;
     };
-    const inferSkillType = (value: string): NonNullable<Combatant["skills"]>[number]["type"] =>
-      /(heal|cure|mend|recovery|recover|restore|regeneration|regen|revive|blessing|prayer)/i.test(value)
-        ? "heal"
-        : "attack";
-    const buildCombatSkills = (value: unknown): Combatant["skills"] => {
-      if (!Array.isArray(value)) return undefined;
-
-      const seenIds = new Set<string>();
-      const skills = value
-        .map((entry) => String(entry).trim())
-        .filter(Boolean)
-        .map((name) => {
-          const id = skillIdFromName(name);
-          if (!id || seenIds.has(id)) return null;
-          seenIds.add(id);
-
-          const type = inferSkillType(name);
-          return {
-            id,
-            name,
-            type,
-            mpCost: type === "heal" ? 10 : 8,
-            power: type === "heal" ? 1.15 : 1.35,
-            description: `${name} (${type === "heal" ? "healing" : "combat"} ability)`,
-          };
-        })
-        .filter((skill): skill is Exclude<typeof skill, null> => !!skill);
-
-      return skills.length > 0 ? skills : undefined;
-    };
-
-    const gameCardByName = new Map<string, StoredGameCard>();
+    const gameCardByName = new Map<string, StoredGameCombatCard>();
     const gameCharacterCards = Array.isArray(chatMeta.gameCharacterCards)
       ? (chatMeta.gameCharacterCards as Array<Record<string, unknown>>)
       : [];
-    for (const card of gameCharacterCards as StoredGameCard[]) {
+    for (const card of gameCharacterCards as StoredGameCombatCard[]) {
       if (typeof card?.name === "string" && card.name.trim()) {
         gameCardByName.set(normalizeTextForMatch(card.name), card);
       }
@@ -8584,8 +8673,6 @@ function GameSurfaceComponent({
         );
         const hpStat = findStat(stats, ["hp", "health", "hit points"]);
         const mpStat = findStat(stats, ["mp", "mana", "magic points", "energy"]);
-        const levelStat = findStat(stats, ["level", "lvl"]);
-        const pLevel = levelStat?.value ?? sessionNumber ?? 5;
         const hpFromCard = readNumeric(cardRpgStats?.hp?.value) ?? readNumeric(cardRpgStats?.hp?.max);
         const maxHpFromCard = readNumeric(cardRpgStats?.hp?.max) ?? hpFromCard;
         const attributeValue = (...aliases: string[]) => {
@@ -8598,6 +8685,12 @@ function GameSurfaceComponent({
           }
           return null;
         };
+        const levelStat = findStat(stats, ["level", "lvl"]);
+        const pLevel = Math.max(
+          1,
+          Math.round(attributeValue("level", "lvl") ?? levelStat?.value ?? sessionNumber ?? 5),
+        );
+        const manaFromCard = readGameCardPool(gameCard, "mp", "mana", "magic points", "energy");
         const attackStat = findStat(stats, ["attack", "atk", "power", "strength"]);
         const defenseStat = findStat(stats, ["defense", "def", "armor", "guard"]);
         const speedStat = findStat(stats, ["speed", "spd", "agility", "dexterity"]);
@@ -8607,8 +8700,9 @@ function GameSurfaceComponent({
         const derivedSpeed = attributeValue("speed", "spd", "dex", "dexterity", "agility") ?? 5 + pLevel;
         const derivedMaxHp = maxHpFromCard ?? 50 + pLevel * 10;
         const derivedHp = hpFromCard ?? derivedMaxHp;
-        const derivedMaxMp = intelligenceValue != null ? 12 + intelligenceValue * 2 : 20 + pLevel * 3;
-        const derivedMp = derivedMaxMp;
+        const derivedMaxMp =
+          manaFromCard?.max ?? (intelligenceValue != null ? 12 + intelligenceValue * 2 : 20 + pLevel * 3);
+        const derivedMp = manaFromCard?.value ?? derivedMaxMp;
 
         return {
           id: m.id,
@@ -8623,7 +8717,7 @@ function GameSurfaceComponent({
           level: pLevel,
           side: "player" as const,
           sprite: m.avatarUrl ?? undefined,
-          skills: buildCombatSkills(gameCard?.abilities),
+          skills: combatSkillsFromSheet(gameCard?.abilities),
         };
       });
 
@@ -8709,7 +8803,12 @@ function GameSurfaceComponent({
         status: npc?.description || undefined,
         avatarUrl: c?.avatarUrl ?? npc?.avatarUrl ?? null,
         avatarCrop: c?.avatarCrop ?? null,
-        level: sessionNumber,
+        level: Math.max(
+          1,
+          Math.round(
+            readGameCardAttribute(gc as StoredGameCombatCard | undefined, "level", "lvl") ?? sessionNumber ?? 1,
+          ),
+        ),
         gameCard: gc
           ? {
               shortDescription: (gc.shortDescription as string) || "",
@@ -8761,7 +8860,12 @@ function GameSurfaceComponent({
         subtitle: "Player Character",
         avatarUrl: personaInfo.avatarUrl ?? null,
         avatarCrop: personaInfo.avatarCrop ?? null,
-        level: sessionNumber,
+        level: Math.max(
+          1,
+          Math.round(
+            readGameCardAttribute(gc as StoredGameCombatCard | undefined, "level", "lvl") ?? sessionNumber ?? 1,
+          ),
+        ),
         status: gameSnapshot?.playerStats?.status || undefined,
         stats: [
           ...(gameSnapshot?.personaStats ?? []).map((s) => ({
@@ -10126,7 +10230,8 @@ function GameSurfaceComponent({
         updateChat.isPending ||
         updateChatMetadata.isPending ||
         activePendingSharedWorldSetupApply
-      ) return;
+      )
+        return;
       useGameModeStore.getState().setSetupActive(false);
       if (canAutoDeleteEmptySetupChat) {
         deleteChat.mutate(activeChatId, {
@@ -10561,15 +10666,15 @@ function GameSurfaceComponent({
           <div className="ml-auto flex shrink-0 items-center gap-1 pt-0.5">
             {/* Hidden for an experience game: it opens a tour of chrome that isn't on screen. */}
             {!experienceOwnsGame ? (
-            <button
-              type="button"
-              onClick={() => setTutorialOpen(true)}
-              className="flex h-7 w-7 items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-[var(--marinara-chat-chrome-button-text)] transition-colors hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-highlight-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]"
-              title={localizeUi("ui.game.gamesurfacecomponent.gameTutorial")}
-              aria-label={localizeUi("ui.game.gamesurfacecomponent.gameTutorial")}
-            >
-              <CircleHelp size={14} />
-            </button>
+              <button
+                type="button"
+                onClick={() => setTutorialOpen(true)}
+                className="flex h-7 w-7 items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-[var(--marinara-chat-chrome-button-text)] transition-colors hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-highlight-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]"
+                title={localizeUi("ui.game.gamesurfacecomponent.gameTutorial")}
+                aria-label={localizeUi("ui.game.gamesurfacecomponent.gameTutorial")}
+              >
+                <CircleHelp size={14} />
+              </button>
             ) : null}
             <button
               type="button"
@@ -11514,10 +11619,7 @@ function GameSurfaceComponent({
               <div
                 ref={hudSurfaceRef}
                 data-chat-resource-drop-surface
-                className={cn(
-                  "relative flex min-h-0 flex-1 flex-col overflow-hidden",
-                  experienceSurfaceClass,
-                )}
+                className={cn("relative flex min-h-0 flex-1 flex-col overflow-hidden", experienceSurfaceClass)}
               >
                 {/* Main mount. pointer-events-none lets clicks fall through empty regions to the
                     narration underneath; the package sets pointer-events-auto on its own chrome. */}
@@ -11985,22 +12087,22 @@ function GameSurfaceComponent({
                           onMaxNavOffsetChange={handleMaxNavOffsetChange}
                           inputSlot={
                             activeExperienceChrome?.providesPlayerInput ? undefined : (
-                            <GameInput
-                              onSend={handleSendGameTurn}
-                              onRollDice={handleRollDice}
-                              hasPartyMembers={partyMembers.length > 0}
-                              pendingMoveLabel={pendingMapMove?.label ?? null}
-                              onClearPendingMove={() => setPendingMapMove(null)}
-                              disabled={gameInputGenerationBlocked || !sessionInteractive}
-                              draftDisabled={!sessionInteractive}
-                              isStreaming={gameInputGenerationBlocked}
-                              inline
-                              draftKey={activeChatId}
-                              focusToken={gameInputFocusToken}
-                              onIllustrate={handleManualSceneIllustration}
-                              spatialCapabilityEnabled={hierarchicalMapsActive}
-                              interruptMode={pendingInterruptMode}
-                            />
+                              <GameInput
+                                onSend={handleSendGameTurn}
+                                onRollDice={handleRollDice}
+                                hasPartyMembers={partyMembers.length > 0}
+                                pendingMoveLabel={pendingMapMove?.label ?? null}
+                                onClearPendingMove={() => setPendingMapMove(null)}
+                                disabled={gameInputGenerationBlocked || !sessionInteractive}
+                                draftDisabled={!sessionInteractive}
+                                isStreaming={gameInputGenerationBlocked}
+                                inline
+                                draftKey={activeChatId}
+                                focusToken={gameInputFocusToken}
+                                onIllustrate={handleManualSceneIllustration}
+                                spatialCapabilityEnabled={hierarchicalMapsActive}
+                                interruptMode={pendingInterruptMode}
+                              />
                             )
                           }
                         />
@@ -12078,22 +12180,22 @@ function GameSurfaceComponent({
                       // declaration is dynamic, so the input returns when it has no action to offer.
                       inputSlot={
                         activeExperienceChrome?.providesPlayerInput ? undefined : (
-                        <GameInput
-                          onSend={handleSendGameTurn}
-                          onRollDice={handleRollDice}
-                          hasPartyMembers={partyMembers.length > 0}
-                          pendingMoveLabel={pendingMapMove?.label ?? null}
-                          onClearPendingMove={() => setPendingMapMove(null)}
-                          disabled={gameInputGenerationBlocked || !sessionInteractive}
-                          draftDisabled={!sessionInteractive}
-                          isStreaming={gameInputGenerationBlocked}
-                          inline
-                          draftKey={activeChatId}
-                          focusToken={gameInputFocusToken}
-                          onIllustrate={handleManualSceneIllustration}
-                          spatialCapabilityEnabled={hierarchicalMapsActive}
-                          interruptMode={pendingInterruptMode}
-                        />
+                          <GameInput
+                            onSend={handleSendGameTurn}
+                            onRollDice={handleRollDice}
+                            hasPartyMembers={partyMembers.length > 0}
+                            pendingMoveLabel={pendingMapMove?.label ?? null}
+                            onClearPendingMove={() => setPendingMapMove(null)}
+                            disabled={gameInputGenerationBlocked || !sessionInteractive}
+                            draftDisabled={!sessionInteractive}
+                            isStreaming={gameInputGenerationBlocked}
+                            inline
+                            draftKey={activeChatId}
+                            focusToken={gameInputFocusToken}
+                            onIllustrate={handleManualSceneIllustration}
+                            spatialCapabilityEnabled={hierarchicalMapsActive}
+                            interruptMode={pendingInterruptMode}
+                          />
                         )
                       }
                     />
@@ -12294,29 +12396,33 @@ function GameSurfaceComponent({
 
               {/* HUD Widgets - Left & Right, tops aligned */}
               {/* Hidden while the package owns the game — it draws its own HUD. */}
-              {!replayActive && !combatUiActive && !experienceOwnsGame && hudWidgets.length > 0 && !compactHudWidgets && (
-                <>
-                  {/* Desktop: full widget cards */}
-                  <div className="pointer-events-none absolute inset-x-3 bottom-24 z-30 hidden items-end justify-between md:flex">
-                    <div className="w-44" data-game-widget-rail="left">
-                      <GameWidgetPanel
-                        widgets={normalizedWidgets}
-                        position="hud_left"
-                        chatId={activeChatId}
-                        constraintsRef={hudSurfaceRef}
-                      />
+              {!replayActive &&
+                !combatUiActive &&
+                !experienceOwnsGame &&
+                hudWidgets.length > 0 &&
+                !compactHudWidgets && (
+                  <>
+                    {/* Desktop: full widget cards */}
+                    <div className="pointer-events-none absolute inset-x-3 bottom-24 z-30 hidden items-end justify-between md:flex">
+                      <div className="w-44" data-game-widget-rail="left">
+                        <GameWidgetPanel
+                          widgets={normalizedWidgets}
+                          position="hud_left"
+                          chatId={activeChatId}
+                          constraintsRef={hudSurfaceRef}
+                        />
+                      </div>
+                      <div className="w-44" data-game-widget-rail="right">
+                        <GameWidgetPanel
+                          widgets={normalizedWidgets}
+                          position="hud_right"
+                          chatId={activeChatId}
+                          constraintsRef={hudSurfaceRef}
+                        />
+                      </div>
                     </div>
-                    <div className="w-44" data-game-widget-rail="right">
-                      <GameWidgetPanel
-                        widgets={normalizedWidgets}
-                        position="hud_right"
-                        chatId={activeChatId}
-                        constraintsRef={hudSurfaceRef}
-                      />
-                    </div>
-                  </div>
-                </>
-              )}
+                  </>
+                )}
             </div>
           </div>
         </DirectionEngine>

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -147,6 +147,7 @@ import {
   STORYBOARD_AGENT_ID,
   formatTextQuotes,
   mergeBuiltInAgentSettings,
+  parseAgentSettingsRecord,
   normalizeAvatarCrop,
   normalizeStoryboardAgentSettings,
   normalizeRpgStatPools,
@@ -2245,7 +2246,9 @@ function GameSurfaceComponent({
    *  package to actually be there. */
   const experienceOwnsGame =
     experienceSurfaceActive || (gameExperienceId !== null && installedCapabilityPackagesPending);
-  const { data: agentConfigs } = useAgentConfigs(storyboardAgentActive);
+  const { data: agentConfigs } = useAgentConfigs(
+    storyboardAgentActive || chatMeta.enableSpriteGeneration === true,
+  );
   const storyboardAgentConfig = useMemo(
     () => agentConfigs?.find((config) => config.type === STORYBOARD_AGENT_ID) ?? null,
     [agentConfigs],
@@ -2255,6 +2258,11 @@ function GameSurfaceComponent({
       normalizeStoryboardAgentSettings(mergeBuiltInAgentSettings(STORYBOARD_AGENT_ID, storyboardAgentConfig?.settings)),
     [storyboardAgentConfig?.settings],
   );
+  const illustratorImageConnectionId = useMemo(() => {
+    const illustrator = agentConfigs?.find((config) => config.type === "illustrator");
+    const connectionId = parseAgentSettingsRecord(illustrator?.settings).imageConnectionId;
+    return typeof connectionId === "string" ? connectionId.trim() : "";
+  }, [agentConfigs]);
 
   useEffect(() => {
     return () => {
@@ -3922,8 +3930,8 @@ function GameSurfaceComponent({
 
   const gameImageGenerationEnabled =
     chatMeta.enableSpriteGeneration === true &&
-    typeof chatMeta.gameImageConnectionId === "string" &&
-    chatMeta.gameImageConnectionId.trim().length > 0;
+    ((typeof chatMeta.gameImageConnectionId === "string" && chatMeta.gameImageConnectionId.trim().length > 0) ||
+      illustratorImageConnectionId.length > 0);
   const storyboardImageGenerationEnabled =
     storyboardAgentActive && (gameImageGenerationEnabled || Boolean(storyboardAgentSettings.imageConnectionId));
   const gameSceneVideosEnabled = chatMeta.gameSceneVideosEnabled !== false;
@@ -7083,7 +7091,7 @@ function GameSurfaceComponent({
       const normalizedName = normalizeNpcAvatarName(displayName);
       if (!normalizedName) return;
 
-      if (!chatMeta.enableSpriteGeneration || !chatMeta.gameImageConnectionId) {
+      if (!gameImageGenerationEnabled) {
         toast.error(localizeUi("ui.game.gamesurfacecomponent.enableGameImageGenerationAndChooseAnImageConnection"));
         return;
       }
@@ -7156,10 +7164,9 @@ function GameSurfaceComponent({
     [
       activeChatId,
       applyGeneratedAssets,
-      chatMeta.enableSpriteGeneration,
-      chatMeta.gameImageConnectionId,
       chatMeta.gameNpcs,
       clearFailedNpcAvatars,
+      gameImageGenerationEnabled,
       runGameAssetGeneration,
       localizeUi,
     ],
@@ -10782,9 +10789,7 @@ function GameSurfaceComponent({
                 onClose={() => setSessionPanelOpen(false)}
                 onNpcPortraitClick={handleNpcPortraitClick}
                 onNpcPortraitGenerate={handleNpcPortraitGenerate}
-                npcPortraitGenerationEnabled={
-                  chatMeta.enableSpriteGeneration === true && typeof chatMeta.gameImageConnectionId === "string"
-                }
+                npcPortraitGenerationEnabled={gameImageGenerationEnabled}
                 generatingNpcPortraitNames={generatingNpcPortraitNames}
                 onNpcRemove={handleRemoveNpcFromJournal}
                 embedded
@@ -12046,10 +12051,7 @@ function GameSurfaceComponent({
                           onNpcPortraitClick={handleNpcPortraitClick}
                           onNpcPortraitGenerate={handleNpcPortraitGenerate}
                           onNpcPortraitLoadError={handleNpcPortraitLoadError}
-                          npcPortraitGenerationEnabled={
-                            chatMeta.enableSpriteGeneration === true &&
-                            typeof chatMeta.gameImageConnectionId === "string"
-                          }
+                          npcPortraitGenerationEnabled={gameImageGenerationEnabled}
                           generatingNpcPortraitNames={generatingNpcPortraitNames}
                           autoPlayBlocked={narrationAutoPlayBlocked || storyboardBackgroundAnimationPlaying}
                           voicePlaybackBlocked={narrationVoicePlaybackBlocked}
@@ -12138,9 +12140,7 @@ function GameSurfaceComponent({
                       onNpcPortraitClick={handleNpcPortraitClick}
                       onNpcPortraitGenerate={handleNpcPortraitGenerate}
                       onNpcPortraitLoadError={handleNpcPortraitLoadError}
-                      npcPortraitGenerationEnabled={
-                        chatMeta.enableSpriteGeneration === true && typeof chatMeta.gameImageConnectionId === "string"
-                      }
+                      npcPortraitGenerationEnabled={gameImageGenerationEnabled}
                       generatingNpcPortraitNames={generatingNpcPortraitNames}
                       autoPlayBlocked={narrationAutoPlayBlocked || storyboardBackgroundAnimationPlaying}
                       voicePlaybackBlocked={narrationVoicePlaybackBlocked}

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -802,6 +802,7 @@ function combatSkillsFromSheet(value: unknown): Combatant["skills"] {
   for (const [index, entry] of value.entries()) {
     const raw = String(entry).trim();
     if (!raw) continue;
+    const declaredType = raw.match(/^\s*\[?(attack|heal(?:ing)?|buff|debuff)\]?/i)?.[1]?.toLowerCase();
     const withoutTypePrefix = raw
       .replace(/^\s*\[(?:attack|heal|healing|buff|debuff)]\s*/i, "")
       .replace(/^\s*(?:attack|heal|healing|buff|debuff)\s*[:|-]\s*/i, "");
@@ -811,9 +812,15 @@ function combatSkillsFromSheet(value: unknown): Combatant["skills"] {
       ? withoutTypePrefix.slice((separator.index ?? 0) + separator[0].length).trim()
       : withoutTypePrefix;
     const id = slugifyCombatantId(`${name}-${index}`);
-    if (!id || seen.has(id)) continue;
-    seen.add(id);
-    const type = inferCombatSkillType(raw);
+    const dedupeKey = slugifyCombatantId(name);
+    if (!id || !dedupeKey || seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    const type =
+      declaredType === "heal" || declaredType === "healing"
+        ? "heal"
+        : declaredType === "buff" || declaredType === "debuff" || declaredType === "attack"
+          ? declaredType
+          : inferCombatSkillType(withoutTypePrefix);
     skills.push({
       id,
       name,
@@ -2246,9 +2253,7 @@ function GameSurfaceComponent({
    *  package to actually be there. */
   const experienceOwnsGame =
     experienceSurfaceActive || (gameExperienceId !== null && installedCapabilityPackagesPending);
-  const { data: agentConfigs } = useAgentConfigs(
-    storyboardAgentActive || chatMeta.enableSpriteGeneration === true,
-  );
+  const { data: agentConfigs } = useAgentConfigs(storyboardAgentActive || chatMeta.enableSpriteGeneration === true);
   const storyboardAgentConfig = useMemo(
     () => agentConfigs?.find((config) => config.type === STORYBOARD_AGENT_ID) ?? null,
     [agentConfigs],

--- a/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
@@ -138,10 +138,15 @@ export function AdvancedParametersSection({
       if (!editableKeys.has(key)) sparse[key] = value;
     }
     for (const key of EDITABLE_PARAMETER_KEYS) {
+      if (key === "enabledParameters") continue;
       if (JSON.stringify(next[key]) !== JSON.stringify(defaults[key])) {
         sparse[key] = next[key];
       }
     }
+    // Send toggles are behavior, not merely editable values. Keep the explicit
+    // map even when it matches the editor fallback so an inherited preset value
+    // cannot make a disabled parameter reappear in the provider request.
+    sparse.enabledParameters = next.enabledParameters ?? STRICT_CONNECTION_PARAMETER_SEND_DEFAULTS;
     onChatParametersChange(sparse);
   };
   const toggleExpanded = () => setExpanded((open) => !open);

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -160,8 +160,15 @@ function normalizeEchoChamberSides(value: unknown): Record<string, EchoChamberSi
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
   const normalized: Record<string, EchoChamberSide> = {};
   for (const [chatId, side] of Object.entries(value)) {
-    if (!chatId.trim() || !["top-left", "top-right", "bottom-left", "bottom-right"].includes(String(side))) continue;
-    normalized[chatId] = side as EchoChamberSide;
+    const normalizedChatId = chatId.trim();
+    if (
+      !normalizedChatId ||
+      typeof side !== "string" ||
+      !["top-left", "top-right", "bottom-left", "bottom-right"].includes(side)
+    ) {
+      continue;
+    }
+    normalized[normalizedChatId] = side as EchoChamberSide;
   }
   return normalized;
 }

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -156,8 +156,19 @@ function normalizeEchoChamberSizes(value: unknown): Record<string, EchoChamberSi
   return normalized;
 }
 
+function normalizeEchoChamberSides(value: unknown): Record<string, EchoChamberSide> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const normalized: Record<string, EchoChamberSide> = {};
+  for (const [chatId, side] of Object.entries(value)) {
+    if (!chatId.trim() || !["top-left", "top-right", "bottom-left", "bottom-right"].includes(String(side))) continue;
+    normalized[chatId] = side as EchoChamberSide;
+  }
+  return normalized;
+}
+
 interface ImmediateUiStorageSnapshot {
   customCursorEnabled: boolean | undefined;
+  echoChamberSides: string;
   echoChamberSizes: string;
 }
 
@@ -165,6 +176,7 @@ function readImmediateUiStorageSnapshot(value: string | null): ImmediateUiStorag
   if (!value) {
     return {
       customCursorEnabled: undefined,
+      echoChamberSides: "{}",
       echoChamberSizes: "{}",
     };
   }
@@ -173,17 +185,20 @@ function readImmediateUiStorageSnapshot(value: string | null): ImmediateUiStorag
     const parsed = JSON.parse(value) as {
       state?: {
         customCursorEnabled?: unknown;
+        echoChamberSideByChatId?: unknown;
         echoChamberSizeByChatId?: unknown;
       };
     };
     return {
       customCursorEnabled:
         typeof parsed.state?.customCursorEnabled === "boolean" ? parsed.state.customCursorEnabled : undefined,
+      echoChamberSides: JSON.stringify(normalizeEchoChamberSides(parsed.state?.echoChamberSideByChatId)),
       echoChamberSizes: JSON.stringify(normalizeEchoChamberSizes(parsed.state?.echoChamberSizeByChatId)),
     };
   } catch {
     return {
       customCursorEnabled: undefined,
+      echoChamberSides: "{}",
       echoChamberSizes: "{}",
     };
   }
@@ -193,7 +208,9 @@ function shouldFlushUiStorageImmediately(previousValue: string | null, nextValue
   const previous = readImmediateUiStorageSnapshot(previousValue);
   const next = readImmediateUiStorageSnapshot(nextValue);
   return (
-    previous.customCursorEnabled !== next.customCursorEnabled || previous.echoChamberSizes !== next.echoChamberSizes
+    previous.customCursorEnabled !== next.customCursorEnabled ||
+    previous.echoChamberSides !== next.echoChamberSides ||
+    previous.echoChamberSizes !== next.echoChamberSizes
   );
 }
 export const TRACKER_PANEL_WIDTH_DEFAULT = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.standard;
@@ -851,6 +868,7 @@ interface UIState {
   // ── EchoChamber ──
   echoChamberOpen: boolean;
   echoChamberSide: EchoChamberSide;
+  echoChamberSideByChatId: Record<string, EchoChamberSide>;
   echoChamberSizeByChatId: Record<string, EchoChamberSize>;
 
   // ── User Status ──
@@ -1108,6 +1126,7 @@ interface UIState {
   dismissLinkApiBanner: () => void;
   toggleEchoChamber: () => void;
   setEchoChamberSide: (side: EchoChamberSide) => void;
+  setEchoChamberSideForChat: (chatId: string, side: EchoChamberSide) => void;
   setEchoChamberSizeForChat: (chatId: string, size: EchoChamberSize) => void;
   setUserStatus: (status: UserStatus) => void;
   setUserStatusManual: (status: UserStatus) => void;
@@ -1508,6 +1527,7 @@ export const useUIStore = create<UIState>()(
       linkApiBannerDismissed: false,
       echoChamberOpen: true,
       echoChamberSide: "bottom-right" as EchoChamberSide,
+      echoChamberSideByChatId: {},
       echoChamberSizeByChatId: {},
       userStatusManual: "active" as const,
       userStatus: "active" as UserStatus,
@@ -2417,6 +2437,17 @@ export const useUIStore = create<UIState>()(
       dismissLinkApiBanner: () => set({ linkApiBannerDismissed: true }),
       toggleEchoChamber: () => set((s) => ({ echoChamberOpen: !s.echoChamberOpen })),
       setEchoChamberSide: (side) => set({ echoChamberSide: side }),
+      setEchoChamberSideForChat: (chatId, side) => {
+        const normalizedChatId = chatId.trim();
+        if (!normalizedChatId) return;
+        set((state) => ({
+          echoChamberSide: side,
+          echoChamberSideByChatId: {
+            ...state.echoChamberSideByChatId,
+            [normalizedChatId]: side,
+          },
+        }));
+      },
       setEchoChamberSizeForChat: (chatId, size) => {
         const normalizedChatId = chatId.trim();
         const normalizedSize = normalizeEchoChamberSize(size);
@@ -2445,7 +2476,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 92,
+      version: 93,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2987,6 +3018,11 @@ export const useUIStore = create<UIState>()(
           persisted.echoChamberSizeByChatId = {};
         }
         persisted.echoChamberSizeByChatId = normalizeEchoChamberSizes(persisted.echoChamberSizeByChatId);
+        // v92 -> v93: remember the Echo Chamber corner independently for each chat.
+        if (version <= 92) {
+          persisted.echoChamberSideByChatId = {};
+        }
+        persisted.echoChamberSideByChatId = normalizeEchoChamberSides(persisted.echoChamberSideByChatId);
         // v87 -> v88: enable Narrator avatar cycling by default for older stores.
         if (version <= 87 && persisted.roleplayNarratorAvatarCycling === undefined) {
           persisted.roleplayNarratorAvatarCycling = true;
@@ -3187,6 +3223,7 @@ export const useUIStore = create<UIState>()(
         linkApiBannerDismissed: state.linkApiBannerDismissed,
         echoChamberOpen: state.echoChamberOpen,
         echoChamberSide: state.echoChamberSide,
+        echoChamberSideByChatId: state.echoChamberSideByChatId,
         echoChamberSizeByChatId: state.echoChamberSizeByChatId,
         userStatusManual: state.userStatusManual,
         userStatus: state.userStatus,

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -1284,6 +1284,14 @@ export function dynamicGameImagePromptRequestOptions(kind: GameDynamicImagePromp
   };
 }
 
+export function shouldUseDynamicGameImagePromptGenerator(args: {
+  enabled: boolean;
+  hasCustomizedIllustratorPrompt: boolean;
+  hasEnabledPromptDirectorOverride: boolean;
+}): boolean {
+  return args.enabled || args.hasCustomizedIllustratorPrompt || args.hasEnabledPromptDirectorOverride;
+}
+
 async function createDynamicGameImagePromptGenerator(args: {
   connections: ReturnType<typeof createConnectionsStorage>;
   agents: ReturnType<typeof createAgentsStorage>;
@@ -1296,9 +1304,19 @@ async function createDynamicGameImagePromptGenerator(args: {
   debugLog?: (message: string, ...args: any[]) => void;
   signal?: AbortSignal;
 }): Promise<GameDynamicImagePromptGenerator | undefined> {
-  if (args.meta.gameImageDynamicPromptEnabled !== true) return undefined;
-
   try {
+    const illustratorPrompt = await resolveGameIllustratorPromptTemplate(args.meta, args.agents);
+    const promptDirectorOverride = await args.promptOverridesStorage?.get(GAME_IMAGE_PROMPT_DIRECTOR.key);
+    if (
+      !shouldUseDynamicGameImagePromptGenerator({
+        enabled: args.meta.gameImageDynamicPromptEnabled === true,
+        hasCustomizedIllustratorPrompt: illustratorPrompt.customized,
+        hasEnabledPromptDirectorOverride: promptDirectorOverride?.enabled === true,
+      })
+    ) {
+      return undefined;
+    }
+
     const { conn, baseUrl, defaultGenerationParameters } = await resolveDynamicGameImagePromptConnection({
       connections: args.connections,
       meta: args.meta,
@@ -1307,12 +1325,11 @@ async function createDynamicGameImagePromptGenerator(args: {
     });
     const parameters = resolveStoredGameGenerationParameters(args.meta, defaultGenerationParameters);
     const provider = await createGameMainProvider(args.connections, conn, baseUrl);
-    const illustratorPromptTemplate = await resolveGameIllustratorPromptTemplate(args.meta, args.agents);
 
     return async (request) => {
       const messages = await buildDynamicGameImagePromptMessages({
         promptOverridesStorage: args.promptOverridesStorage,
-        illustratorPromptTemplate,
+        illustratorPromptTemplate: illustratorPrompt.promptTemplate,
         request,
         meta: args.meta,
         setupConfig: args.setupConfig,
@@ -1949,10 +1966,10 @@ async function resolveGameImageConnectionId(
 async function resolveGameIllustratorPromptTemplate(
   meta: Record<string, unknown>,
   agents: ReturnType<typeof createAgentsStorage>,
-): Promise<string | null> {
+): Promise<{ promptTemplate: string | null; customized: boolean }> {
   try {
     const illustrator = await agents.getByType("illustrator");
-    if (!illustrator) return null;
+    if (!illustrator) return { promptTemplate: null, customized: false };
     const selections =
       meta.agentPromptTemplateIds &&
       typeof meta.agentPromptTemplateIds === "object" &&
@@ -1960,16 +1977,21 @@ async function resolveGameIllustratorPromptTemplate(
         ? (meta.agentPromptTemplateIds as Record<string, unknown>)
         : {};
     const selectedPromptTemplateId = readTrimmedString(selections.illustrator);
+    const fallbackPromptTemplate = getDefaultAgentPrompt("illustrator").trim();
     const promptTemplate = resolveAgentPromptTemplate({
       promptTemplate: illustrator.promptTemplate,
-      fallbackPromptTemplate: getDefaultAgentPrompt("illustrator"),
+      fallbackPromptTemplate,
       settings: illustrator.settings,
       selectedPromptTemplateId,
     }).trim();
-    return promptTemplate || null;
+    return {
+      promptTemplate: promptTemplate || null,
+      customized:
+        selectedPromptTemplateId !== null || (promptTemplate.length > 0 && promptTemplate !== fallbackPromptTemplate),
+    };
   } catch (err) {
     logger.warn(err, "[game.routes] Failed to resolve the selected Illustrator prompt template");
-    return null;
+    return { promptTemplate: null, customized: false };
   }
 }
 
@@ -11615,10 +11637,7 @@ export async function gameRoutes(app: FastifyInstance) {
                   if (isLikelyTruncatedJsonResponse(refinementContent, refinementResult.finishReason)) {
                     throw new Error("Animation Planner returned a truncated image-aware motion beat");
                   }
-                  const extraction = extractLeadingThinkingBlocks(
-                    refinementContent,
-                    parameters?.customThinkingTags,
-                  );
+                  const extraction = extractLeadingThinkingBlocks(refinementContent, parameters?.customThinkingTags);
                   const refinement = resolveStoryboardAnimationRefinement(
                     extraction.content,
                     plannedFrame.narrationBeat,

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -142,6 +142,8 @@ import {
   GAME_STORYBOARD_PROMPT_TEMPLATE_VARIABLES,
   normalizeVideoGenerationUserSettings,
   normalizeAgentPromptTemplateOptions,
+  getDefaultAgentPrompt,
+  resolveAgentPromptTemplate,
   isClaudeAdaptiveOnlyNoSamplingModel,
   localAuthProviderBaseUrl,
   sceneAnalysisRequestSchema,
@@ -1143,6 +1145,7 @@ function sanitizeDynamicGameImagePromptResponse(raw: string, maxCharacters: numb
 
 export async function buildDynamicGameImagePromptMessages(args: {
   promptOverridesStorage?: PromptOverridesStorage;
+  illustratorPromptTemplate?: string | null;
   request: GameDynamicImagePromptRequest;
   meta: Record<string, unknown>;
   setupConfig: Record<string, unknown> | null;
@@ -1189,9 +1192,21 @@ export async function buildDynamicGameImagePromptMessages(args: {
     sourcePrompt,
     maxCharacters: args.request.maxCharacters,
   };
-  const systemPrompt = args.promptOverridesStorage
+  const directorPrompt = args.promptOverridesStorage
     ? await loadPrompt(args.promptOverridesStorage, GAME_IMAGE_PROMPT_DIRECTOR, vars)
     : GAME_IMAGE_PROMPT_DIRECTOR.defaultBuilder(vars);
+  const illustratorPromptTemplate = compactDynamicPromptText(args.illustratorPromptTemplate ?? "", 6000);
+  const systemPrompt = illustratorPromptTemplate
+    ? [
+        directorPrompt,
+        [
+          "<selected_illustrator_prompt_template>",
+          "Apply the relevant visual, content, and provider-format requirements from this selected Illustrator template. The Game Prompt Director output contract remains authoritative.",
+          illustratorPromptTemplate,
+          "</selected_illustrator_prompt_template>",
+        ].join("\n"),
+      ].join("\n\n")
+    : directorPrompt;
   return [
     { role: "system", content: systemPrompt },
     {
@@ -1271,6 +1286,7 @@ export function dynamicGameImagePromptRequestOptions(kind: GameDynamicImagePromp
 
 async function createDynamicGameImagePromptGenerator(args: {
   connections: ReturnType<typeof createConnectionsStorage>;
+  agents: ReturnType<typeof createAgentsStorage>;
   promptOverridesStorage?: PromptOverridesStorage;
   chat: NonNullable<StoredChatRecord>;
   meta: Record<string, unknown>;
@@ -1291,10 +1307,12 @@ async function createDynamicGameImagePromptGenerator(args: {
     });
     const parameters = resolveStoredGameGenerationParameters(args.meta, defaultGenerationParameters);
     const provider = await createGameMainProvider(args.connections, conn, baseUrl);
+    const illustratorPromptTemplate = await resolveGameIllustratorPromptTemplate(args.meta, args.agents);
 
     return async (request) => {
       const messages = await buildDynamicGameImagePromptMessages({
         promptOverridesStorage: args.promptOverridesStorage,
+        illustratorPromptTemplate,
         request,
         meta: args.meta,
         setupConfig: args.setupConfig,
@@ -1924,6 +1942,33 @@ async function resolveGameImageConnectionId(
     return readTrimmedString(parseSettingsRecord(illustrator?.settings).imageConnectionId);
   } catch (err) {
     logger.warn(err, "[game.routes] Failed to resolve Illustrator image connection fallback");
+    return null;
+  }
+}
+
+async function resolveGameIllustratorPromptTemplate(
+  meta: Record<string, unknown>,
+  agents: ReturnType<typeof createAgentsStorage>,
+): Promise<string | null> {
+  try {
+    const illustrator = await agents.getByType("illustrator");
+    if (!illustrator) return null;
+    const selections =
+      meta.agentPromptTemplateIds &&
+      typeof meta.agentPromptTemplateIds === "object" &&
+      !Array.isArray(meta.agentPromptTemplateIds)
+        ? (meta.agentPromptTemplateIds as Record<string, unknown>)
+        : {};
+    const selectedPromptTemplateId = readTrimmedString(selections.illustrator);
+    const promptTemplate = resolveAgentPromptTemplate({
+      promptTemplate: illustrator.promptTemplate,
+      fallbackPromptTemplate: getDefaultAgentPrompt("illustrator"),
+      settings: illustrator.settings,
+      selectedPromptTemplateId,
+    }).trim();
+    return promptTemplate || null;
+  } catch (err) {
+    logger.warn(err, "[game.routes] Failed to resolve the selected Illustrator prompt template");
     return null;
   }
 }
@@ -12174,6 +12219,7 @@ export async function gameRoutes(app: FastifyInstance) {
         : null;
     const dynamicPromptGenerator = await createDynamicGameImagePromptGenerator({
       connections,
+      agents,
       promptOverridesStorage,
       chat,
       meta,
@@ -12592,6 +12638,7 @@ export async function gameRoutes(app: FastifyInstance) {
       );
       const dynamicPromptGenerator = await createDynamicGameImagePromptGenerator({
         connections,
+        agents,
         promptOverridesStorage,
         chat,
         meta,

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -1307,9 +1307,10 @@ async function createDynamicGameImagePromptGenerator(args: {
   try {
     const illustratorPrompt = await resolveGameIllustratorPromptTemplate(args.meta, args.agents);
     const promptDirectorOverride = await args.promptOverridesStorage?.get(GAME_IMAGE_PROMPT_DIRECTOR.key);
+    const explicitlyEnabled = args.meta.gameImageDynamicPromptEnabled === true;
     if (
       !shouldUseDynamicGameImagePromptGenerator({
-        enabled: args.meta.gameImageDynamicPromptEnabled === true,
+        enabled: explicitlyEnabled,
         hasCustomizedIllustratorPrompt: illustratorPrompt.customized,
         hasEnabledPromptDirectorOverride: promptDirectorOverride?.enabled === true,
       })
@@ -1317,12 +1318,23 @@ async function createDynamicGameImagePromptGenerator(args: {
       return undefined;
     }
 
-    const { conn, baseUrl, defaultGenerationParameters } = await resolveDynamicGameImagePromptConnection({
-      connections: args.connections,
-      meta: args.meta,
-      setupConfig: args.setupConfig,
-      chatConnectionId: args.chat.connectionId,
-    });
+    let resolvedConnection;
+    try {
+      resolvedConnection = await resolveDynamicGameImagePromptConnection({
+        connections: args.connections,
+        meta: args.meta,
+        setupConfig: args.setupConfig,
+        chatConnectionId: args.chat.connectionId,
+      });
+    } catch (err) {
+      if (explicitlyEnabled) throw err;
+      logger.warn(
+        err,
+        "[game/dynamic-image-prompt] No text connection available for implicit prompt rewriting; continuing without it",
+      );
+      return undefined;
+    }
+    const { conn, baseUrl, defaultGenerationParameters } = resolvedConnection;
     const parameters = resolveStoredGameGenerationParameters(args.meta, defaultGenerationParameters);
     const provider = await createGameMainProvider(args.connections, conn, baseUrl);
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -2816,6 +2816,10 @@ export async function generateRoutes(app: FastifyInstance) {
           });
         }
 
+        let generationProviderOrigin: { model: string; provider: string } = {
+          model: conn.model,
+          provider: conn.provider,
+        };
         const providerRuntime = resolveGenerationProviderRuntime({
           connectionId: connId ?? "",
           connection: conn,
@@ -2823,6 +2827,12 @@ export async function generateRoutes(app: FastifyInstance) {
           fallbackConnection: mainFallbackConnection,
           fallbackBaseUrl: mainFallbackBaseUrl,
           onFallback,
+          onProviderUsed: (origin) => {
+            generationProviderOrigin =
+              origin.kind === "fallback"
+                ? { model: origin.model, provider: origin.provider }
+                : { model: conn.model, provider: conn.provider };
+          },
           chatMode,
           isSceneChat,
           chatParameters: chatMeta.chatParameters,
@@ -5406,6 +5416,7 @@ export async function generateRoutes(app: FastifyInstance) {
           oocMessages: string[];
           characterId: string | null;
         } | null> => {
+          generationProviderOrigin = { model: conn.model, provider: conn.provider };
           let recoveredAlreadyAppliedSpatialTurn = false;
           const targetCharacterProfile = targetCharId ? characterMacroProfilesById.get(targetCharId) : undefined;
           const deferredTargetCharacterProfile = deferCharacterMacros ? targetCharacterProfile : undefined;
@@ -6826,8 +6837,8 @@ export async function generateRoutes(app: FastifyInstance) {
           } else if (savedMsg?.id) {
             const extraUpdate: Record<string, unknown> = {
               generationInfo: {
-                model: conn.model,
-                provider: conn.provider,
+                model: generationProviderOrigin.model,
+                provider: generationProviderOrigin.provider,
                 temperature: temperature ?? null,
                 maxTokens: effectiveMaxTokensForSend ?? null,
                 maxContext: suppressModelParameters ? null : (effectiveMaxContext ?? connectionMaxContext ?? null),

--- a/packages/server/src/services/generation/provider-generation-runtime.ts
+++ b/packages/server/src/services/generation/provider-generation-runtime.ts
@@ -21,7 +21,11 @@ import {
 import { mergeModelContextLimit, resolveStoredModelContextLimit } from "./model-access-policy.js";
 import { normalizeChatTopP } from "./generation-parameters.js";
 import { clampGenerationMaxOutputTokens } from "./output-token-limits.js";
-import { withConnectionFallbackProvider, type FallbackConnection } from "../llm/connection-fallback-provider.js";
+import {
+  withConnectionFallbackProvider,
+  type FallbackConnection,
+  type GenerationProviderOrigin,
+} from "../llm/connection-fallback-provider.js";
 import type { GenerationFallbackNotifier } from "./fallback-notification.js";
 
 type GenerationConnection = {
@@ -43,6 +47,7 @@ type GenerationProviderRuntimeArgs = {
   fallbackConnection?: FallbackConnection | null;
   fallbackBaseUrl?: string;
   onFallback?: GenerationFallbackNotifier;
+  onProviderUsed?: (origin: GenerationProviderOrigin) => void;
   chatMode: string;
   isSceneChat: boolean;
   chatParameters: unknown;
@@ -219,6 +224,7 @@ export function resolveGenerationProviderRuntime(args: GenerationProviderRuntime
     fallbackBaseUrl: args.fallbackBaseUrl ?? "",
     category: "main",
     onFallback: args.onFallback,
+    onProviderUsed: args.onProviderUsed,
   });
 
   return {

--- a/packages/server/src/services/llm/connection-fallback-provider.ts
+++ b/packages/server/src/services/llm/connection-fallback-provider.ts
@@ -33,6 +33,10 @@ export type FallbackConnection = {
   treatAsLocalEndpoint?: string | boolean | null;
 };
 
+export type GenerationProviderOrigin =
+  | { kind: "primary" }
+  | { kind: "fallback"; provider: string; model: string };
+
 type ConnectionFallbackProviderArgs = {
   primary: BaseLLMProvider;
   primaryConnectionId: string;
@@ -40,6 +44,7 @@ type ConnectionFallbackProviderArgs = {
   fallbackBaseUrl: string;
   category: "main" | "agents";
   onFallback?: GenerationFallbackNotifier;
+  onProviderUsed?: (origin: GenerationProviderOrigin) => void;
   admissionMode?: ConnectionAdmissionMode;
 };
 
@@ -120,6 +125,7 @@ export class ConnectionFallbackProvider extends BaseLLMProvider {
     private readonly onFallback?: GenerationFallbackNotifier,
     /** Reports the one logical attempt's outcome once the primary-plus-fallback chain settles. */
     private readonly settleAttempt?: (outcome: "completed" | "failed") => Promise<void>,
+    private readonly onProviderUsed?: (origin: GenerationProviderOrigin) => void,
   ) {
     super("", "", primary.maxContextValue ?? undefined, null, primary.maxTokensOverrideValue);
   }
@@ -180,12 +186,19 @@ export class ConnectionFallbackProvider extends BaseLLMProvider {
     options: ChatOptions,
   ): AsyncGenerator<string, LLMUsage | void, unknown> {
     let emittedUsableOutput = false;
+    let reportedPrimary = false;
+    const reportPrimary = () => {
+      if (reportedPrimary) return;
+      reportedPrimary = true;
+      this.onProviderUsed?.({ kind: "primary" });
+    };
     try {
       const primaryOptions = options.onToken
         ? {
             ...options,
             onToken: async (chunk: string) => {
               emittedUsableOutput ||= chunk.trim().length > 0;
+              if (chunk.trim().length > 0) reportPrimary();
               await options.onToken?.(chunk);
             },
           }
@@ -195,10 +208,14 @@ export class ConnectionFallbackProvider extends BaseLLMProvider {
         let result = await generation.next();
         while (!result.done) {
           emittedUsableOutput ||= result.value.trim().length > 0;
+          if (result.value.trim().length > 0) reportPrimary();
           yield result.value;
           result = await generation.next();
         }
-        if (emittedUsableOutput || options.signal?.aborted) return result.value;
+        if (emittedUsableOutput || options.signal?.aborted) {
+          if (emittedUsableOutput) reportPrimary();
+          return result.value;
+        }
       } finally {
         // Drive the primary to completion if our consumer abandoned us mid-stream. The manual
         // loop above does not forward an early return the way `yield*` would, so without this
@@ -216,7 +233,39 @@ export class ConnectionFallbackProvider extends BaseLLMProvider {
       await this.logFallback(error);
     }
     options.signal?.throwIfAborted();
-    return yield* this.fallback.chat(messages, fallbackOptions(options, this.connection));
+    let reportedFallback = false;
+    const reportFallback = () => {
+      if (reportedFallback) return;
+      reportedFallback = true;
+      this.onProviderUsed?.({
+        kind: "fallback",
+        provider: this.connection.provider,
+        model: this.connection.model,
+      });
+    };
+    const nextOptions = fallbackOptions(options, this.connection);
+    if (nextOptions.onToken) {
+      const onToken = nextOptions.onToken;
+      nextOptions.onToken = async (chunk: string) => {
+        if (chunk.trim().length > 0) reportFallback();
+        await onToken(chunk);
+      };
+    }
+    const fallbackGeneration = this.fallback.chat(messages, nextOptions);
+    try {
+      let result = await fallbackGeneration.next();
+      while (!result.done) {
+        if (result.value.trim().length > 0) reportFallback();
+        yield result.value;
+        result = await fallbackGeneration.next();
+      }
+      reportFallback();
+      return result.value;
+    } finally {
+      await fallbackGeneration.return(undefined).catch((closeError: unknown) => {
+        logger.warn(closeError, "[%s-fallback] Failed to close the fallback generation stream", this.category);
+      });
+    }
   }
 
   async chatComplete(messages: ChatMessage[], options: ChatOptions): Promise<ChatCompletionResult> {
@@ -234,14 +283,23 @@ export class ConnectionFallbackProvider extends BaseLLMProvider {
     try {
       const result = await this.primary.chatComplete(messages, options);
       const hasUsableOutput = Boolean(result.content?.trim()) || result.toolCalls.length > 0;
-      if (hasUsableOutput || options.signal?.aborted) return result;
+      if (hasUsableOutput || options.signal?.aborted) {
+        if (hasUsableOutput) this.onProviderUsed?.({ kind: "primary" });
+        return result;
+      }
       await this.logFallback(new Error("Primary provider returned an empty completion"));
     } catch (error) {
       if (isAbortFailure(error, options.signal) || isConnectionAdmissionFailure(error)) throw error;
       await this.logFallback(error);
     }
     options.signal?.throwIfAborted();
-    return this.fallback.chatComplete(messages, fallbackOptions(options, this.connection));
+    const result = await this.fallback.chatComplete(messages, fallbackOptions(options, this.connection));
+    this.onProviderUsed?.({
+      kind: "fallback",
+      provider: this.connection.provider,
+      model: this.connection.model,
+    });
+    return result;
   }
 
   async embed(texts: string[], model: string, signal?: AbortSignal): Promise<number[][]> {
@@ -256,6 +314,7 @@ export function withConnectionFallbackProvider({
   fallbackBaseUrl,
   category,
   onFallback,
+  onProviderUsed,
   admissionMode = { kind: "foreground" },
 }: ConnectionFallbackProviderArgs): BaseLLMProvider {
   const { primaryMode, fallbackMode, settle } = splitConnectionAttemptAcrossFallback(admissionMode);
@@ -284,5 +343,13 @@ export function withConnectionFallbackProvider({
     fallbackConnection.id,
     fallbackMode,
   );
-  return new ConnectionFallbackProvider(admittedPrimary, fallback, fallbackConnection, category, onFallback, settle);
+  return new ConnectionFallbackProvider(
+    admittedPrimary,
+    fallback,
+    fallbackConnection,
+    category,
+    onFallback,
+    settle,
+    onProviderUsed,
+  );
 }

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -642,6 +642,7 @@ import {
   sanitizeNpcPortraitAppearanceText,
   selectLatestGameTurnNarration,
   selectStoryboardAppearanceCharacterNames,
+  shouldUseDynamicGameImagePromptGenerator,
 } from "../../packages/server/src/routes/game.routes.js";
 import { buildLegacyDefaultAgentConfigUpdate } from "../../packages/server/src/services/agents/default-prompt-migration.js";
 import { buildMemoryRecallBlock } from "../../packages/server/src/services/generation/memory-recall-context.js";
@@ -6603,6 +6604,30 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
 
       const requestOptions = dynamicGameImagePromptRequestOptions("portrait");
       assert.equal("responseFormat" in requestOptions, false);
+      assert.equal(
+        shouldUseDynamicGameImagePromptGenerator({
+          enabled: false,
+          hasCustomizedIllustratorPrompt: true,
+          hasEnabledPromptDirectorOverride: false,
+        }),
+        true,
+      );
+      assert.equal(
+        shouldUseDynamicGameImagePromptGenerator({
+          enabled: false,
+          hasCustomizedIllustratorPrompt: false,
+          hasEnabledPromptDirectorOverride: true,
+        }),
+        true,
+      );
+      assert.equal(
+        shouldUseDynamicGameImagePromptGenerator({
+          enabled: false,
+          hasCustomizedIllustratorPrompt: false,
+          hasEnabledPromptDirectorOverride: false,
+        }),
+        false,
+      );
     },
   },
   {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -6580,6 +6580,7 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       } satisfies PromptOverridesStorage;
       const messages = await buildDynamicGameImagePromptMessages({
         promptOverridesStorage,
+        illustratorPromptTemplate: "Always include the distinctive tag chromatic_aberration_test.",
         request: {
           kind: "portrait",
           title: "Sentinel",
@@ -6593,7 +6594,8 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         latestTurnNarration: "This must not be added to a portrait prompt.",
       });
 
-      assert.equal(messages[0]?.content, override);
+      assert.match(messages[0]?.content ?? "", new RegExp(override));
+      assert.match(messages[0]?.content ?? "", /chromatic_aberration_test/);
       assert.match(messages[1]?.content ?? "", /Appearance traits: towering alien/);
       assert.doesNotMatch(messages[1]?.content ?? "", /latest_gm_turn|must not be added/i);
       assert.doesNotMatch(messages[1]?.content ?? "", /copy the Required canonical NPC visual profile/i);

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -34,6 +34,7 @@ import {
   ConnectionFallbackProvider,
   withConnectionFallbackProvider,
   type FallbackConnection,
+  type GenerationProviderOrigin,
 } from "../../packages/server/src/services/llm/connection-fallback-provider.js";
 import {
   BaseLLMProvider,
@@ -1416,7 +1417,16 @@ for (const drive of [
 
 const primaryFailure = new RegressionProvider([], new Error("primary unavailable"));
 const successfulFallback = new RegressionProvider(["fallback response"]);
-const fallbackProvider = new ConnectionFallbackProvider(primaryFailure, successfulFallback, fallbackConnection, "main");
+const usedProviderOrigins: GenerationProviderOrigin[] = [];
+const fallbackProvider = new ConnectionFallbackProvider(
+  primaryFailure,
+  successfulFallback,
+  fallbackConnection,
+  "main",
+  undefined,
+  undefined,
+  (origin) => usedProviderOrigins.push(origin),
+);
 assert.equal(
   await collectProviderOutput(fallbackProvider, {
     model: "primary-model",
@@ -1428,6 +1438,7 @@ assert.equal(
 );
 assert.equal(primaryFailure.calls, 1);
 assert.equal(successfulFallback.calls, 1);
+assert.deepEqual(usedProviderOrigins, [{ kind: "fallback", provider: "custom", model: "fallback-model" }]);
 assert.equal(successfulFallback.lastOptions?.model, "fallback-model");
 assert.equal(successfulFallback.lastOptions?.temperature, 0.35);
 assert.equal(successfulFallback.lastOptions?.maxTokens, 512);


### PR DESCRIPTION
> [!IMPORTANT]
> This assigned-issue sweep targets `staging` and keeps each fix deliberately focused.

## Linked issues

Closes #4879
Closes #4880
Closes #4881
Closes #4882
Closes #4883

## Why this change

Five user-facing regressions could make Marinara report the wrong generating model, ignore configured Game image prompts and character sheets, forget Echo Chamber placement, or send a disabled generation parameter. This PR corrects those behaviors without broad refactors.

## What changed

- Records the provider and model that actually produced a message after a connection fallback.
- Applies Game asset prompt overrides, the selected Illustrator prompt template, and the Illustrator image connection to automatic and manual Game image generation. Explicit custom prompt settings activate the existing prompt-director path even if its general toggle is off, while image-only setups continue without optional rewriting.
- Seeds Game combatants from saved character-sheet levels, resources, combat stats, and typed abilities; preserves zero HP and matches legacy card-name variants.
- Persists the Echo Chamber corner per chat and flushes layout changes immediately.
- Makes the generation-parameter enable switches authoritative, so disabled Verbosity is omitted even when a preset retains a selected value.
- Adds focused regression and browser coverage, plus release-note entries under `Unreleased`.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Verification notes

Automated checks completed by the authoring agent:

- `pnpm check`
- `pnpm regression:providers`
- `pnpm regression:prompt`
- Targeted desktop Playwright coverage for per-chat Echo Chamber persistence, UI-store migration, character-sheet combat parsing and hydration, and Game character-sheet Retry behavior (4 passed)

The complete UI smoke suite was also sampled during development; unrelated fixture and selector timeouts made that broad run noisy, so the affected scenarios were corrected where needed and rerun in isolation successfully.

Manual browser verification remains for the maintainer.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `docs-i18n` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing documentation or version files changed. `CHANGELOG.md` contains the five `Unreleased` fix entries.

## UI evidence (if applicable)

Focused Playwright scenarios cover the changed persisted UI behavior; maintainers should manually verify the final visual state in their normal local setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Game combat now uses saved character cards for stats, resources, abilities, levels, and portraits.
  * Game image generation supports configured Illustrator prompt templates and customized prompt settings.
  * Echo Chamber positions can be saved separately for each chat.
  * Generation records the provider and model actually used, including fallback services.

* **Bug Fixes**
  * Chat generation-parameter toggles now persist reliably.
  * Experience-driven games provide improved controls and hide unsupported interface elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->