### PR TITLE
Fix assigned SwarmUI, Roleplay, and lorebook issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added SwarmUI as a video-generation backend, including authenticated distributed ComfyUI workflow submission, base64 reference images, model discovery, and MP4 retrieval (#4885).
 - Added responsive batch selection to chat Galleries, with filtered Select All, confirmed multi-image downloads and deletes, and selection cleanup between chats (#4859).
 - Added optional image prompting instructions to image connections, applying them inside existing selfie and Illustrator prompt-writing calls before provider review or generation.
 - Added a Gallery image-agent picker that can run any active custom image-producing agent alongside the base Illustrator (#4846).
@@ -50,6 +51,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept explicitly selected persona-linked lorebooks usable outside their owner persona while preserving automatic owner matching and chat exclusions (#4887).
+- Extended the Roleplay New Start divider across the full message body for user messages as well as assistant messages (#4886).
 - Applied Game image prompt overrides and the selected Illustrator prompt template to Game prompt-director requests, including manual portraits that use the Illustrator agent's image connection and explicitly customized prompt settings when the general dynamic-prompt toggle is off (#4880).
 - Made Game combat use character-sheet levels, resource pools, and typed abilities instead of deriving levels from HP and treating every ability as an attack (#4881).
 - Recorded the fallback provider and model on messages it actually generated instead of displaying the failed primary model (#4879).

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -2662,7 +2662,7 @@ export const ChatMessage = memo(function ChatMessage({
 
             {/* Conversation start marker */}
             {isConversationStart && (
-              <div className="mb-1 px-1">
+              <div className="mb-1 w-full px-1">
                 <div
                   aria-hidden="true"
                   className="mari-chrome-accent-progress mari-accent-animated mb-1.5 h-0.5 w-full rounded-full"

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -156,6 +156,7 @@ const VIDEO_REFERENCE_UPLOAD_EXPIRY_OPTIONS: Array<{ value: VideoReferenceUpload
 ];
 
 function videoSourceToDefaultsService(value: string | null | undefined): VideoDefaultsService {
+  if (value === "swarmui") return "comfyui";
   return value === "xai" ||
     value === "openrouter" ||
     value === "atlas" ||
@@ -179,6 +180,7 @@ function videoSelectionToDefaultsService(
 }
 
 function videoSourceToProviderOption(value: string | null | undefined): string {
+  if (value?.trim() === "swarmui") return "swarmui";
   const service = videoSourceToDefaultsService(value);
   return service === "gemini_omni" || service === "google_veo" ? "google_ai_studio" : service;
 }
@@ -488,6 +490,8 @@ export function ConnectionEditor() {
       const label = labelMsg + ": " + msg.split("\n")[0];
       return { parseError: true as const, label, charPos };
     }
+    const isSwarmUiVideoWorkflow =
+      (localVideoGenerationSource || localVideoService || inferVideoSource(localModel, localBaseUrl)) === "swarmui";
     const KNOWN_SUBS =
       localProvider === "video_generation"
         ? [
@@ -499,7 +503,11 @@ export function ConnectionEditor() {
             { token: "%length_s%", label: "%length_s%", critical: false },
             { token: "%fps%", label: "%fps%", critical: false },
             { token: "%duration_seconds%", label: "%duration_seconds%", critical: false },
-            { token: "%reference_image_name%", label: "%reference_image_name%", critical: false },
+            {
+              token: isSwarmUiVideoWorkflow ? "%reference_image%" : "%reference_image_name%",
+              label: isSwarmUiVideoWorkflow ? "%reference_image%" : "%reference_image_name%",
+              critical: false,
+            },
           ]
         : [
             { token: "%prompt%", label: "%prompt%", critical: true },
@@ -519,7 +527,7 @@ export function ConnectionEditor() {
       return !wf.includes(token);
     });
     return { parseError: false as const, missing };
-  }, [localComfyuiWorkflow, localProvider]);
+  }, [localBaseUrl, localComfyuiWorkflow, localModel, localProvider, localVideoGenerationSource, localVideoService]);
 
   const effectiveImageGenerationSource = useMemo(() => {
     if (localProvider !== "image_generation") return "";
@@ -537,10 +545,6 @@ export function ConnectionEditor() {
     localProvider === "image_generation"
       ? localImageGenerationSource || localImageService || effectiveImageGenerationSource
       : "";
-  const swarmUiWorkflowError =
-    selectedImageService === "swarmui" && /%reference_image_name(?:_0[1-4])?%/.test(localComfyuiWorkflow)
-      ? localizeUi("ui.connections.connectioneditor.swarmuiDoesNotSupportReferenceImageName")
-      : null;
   const selectedImageDefaultsService = imageSourceToDefaultsService(selectedImageService);
   const supportsGptImageQuality =
     localProvider === "image_generation" &&
@@ -552,12 +556,18 @@ export function ConnectionEditor() {
       : "";
   const selectedVideoProvider = videoSourceToProviderOption(selectedVideoService);
   const selectedVideoDefaultsService = videoSelectionToDefaultsService(selectedVideoService, localModel, localBaseUrl);
+  const swarmUiWorkflowError =
+    (selectedImageService === "swarmui" || selectedVideoProvider === "swarmui") &&
+    /%reference_image_name(?:_0[1-4])?%/.test(localComfyuiWorkflow)
+      ? localizeUi("ui.connections.connectioneditor.swarmuiDoesNotSupportReferenceImageName")
+      : null;
   const usesComfyUiWorkflow =
     (localProvider === "image_generation" &&
       (selectedImageService === "comfyui" ||
         selectedImageService === "swarmui" ||
         selectedImageService === "runpod_comfyui")) ||
-    (localProvider === "video_generation" && selectedVideoProvider === "comfyui");
+    (localProvider === "video_generation" &&
+      (selectedVideoProvider === "comfyui" || selectedVideoProvider === "swarmui"));
   const apiKeyLink =
     localProvider === "image_generation" && selectedImageService === "arli"
       ? { label: t("connections.mediaSources.arli.apiKeyLink"), url: "https://www.arliai.com/docs/api?lang=en" }
@@ -577,7 +587,8 @@ export function ConnectionEditor() {
             ? API_KEY_LINKS.openrouter
             : localProvider === "video_generation" && selectedVideoDefaultsService === "seedance"
               ? { label: "Open Seedance API docs", url: "https://seedance2.ai/api-docs" }
-              : localProvider === "video_generation" && selectedVideoDefaultsService === "comfyui"
+              : localProvider === "video_generation" &&
+                  (selectedVideoProvider === "comfyui" || selectedVideoProvider === "swarmui")
                 ? undefined
                 : API_KEY_LINKS[localProvider];
 
@@ -717,7 +728,8 @@ export function ConnectionEditor() {
       openrouterProvider: localOpenrouterProvider || null,
       imageGenerationSource: isImageProvider ? localImageGenerationSource || localImageService || null : null,
       comfyuiWorkflow:
-        isImageProvider || (isVideoProvider && selectedVideoProvider === "comfyui")
+        isImageProvider ||
+        (isVideoProvider && (selectedVideoProvider === "comfyui" || selectedVideoProvider === "swarmui"))
           ? localComfyuiWorkflow || null
           : null,
       imageService: isImageProvider ? localImageGenerationSource || localImageService || null : null,
@@ -726,7 +738,11 @@ export function ConnectionEditor() {
       imagePromptInstructions: isImageProvider ? normalizeImagePromptInstructions(localImagePromptInstructions) : null,
       imageGenerationQuality: isImageProvider ? localImageGenerationQuality : "auto",
       videoGenerationSource: isVideoProvider ? selectedVideoProvider || null : null,
-      videoService: isVideoProvider ? selectedVideoDefaultsService : null,
+      videoService: isVideoProvider
+        ? selectedVideoProvider === "swarmui"
+          ? "swarmui"
+          : selectedVideoDefaultsService
+        : null,
       maxTokensOverride: localMaxTokensOverride ?? null,
       claudeFastMode: localClaudeFastMode,
       treatAsLocalEndpoint: canTreatAsLocalEndpoint ? localTreatAsLocalEndpoint : false,
@@ -899,7 +915,11 @@ export function ConnectionEditor() {
           : null;
     const imageService = isImageProvider ? localImageGenerationSource || localImageService || null : null;
     const videoProvider = isVideoProvider ? selectedVideoProvider || null : null;
-    const videoService = isVideoProvider ? selectedVideoDefaultsService : null;
+    const videoService = isVideoProvider
+      ? videoProvider === "swarmui"
+        ? "swarmui"
+        : selectedVideoDefaultsService
+      : null;
     const canTreatAsLocalEndpoint = canProviderTreatAsLocalEndpoint(localProvider);
     const supportsDirectEmbeddings = providerSupportsDirectEmbeddingConfig(localProvider);
     const existingEmbeddingModel = (conn as { embeddingModel?: string | null } | undefined)?.embeddingModel ?? "";
@@ -932,7 +952,9 @@ export function ConnectionEditor() {
       imagePromptInstructions: isImageProvider ? normalizeImagePromptInstructions(localImagePromptInstructions) : null,
       imageGenerationQuality: isImageProvider ? localImageGenerationQuality : "auto",
       comfyuiWorkflow:
-        isImageProvider || (isVideoProvider && videoProvider === "comfyui") ? localComfyuiWorkflow || null : null,
+        isImageProvider || (isVideoProvider && (videoProvider === "comfyui" || videoProvider === "swarmui"))
+          ? localComfyuiWorkflow || null
+          : null,
       claudeFastMode: localClaudeFastMode,
     };
 
@@ -1661,9 +1683,18 @@ export function ConnectionEditor() {
               <div className="grid grid-cols-2 gap-1.5">
                 {VIDEO_GENERATION_SOURCES.map((src) => {
                   const isActive = selectedVideoProvider === src.id;
-                  const sourceName = src.id === "atlas" ? t("connections.mediaSources.atlas.name") : src.name;
+                  const sourceName =
+                    src.id === "atlas"
+                      ? t("connections.mediaSources.atlas.name")
+                      : src.id === "swarmui"
+                        ? t("connections.mediaSources.swarmui.name")
+                        : src.name;
                   const sourceDescription =
-                    src.id === "atlas" ? t("connections.mediaSources.atlas.videoDescription") : src.description;
+                    src.id === "atlas"
+                      ? t("connections.mediaSources.atlas.videoDescription")
+                      : src.id === "swarmui"
+                        ? t("connections.mediaSources.swarmui.videoDescription")
+                        : src.description;
                   return (
                     <button
                       key={src.id}
@@ -1707,6 +1738,11 @@ export function ConnectionEditor() {
                   );
                 })}
               </div>
+              {selectedVideoProvider === "swarmui" && (
+                <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+                  {t("connections.mediaSources.swarmui.authHelp")}
+                </p>
+              )}
               <p className="text-[0.625rem] text-[var(--muted-foreground)]">{localizeUi("ui.connections.connectioneditor.sceneVideosAreGeneratedFromTheCurrentGameIllustration")}</p>
             </FieldGroup>
           )}
@@ -1939,7 +1975,9 @@ export function ConnectionEditor() {
               icon={<Zap size="0.875rem" className="text-sky-400" />}
               help={
                 localProvider === "video_generation"
-                  ?localizeUi("ui.connections.connectioneditor.pasteAComfyuiVideoWorkflowInApiFormatUse")
+                  ? selectedVideoProvider === "swarmui"
+                    ? t("connections.mediaSources.swarmui.videoWorkflowHelp")
+                    : localizeUi("ui.connections.connectioneditor.pasteAComfyuiVideoWorkflowInApiFormatUse")
                   : selectedImageService === "runpod_comfyui"
                     ?localizeUi("ui.connections.connectioneditor.pasteYourComfyuiWorkflowJsonApiFormatRunpodNeeds")
                     : selectedImageService === "swarmui"

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -286,6 +286,8 @@
   "connections.mediaSources.swarmui.authHelp": "If this SwarmUI server requires an account, paste a Swarm Auth Token into the API Key field. Leave it empty for an unauthenticated local server.",
   "connections.mediaSources.swarmui.imageDescription": "Generate images through SwarmUI, including ComfyUI workflows distributed across its backend queue.",
   "connections.mediaSources.swarmui.name": "SwarmUI",
+  "connections.mediaSources.swarmui.videoDescription": "Generate videos through SwarmUI using ComfyUI workflows distributed across its backend queue.",
+  "connections.mediaSources.swarmui.videoWorkflowHelp": "Paste a required ComfyUI API-format video workflow for SwarmUI. Marinara resolves prompt, model, dimensions, duration, FPS, seed, LoRA, and base64 reference-image placeholders before submitting it through SwarmUI's distributed queue.",
   "connections.mediaSources.zai.apiKeyLink": "Get your Z.AI API key",
   "connections.mediaSources.zai.imageDescription": "Generate images with GLM-Image and CogView through Z.AI's native API.",
   "connections.mediaSources.zai.name": "Z.AI",

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -52,6 +52,7 @@ const CONNECTION_TEST_ERROR_PREVIEW_CHARS = 2000;
 const CONNECTION_IMAGES_DIR = join(DATA_DIR, "connections", "images");
 const SWARMUI_CONTROL_REQUEST_TIMEOUT_MS = 15_000;
 const DEFAULT_COMFYUI_VIDEO_BASE_URL = "http://127.0.0.1:8188";
+const DEFAULT_SWARMUI_VIDEO_BASE_URL = "http://127.0.0.1:7801";
 const DEFAULT_GEMINI_OMNI_VIDEO_MODEL = "gemini-omni-flash-preview";
 const DEFAULT_GEMINI_OMNI_VIDEO_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 const DEFAULT_GOOGLE_VEO_VIDEO_MODEL = "veo-3.1-generate-preview";
@@ -187,14 +188,17 @@ function localUrlPolicyForProvider(provider: string, imageSource: string) {
     (imageSource === "comfyui" || imageSource === "swarmui" || imageSource === "automatic1111");
   const isImage = provider === "image_generation";
   const isVideo = provider === "video_generation";
+  const isLocalVideoBackend = isVideo && (imageSource === "comfyui" || imageSource === "swarmui");
   return {
     allowLocal: isVideo
-      ? false
+      ? isLocalVideoBackend
       : isLocalImageBackend || (isImage && isImageLocalUrlsEnabled())
         ? true
         : isProviderLocalUrlsEnabled(),
     allowLoopback: true,
-    allowMdns: !isVideo && (provider !== "image_generation" || isLocalImageBackend || isImageLocalUrlsEnabled()),
+    allowMdns:
+      isLocalVideoBackend ||
+      (!isVideo && (provider !== "image_generation" || isLocalImageBackend || isImageLocalUrlsEnabled())),
     allowedProtocols: ["https:", "http:"],
     flagName: isImage ? "IMAGE_LOCAL_URLS_ENABLED" : "PROVIDER_LOCAL_URLS_ENABLED",
   };
@@ -743,7 +747,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
         if (videoSource === "atlas") {
           return { models: ATLAS_CLOUD_VIDEO_MODELS.map((model) => ({ id: model.id, name: model.name })) };
         }
-        if (videoSource !== "comfyui") {
+        if (videoSource !== "comfyui" && videoSource !== "swarmui") {
           const models = MODEL_LISTS.video_generation.map((m) => ({ id: m.id, name: m.name }));
           return { models };
         }
@@ -855,7 +859,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
         return { models: knownStabilityImageModels() };
       }
 
-      if (conn.provider === "image_generation" && imageSource === "swarmui") {
+      if ((conn.provider === "image_generation" || conn.provider === "video_generation") && mediaSource === "swarmui") {
         const sessionId = await createSwarmUiSession(baseUrl, conn.apiKey || "");
         const result = await postSwarmUiJson(baseUrl, conn.apiKey || "", "ListT2IParams", { session_id: sessionId });
         const modelGroups = isRecord(result) && isRecord(result.models) ? result.models : {};
@@ -1213,15 +1217,18 @@ export async function connectionsRoutes(app: FastifyInstance) {
       explicitVideoSource || (inferredVideoSource !== "gemini_omni" ? inferredVideoSource : defaults.service);
     const rawVideoServiceHint = conn.videoService || videoSource;
     const videoServiceHint =
-      rawVideoServiceHint === "google_ai_studio"
-        ? inferVideoSource(conn.model || "", conn.baseUrl || "")
-        : rawVideoServiceHint;
+      videoSource === "swarmui"
+        ? "swarmui"
+        : rawVideoServiceHint === "google_ai_studio"
+          ? inferVideoSource(conn.model || "", conn.baseUrl || "")
+          : rawVideoServiceHint;
     const isXaiVideo = videoSource === "xai" || videoServiceHint === "xai";
     const isGoogleVeoVideo = videoSource === "google_veo" || videoServiceHint === "google_veo";
     const isOpenRouterVideo = videoSource === "openrouter" || videoServiceHint === "openrouter";
     const isAtlasVideo = videoSource === "atlas" || videoServiceHint === "atlas";
     const isSeedanceVideo = videoSource === "seedance" || videoServiceHint === "seedance";
-    const isComfyUiVideo = videoSource === "comfyui" || videoServiceHint === "comfyui";
+    const isSwarmUiVideo = videoSource === "swarmui" || videoServiceHint === "swarmui";
+    const isComfyUiVideo = videoSource === "comfyui" || videoServiceHint === "comfyui" || isSwarmUiVideo;
     const baseUrl = (
       conn.baseUrl ||
       (isXaiVideo
@@ -1234,9 +1241,11 @@ export async function connectionsRoutes(app: FastifyInstance) {
               ? DEFAULT_ATLAS_CLOUD_VIDEO_BASE_URL
               : isSeedanceVideo
                 ? DEFAULT_SEEDANCE_VIDEO_BASE_URL
-                : isComfyUiVideo
-                  ? DEFAULT_COMFYUI_VIDEO_BASE_URL
-                  : providerDef?.defaultBaseUrl || DEFAULT_GEMINI_OMNI_VIDEO_BASE_URL)
+                : isSwarmUiVideo
+                  ? DEFAULT_SWARMUI_VIDEO_BASE_URL
+                  : isComfyUiVideo
+                    ? DEFAULT_COMFYUI_VIDEO_BASE_URL
+                    : providerDef?.defaultBaseUrl || DEFAULT_GEMINI_OMNI_VIDEO_BASE_URL)
     ).replace(/\/+$/, "");
     const videoModel =
       conn.model ||

--- a/packages/server/src/routes/sprites.routes.ts
+++ b/packages/server/src/routes/sprites.routes.ts
@@ -358,15 +358,18 @@ function resolveVideoConnection(connection: VideoGenerationConnection) {
       : inferVideoSource(connection.model || "", connection.baseUrl || ""));
   const rawServiceHint = connection.videoService || source;
   const serviceHint =
-    rawServiceHint === "google_ai_studio"
-      ? inferVideoSource(connection.model || "", connection.baseUrl || "")
-      : rawServiceHint;
+    source === "swarmui"
+      ? "swarmui"
+      : rawServiceHint === "google_ai_studio"
+        ? inferVideoSource(connection.model || "", connection.baseUrl || "")
+        : rawServiceHint;
   const isXaiVideo = source === "xai" || serviceHint === "xai";
   const isGoogleVeoVideo = source === "google_veo" || serviceHint === "google_veo";
   const isOpenRouterVideo = source === "openrouter" || serviceHint === "openrouter";
   const isAtlasVideo = source === "atlas" || serviceHint === "atlas";
   const isSeedanceVideo = source === "seedance" || serviceHint === "seedance";
-  const isComfyUiVideo = source === "comfyui" || serviceHint === "comfyui";
+  const isSwarmUiVideo = source === "swarmui" || serviceHint === "swarmui";
+  const isComfyUiVideo = source === "comfyui" || serviceHint === "comfyui" || isSwarmUiVideo;
   return {
     source,
     serviceHint,
@@ -382,9 +385,11 @@ function resolveVideoConnection(connection: VideoGenerationConnection) {
               ? "https://api.atlascloud.ai/api/v1"
               : isSeedanceVideo
                 ? "https://api.seedance2.ai"
-                : isComfyUiVideo
-                  ? "http://127.0.0.1:8188"
-                  : "https://generativelanguage.googleapis.com/v1beta"),
+                : isSwarmUiVideo
+                  ? "http://127.0.0.1:7801"
+                  : isComfyUiVideo
+                    ? "http://127.0.0.1:8188"
+                    : "https://generativelanguage.googleapis.com/v1beta"),
     model:
       connection.model ||
       (isXaiVideo

--- a/packages/server/src/services/generation/media-connection-fallback.ts
+++ b/packages/server/src/services/generation/media-connection-fallback.ts
@@ -80,7 +80,10 @@ export async function resolveVideoConnectionFallback(
     source,
     baseUrl,
     apiKey: connection.apiKey || "",
-    serviceHint: String(connection.videoService ?? connection.videoGenerationSource ?? source),
+    serviceHint:
+      source === "swarmui"
+        ? "swarmui"
+        : String(connection.videoService ?? connection.videoGenerationSource ?? source),
     model,
     comfyWorkflow: connection.comfyuiWorkflow || undefined,
     comfyLoras: comfyDefaults?.loras ?? [],

--- a/packages/server/src/services/lorebook/index.ts
+++ b/packages/server/src/services/lorebook/index.ts
@@ -15,7 +15,6 @@ import type {
 } from "@marinara-engine/shared";
 import { createCharactersStorage } from "../storage/characters.storage.js";
 import { createLorebooksStorage } from "../storage/lorebooks.storage.js";
-import { GAME_LOREBOOK_KEEPER_SOURCE_ID } from "./game-lorebook-scope.js";
 import {
   scanForActivatedEntries,
   lorebookEntryPassesContextFilters,
@@ -239,26 +238,8 @@ function resolveOpeningPinnedScanMessages(messages: ScanMessage[], scanDepth: nu
     .map((item) => item.message);
 }
 
-function resolveLorebookCharacterIds(book: Pick<RelevantLorebook, "characterId" | "characterIds">): string[] {
-  return uniqueStrings([...(book.characterIds ?? []), book.characterId]);
-}
-
-function resolveLorebookPersonaIds(book: Pick<RelevantLorebook, "personaId" | "personaIds">): string[] {
-  return uniqueStrings([...(book.personaIds ?? []), book.personaId]);
-}
-
 function activeLorebookMatchesFilters(book: RelevantLorebook, filters: LorebookFilters): boolean {
-  if (!filters.activeLorebookIds?.includes(book.id)) return false;
-  if (book.sourceAgentId === GAME_LOREBOOK_KEEPER_SOURCE_ID) return true;
-
-  const characterIds = resolveLorebookCharacterIds(book);
-  if (characterIds.length > 0) return characterIds.some((id) => filters.characterIds?.includes(id));
-
-  const personaIds = resolveLorebookPersonaIds(book);
-  if (personaIds.length > 0) return !!filters.personaId && personaIds.includes(filters.personaId);
-
-  if (book.chatId) return book.chatId === filters.chatId;
-  return true;
+  return filters.activeLorebookIds?.includes(book.id) === true;
 }
 
 function pushSourceText(

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -27,7 +27,6 @@ import {
 } from "@marinara-engine/shared";
 import { collectEffectivelyDisabledFolderIds, collectFolderSubtreeIds } from "@marinara-engine/shared";
 import { normalizeTimestampOverrides, type TimestampOverrides } from "../import/import-timestamps.js";
-import { GAME_LOREBOOK_KEEPER_SOURCE_ID } from "../lorebook/game-lorebook-scope.js";
 import { toPaginatedList } from "../../utils/list-pagination.js";
 
 function normalizeLorebookEntryLimit(value: unknown): number {
@@ -127,26 +126,10 @@ type LorebookScopeFilters = {
 
 type LinkedLorebook = {
   id: string;
-  characterId?: string | null;
-  characterIds?: string[];
-  personaId?: string | null;
-  personaIds?: string[];
-  chatId?: string | null;
-  sourceAgentId?: string | null;
 };
 
 function activeLorebookMatchesFilters(book: LinkedLorebook, filters: LorebookScopeFilters): boolean {
-  if (!filters.activeLorebookIds?.includes(book.id)) return false;
-  if (book.sourceAgentId === GAME_LOREBOOK_KEEPER_SOURCE_ID) return true;
-
-  const characterIds = resolveLinkIds(book.characterIds, book.characterId);
-  if (characterIds.length > 0) return characterIds.some((id) => filters.characterIds?.includes(id));
-
-  const personaIds = resolveLinkIds(book.personaIds, book.personaId);
-  if (personaIds.length > 0) return !!filters.personaId && personaIds.includes(filters.personaId);
-
-  if (book.chatId) return book.chatId === filters.chatId;
-  return true;
+  return filters.activeLorebookIds?.includes(book.id) === true;
 }
 
 /** Parse DB row booleans ("true"/"false") → real booleans and JSON strings → objects. */
@@ -720,7 +703,7 @@ export function createLorebooksStorage(db: DB) {
      * Get all enabled entries from lorebooks that are relevant for a given context.
      * A lorebook is relevant if it's enabled AND one of:
      *  - `isGlobal` is true
-     *  - Its ID is in `activeLorebookIds`, while any character/persona/chat owner link still matches this context
+     *  - Its ID is in `activeLorebookIds`
      *  - Its `characterId` matches one of the chat's active characters
      *  - Its `personaId` matches the chat's active persona
      *  - Its `chatId` matches the current chat
@@ -763,7 +746,7 @@ export function createLorebooksStorage(db: DB) {
           if (b.sourceAgentId && excludedSourceAgentIds.has(b.sourceAgentId)) return false;
           // Globally active lorebooks bypass all scope filters
           if (b.isGlobal) return true;
-          // Explicitly added to this chat, while still respecting owner links.
+          // Explicitly added to this chat.
           if (activeLorebookMatchesFilters(b, filters)) return true;
           // Belongs to one of the active characters
           if ((b.characterIds ?? []).some((id) => filters.characterIds?.includes(id))) return true;

--- a/packages/server/src/services/video/game-video-runtime.ts
+++ b/packages/server/src/services/video/game-video-runtime.ts
@@ -26,6 +26,7 @@ const DEFAULT_ATLAS_CLOUD_VIDEO_BASE_URL = "https://api.atlascloud.ai/api/v1";
 const DEFAULT_SEEDANCE_VIDEO_MODEL = "seedance-2-0";
 const DEFAULT_SEEDANCE_VIDEO_BASE_URL = "https://api.seedance2.ai";
 const DEFAULT_COMFYUI_VIDEO_BASE_URL = "http://127.0.0.1:8188";
+const DEFAULT_SWARMUI_VIDEO_BASE_URL = "http://127.0.0.1:7801";
 
 interface VideoRuntimeConnection {
   baseUrl?: string | null;
@@ -92,16 +93,19 @@ export function resolveGameVideoRuntime(connection: VideoRuntimeConnection): Gam
       : inferVideoSource(connection.model || "", connection.baseUrl || ""));
   const rawServiceHint = connection.videoService || source;
   const serviceHint =
-    rawServiceHint === "google_ai_studio"
-      ? inferVideoSource(connection.model || "", connection.baseUrl || "")
-      : rawServiceHint;
+    source === "swarmui"
+      ? "swarmui"
+      : rawServiceHint === "google_ai_studio"
+        ? inferVideoSource(connection.model || "", connection.baseUrl || "")
+        : rawServiceHint;
   const isXai = source === "xai" || serviceHint === "xai";
   const isGeminiOmni = source === "gemini_omni" || serviceHint === "gemini_omni";
   const isGoogleVeo = source === "google_veo" || serviceHint === "google_veo";
   const isOpenRouter = source === "openrouter" || serviceHint === "openrouter";
   const isAtlas = source === "atlas" || serviceHint === "atlas";
   const isSeedance = source === "seedance" || serviceHint === "seedance";
-  const isComfyUi = source === "comfyui" || serviceHint === "comfyui";
+  const isSwarmUi = source === "swarmui" || serviceHint === "swarmui";
+  const isComfyUi = source === "comfyui" || serviceHint === "comfyui" || isSwarmUi;
   const activeDefaults = isXai
     ? videoDefaults.xai
     : isGoogleVeo
@@ -144,9 +148,11 @@ export function resolveGameVideoRuntime(connection: VideoRuntimeConnection): Gam
               ? DEFAULT_ATLAS_CLOUD_VIDEO_BASE_URL
               : isSeedance
                 ? DEFAULT_SEEDANCE_VIDEO_BASE_URL
-                : isComfyUi
-                  ? DEFAULT_COMFYUI_VIDEO_BASE_URL
-                  : DEFAULT_GEMINI_OMNI_BASE_URL),
+                : isSwarmUi
+                  ? DEFAULT_SWARMUI_VIDEO_BASE_URL
+                  : isComfyUi
+                    ? DEFAULT_COMFYUI_VIDEO_BASE_URL
+                    : DEFAULT_GEMINI_OMNI_BASE_URL),
     apiKey: connection.apiKey || "",
     model:
       connection.model ||

--- a/packages/server/src/services/video/video-generation.ts
+++ b/packages/server/src/services/video/video-generation.ts
@@ -80,6 +80,7 @@ export interface VideoGenerationResult {
 const GAME_SCENE_VIDEOS_DIR = join(DATA_DIR, "game-scene-videos");
 const VIDEO_GEN_TIMEOUT = Number(process.env.VIDEO_GEN_TIMEOUT_MS ?? 1_800_000);
 const MAX_VIDEO_RESPONSE_BYTES = Number(process.env.VIDEO_GEN_MAX_RESPONSE_BYTES ?? 160 * 1024 * 1024);
+const MAX_VIDEO_JSON_RESPONSE_BYTES = Math.ceil((MAX_VIDEO_RESPONSE_BYTES * 4) / 3) + 1024 * 1024;
 const DEFAULT_GEMINI_OMNI_MODEL = "gemini-omni-flash-preview";
 const DEFAULT_GOOGLE_VEO_MODEL = "veo-3.1-generate-preview";
 const DEFAULT_XAI_VIDEO_MODEL = "grok-imagine-video-1.5";
@@ -139,7 +140,8 @@ async function generateVideoUnqueued(
   serviceHint: string,
   request: VideoGenerationRequest,
 ): Promise<VideoGenerationResult> {
-  const resolvedService = normalizeVideoService(serviceHint || source);
+  const resolvedService =
+    normalizeVideoService(source) === "swarmui" ? "swarmui" : normalizeVideoService(serviceHint || source);
   const primaryRequest = { ...request, fallback: undefined };
   try {
     if (resolvedService === "gemini_omni") {
@@ -175,6 +177,11 @@ async function generateVideoUnqueued(
     if (resolvedService === "comfyui") {
       return await withVideoGenerationDeadline(request.signal, VIDEO_GEN_TIMEOUT, (signal) =>
         generateComfyUiVideo(baseUrl, { ...primaryRequest, signal }),
+      );
+    }
+    if (resolvedService === "swarmui") {
+      return await withVideoGenerationDeadline(request.signal, VIDEO_GEN_TIMEOUT, (signal) =>
+        generateSwarmUiVideo(baseUrl, apiKey, { ...primaryRequest, signal }),
       );
     }
     throw new Error(`Unsupported video generation service: ${resolvedService || serviceHint || source}`);
@@ -307,6 +314,9 @@ function normalizeVideoService(value: string): string {
   if (normalized === "comfyui" || normalized === "comfy-ui") {
     return "comfyui";
   }
+  if (normalized === "swarmui" || normalized === "swarm-ui") {
+    return "swarmui";
+  }
   return normalized;
 }
 
@@ -365,7 +375,13 @@ export function resolveComfyUiVideoWorkflowPlaceholders(
     VideoGenerationRequest,
     "prompt" | "model" | "durationSeconds" | "ltxDirectorPrompt" | "comfyLoras" | "fps"
   >,
-  runtime: { seed: number; width: number; height: number; referenceImageName?: string },
+  runtime: {
+    seed: number;
+    width: number;
+    height: number;
+    referenceImageName?: string;
+    referenceImageBase64?: string;
+  },
 ): unknown {
   const ltxDirectorPrompt = resolveLtxDirectorPromptInput(request);
   const fps = normalizeComfyUiVideoFps(request.fps);
@@ -385,6 +401,7 @@ export function resolveComfyUiVideoWorkflowPlaceholders(
   Object.assign(replacements, buildComfyUiLoraWorkflowReplacements(request.comfyLoras));
   if (request.model?.trim()) replacements["%model%"] = request.model.trim();
   if (runtime.referenceImageName) replacements["%reference_image_name%"] = runtime.referenceImageName;
+  if (runtime.referenceImageBase64) replacements["%reference_image%"] = runtime.referenceImageBase64;
   return replaceComfyUiVideoPlaceholders(workflow, replacements);
 }
 
@@ -459,6 +476,162 @@ function collectComfyUiVideoFiles(entry: ComfyUiHistoryEntry): ComfyUiOutputFile
     }
   }
   return files;
+}
+
+function swarmUiVideoHeaders(apiKey: string): Record<string, string> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const token = apiKey.trim();
+  if (token) headers.Cookie = `swarm_token=${encodeURIComponent(token)}`;
+  return headers;
+}
+
+function swarmUiVideoApiError(value: unknown): string | null {
+  const record = asRecord(value);
+  const error = readString(record.error);
+  const errorId = readString(record.error_id);
+  return error || errorId;
+}
+
+async function createSwarmUiVideoSession(baseUrl: string, apiKey: string, signal?: AbortSignal): Promise<string> {
+  const response = await comfyUiVideoFetch(`${baseUrl}/API/GetNewSession`, {
+    method: "POST",
+    headers: swarmUiVideoHeaders(apiKey),
+    body: "{}",
+    signal,
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`SwarmUI session request failed (${response.status}): ${formatProviderError(text)}`);
+  }
+  let result: unknown;
+  try {
+    result = JSON.parse(text) as unknown;
+  } catch {
+    throw new Error("SwarmUI session request returned invalid JSON");
+  }
+  const apiError = swarmUiVideoApiError(result);
+  if (apiError) throw new Error(`SwarmUI API error: ${apiError}`);
+  const sessionId = readString(asRecord(result).session_id);
+  if (!sessionId) throw new Error("SwarmUI did not return a session_id");
+  return sessionId;
+}
+
+export function buildSwarmUiVideoGenerationBody(
+  request: VideoGenerationRequest,
+  sessionId: string,
+  seed = Math.floor(Math.random() * 2 ** 32),
+): Record<string, unknown> {
+  const workflowText = request.comfyWorkflow?.trim();
+  if (!workflowText) throw new Error("SwarmUI video generation requires an API-format workflow");
+  if (/%reference_image_name(?:_0[1-4])?%/.test(workflowText)) {
+    throw new Error(
+      "SwarmUI workflows must use %reference_image% placeholders; backend-local filenames cannot be distributed safely.",
+    );
+  }
+  let workflow: unknown;
+  try {
+    workflow = JSON.parse(workflowText) as unknown;
+  } catch {
+    throw new Error("Invalid SwarmUI video workflow JSON");
+  }
+
+  const landscape =
+    request.resolution === "480p"
+      ? { width: 832, height: 480 }
+      : request.resolution === "1080p"
+        ? { width: 1920, height: 1080 }
+        : { width: 1280, height: 720 };
+  const dimensions = request.aspectRatio === "9:16" ? { width: landscape.height, height: landscape.width } : landscape;
+  const resolvedWorkflow = resolveComfyUiVideoWorkflowPlaceholders(workflow, request, {
+    seed,
+    width: dimensions.width,
+    height: dimensions.height,
+    referenceImageBase64: request.referenceImage ? stripDataUrl(request.referenceImage.base64) : undefined,
+  });
+  return {
+    session_id: sessionId,
+    images: 1,
+    donotsave: true,
+    prompt: request.prompt,
+    width: dimensions.width,
+    height: dimensions.height,
+    seed,
+    ...(request.model?.trim() ? { model: request.model.trim() } : {}),
+    comfyworkflowraw: JSON.stringify(resolvedWorkflow),
+  };
+}
+
+export function parseSwarmUiVideoReference(value: unknown): string {
+  const apiError = swarmUiVideoApiError(value);
+  if (apiError) throw new Error(`SwarmUI API error: ${apiError}`);
+  const outputs = asRecord(value).images;
+  if (!Array.isArray(outputs)) throw new Error("SwarmUI did not return an images array");
+  const video = outputs.find(
+    (candidate): candidate is string =>
+      typeof candidate === "string" &&
+      (candidate.trim().toLowerCase().split(/[?#]/u, 1)[0]?.endsWith(".mp4") === true ||
+        candidate.trim().toLowerCase().startsWith("data:video/mp4")),
+  );
+  if (!video) throw new Error("SwarmUI completed without an MP4 video output");
+  return video.trim();
+}
+
+async function generateSwarmUiVideo(
+  baseUrl: string,
+  apiKey: string,
+  request: VideoGenerationRequest,
+): Promise<VideoGenerationResult> {
+  const base = baseUrl.replace(/\/+$/, "");
+  const sessionId = await createSwarmUiVideoSession(base, apiKey, request.signal);
+  const body = buildSwarmUiVideoGenerationBody(request, sessionId);
+  const debugBody: Record<string, unknown> = { ...body, session_id: "[session]" };
+  if (request.referenceImage && typeof debugBody.comfyworkflowraw === "string") {
+    debugBody.comfyworkflowraw = debugBody.comfyworkflowraw.replaceAll(
+      stripDataUrl(request.referenceImage.base64),
+      "[redacted reference image]",
+    );
+  }
+  logDebugOverride(
+    request.debugMode === true || isDebugAgentsEnabled(),
+    "[video-gen/swarmui] final request payload:\n%s",
+    JSON.stringify(debugBody, null, 2),
+  );
+
+  const response = await comfyUiVideoFetch(
+    `${base}/API/GenerateText2Image`,
+    {
+      method: "POST",
+      headers: swarmUiVideoHeaders(apiKey),
+      body: JSON.stringify(body),
+      signal: request.signal,
+    },
+    MAX_VIDEO_JSON_RESPONSE_BYTES,
+  );
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`SwarmUI video generation failed (${response.status}): ${formatProviderError(text)}`);
+  }
+  let result: unknown;
+  try {
+    result = JSON.parse(text) as unknown;
+  } catch {
+    throw new Error("SwarmUI video generation returned invalid JSON");
+  }
+  const videoReference = parseSwarmUiVideoReference(result);
+  let videoBuffer: Buffer;
+  if (videoReference.startsWith("data:video/mp4")) {
+    videoBuffer = Buffer.from(stripDataUrl(videoReference), "base64");
+  } else {
+    const videoResponse = await comfyUiVideoFetch(
+      new URL(videoReference, `${base}/`),
+      { headers: swarmUiVideoHeaders(apiKey), signal: request.signal },
+      MAX_VIDEO_RESPONSE_BYTES,
+    );
+    if (!videoResponse.ok) throw new Error(`SwarmUI video fetch failed (${videoResponse.status})`);
+    videoBuffer = Buffer.from(await videoResponse.arrayBuffer());
+  }
+  if (!isMp4Buffer(videoBuffer)) throw new Error("SwarmUI returned a non-MP4 video output");
+  return { base64: videoBuffer.toString("base64"), mimeType: "video/mp4", ext: "mp4" };
 }
 
 async function generateComfyUiVideo(baseUrl: string, request: VideoGenerationRequest): Promise<VideoGenerationResult> {

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -640,6 +640,13 @@ export const VIDEO_GENERATION_SOURCES: VideoGenSource[] = [
     defaultBaseUrl: "http://127.0.0.1:8188",
     requiresApiKey: false,
   },
+  {
+    id: "swarmui",
+    name: "SwarmUI",
+    description: "Swarm-managed video generation through distributed ComfyUI workflows.",
+    defaultBaseUrl: "http://127.0.0.1:7801",
+    requiresApiKey: false,
+  },
 ];
 
 export const IMAGE_GENERATION_SOURCES: ImageGenSource[] = [
@@ -895,6 +902,7 @@ const VIDEO_GEN_MODELS: KnownModel[] = [
 export function inferVideoSource(model: string, baseUrl: string): string {
   const m = model.toLowerCase();
   const u = baseUrl.toLowerCase();
+  if (m === "swarmui" || u.includes(":7801") || u.includes("swarmui")) return "swarmui";
   if (m === "comfyui" || u.includes(":8188") || u.includes("comfyui")) return "comfyui";
   if (m === "atlas" || u.includes("atlascloud.ai")) return "atlas";
   if (m === "seedance" || m.startsWith("seedance-") || u.includes("seedance2.ai")) return "seedance";

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -284,11 +284,16 @@ import {
   ATLAS_CLOUD_IMAGE_MODELS,
   ATLAS_CLOUD_VIDEO_MODELS,
   IMAGE_GENERATION_SOURCES,
+  VIDEO_GENERATION_SOURCES,
   ZAI_IMAGE_MODELS,
   inferImageSource,
   inferVideoSource,
 } from "../../packages/shared/src/constants/model-lists.js";
 import { resolveSceneVideoPrompt } from "../../packages/server/src/services/video/scene-video-prompt-review.js";
+import {
+  buildSwarmUiVideoGenerationBody,
+  parseSwarmUiVideoReference,
+} from "../../packages/server/src/services/video/video-generation.js";
 import {
   buildLorebookEntryCreateRow,
   buildPersonaCreateRow,
@@ -3018,6 +3023,63 @@ assert.deepEqual(JSON.parse(String(swarmUiBody.comfyworkflowraw)), {
 });
 assert.equal(parseSwarmUiImageReference({ images: ["View/local/raw/output.png"] }), "View/local/raw/output.png");
 assert.throws(() => parseSwarmUiImageReference({ error: "queue unavailable" }), /queue unavailable/u);
+assert.equal(inferVideoSource("", "http://127.0.0.1:7801"), "swarmui");
+assert.ok(VIDEO_GENERATION_SOURCES.some((source) => source.id === "swarmui"));
+const swarmUiVideoBody = buildSwarmUiVideoGenerationBody(
+  {
+    prompt: "a blue fox waves",
+    durationSeconds: 5,
+    aspectRatio: "9:16",
+    resolution: "720p",
+    model: "wan-video.safetensors",
+    referenceImage: { base64: "data:image/png;base64,cG5n", mimeType: "image/png" },
+    comfyWorkflow: JSON.stringify({
+      "1": {
+        class_type: "VideoNode",
+        inputs: {
+          prompt: "%prompt%",
+          width: "%width%",
+          height: "%height%",
+          frames: "%length%",
+          fps: "%fps%",
+          image: "%reference_image%",
+        },
+      },
+    }),
+    fps: 16,
+  },
+  "video-session",
+  42,
+);
+assert.equal(swarmUiVideoBody.session_id, "video-session");
+assert.equal(swarmUiVideoBody.width, 720);
+assert.equal(swarmUiVideoBody.height, 1280);
+assert.deepEqual(JSON.parse(String(swarmUiVideoBody.comfyworkflowraw)), {
+  "1": {
+    class_type: "VideoNode",
+    inputs: {
+      prompt: "a blue fox waves",
+      width: 720,
+      height: 1280,
+      frames: 80,
+      fps: 16,
+      image: "cG5n",
+    },
+  },
+});
+assert.equal(parseSwarmUiVideoReference({ images: ["View/local/raw/output.mp4"] }), "View/local/raw/output.mp4");
+assert.throws(
+  () => buildSwarmUiVideoGenerationBody(
+    {
+      prompt: "video",
+      durationSeconds: 5,
+      aspectRatio: "16:9",
+      comfyWorkflow: '{"image":"%reference_image_name%"}',
+    },
+    "video-session",
+  ),
+  /must use %reference_image%/u,
+);
 assert.deepEqual(
   ZAI_IMAGE_MODELS.map((model) => model.id),
   ["glm-image", "cogview-4-250304"],
@@ -3628,6 +3690,11 @@ const chatRowPeekSource = readFileSync(
 assert.match(assignedSweepChatAreaSource, /export const ChatArea = memo\(function ChatArea/u);
 assert.doesNotMatch(assignedSweepChatAreaSource, /updateMessage(?:Extra)?\.mutate/u);
 assert.match(chatMessageSource, /mari-chrome-accent-progress mari-accent-animated mb-1\.5 h-0\.5/u);
+assert.match(
+  chatMessageSource,
+  /isConversationStart && \(\s*<div className="mb-1 w-full px-1">/u,
+  "Roleplay New Start dividers must span user and assistant message bodies",
+);
 assert.match(chatMessageSource, /pointer-events-auto relative z-30 flex h-11 w-11/u);
 assert.match(chatRowPeekSource, /mari-chrome-accent-text-muted mari-accent-animated text-\[0\.6875rem\]/u);
 assert.match(assignedSweepChatAreaSource, /mari-chrome-accent-text-muted mari-accent-animated max-w-sm text-xs/u);
@@ -6634,7 +6701,7 @@ try {
   );
   assert.match(
     connectionEditorSource,
-    /const swarmUiWorkflowError =\s*selectedImageService === "swarmui"[\s\S]{0,180}%reference_image_name/u,
+    /const swarmUiWorkflowError =\s*\(selectedImageService === "swarmui" \|\| selectedVideoProvider === "swarmui"\)[\s\S]{0,180}%reference_image_name/u,
     "SwarmUI workflow validation must reject backend-local reference-image filenames before save",
   );
   assert.match(connectionEditorSource, /if \(swarmUiWorkflowError\) \{[\s\S]{0,180}throw new Error/u);

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -719,6 +719,7 @@ import {
   lorebookSimilarityBaseline,
 } from "../../packages/server/src/services/lorebook/embeddings.js";
 import {
+  filterRelevantLorebooks,
   resolveAndBudgetActivatedLorebookEntries,
   scopeLorebookScanResultToCharacterContext,
 } from "../../packages/server/src/services/lorebook/index.js";
@@ -884,6 +885,49 @@ const keywordOptions = {
 };
 
 const cases: RegressionCase[] = [
+  {
+    name: "explicitly selected persona lorebooks remain usable outside their owner persona",
+    run() {
+      const personaLinkedBook = {
+        id: "persona-lorebook",
+        name: "Persona lorebook",
+        enabled: true,
+        scanDepth: 2,
+        tokenBudget: 2048,
+        entryLimit: 0,
+        recursiveScanning: false,
+        maxRecursionDepth: 3,
+        vectorScoreThreshold: 0.35,
+        vectorMaxResults: 8,
+        isGlobal: false,
+        characterId: null,
+        characterIds: [],
+        personaId: "owner-persona",
+        personaIds: ["owner-persona"],
+        chatId: null,
+        scope: { mode: "all" as const, chatIds: [] },
+        sourceAgentId: null,
+      } satisfies Parameters<typeof filterRelevantLorebooks>[0][number];
+
+      assert.deepEqual(
+        filterRelevantLorebooks([personaLinkedBook], {
+          personaId: "different-persona",
+          activeLorebookIds: [personaLinkedBook.id],
+        }),
+        [personaLinkedBook],
+      );
+      assert.deepEqual(filterRelevantLorebooks([personaLinkedBook], { personaId: "different-persona" }), []);
+      assert.deepEqual(filterRelevantLorebooks([personaLinkedBook], { personaId: "owner-persona" }), [personaLinkedBook]);
+      const lorebookStorageSource = readFileSync(
+        new URL("../../packages/server/src/services/storage/lorebooks.storage.ts", import.meta.url),
+        "utf8",
+      );
+      assert.match(
+        lorebookStorageSource,
+        /function activeLorebookMatchesFilters[\s\S]{0,220}return filters\.activeLorebookIds\?\.includes\(book\.id\) === true;/u,
+      );
+    },
+  },
   {
     name: "Storyboard chat settings override agent defaults for Game and Roleplay",
     async run() {


### PR DESCRIPTION
## Linked issue

Closes #4885
Closes #4886
Closes #4887

## Why this change

- Add the missing SwarmUI video path so an existing SwarmUI connection can run distributed ComfyUI video workflows through the same queue used for images.
- Keep the Roleplay New Start boundary visually consistent for user and assistant messages.
- Let a lorebook that the user explicitly selects remain usable even when it is attached to a different persona.

## What changed

- Added SwarmUI to video connection selection, inference, model discovery, local endpoint policy, authenticated session creation, workflow placeholder substitution, fallback routing, sprite/gallery/game runtime resolution, and MP4 retrieval.
- Made the Roleplay New Start marker fill the available message-body width.
- Made explicit active lorebook IDs override character, persona, and chat ownership links while retaining enabled, scope, and exclusion gates.
- Added English localization, Unreleased changelog entries, and focused regression coverage.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Automated verification notes

- `pnpm check` passed locally.
- `pnpm regression:prompt` passed, including positive and negative persona-lorebook selection cases.
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts` passed, including SwarmUI video body, placeholder, inference, MP4 response, and Roleplay divider guards.
- Client and server lint passed after the final patch.
- `pnpm smoke:ui` completed 330 cases: 206 passed, 104 skipped, and 20 unrelated staging-baseline failures across Character library availability, Professor Mari Home fixtures, Achievements fixture data, agent catalog availability, and one mobile transcript fixture. None touch this patch.
- `pnpm regression:roleplay` is blocked by an unrelated stale baseline assertion expecting UI persistence version 90 on current staging.

### Manual verification notes

- Manual provider verification requires a running SwarmUI video workflow and remains for maintainer testing.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

The Unreleased changelog is updated. No user-facing documentation page or version metadata changed.

## UI evidence (if applicable)

- The Roleplay change is a one-class width correction covered by the focused source regression; no screenshot is attached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SwarmUI support for video generation, including local connections, workflow validation, reference images, model discovery, and video downloads.
  - Added guidance for configuring SwarmUI video workflows.
  - Explicitly selected persona-linked lorebooks now remain available regardless of ownership links.

- **Bug Fixes**
  - Fixed Roleplay New Start dividers so they span the full message width.
  - Improved video workflow placeholder handling and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->