### PR TITLE
[docs-i18n] card-css-theming: mirror the opacity-not-box-shadow glow fix

### DIFF
--- a/de/appearance/card-css-theming.md
+++ b/de/appearance/card-css-theming.md
@@ -327,14 +327,16 @@ Füge das Ganze am Stück in die **Creator Notes** ein und aktiviere dann **Card
 
 ```html
 <style>
-  /* shared keyframe */
+  /* shared keyframe. Animate OPACITY, never box-shadow: box-shadow is a "paint"
+     property, so animating it repaints and re-blurs the whole element every frame
+     (which pins weak GPUs). Animating a layer's opacity is GPU-composited and cheap. */
   @keyframes grimoire-pulse {
     0%,
     100% {
-      box-shadow: 0 0 12px rgba(168, 85, 247, 0.35), inset 0 0 18px rgba(80, 0, 60, 0.5);
+      opacity: 0.35;
     }
     50% {
-      box-shadow: 0 0 24px rgba(220, 38, 120, 0.55), inset 0 0 26px rgba(120, 0, 80, 0.6);
+      opacity: 1;
     }
   }
 
@@ -389,9 +391,25 @@ Füge das Ganze am Stück in die **Creator Notes** ein und aktiviere dann **Card
       background: linear-gradient(135deg, #1a0a24 0%, #2d0a2e 55%, #3a0a1e 100%);
       border: 1px solid rgba(220, 38, 120, 0.45);
       border-radius: 4px 16px 16px 16px;
-      animation: grimoire-pulse 4s ease-in-out infinite;
       position: relative;
       overflow: hidden;
+      /* a steady outer halo. An element's own box-shadow is not clipped by its own
+         overflow: hidden, so this bloom shows even though message content is clipped. */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+    }
+    /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
+       composited) instead of the bubble's box-shadow (expensive: a full repaint every
+       frame). overflow: hidden clips a child's OUTER shadow, so the pulse rides the inset
+       glow while the halo above stays steady. pointer-events keeps it click-through. */
+    [data-card-css] .mari-message-bubble::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      pointer-events: none;
+      box-shadow: inset 0 0 26px rgba(120, 0, 80, 0.65);
+      animation: grimoire-pulse 4s ease-in-out infinite;
+      will-change: opacity;
     }
     [data-card-css] .mari-message-bubble::before {
       content: "✦";

--- a/de/appearance/card-css-theming.md
+++ b/de/appearance/card-css-theming.md
@@ -394,8 +394,10 @@ Füge das Ganze am Stück in die **Creator Notes** ein und aktiviere dann **Card
       position: relative;
       overflow: hidden;
       /* a steady outer halo. An element's own box-shadow is not clipped by its own
-         overflow: hidden, so this bloom shows even though message content is clipped. */
-      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+         overflow: hidden, so this bloom shows even though message content is clipped.
+         (No inset here: the pulsing inset glow lives on the ::after, so a static inset
+         would stack with it and over-brighten the inner glow.) */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4);
     }
     /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
        composited) instead of the bubble's box-shadow (expensive: a full repaint every

--- a/es/appearance/card-css-theming.md
+++ b/es/appearance/card-css-theming.md
@@ -327,14 +327,16 @@ Pégala entera en **Creator Notes**, y luego activa **Card Theming** en **Chat S
 
 ```html
 <style>
-  /* shared keyframe */
+  /* shared keyframe. Animate OPACITY, never box-shadow: box-shadow is a "paint"
+     property, so animating it repaints and re-blurs the whole element every frame
+     (which pins weak GPUs). Animating a layer's opacity is GPU-composited and cheap. */
   @keyframes grimoire-pulse {
     0%,
     100% {
-      box-shadow: 0 0 12px rgba(168, 85, 247, 0.35), inset 0 0 18px rgba(80, 0, 60, 0.5);
+      opacity: 0.35;
     }
     50% {
-      box-shadow: 0 0 24px rgba(220, 38, 120, 0.55), inset 0 0 26px rgba(120, 0, 80, 0.6);
+      opacity: 1;
     }
   }
 
