### PR TITLE
docs(card-css): animate opacity, not box-shadow, in the glow example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Rewrote the animated glow in the Card CSS Theming guide example to animate `opacity` on an overlay layer instead of the message bubble's `box-shadow`. Animating `box-shadow` forced a full repaint every frame and could pin a weak GPU; the example now demonstrates the GPU-composited pattern instead (#4897).
 - Matched Feature agent pages to the shared Agent editor chrome and Chroma accent, and correctly recognized their owning package as installed. (#4892)
 - Kept the Your Guide Professor Mari action icon synchronized with its label color.
 - Kept Sidecar tracker counts and bulk local assignment current when capability Agent packages hydrate or refresh, and centralized Agent result-type admission behind one shared compatibility-tested vocabulary.

--- a/docs/appearance/card-css-theming.md
+++ b/docs/appearance/card-css-theming.md
@@ -327,14 +327,16 @@ Paste it whole into **Creator Notes**, then enable **Card Theming** in **Chat Se
 
 ```html
 <style>
-  /* shared keyframe */
+  /* shared keyframe. Animate OPACITY, never box-shadow: box-shadow is a "paint"
+     property, so animating it repaints and re-blurs the whole element every frame
+     (which pins weak GPUs). Animating a layer's opacity is GPU-composited and cheap. */
   @keyframes grimoire-pulse {
     0%,
     100% {
-      box-shadow: 0 0 12px rgba(168, 85, 247, 0.35), inset 0 0 18px rgba(80, 0, 60, 0.5);
+      opacity: 0.35;
     }
     50% {
-      box-shadow: 0 0 24px rgba(220, 38, 120, 0.55), inset 0 0 26px rgba(120, 0, 80, 0.6);
+      opacity: 1;
     }
   }
 
@@ -389,9 +391,25 @@ Paste it whole into **Creator Notes**, then enable **Card Theming** in **Chat Se
       background: linear-gradient(135deg, #1a0a24 0%, #2d0a2e 55%, #3a0a1e 100%);
       border: 1px solid rgba(220, 38, 120, 0.45);
       border-radius: 4px 16px 16px 16px;
-      animation: grimoire-pulse 4s ease-in-out infinite;
       position: relative;
       overflow: hidden;
+      /* a steady outer halo. An element's own box-shadow is not clipped by its own
+         overflow: hidden, so this bloom shows even though message content is clipped. */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+    }
+    /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
+       composited) instead of the bubble's box-shadow (expensive: a full repaint every
+       frame). overflow: hidden clips a child's OUTER shadow, so the pulse rides the inset
+       glow while the halo above stays steady. pointer-events keeps it click-through. */
+    [data-card-css] .mari-message-bubble::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      pointer-events: none;
+      box-shadow: inset 0 0 26px rgba(120, 0, 80, 0.65);
+      animation: grimoire-pulse 4s ease-in-out infinite;
+      will-change: opacity;
     }
     [data-card-css] .mari-message-bubble::before {
       content: "✦";

--- a/docs/appearance/card-css-theming.md
+++ b/docs/appearance/card-css-theming.md
@@ -394,8 +394,10 @@ Paste it whole into **Creator Notes**, then enable **Card Theming** in **Chat Se
       position: relative;
       overflow: hidden;
       /* a steady outer halo. An element's own box-shadow is not clipped by its own
-         overflow: hidden, so this bloom shows even though message content is clipped. */
-      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+         overflow: hidden, so this bloom shows even though message content is clipped.
+         (No inset here: the pulsing inset glow lives on the ::after, so a static inset
+         would stack with it and over-brighten the inner glow.) */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4);
     }
     /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
        composited) instead of the bubble's box-shadow (expensive: a full repaint every


### PR DESCRIPTION
## Linked issue

Related to #4897. This fixes the documented example that triggers the problem; the engine-side scoping fixes (the two reduce toggles) remain tracked in that issue.

## Why this change

- The Card CSS Theming guide's showcase example animates `box-shadow` (`@keyframes grimoire-pulse`) on every roleplay message bubble. `box-shadow` is a paint property, so animating it forces a full repaint and blur recomputation of the bubble on every frame. On a weak/integrated GPU this pins the card (a reporter saw ~53% GPU with fans audible, and 158 fps of continuous repaints in the DevTools FPS meter; Paint flashing lit up the whole message bubble), and any `backdrop-filter` panel layered over it re-blurs too.
- Because this is the flagship "here is everything you can do" example, every creator who copies it inherits the footgun. The example should teach the performant pattern instead.

## What changed

- Reworked the `grimoire-pulse` glow so it animates `opacity` on a full-bleed `::after` overlay instead of the bubble's `box-shadow`. Opacity is GPU-composited, so the pulse costs almost nothing.
- The steady outer halo stays as a static `box-shadow` on the bubble; the pulsing inner glow rides the overlay. `overflow: hidden` is preserved (message content, e.g. inline GIFs, stays clipped to the rounded corners), and the overlay is `pointer-events: none` so it never intercepts clicks.
- Added CSS comments explaining the paint-vs-compositor reason, so the lesson travels with the code.
- Added a CHANGELOG entry.
- Sanitizer-safe: checked against `packages/client/src/lib/card-css.ts` (blocklist model, not allowlist; `opacity`, `pointer-events`, `will-change`, `::after`, and `content: ""` all pass, and the theme-token blocklist is untouched).

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran `pnpm regression:docs` locally: passed (validates doc structure across all 11 languages: en, de, es, fr, hi, ja, ko, pl, pt-br, ru, zh-hans).
- Still needs a human render pass (I could not run the dev server here without colliding with a live install): paste the example into a card, enable Card Theming, and confirm the roleplay bubble still pulses (light + dark), the outer halo shows, and inline image/GIF corners stay clipped.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

Notes: CHANGELOG updated. A companion `docs-i18n` PR mirrors the identical code-block change to all 10 locale copies of `card-css-theming.md` (the CSS block is byte-identical across locales, so no translation is required); link added once opened.

## UI evidence (if applicable)

Docs-only (an example code block). The reporter's DevTools Paint-flashing capture showed the entire message bubble repainting every frame before the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Card CSS Theming guide’s animated glow example.
  - The inner glow now animates overlay opacity while the bubble’s outer halo remains static.
  - Added a changelog entry documenting the correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->