### PR TITLE
Centralize Agent result types and hydrate Sidecar trackers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept Sidecar tracker counts and bulk local assignment current when capability Agent packages hydrate or refresh, and centralized Agent result-type admission behind one shared compatibility-tested vocabulary.
 - Kept explicitly selected persona-linked lorebooks usable outside their owner persona while preserving automatic owner matching and chat exclusions (#4887).
 - Extended the Roleplay New Start divider across the full message body for user messages as well as assistant messages (#4886).
 - Applied Game image prompt overrides and the selected Illustrator prompt template to Game prompt-director requests, including manual portraits that use the Illustrator agent's image connection and explicitly customized prompt settings when the general dynamic-prompt toggle is off (#4880).

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -33,12 +33,15 @@ import {
 import { handleFolderRenameKeyDown, useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { useTouchFolderDrag } from "../../hooks/use-touch-folder-drag";
 import { useAgentConfigs, useCreateAgent, useUpdateAgent } from "../../hooks/use-agents";
-import { useInstalledCapabilityPackages } from "../../hooks/use-capability-packages";
+import {
+  selectVisibleTrackerCapabilityAgents,
+  useCapabilityAgentRegistry,
+  useInstalledCapabilityPackages,
+} from "../../hooks/use-capability-packages";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore, type ConnectionPanelSort } from "../../stores/ui.store";
 import { GEMMA_RESTART_MESSAGE, useSidecarStore } from "../../stores/sidecar.store";
 import {
-  BUILT_IN_AGENTS,
   LOCAL_SIDECAR_CONNECTION_ID,
   getDefaultAgentPrompt,
   type ConnectionFolder,
@@ -199,6 +202,7 @@ function getDroppedConnectionIds(event: DragEvent<HTMLElement>, fallbackId: stri
 function SidecarCard() {
   const { t: localizeUi } = useUiTranslation();
   const { data: agentConfigs } = useAgentConfigs();
+  const { data: capabilityAgents } = useCapabilityAgentRegistry();
   const { data: installedCapabilityPackages } = useInstalledCapabilityPackages();
   const createAgent = useCreateAgent();
   const updateAgentConnection = useUpdateAgent();
@@ -250,8 +254,8 @@ function SidecarCard() {
   const nativeToolLabel =
     config.backend === "llama_cpp" ? ` • Native tools ${config.enableNativeToolCalls ? "on" : "off"}` : "";
   const trackerAgents = useMemo(
-    () => BUILT_IN_AGENTS.filter((agent) => agent.category === "tracker" && !agent.libraryHidden),
-    [],
+    () => selectVisibleTrackerCapabilityAgents(capabilityAgents),
+    [capabilityAgents],
   );
   const trackerLocalCount = useMemo(() => {
     const configs = (agentConfigs ?? []) as Array<{ type: string; connectionId: string | null }>;

--- a/packages/client/src/hooks/use-capability-packages.ts
+++ b/packages/client/src/hooks/use-capability-packages.ts
@@ -50,6 +50,13 @@ export function useCapabilityAgentRegistry(enabled = true) {
   return query;
 }
 
+/** Select visible tracker manifests from the React Query registry result. */
+export function selectVisibleTrackerCapabilityAgents(
+  agents: BuiltInAgentManifest[] | undefined,
+): BuiltInAgentManifest[] {
+  return (agents ?? []).filter((agent) => agent.category === "tracker" && !agent.libraryHidden);
+}
+
 /**
  * Installed packages that can provide a game's EXPERIENCE: runtime-ready, declaring the `game-surface`
  * slot, and carrying the client entrypoint that renders it. Shared so the setup chooser can only ever

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -16,6 +16,7 @@ import type {
   GenerationParameterSendMap,
 } from "@marinara-engine/shared";
 import {
+  AGENT_RESULT_TYPE_VALUES,
   characterTrackerLockKey,
   compactQuestProgressForContext,
   customAgentHasCapability,
@@ -2866,36 +2867,7 @@ const AGENT_RESULT_TYPE_MAP: Record<string, AgentResultType> = {
   "about-me-keeper": "about_me_update",
 };
 
-const AGENT_RESULT_TYPES = new Set<AgentResultType>([
-  "game_state_update",
-  "text_rewrite",
-  "sprite_change",
-  "echo_message",
-  "quest_update",
-  "image_prompt",
-  "context_injection",
-  "continuity_check",
-  "director_event",
-  "lorebook_update",
-  "character_card_update",
-  "background_change",
-  "character_tracker_update",
-  "persona_stats_update",
-  "custom_tracker_update",
-  "spotify_control",
-  "youtube_control",
-  "local_music_control",
-  "haptic_command",
-  "cyoa_choices",
-  "secret_plot",
-  "game_master_narration",
-  "party_action",
-  "game_map_update",
-  "game_state_transition",
-  "prompt_patch",
-  "frontend_theme_update",
-  "about_me_update",
-]);
+const AGENT_RESULT_TYPES = new Set<AgentResultType>(AGENT_RESULT_TYPE_VALUES);
 
 const TEXT_RESULT_TYPES = new Set<AgentResultType>(["context_injection", "director_event"]);
 

--- a/packages/shared/src/schemas/agent.schema.ts
+++ b/packages/shared/src/schemas/agent.schema.ts
@@ -3,40 +3,11 @@
 // ──────────────────────────────────────────────
 import { z } from "zod";
 import { MAX_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH } from "../constants/agent-activation.js";
-import { CUSTOM_AGENT_CAPABILITY_IDS } from "../types/agent.js";
+import { AGENT_RESULT_TYPE_VALUES, CUSTOM_AGENT_CAPABILITY_IDS } from "../types/agent.js";
 
 export const agentPhaseSchema = z.enum(["pre_generation", "parallel", "post_processing"]);
 
-export const agentResultTypeSchema = z.enum([
-  "game_state_update",
-  "text_rewrite",
-  "sprite_change",
-  "echo_message",
-  "quest_update",
-  "image_prompt",
-  "context_injection",
-  "continuity_check",
-  "director_event",
-  "lorebook_update",
-  "character_card_update",
-  "background_change",
-  "character_tracker_update",
-  "persona_stats_update",
-  "custom_tracker_update",
-  "spotify_control",
-  "youtube_control",
-  "local_music_control",
-  "haptic_command",
-  "cyoa_choices",
-  "secret_plot",
-  "game_master_narration",
-  "party_action",
-  "game_map_update",
-  "game_state_transition",
-  "prompt_patch",
-  "frontend_theme_update",
-  "about_me_update",
-]);
+export const agentResultTypeSchema = z.enum(AGENT_RESULT_TYPE_VALUES);
 
 export const customAgentActivationSettingsSchema = z.object({
   activationKeywords: z.array(z.string().trim().min(1)).max(100).optional(),

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -34,36 +34,40 @@ export function normalizeAgentPhaseForType(
   return normalizeAgentPhaseValue(configuredPhase, fallback);
 }
 
+/** Ordered vocabulary of result types that agents can produce. */
+export const AGENT_RESULT_TYPE_VALUES = [
+  "game_state_update",
+  "text_rewrite",
+  "sprite_change",
+  "echo_message",
+  "quest_update",
+  "image_prompt",
+  "context_injection",
+  "continuity_check",
+  "director_event",
+  "lorebook_update",
+  "character_card_update",
+  "background_change",
+  "character_tracker_update",
+  "persona_stats_update",
+  "custom_tracker_update",
+  "spotify_control",
+  "youtube_control",
+  "local_music_control",
+  "haptic_command",
+  "cyoa_choices",
+  "secret_plot",
+  "game_master_narration",
+  "party_action",
+  "game_map_update",
+  "game_state_transition",
+  "prompt_patch",
+  "frontend_theme_update",
+  "about_me_update",
+] as const;
+
 /** The result type an agent can produce. */
-export type AgentResultType =
-  | "game_state_update"
-  | "text_rewrite"
-  | "sprite_change"
-  | "echo_message"
-  | "quest_update"
-  | "image_prompt"
-  | "context_injection"
-  | "continuity_check"
-  | "director_event"
-  | "lorebook_update"
-  | "character_card_update"
-  | "background_change"
-  | "character_tracker_update"
-  | "persona_stats_update"
-  | "custom_tracker_update"
-  | "spotify_control"
-  | "youtube_control"
-  | "local_music_control"
-  | "haptic_command"
-  | "cyoa_choices"
-  | "secret_plot"
-  | "game_master_narration"
-  | "party_action"
-  | "game_map_update"
-  | "game_state_transition"
-  | "prompt_patch"
-  | "frontend_theme_update"
-  | "about_me_update";
+export type AgentResultType = (typeof AGENT_RESULT_TYPE_VALUES)[number];
 
 /** Configuration for a single agent. */
 export interface AgentConfig {

--- a/scripts/regressions/agent-registry-hydration.regression.ts
+++ b/scripts/regressions/agent-registry-hydration.regression.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import { replaceBuiltInAgentDefinitions, type BuiltInAgentManifest } from "../../packages/shared/dist/index.js";
 import { buildRoleplayAgentSettingsOrder } from "../../packages/client/src/lib/agent-settings-order.js";
+import { selectVisibleTrackerCapabilityAgents } from "../../packages/client/src/hooks/use-capability-packages.js";
 import { isReviewableWriterAgentType } from "../../packages/server/src/services/generation/runtime-agent-sections.js";
 
 const manifests: BuiltInAgentManifest[] = [
@@ -110,5 +112,69 @@ const activeSettingsOrder = ["writer", "tracker", "misc"].flatMap((category) =>
     .map((agent) => agent.id),
 );
 assert.deepEqual(activeSettingsOrder, menuOrder, "Roleplay quick links and active settings must share one order");
+
+// Connections can mount before this query resolves. It must use the React Query
+// result, rather than reading the mutable shared registry that is already hydrated.
+assert.deepEqual(
+  selectVisibleTrackerCapabilityAgents(undefined),
+  [],
+  "Connections must show no tracker agents until the capability-agent query hydrates",
+);
+assert.deepEqual(
+  selectVisibleTrackerCapabilityAgents(manifests).map((agent) => agent.id),
+  ["late-tracker"],
+  "Connections must include hydrated visible trackers and exclude hidden agents",
+);
+
+const refreshedManifests = manifests.map((agent) =>
+  agent.id === "late-tracker" ? { ...agent, id: "refreshed-tracker", name: "Refreshed tracker" } : agent,
+);
+assert.deepEqual(
+  selectVisibleTrackerCapabilityAgents(refreshedManifests).map((agent) => agent.id),
+  ["refreshed-tracker"],
+  "Connections must use refreshed capability-agent definitions while it remains mounted",
+);
+
+const connectionsPanelSource = await readFile(
+  new URL("../../packages/client/src/components/panels/ConnectionsPanel.tsx", import.meta.url),
+  "utf8",
+);
+const sidecarCardStart = connectionsPanelSource.indexOf("function SidecarCard()");
+const sidecarCardEnd = connectionsPanelSource.indexOf("\nfunction connectionMatchesSearch", sidecarCardStart);
+assert.ok(sidecarCardStart >= 0 && sidecarCardEnd > sidecarCardStart, "Connections must retain the Sidecar card");
+const sidecarCardSource = connectionsPanelSource.slice(sidecarCardStart, sidecarCardEnd);
+assert.match(
+  sidecarCardSource,
+  /const \{ data: capabilityAgents \} = useCapabilityAgentRegistry\(\);/u,
+  "Connections must subscribe to React-visible capability-agent query data",
+);
+assert.match(
+  sidecarCardSource,
+  /const trackerAgents = useMemo\(\s*\(\) => selectVisibleTrackerCapabilityAgents\(capabilityAgents\),\s*\[capabilityAgents\],\s*\);/u,
+  "Connections must recompute visible trackers when capability-agent query data changes",
+);
+assert.match(
+  sidecarCardSource,
+  /const trackerLocalCount = useMemo\(\(\) => \{[\s\S]*?return trackerAgents\.filter\([\s\S]*?\}, \[agentConfigs, trackerAgents\]\);/u,
+  "the Sidecar count must consume the reactive tracker list",
+);
+const assignHandlerStart = sidecarCardSource.indexOf("const handleAssignTrackersToLocal = async () => {");
+const assignHandlerEnd = sidecarCardSource.indexOf("\n  const handleModelLoadToggle", assignHandlerStart);
+assert.ok(assignHandlerStart >= 0 && assignHandlerEnd > assignHandlerStart, "Connections must retain assign-all handling");
+assert.match(
+  sidecarCardSource.slice(assignHandlerStart, assignHandlerEnd),
+  /trackerAgents\.map\(async \(agent\) => \{/u,
+  "assign-all must consume the same reactive tracker list",
+);
+assert.match(
+  sidecarCardSource,
+  /onClick=\{\(\) => void handleAssignTrackersToLocal\(\)\}/u,
+  "the assign-all button must invoke the reactive tracker handler",
+);
+assert.match(
+  sidecarCardSource,
+  /\{trackerLocalCount\}\/\{trackerAgents\.length\}/u,
+  "the rendered Sidecar count must use the reactive assigned and total tracker values",
+);
 
 console.info("Agent registry hydration regression passed.");

--- a/scripts/regressions/agent-runtime.regression.ts
+++ b/scripts/regressions/agent-runtime.regression.ts
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
-import { executeAgent, executeAgentBatch } from "../../packages/server/src/services/agents/agent-executor.js";
+import {
+  executeAgent,
+  executeAgentBatch,
+  resolveAgentResultType,
+} from "../../packages/server/src/services/agents/agent-executor.js";
 import { createAgentPipeline, type ResolvedAgent } from "../../packages/server/src/services/agents/agent-pipeline.js";
 import { resolveAgentPipelineAgents } from "../../packages/server/src/services/generation/agent-resolution.js";
 import { buildLlamaArgs } from "../../packages/server/src/services/sidecar/sidecar-launch-plan.js";
@@ -9,7 +13,8 @@ import {
   type ChatMessage,
   type ChatOptions,
 } from "../../packages/server/src/services/llm/base-provider.js";
-import type { AgentContext } from "../../packages/shared/src/types/agent.js";
+import { agentResultTypeSchema } from "../../packages/shared/src/schemas/agent.schema.js";
+import { AGENT_RESULT_TYPE_VALUES, type AgentContext } from "../../packages/shared/src/types/agent.js";
 
 class RecordingProvider extends BaseLLMProvider {
   calls = 0;
@@ -59,6 +64,73 @@ const context: AgentContext = {
   chatSummary: null,
   streaming: false,
 };
+
+// This test oracle intentionally duplicates the public compatibility contract so
+// coordinated production changes cannot make a breaking vocabulary edit invisible.
+const EXPECTED_AGENT_RESULT_TYPE_VALUES = [
+  "game_state_update",
+  "text_rewrite",
+  "sprite_change",
+  "echo_message",
+  "quest_update",
+  "image_prompt",
+  "context_injection",
+  "continuity_check",
+  "director_event",
+  "lorebook_update",
+  "character_card_update",
+  "background_change",
+  "character_tracker_update",
+  "persona_stats_update",
+  "custom_tracker_update",
+  "spotify_control",
+  "youtube_control",
+  "local_music_control",
+  "haptic_command",
+  "cyoa_choices",
+  "secret_plot",
+  "game_master_narration",
+  "party_action",
+  "game_map_update",
+  "game_state_transition",
+  "prompt_patch",
+  "frontend_theme_update",
+  "about_me_update",
+] as const;
+
+assert.deepEqual(
+  AGENT_RESULT_TYPE_VALUES,
+  EXPECTED_AGENT_RESULT_TYPE_VALUES,
+  "agent result vocabulary must retain its exact public values and order",
+);
+assert.deepEqual(
+  agentResultTypeSchema.options,
+  EXPECTED_AGENT_RESULT_TYPE_VALUES,
+  "agent result schema must retain the public vocabulary order",
+);
+assert.equal(
+  agentResultTypeSchema.safeParse("unrecognized_result_type").success,
+  false,
+  "agent result schema must reject unknown values",
+);
+for (const resultType of AGENT_RESULT_TYPE_VALUES) {
+  assert.equal(agentResultTypeSchema.safeParse(resultType).success, true, `${resultType} must be schema-accepted`);
+  assert.equal(
+    resolveAgentResultType({ type: "custom-agent", settings: { resultType } }),
+    resultType,
+    `${resultType} must be runtime-admitted`,
+  );
+}
+assert.equal(
+  resolveAgentResultType({ type: "world-state", settings: { resultType: "unrecognized_result_type" } }),
+  "game_state_update",
+  "an unknown configured result type should retain its built-in mapping fallback",
+);
+assert.equal(
+  resolveAgentResultType({ type: "custom-agent", settings: { resultType: "unrecognized_result_type" } }),
+  "context_injection",
+  "an unknown configured result type should fall back to context injection when unmapped",
+);
 
 const defaultTemperatureProvider = new RecordingProvider();
 await executeAgent(makeAgent("temperature-default"), context, defaultTemperatureProvider, "agent-model");


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #4889

## Why this change

- Connections could mount before capability Agent hydration and retain a stale Sidecar tracker list because it memoized the mutable built-in registry once.
- The ordered Agent result-type vocabulary had three handwritten production owners, making future additions or compatibility changes easier to apply inconsistently.

## What changed

- Added `AGENT_RESULT_TYPE_VALUES` as the sole production vocabulary owner and derived `AgentResultType`, the Zod enum, and executor admission from it.
- Preserved all 28 values, order, built-in mappings, music/HTML overrides, and mapped/unmapped unknown-value fallbacks.
- Independently pinned the ordered compatibility vocabulary in the runtime regression so accidental removals, substitutions, additions, or reorders fail visibly while intentional changes remain possible through an explicit test update.
- Added a visible-tracker selector over React Query capability-Agent data and subscribed `SidecarCard` to hydration/refresh updates.
- Kept displayed assigned/total counts and bulk local assignment on the same current visible tracker list, excluding hidden trackers.
- Added focused hydration/refresh and production-wiring regression coverage.
- Added a concise `[Unreleased]` changelog entry.

## Validation

The checkboxes remain intentionally unchecked for human confirmation even where local proof exists.

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Recorded local proof

- `pnpm check` — passed on final prepared commit `9b1a802185cc54a1e42e6a341ba2778c77219a08`.
- `pnpm regression:agent-runtime` — passed.
- `pnpm regression:agent-registry-hydration` — passed.
- `git diff --check` — passed.
- Negative controls:
  - disabling the capability-Agent query failed the intended subscription assertion;
  - replacing the rendered tracker count with `{0}/{0}` failed the intended count assertion;
  - swapping the first two production result-type values failed the independent ordered-vocabulary assertion.
- Independent code review and four-lens Bunny Review are closed with no current findings.

### Manual verification notes

- Started an isolated disposable headed Edge session from the feature worktree.
- Dismissed onboarding, opened Connections, and inspected the Local Model card on desktop and at 390×844 mobile.
- `/api/capability-packages/agents`, `/api/capability-packages/installed`, agent/config, connection, and Sidecar status requests returned 200.
- Browser console errors: 0; failed non-static requests: 0.
- The isolated runtime had no downloaded local Sidecar model, so the conditional tracker count and assign-all control were not visible. Their changed wiring is covered by the deterministic hydration regression, production-source contracts, negative controls, and direct query/invalidation inspection.
- No container validation was run. Light/dark theme behavior, error states, and a fully downloaded local model were not manually exercised; the production patch does not change styling or layout.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

`CHANGELOG.md` is updated. No version bump or translated-document change is required. Checkboxes remain for human confirmation.

## UI evidence (if applicable)

No screenshots or recordings are attached. The change repairs data sourcing without visual redesign; bounded headed desktop/mobile proof is recorded above.

## Risks and known limitations

- The current Sidecar production-wiring guard is intentionally formatting-sensitive static proof. Mounted refresh/click lifecycle hardening is queued separately as `TODO-20260811-001`; it is not a current production defect or submission blocker.
- Intentional future result-type changes must update the test-only compatibility oracle and consider migration/fallback handling when persisted or package-authored values are removed or renamed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tracker counts and bulk assignments now refresh correctly when Agent packages are hydrated or refreshed.
  - Tracker selections consistently reflect currently visible tracker capabilities.
  - Improved compatibility and validation for supported Agent result types.

- **Tests**
  - Added regression coverage for tracker updates before and after hydration.
  - Added validation for supported, unknown, built-in, and custom Agent result types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->