@@ -389,9 +391,25 @@ Pégala entera en **Creator Notes**, y luego activa **Card Theming** en **Chat S
       background: linear-gradient(135deg, #1a0a24 0%, #2d0a2e 55%, #3a0a1e 100%);
       border: 1px solid rgba(220, 38, 120, 0.45);
       border-radius: 4px 16px 16px 16px;
-      animation: grimoire-pulse 4s ease-in-out infinite;
       position: relative;
       overflow: hidden;
+      /* a steady outer halo. An element's own box-shadow is not clipped by its own
+         overflow: hidden, so this bloom shows even though message content is clipped. */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+    }
+    /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
+       composited) instead of the bubble's box-shadow (expensive: a full repaint every
+       frame). overflow: hidden clips a child's OUTER shadow, so the pulse rides the inset
+       glow while the halo above stays steady. pointer-events keeps it click-through. */
+    [data-card-css] .mari-message-bubble::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      pointer-events: none;
+      box-shadow: inset 0 0 26px rgba(120, 0, 80, 0.65);
+      animation: grimoire-pulse 4s ease-in-out infinite;
+      will-change: opacity;
     }
     [data-card-css] .mari-message-bubble::before {
       content: "✦";

--- a/es/appearance/card-css-theming.md
+++ b/es/appearance/card-css-theming.md
@@ -394,8 +394,10 @@ Pégala entera en **Creator Notes**, y luego activa **Card Theming** en **Chat S
       position: relative;
       overflow: hidden;
       /* a steady outer halo. An element's own box-shadow is not clipped by its own
-         overflow: hidden, so this bloom shows even though message content is clipped. */
-      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+         overflow: hidden, so this bloom shows even though message content is clipped.
+         (No inset here: the pulsing inset glow lives on the ::after, so a static inset
+         would stack with it and over-brighten the inner glow.) */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4);
     }
     /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
        composited) instead of the bubble's box-shadow (expensive: a full repaint every

--- a/fr/appearance/card-css-theming.md
+++ b/fr/appearance/card-css-theming.md
@@ -394,8 +394,10 @@ Colle-la en entier dans le champ **Creator Notes**, puis active **Card Theming**
       position: relative;
       overflow: hidden;
       /* a steady outer halo. An element's own box-shadow is not clipped by its own
-         overflow: hidden, so this bloom shows even though message content is clipped. */
-      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+         overflow: hidden, so this bloom shows even though message content is clipped.
+         (No inset here: the pulsing inset glow lives on the ::after, so a static inset
+         would stack with it and over-brighten the inner glow.) */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4);
     }
     /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
        composited) instead of the bubble's box-shadow (expensive: a full repaint every

--- a/fr/appearance/card-css-theming.md
+++ b/fr/appearance/card-css-theming.md
@@ -327,14 +327,16 @@ Colle-la en entier dans le champ **Creator Notes**, puis active **Card Theming**
 
 ```html
 <style>
-  /* shared keyframe */
+  /* shared keyframe. Animate OPACITY, never box-shadow: box-shadow is a "paint"
+     property, so animating it repaints and re-blurs the whole element every frame
+     (which pins weak GPUs). Animating a layer's opacity is GPU-composited and cheap. */
   @keyframes grimoire-pulse {
     0%,
     100% {
-      box-shadow: 0 0 12px rgba(168, 85, 247, 0.35), inset 0 0 18px rgba(80, 0, 60, 0.5);
+      opacity: 0.35;
     }
     50% {
-      box-shadow: 0 0 24px rgba(220, 38, 120, 0.55), inset 0 0 26px rgba(120, 0, 80, 0.6);
+      opacity: 1;
     }
   }
 
@@ -389,9 +391,25 @@ Colle-la en entier dans le champ **Creator Notes**, puis active **Card Theming**
       background: linear-gradient(135deg, #1a0a24 0%, #2d0a2e 55%, #3a0a1e 100%);
       border: 1px solid rgba(220, 38, 120, 0.45);
       border-radius: 4px 16px 16px 16px;
-      animation: grimoire-pulse 4s ease-in-out infinite;
       position: relative;
       overflow: hidden;
+      /* a steady outer halo. An element's own box-shadow is not clipped by its own
+         overflow: hidden, so this bloom shows even though message content is clipped. */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+    }
+    /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
+       composited) instead of the bubble's box-shadow (expensive: a full repaint every
+       frame). overflow: hidden clips a child's OUTER shadow, so the pulse rides the inset
+       glow while the halo above stays steady. pointer-events keeps it click-through. */
+    [data-card-css] .mari-message-bubble::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      pointer-events: none;
+      box-shadow: inset 0 0 26px rgba(120, 0, 80, 0.65);
+      animation: grimoire-pulse 4s ease-in-out infinite;
+      will-change: opacity;
     }
     [data-card-css] .mari-message-bubble::before {
       content: "✦";

--- a/hi/appearance/card-css-theming.md
+++ b/hi/appearance/card-css-theming.md
@@ -394,8 +394,10 @@ font-family: "Courier New", Consolas, monospace;
       position: relative;
       overflow: hidden;
       /* a steady outer halo. An element's own box-shadow is not clipped by its own
-         overflow: hidden, so this bloom shows even though message content is clipped. */
-      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+         overflow: hidden, so this bloom shows even though message content is clipped.
+         (No inset here: the pulsing inset glow lives on the ::after, so a static inset
+         would stack with it and over-brighten the inner glow.) */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4);
     }
     /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
        composited) instead of the bubble's box-shadow (expensive: a full repaint every

--- a/hi/appearance/card-css-theming.md
+++ b/hi/appearance/card-css-theming.md
@@ -327,14 +327,16 @@ font-family: "Courier New", Consolas, monospace;
 
 ```html
 <style>
