### PR TITLE
Fix Music DJ Spotify playback verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Restored Music DJ Spotify playback by clearing the previous repeat mode before replacing a multi-song context, reapplying repeat only after the selected first track is verified, and surfacing persistent URI mismatches as failures instead of false pending successes (#4903).
 - Made persona saves reliable: the editor now sends only the fields you actually changed, keeps edits made while a save is still running, prevents saves and avatar replacements from overlapping, blocks its own Back and Discard controls mid-write, and explains exactly which field a rejected save objected to — including an empty persona name.
 - Made Reduce Ambient Animations & Effects flatten costly backdrop blur on desktop as well as mobile, including shared Conversation overlays (#4897).
 - Applied embedded character-card fields when replacing an existing character's avatar, so updated card PNGs refresh the matching editor sections (#4896).

--- a/packages/server/src/services/tools/tool-executor.ts
+++ b/packages/server/src/services/tools/tool-executor.ts
@@ -1329,6 +1329,17 @@ async function primeSpotifyPlaybackDevice(
   await wait(SPOTIFY_PLAYBACK_SETTLE_MS);
 }
 
+async function clearSpotifyRepeatBeforePlayback(accessToken: string, deviceId: string | null): Promise<void> {
+  for (const delay of SPOTIFY_REPEAT_RETRY_DELAYS_MS) {
+    if (delay > 0) await wait(delay);
+    const repeat = await applySpotifyRepeatAfterPlay(accessToken, "off", deviceId);
+    if (repeat !== "off") continue;
+    const snapshot = await fetchSpotifyPlaybackSnapshot(accessToken);
+    if (snapshot?.repeatState === "off") return;
+  }
+  logger.debug("[spotify] Repeat-off could not be verified before replacing the playback context");
+}
+
 async function verifyOrNudgeSpotifyPlayback(args: {
   accessToken: string;
   body: SpotifyPlayRequestBody;
@@ -1842,6 +1853,8 @@ async function spotifyPlay(
 
     if (singleTrackUri && effectiveRepeatAfterPlay === "track") {
       await applySpotifyRepeatAfterPlay(creds.accessToken, "off", playDeviceId);
+    } else if (repeatTrackList && beforePlayback?.repeatState !== "off") {
+      await clearSpotifyRepeatBeforePlayback(creds.accessToken, playDeviceId);
     }
 
     if (uris.length === 1 && !firstUri.startsWith("spotify:track:")) {
@@ -1901,7 +1914,9 @@ async function spotifyPlay(
     const play = await requestSpotifyPlayback(creds.accessToken, playDeviceId, body);
     if (!play.ok) return { error: play.error };
     if (singleTrackUri) await wait(SPOTIFY_PLAYBACK_SETTLE_MS);
-    let repeat = await applySpotifyRepeatAfterPlay(creds.accessToken, effectiveRepeatAfterPlay, playDeviceId);
+    let repeat = repeatTrackList
+      ? null
+      : await applySpotifyRepeatAfterPlay(creds.accessToken, effectiveRepeatAfterPlay, playDeviceId);
     const requireFirstUriMatch = singleTrackUri || (allTrackUris && uris.length > 1);
     let current = await verifyOrNudgeSpotifyPlayback({
       accessToken: creds.accessToken,
@@ -1913,6 +1928,7 @@ async function spotifyPlay(
       expectedUris: playbackUris,
       requireFirstUri: requireFirstUriMatch,
     });
+    const playbackVerified = spotifyPlaybackMatches(current, playbackUris, requireFirstUriMatch);
     if (singleTrackUri && effectiveRepeatAfterPlay === "track" && current?.repeatState !== "track") {
       repeat = await applySpotifyRepeatAfterPlay(creds.accessToken, "track", current?.deviceId ?? playDeviceId, 3);
       current = await verifyOrNudgeSpotifyPlayback({
@@ -1926,7 +1942,7 @@ async function spotifyPlay(
         requireFirstUri: true,
       });
     }
-    if (repeatTrackList && current?.repeatState !== "context") {
+    if (repeatTrackList && playbackVerified && current?.repeatState !== "context") {
       for (const delay of SPOTIFY_REPEAT_RETRY_DELAYS_MS) {
         if (delay > 0) await wait(delay);
         repeat = await applySpotifyRepeatAfterPlay(
@@ -1949,26 +1965,20 @@ async function spotifyPlay(
         playbackUris[0] ?? firstUri,
         current?.repeatState ?? "unknown",
       );
-      const queuedAfterStart = await queueSpotifyTracks(
-        creds.accessToken,
-        current?.deviceId ?? playDeviceId,
-        queuedTrackUris,
-      );
-      const totalQueued = playbackUris.length + queuedAfterStart;
-      await rememberSpotifyPlayedTracks(context, uris);
+      const currentUri = current?.trackUri ?? null;
+      const error =
+        currentUri === (playbackUris[0] ?? firstUri)
+          ? `Spotify started the selected track, but failed to apply ${effectiveRepeatAfterPlay ?? "the requested"} repeat mode.`
+          : `Spotify playback failed to start the selected track on ${current?.deviceName ?? targetDeviceName ?? "the active device"}.`;
       return {
-        applied: true,
-        playbackPending: true,
-        verification: "pending",
+        error,
+        verification: "failed",
         uris,
         reason,
         repeat,
         repeatState: current?.repeatState ?? repeat ?? null,
-        currentUri: current?.trackUri ?? null,
+        currentUri,
         device: current?.deviceName ?? targetDeviceName,
-        queued: totalQueued,
-        queueRequested: uris.length,
-        display: formatSpotifyPlaybackPendingDisplay(firstUri, reason, current?.deviceName ?? targetDeviceName),
       };
     }
     const queuedAfterStart = await queueSpotifyTracks(

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -2135,6 +2135,11 @@ const cases: RegressionCase[] = [
           );
         }
         if (url.pathname === "/v1/me/player/play" && method === "PUT") {
+          assert.equal(
+            repeatState,
+            "off",
+            "Music DJ must clear the previous repeat mode before replacing Spotify's playback context",
+          );
           const body = JSON.parse(String(init?.body ?? "{}")) as { uris?: string[]; position_ms?: number };
           playbackBodies.push(body);
           activeUri = body.uris?.[0] ?? activeUri;
@@ -2178,6 +2183,7 @@ const cases: RegressionCase[] = [
         };
         assert.deepEqual(playbackBodies[0]?.uris, selectedUris);
         assert.deepEqual(queuedUris, [], "repeatable Music DJ selections must not use Spotify's disposable queue");
+        assert.deepEqual(repeatStates, ["off", "context"]);
         assert.equal(repeatStates.at(-1), "context");
         assert.equal(payload.repeat, "context");
         assert.equal(payload.repeatState, "context");
@@ -2306,17 +2312,19 @@ const cases: RegressionCase[] = [
           },
         );
 
-        assert.equal(results[0]?.success, true);
+        assert.equal(results[0]?.success, false);
         const payload = JSON.parse(results[0]!.result) as {
+          error?: string;
           applied?: boolean;
           playbackPending?: boolean;
           verification?: string;
           repeatState?: string;
         };
-        assert.equal(repeatRequests, 4, "Spotify repeat should be retried while playback reports it as off");
-        assert.equal(payload.applied, true);
-        assert.equal(payload.playbackPending, true);
-        assert.equal(payload.verification, "pending");
+        assert.equal(repeatRequests, 3, "Spotify repeat should be retried while playback reports it as off");
+        assert.match(payload.error ?? "", /failed to apply context repeat mode/u);
+        assert.equal(payload.applied, undefined);
+        assert.equal(payload.playbackPending, undefined);
+        assert.equal(payload.verification, "failed");
         assert.equal(payload.repeatState, "off");
       } finally {
         globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Linked issue

Closes #4903

## Why this change

- Music DJ can receive a successful Spotify API response while the active device continues playing the previous track. Marinara currently marks that unverified command as applied, preventing a meaningful fallback and leaving users without music.

## What changed

- Clear and verify Spotify's previous repeat mode before replacing a repeatable multi-track playback context.
- Reapply context repeat only after Spotify reports the selected first track as active, while preserving the established single-track sequence.
- Return persistent playback or repeat verification mismatches as failures instead of successful `playbackPending` results.
- Strengthen the Spotify regression fixtures to reject unsafe request ordering and false verification success.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated verification: `pnpm regression:prompt`.
- Automated verification: `pnpm regression:manual-agent-retry`.
- Automated verification: `pnpm check`.
- A live Spotify Premium account/device was not available to the automated repository harness. Manually verify that a multi-track Music DJ selection replaces the currently playing song and retains context repeat.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not applicable; this is a server-side Spotify playback fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Spotify playback reliability when starting multi-track sessions.
  * Repeat mode is now verified after playback begins, reducing incorrect repeat behavior.
  * Playback failures now provide clearer error reporting instead of remaining pending.
  * Added handling for cases where Spotify playback does not start as expected.

* **Documentation**
  * Updated the changelog with the restored Spotify playback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->