-  /* shared keyframe */
+  /* shared keyframe. Animate OPACITY, never box-shadow: box-shadow is a "paint"
+     property, so animating it repaints and re-blurs the whole element every frame
+     (which pins weak GPUs). Animating a layer's opacity is GPU-composited and cheap. */
   @keyframes grimoire-pulse {
     0%,
     100% {
-      box-shadow: 0 0 12px rgba(168, 85, 247, 0.35), inset 0 0 18px rgba(80, 0, 60, 0.5);
+      opacity: 0.35;
     }
     50% {
-      box-shadow: 0 0 24px rgba(220, 38, 120, 0.55), inset 0 0 26px rgba(120, 0, 80, 0.6);
+      opacity: 1;
     }
   }
 
@@ -389,9 +391,25 @@ font-family: "Courier New", Consolas, monospace;
       background: linear-gradient(135deg, #1a0a24 0%, #2d0a2e 55%, #3a0a1e 100%);
       border: 1px solid rgba(220, 38, 120, 0.45);
       border-radius: 4px 16px 16px 16px;
-      animation: grimoire-pulse 4s ease-in-out infinite;
       position: relative;
       overflow: hidden;
+      /* a steady outer halo. An element's own box-shadow is not clipped by its own
+         overflow: hidden, so this bloom shows even though message content is clipped. */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+    }
+    /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
+       composited) instead of the bubble's box-shadow (expensive: a full repaint every
+       frame). overflow: hidden clips a child's OUTER shadow, so the pulse rides the inset
+       glow while the halo above stays steady. pointer-events keeps it click-through. */
+    [data-card-css] .mari-message-bubble::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      pointer-events: none;
+      box-shadow: inset 0 0 26px rgba(120, 0, 80, 0.65);
+      animation: grimoire-pulse 4s ease-in-out infinite;
+      will-change: opacity;
     }
     [data-card-css] .mari-message-bubble::before {
       content: "✦";

--- a/ja/appearance/card-css-theming.md
+++ b/ja/appearance/card-css-theming.md
@@ -394,8 +394,10 @@ font-family: "Courier New", Consolas, monospace;
       position: relative;
       overflow: hidden;
       /* a steady outer halo. An element's own box-shadow is not clipped by its own
-         overflow: hidden, so this bloom shows even though message content is clipped. */
-      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+         overflow: hidden, so this bloom shows even though message content is clipped.
+         (No inset here: the pulsing inset glow lives on the ::after, so a static inset
+         would stack with it and over-brighten the inner glow.) */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4);
     }
     /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
        composited) instead of the bubble's box-shadow (expensive: a full repaint every

--- a/ja/appearance/card-css-theming.md
+++ b/ja/appearance/card-css-theming.md
@@ -327,14 +327,16 @@ font-family: "Courier New", Consolas, monospace;
 
 ```html
 <style>
-  /* shared keyframe */
+  /* shared keyframe. Animate OPACITY, never box-shadow: box-shadow is a "paint"
+     property, so animating it repaints and re-blurs the whole element every frame
+     (which pins weak GPUs). Animating a layer's opacity is GPU-composited and cheap. */
   @keyframes grimoire-pulse {
     0%,
     100% {
-      box-shadow: 0 0 12px rgba(168, 85, 247, 0.35), inset 0 0 18px rgba(80, 0, 60, 0.5);
+      opacity: 0.35;
     }
     50% {
-      box-shadow: 0 0 24px rgba(220, 38, 120, 0.55), inset 0 0 26px rgba(120, 0, 80, 0.6);
+      opacity: 1;
     }
   }
 
@@ -389,9 +391,25 @@ font-family: "Courier New", Consolas, monospace;
       background: linear-gradient(135deg, #1a0a24 0%, #2d0a2e 55%, #3a0a1e 100%);
       border: 1px solid rgba(220, 38, 120, 0.45);
       border-radius: 4px 16px 16px 16px;
-      animation: grimoire-pulse 4s ease-in-out infinite;
       position: relative;
       overflow: hidden;
+      /* a steady outer halo. An element's own box-shadow is not clipped by its own
+         overflow: hidden, so this bloom shows even though message content is clipped. */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+    }
+    /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
+       composited) instead of the bubble's box-shadow (expensive: a full repaint every
+       frame). overflow: hidden clips a child's OUTER shadow, so the pulse rides the inset
+       glow while the halo above stays steady. pointer-events keeps it click-through. */
+    [data-card-css] .mari-message-bubble::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      pointer-events: none;
+      box-shadow: inset 0 0 26px rgba(120, 0, 80, 0.65);
+      animation: grimoire-pulse 4s ease-in-out infinite;
+      will-change: opacity;
     }
     [data-card-css] .mari-message-bubble::before {
       content: "✦";

--- a/ko/appearance/card-css-theming.md
+++ b/ko/appearance/card-css-theming.md
@@ -394,8 +394,10 @@ font-family: "Courier New", Consolas, monospace;
       position: relative;
       overflow: hidden;
       /* a steady outer halo. An element's own box-shadow is not clipped by its own
-         overflow: hidden, so this bloom shows even though message content is clipped. */
-      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+         overflow: hidden, so this bloom shows even though message content is clipped.
+         (No inset here: the pulsing inset glow lives on the ::after, so a static inset
+         would stack with it and over-brighten the inner glow.) */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4);
     }
     /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
        composited) instead of the bubble's box-shadow (expensive: a full repaint every

--- a/ko/appearance/card-css-theming.md
+++ b/ko/appearance/card-css-theming.md
@@ -327,14 +327,16 @@ font-family: "Courier New", Consolas, monospace;
 
 ```html
 <style>
-  /* shared keyframe */
+  /* shared keyframe. Animate OPACITY, never box-shadow: box-shadow is a "paint"
+     property, so animating it repaints and re-blurs the whole element every frame
+     (which pins weak GPUs). Animating a layer's opacity is GPU-composited and cheap. */
   @keyframes grimoire-pulse {
     0%,
     100% {
-      box-shadow: 0 0 12px rgba(168, 85, 247, 0.35), inset 0 0 18px rgba(80, 0, 60, 0.5);
+      opacity: 0.35;
     }
     50% {
-      box-shadow: 0 0 24px rgba(220, 38, 120, 0.55), inset 0 0 26px rgba(120, 0, 80, 0.6);
+      opacity: 1;
     }
   }
 
@@ -389,9 +391,25 @@ font-family: "Courier New", Consolas, monospace;
       background: linear-gradient(135deg, #1a0a24 0%, #2d0a2e 55%, #3a0a1e 100%);
       border: 1px solid rgba(220, 38, 120, 0.45);
       border-radius: 4px 16px 16px 16px;
-      animation: grimoire-pulse 4s ease-in-out infinite;
       position: relative;
       overflow: hidden;
+      /* a steady outer halo. An element's own box-shadow is not clipped by its own
+         overflow: hidden, so this bloom shows even though message content is clipped. */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+    }
+    /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
+       composited) instead of the bubble's box-shadow (expensive: a full repaint every
+       frame). overflow: hidden clips a child's OUTER shadow, so the pulse rides the inset
+       glow while the halo above stays steady. pointer-events keeps it click-through. */
+    [data-card-css] .mari-message-bubble::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      pointer-events: none;
+      box-shadow: inset 0 0 26px rgba(120, 0, 80, 0.65);
+      animation: grimoire-pulse 4s ease-in-out infinite;
+      will-change: opacity;
     }
     [data-card-css] .mari-message-bubble::before {
       content: "✦";

--- a/pl/appearance/card-css-theming.md
+++ b/pl/appearance/card-css-theming.md
@@ -394,8 +394,10 @@ Wklej całość w pole **Creator Notes**, a potem włącz **Card Theming** w **C
       position: relative;
       overflow: hidden;
       /* a steady outer halo. An element's own box-shadow is not clipped by its own
-         overflow: hidden, so this bloom shows even though message content is clipped. */
-      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+         overflow: hidden, so this bloom shows even though message content is clipped.
+         (No inset here: the pulsing inset glow lives on the ::after, so a static inset
+         would stack with it and over-brighten the inner glow.) */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4);
     }
     /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
        composited) instead of the bubble's box-shadow (expensive: a full repaint every

--- a/pl/appearance/card-css-theming.md
+++ b/pl/appearance/card-css-theming.md
@@ -327,14 +327,16 @@ Wklej całość w pole **Creator Notes**, a potem włącz **Card Theming** w **C
 
 ```html
 <style>
-  /* shared keyframe */
+  /* shared keyframe. Animate OPACITY, never box-shadow: box-shadow is a "paint"
+     property, so animating it repaints and re-blurs the whole element every frame
+     (which pins weak GPUs). Animating a layer's opacity is GPU-composited and cheap. */
   @keyframes grimoire-pulse {
     0%,
     100% {
-      box-shadow: 0 0 12px rgba(168, 85, 247, 0.35), inset 0 0 18px rgba(80, 0, 60, 0.5);
+      opacity: 0.35;
     }
     50% {
-      box-shadow: 0 0 24px rgba(220, 38, 120, 0.55), inset 0 0 26px rgba(120, 0, 80, 0.6);
+      opacity: 1;
     }
   }
 
@@ -389,9 +391,25 @@ Wklej całość w pole **Creator Notes**, a potem włącz **Card Theming** w **C
       background: linear-gradient(135deg, #1a0a24 0%, #2d0a2e 55%, #3a0a1e 100%);
       border: 1px solid rgba(220, 38, 120, 0.45);
       border-radius: 4px 16px 16px 16px;
-      animation: grimoire-pulse 4s ease-in-out infinite;
       position: relative;
       overflow: hidden;
+      /* a steady outer halo. An element's own box-shadow is not clipped by its own
+         overflow: hidden, so this bloom shows even though message content is clipped. */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+    }
+    /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
+       composited) instead of the bubble's box-shadow (expensive: a full repaint every
+       frame). overflow: hidden clips a child's OUTER shadow, so the pulse rides the inset
+       glow while the halo above stays steady. pointer-events keeps it click-through. */
+    [data-card-css] .mari-message-bubble::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      pointer-events: none;
+      box-shadow: inset 0 0 26px rgba(120, 0, 80, 0.65);
+      animation: grimoire-pulse 4s ease-in-out infinite;
+      will-change: opacity;
     }
     [data-card-css] .mari-message-bubble::before {
       content: "✦";

--- a/pt-br/appearance/card-css-theming.md
+++ b/pt-br/appearance/card-css-theming.md
@@ -327,14 +327,16 @@ Cole tudo no campo **Creator Notes** e ative o **Card Theming** em **Chat Settin
 
 ```html
 <style>
-  /* shared keyframe */
+  /* shared keyframe. Animate OPACITY, never box-shadow: box-shadow is a "paint"
+     property, so animating it repaints and re-blurs the whole element every frame
+     (which pins weak GPUs). Animating a layer's opacity is GPU-composited and cheap. */
   @keyframes grimoire-pulse {
     0%,
     100% {
-      box-shadow: 0 0 12px rgba(168, 85, 247, 0.35), inset 0 0 18px rgba(80, 0, 60, 0.5);
+      opacity: 0.35;
     }
     50% {
-      box-shadow: 0 0 24px rgba(220, 38, 120, 0.55), inset 0 0 26px rgba(120, 0, 80, 0.6);
+      opacity: 1;
     }
   }
 
@@ -389,9 +391,25 @@ Cole tudo no campo **Creator Notes** e ative o **Card Theming** em **Chat Settin
       background: linear-gradient(135deg, #1a0a24 0%, #2d0a2e 55%, #3a0a1e 100%);
       border: 1px solid rgba(220, 38, 120, 0.45);
       border-radius: 4px 16px 16px 16px;
-      animation: grimoire-pulse 4s ease-in-out infinite;
       position: relative;
       overflow: hidden;
+      /* a steady outer halo. An element's own box-shadow is not clipped by its own
+         overflow: hidden, so this bloom shows even though message content is clipped. */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+    }
+    /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
+       composited) instead of the bubble's box-shadow (expensive: a full repaint every
+       frame). overflow: hidden clips a child's OUTER shadow, so the pulse rides the inset
+       glow while the halo above stays steady. pointer-events keeps it click-through. */
+    [data-card-css] .mari-message-bubble::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      pointer-events: none;
+      box-shadow: inset 0 0 26px rgba(120, 0, 80, 0.65);
+      animation: grimoire-pulse 4s ease-in-out infinite;
+      will-change: opacity;
     }
     [data-card-css] .mari-message-bubble::before {
       content: "✦";

--- a/pt-br/appearance/card-css-theming.md
+++ b/pt-br/appearance/card-css-theming.md
@@ -394,8 +394,10 @@ Cole tudo no campo **Creator Notes** e ative o **Card Theming** em **Chat Settin
       position: relative;
       overflow: hidden;
       /* a steady outer halo. An element's own box-shadow is not clipped by its own
-         overflow: hidden, so this bloom shows even though message content is clipped. */
-      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+         overflow: hidden, so this bloom shows even though message content is clipped.
+         (No inset here: the pulsing inset glow lives on the ::after, so a static inset
+         would stack with it and over-brighten the inner glow.) */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4);
     }
     /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
        composited) instead of the bubble's box-shadow (expensive: a full repaint every

--- a/ru/appearance/card-css-theming.md
+++ b/ru/appearance/card-css-theming.md
@@ -394,8 +394,10 @@ font-family: "Courier New", Consolas, monospace;
       position: relative;
       overflow: hidden;
       /* a steady outer halo. An element's own box-shadow is not clipped by its own
-         overflow: hidden, so this bloom shows even though message content is clipped. */
-      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+         overflow: hidden, so this bloom shows even though message content is clipped.
+         (No inset here: the pulsing inset glow lives on the ::after, so a static inset
+         would stack with it and over-brighten the inner glow.) */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4);
     }
     /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
        composited) instead of the bubble's box-shadow (expensive: a full repaint every

--- a/ru/appearance/card-css-theming.md
+++ b/ru/appearance/card-css-theming.md
@@ -327,14 +327,16 @@ font-family: "Courier New", Consolas, monospace;
 
 ```html
 <style>
-  /* shared keyframe */
+  /* shared keyframe. Animate OPACITY, never box-shadow: box-shadow is a "paint"
+     property, so animating it repaints and re-blurs the whole element every frame
+     (which pins weak GPUs). Animating a layer's opacity is GPU-composited and cheap. */
   @keyframes grimoire-pulse {
     0%,
     100% {
-      box-shadow: 0 0 12px rgba(168, 85, 247, 0.35), inset 0 0 18px rgba(80, 0, 60, 0.5);
+      opacity: 0.35;
     }
     50% {
-      box-shadow: 0 0 24px rgba(220, 38, 120, 0.55), inset 0 0 26px rgba(120, 0, 80, 0.6);
+      opacity: 1;
     }
   }
 
@@ -389,9 +391,25 @@ font-family: "Courier New", Consolas, monospace;
       background: linear-gradient(135deg, #1a0a24 0%, #2d0a2e 55%, #3a0a1e 100%);
       border: 1px solid rgba(220, 38, 120, 0.45);
       border-radius: 4px 16px 16px 16px;
-      animation: grimoire-pulse 4s ease-in-out infinite;
       position: relative;
       overflow: hidden;
+      /* a steady outer halo. An element's own box-shadow is not clipped by its own
+         overflow: hidden, so this bloom shows even though message content is clipped. */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+    }
+    /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
+       composited) instead of the bubble's box-shadow (expensive: a full repaint every
+       frame). overflow: hidden clips a child's OUTER shadow, so the pulse rides the inset
+       glow while the halo above stays steady. pointer-events keeps it click-through. */
+    [data-card-css] .mari-message-bubble::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      pointer-events: none;
+      box-shadow: inset 0 0 26px rgba(120, 0, 80, 0.65);
+      animation: grimoire-pulse 4s ease-in-out infinite;
+      will-change: opacity;
     }
     [data-card-css] .mari-message-bubble::before {
       content: "✦";

--- a/zh-hans/appearance/card-css-theming.md
+++ b/zh-hans/appearance/card-css-theming.md
@@ -394,8 +394,10 @@ font-family: "Courier New", Consolas, monospace;
       position: relative;
       overflow: hidden;
       /* a steady outer halo. An element's own box-shadow is not clipped by its own
-         overflow: hidden, so this bloom shows even though message content is clipped. */
-      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+         overflow: hidden, so this bloom shows even though message content is clipped.
+         (No inset here: the pulsing inset glow lives on the ::after, so a static inset
+         would stack with it and over-brighten the inner glow.) */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4);
     }
     /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
        composited) instead of the bubble's box-shadow (expensive: a full repaint every

--- a/zh-hans/appearance/card-css-theming.md
+++ b/zh-hans/appearance/card-css-theming.md
@@ -327,14 +327,16 @@ font-family: "Courier New", Consolas, monospace;
 
 ```html
 <style>
-  /* shared keyframe */
+  /* shared keyframe. Animate OPACITY, never box-shadow: box-shadow is a "paint"
+     property, so animating it repaints and re-blurs the whole element every frame
+     (which pins weak GPUs). Animating a layer's opacity is GPU-composited and cheap. */
   @keyframes grimoire-pulse {
     0%,
     100% {
-      box-shadow: 0 0 12px rgba(168, 85, 247, 0.35), inset 0 0 18px rgba(80, 0, 60, 0.5);
+      opacity: 0.35;
     }
     50% {
-      box-shadow: 0 0 24px rgba(220, 38, 120, 0.55), inset 0 0 26px rgba(120, 0, 80, 0.6);
+      opacity: 1;
     }
   }
 
@@ -389,9 +391,25 @@ font-family: "Courier New", Consolas, monospace;
       background: linear-gradient(135deg, #1a0a24 0%, #2d0a2e 55%, #3a0a1e 100%);
       border: 1px solid rgba(220, 38, 120, 0.45);
       border-radius: 4px 16px 16px 16px;
-      animation: grimoire-pulse 4s ease-in-out infinite;
       position: relative;
       overflow: hidden;
+      /* a steady outer halo. An element's own box-shadow is not clipped by its own
+         overflow: hidden, so this bloom shows even though message content is clipped. */
+      box-shadow: 0 0 16px rgba(190, 70, 190, 0.4), inset 0 0 18px rgba(80, 0, 60, 0.5);
+    }
+    /* the breathing inner glow. Animate a full-bleed overlay's OPACITY (cheap, GPU
+       composited) instead of the bubble's box-shadow (expensive: a full repaint every
+       frame). overflow: hidden clips a child's OUTER shadow, so the pulse rides the inset
+       glow while the halo above stays steady. pointer-events keeps it click-through. */
+    [data-card-css] .mari-message-bubble::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      pointer-events: none;
+      box-shadow: inset 0 0 26px rgba(120, 0, 80, 0.65);
+      animation: grimoire-pulse 4s ease-in-out infinite;
+      will-change: opacity;
     }
     [data-card-css] .mari-message-bubble::before {
       content: "✦";


### PR DESCRIPTION
## Linked issue

Related to #4897. Mirrors the staging docs PR #4899.

## Why this change

Keeps the translated Card CSS Theming guides in sync with #4899, which fixes the showcase glow example: it animated `box-shadow` (a paint property) on every roleplay bubble, forcing a full repaint every frame and pinning weak GPUs. The example now animates `opacity` on a `pointer-events: none` overlay instead (GPU-composited).

## What changed

- Applied the identical code-block replacement to all 10 locale copies of `appearance/card-css-theming.md` (de, es, fr, hi, ja, ko, pl, pt-br, ru, zh-hans).
- No translation was required: the CSS example block, including its explanatory comments, is byte-identical across every locale (the comments are kept in English in all of them), so this is a pure code mirror of #4899.

## Validation

- The CSS is byte-for-byte identical to the English change validated by `pnpm regression:docs` in #4899 (which checks doc structure across all 11 languages).
- Applied with a strict-match script: each file had to contain the exact pre-change block exactly once before it was replaced, so no locale was silently skipped or partially edited. Verified afterward that all 10 files carry the opacity keyframe and the `::after` overlay and no longer contain the animated `box-shadow` keyframe.
- This branch is docs-only, so there is no app build to run here. The CHANGELOG entry lives in #4899.
