### PR TITLE
Fix preset Markdown, Mari drafts, and chat formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added Markdown previews to Conversation, Game, and section content in the preset editor, matching character and lorebook authoring (#4916).
+- Added Discord-style `__underline__` and `-# subtext` rendering throughout chat history and other shared Markdown surfaces (#4914).
 - Let Professor Mari set every user-editable lorebook entry setting when she creates or edits entries, not just the keyword-matching controls: activation chance (`probability`, clamped 0-100), timing (`sticky`, `cooldown`, `delay`, `ephemeral`), recursion (`preventRecursion`, `excludeRecursion`, `delayUntilRecursion`), inclusion-group weight, per-entry scan depth, lock, folder placement, character/tag/trigger matching filters, and per-entry vectorization (which she only enables when an embedding model is configured) (#4791).
 - Added shared and per-character New Start context markers to group Roleplay, with an avatar target picker and character-colored dividers that let newly introduced characters begin from a later message without truncating the rest of the cast's history (#4905).
 - Added character-targeted Roleplay message hiding through `/hide <character> <number/range>`, including quoted names and the existing single, range, and comma-separated message selectors (#4906).
@@ -57,6 +59,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Preserved unsent Home Professor Mari messages across editor navigation and app restarts until they are sent or explicitly cleared (#4915).
 - Taught workspace Professor Mari to revise an existing saved memory when asked, instead of declining that a matching memory "already exists": her guidance now includes a read-then-rewrite recipe and worked example for editing a memory's content in place (the same pattern she uses for preset sections), which also works on an enabled or persistent memory without turning it off (#4917).
 - Made Force To Call Tool serialize native required-tool controls for Google Gemini, Vertex AI, and compatible Anthropic requests, while safely falling back to automatic choice for manual Claude extended thinking and Mythos (#4907).
 - Fixed the open-issues regression failing on Windows checkouts: its chat-summary reorder check matched the entry container and the touch-reorder row within a fixed character distance that CRLF line endings pushed just over the limit, so it now verifies the shared desktop and touch reorder surface on the row element directly, independent of line endings and where the row is defined (#4911).

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -112,6 +112,7 @@ import { useTranslation, useTranslation as useUiTranslation } from "react-i18nex
 const MARI_AVATAR_URL = "/sprites/mari/Mari_profile.png";
 const MARI_CHIBI_URL = "/sprites/mari/chibi-professor-mari.png";
 const PROFESSOR_MARI_WELCOME_MESSAGE_ID = "__professor_mari_home_welcome__";
+const PROFESSOR_MARI_DRAFT_KEY = "__home_professor_mari__";
 const MARI_CONNECTION_STORAGE_KEY = "marinara:home-professor-mari-connection-id";
 const PROFESSOR_MARI_ERROR_TOAST_DURATION_MS = 120_000;
 const WORKSPACE_SETTLE_POLL_MS = 1_500;
@@ -2909,7 +2910,15 @@ export function HomeProfessorMariChat({
   const trackAchievement = useTrackAchievement();
   const [chatId, setChatId] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
-  const [draft, setDraft] = useState("");
+  const draft = useChatStore((state) => state.inputDrafts.get(PROFESSOR_MARI_DRAFT_KEY) ?? "");
+  const setInputDraft = useChatStore((state) => state.setInputDraft);
+  const setDraft = useCallback(
+    (next: string | ((current: string) => string)) => {
+      const current = useChatStore.getState().inputDrafts.get(PROFESSOR_MARI_DRAFT_KEY) ?? "";
+      setInputDraft(PROFESSOR_MARI_DRAFT_KEY, typeof next === "function" ? next(current) : next);
+    },
+    [setInputDraft],
+  );
   const [attachments, setAttachments] = useState<ProfessorMariAttachment[]>([]);
   const [isReadingAttachments, setIsReadingAttachments] = useState(false);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(() => readStoredConnectionId());
@@ -3728,7 +3737,7 @@ export function HomeProfessorMariChat({
     if (chatHistoryOpen) await loadChatHistory();
     await qc.invalidateQueries({ queryKey: chatKeys.messages(chat.id) });
     toast.success(localizeUi("ui.chat.homeprofessormarichat.professorMariSPreviousChatWasSaved"));
-  }, [chatHistoryOpen, clearMariChips, effectiveConnectionId, loadChatHistory, qc, setActiveChatId, localizeUi]);
+  }, [chatHistoryOpen, clearMariChips, effectiveConnectionId, loadChatHistory, qc, setActiveChatId, setDraft, localizeUi]);
 
   const guidedPlan = professorMariSuggestionsEnabled && mariPlanChatId === chatId ? mariPlan : null;
   const guidedPlanStep = guidedPlan ? (guidedPlan[mariPlanCursor] ?? null) : null;
@@ -3761,7 +3770,7 @@ export function HomeProfessorMariChat({
       setDraft((current) => (current.trim() ? `${current.trimEnd()} ${chip.prompt}` : chip.prompt));
       focusComposer();
     },
-    [clearMariPlan, focusComposer, guidedPlanStep, recordMariPlanAnswer],
+    [clearMariPlan, focusComposer, guidedPlanStep, recordMariPlanAnswer, setDraft],
   );
 
   const runRestart = useCallback(async () => {
@@ -4205,7 +4214,7 @@ export function HomeProfessorMariChat({
       }
       return true;
     },
-    [chatId, loadChatHistory, qc, localizeUi],
+    [chatId, loadChatHistory, qc, setDraft, localizeUi],
   );
 
   const handleDeleteProfessorChat = useCallback(

--- a/packages/client/src/components/game/AnimatedText.tsx
+++ b/packages/client/src/components/game/AnimatedText.tsx
@@ -230,7 +230,7 @@ export function AnimatedText({ html, className, style }: AnimatedTextProps) {
     result = wrapCharactersForWave(result);
     // Re-sanitize after our additions
     return DOMPurify.sanitize(result, {
-      ALLOWED_TAGS: ["strong", "em", "br", "span"],
+      ALLOWED_TAGS: ["strong", "em", "u", "small", "br", "span"],
       ALLOWED_ATTR: ["class", "style"],
     });
   }, [html, textEffectsEnabled]);
@@ -243,7 +243,7 @@ export function animateTextHtml(html: string, enabled = true): string {
   let result = applyTextEffects(html, enabled);
   result = wrapCharactersForWave(result);
   return DOMPurify.sanitize(result, {
-    ALLOWED_TAGS: ["strong", "em", "br", "span"],
+    ALLOWED_TAGS: ["strong", "em", "u", "small", "br", "span"],
     ALLOWED_ATTR: ["class", "style"],
   });
 }

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -6639,7 +6639,7 @@ export function formatNarration(content: string, boldDialogue = true): string {
     .replace(/\[state:\s*(\w+)\]/gi, (_match, state: string) =>
       commandBadge("bg-sky-500/20 text-sky-300", "⚡ State", state),
     )
-    .replace(/(^|\n)\s*-#\s+([^\n]*)/g, '$1<small class="mari-md-subtext">$2</small>')
+    .replace(/(^|\n)[ \t]*-#(?:[ \t]+([^\n]*))?(?=\n|$)/g, '$1<small class="mari-md-subtext">$2</small>')
     .replace(/\*\*(.+?)\*\*/gs, "<strong>$1</strong>")
     .replace(/__(.+?)__/gs, '<u class="mari-md-underline">$1</u>')
     .replace(/\*(.+?)\*/gs, "<em>$1</em>")

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -6639,7 +6639,9 @@ export function formatNarration(content: string, boldDialogue = true): string {
     .replace(/\[state:\s*(\w+)\]/gi, (_match, state: string) =>
       commandBadge("bg-sky-500/20 text-sky-300", "⚡ State", state),
     )
+    .replace(/(^|\n)\s*-#\s+([^\n]*)/g, '$1<small class="mari-md-subtext">$2</small>')
     .replace(/\*\*(.+?)\*\*/gs, "<strong>$1</strong>")
+    .replace(/__(.+?)__/gs, '<u class="mari-md-underline">$1</u>')
     .replace(/\*(.+?)\*/gs, "<em>$1</em>")
     .replace(/\n/g, "<br />");
 
@@ -6648,5 +6650,8 @@ export function formatNarration(content: string, boldDialogue = true): string {
     html = html.replace(narrationQuoteRe, (match) => `<strong>${match}</strong>`);
   }
 
-  return DOMPurify.sanitize(html, { ALLOWED_TAGS: ["strong", "em", "br", "span"], ALLOWED_ATTR: ["class"] });
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: ["strong", "em", "u", "small", "br", "span"],
+    ALLOWED_ATTR: ["class"],
+  });
 }

--- a/packages/client/src/components/game/GameReadableDisplay.tsx
+++ b/packages/client/src/components/game/GameReadableDisplay.tsx
@@ -135,10 +135,15 @@ export function GameReadableDisplay({ type, content, onClose }: GameReadableDisp
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
       .replace(/>/g, "&gt;")
+      .replace(/(^|\n)\s*-#\s+([^\n]*)/g, '$1<small class="mari-md-subtext">$2</small>')
       .replace(/\*\*(.+?)\*\*/gs, "<strong>$1</strong>")
+      .replace(/__(.+?)__/gs, '<u class="mari-md-underline">$1</u>')
       .replace(/\*(.+?)\*/gs, "<em>$1</em>")
       .replace(/\n/g, "<br />");
-    return DOMPurify.sanitize(html, { ALLOWED_TAGS: ["strong", "em", "br"] });
+    return DOMPurify.sanitize(html, {
+      ALLOWED_TAGS: ["strong", "em", "u", "small", "br"],
+      ALLOWED_ATTR: ["class"],
+    });
   }, [content]);
 
   return (

--- a/packages/client/src/components/game/GameReadableDisplay.tsx
+++ b/packages/client/src/components/game/GameReadableDisplay.tsx
@@ -135,7 +135,7 @@ export function GameReadableDisplay({ type, content, onClose }: GameReadableDisp
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
       .replace(/>/g, "&gt;")
-      .replace(/(^|\n)\s*-#\s+([^\n]*)/g, '$1<small class="mari-md-subtext">$2</small>')
+      .replace(/(^|\n)[ \t]*-#(?:[ \t]+([^\n]*))?(?=\n|$)/g, '$1<small class="mari-md-subtext">$2</small>')
       .replace(/\*\*(.+?)\*\*/gs, "<strong>$1</strong>")
       .replace(/__(.+?)__/gs, '<u class="mari-md-underline">$1</u>')
       .replace(/\*(.+?)\*/gs, "<em>$1</em>")

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -1071,6 +1071,7 @@ function PromptsTab({
           placeholder={localizeUi("ui.presets.promptstab.leaveEmptyToUseMarinaraSBuiltInConversation")}
           className="mari-editor-field min-h-[12rem] w-full p-3 font-mono text-xs"
           formatOnChange={formatPrompt}
+          showMarkdownPreview
           spellCheck={false}
         />
       </FieldGroup>
@@ -1090,6 +1091,7 @@ function PromptsTab({
           placeholder={localizeUi("ui.presets.promptstab.leaveEmptyToUseMarinaraSBuiltInGame")}
           className="mari-editor-field min-h-[12rem] w-full p-3 font-mono text-xs"
           formatOnChange={formatPrompt}
+          showMarkdownPreview
           spellCheck={false}
         />
       </FieldGroup>
@@ -2960,6 +2962,7 @@ function SectionContentTextarea({
       onExpandedClose={commit}
       formatOnChange={(textarea, inputEvent) => applyTextareaQuoteFormat(textarea, quoteFormat, inputEvent)}
       title={sectionName ?localizeUi("ui.presets.sectioncontenttextarea.editValue1", { value1: sectionName }) :localizeUi("ui.presets.sectioncontenttextarea.editPrompt")}
+      showMarkdownPreview
       className="mari-editor-field min-h-[7.5rem] w-full p-2.5 font-mono text-xs"
       placeholder={localizeUi("ui.presets.sectioncontenttextarea.promptContentSupportsUserCharCommentTrimMacros")}
     />

--- a/packages/client/src/lib/inline-markdown-regex.ts
+++ b/packages/client/src/lib/inline-markdown-regex.ts
@@ -1,5 +1,8 @@
 export const MD_LINK_TARGET_SOURCE = String.raw`(?:https?:\/\/[^)\s]+|card:\/\/[^)\s]+|\/api\/[^)\s]+)`;
 
+/** Discord-style line-level subtext, which must be checked before unordered lists. */
+export const DISCORD_SUBTEXT_RE = /^\s*-#(?:\s+(.*)|\s*)$/;
+
 export const INLINE_MD_RE = new RegExp(
   "\\\\([-\\\\*_~`#|>!=\\[\\]{}])|(!?\\[([^\\]]*)\\]\\((" +
     MD_LINK_TARGET_SOURCE +

--- a/packages/client/src/lib/markdown.tsx
+++ b/packages/client/src/lib/markdown.tsx
@@ -5,7 +5,7 @@ import { type ReactNode } from "react";
 import { normalizeCardAssetImageSyntax, resolveCardAssetUrl } from "./card-asset-links";
 import { convertBasicLatexSymbols, convertBasicLatexSymbolsInHtml } from "./latex-symbols";
 import { useUIStore } from "../stores/ui.store";
-import { INLINE_MD_RE, MD_LINK_TARGET_SOURCE } from "./inline-markdown-regex";
+import { DISCORD_SUBTEXT_RE, INLINE_MD_RE, MD_LINK_TARGET_SOURCE } from "./inline-markdown-regex";
 
 // ─── Inline Markdown ────────────────────────────────────────────────────────
 
@@ -20,7 +20,7 @@ import { INLINE_MD_RE, MD_LINK_TARGET_SOURCE } from "./inline-markdown-regex";
  *   7     Strikethrough     ~~text~~
  *   8     Bold-italic       ***text***   (must precede bold)
  *   9     Bold              **text**
- *   10    Italic (__)       __text__
+ *   10    Underline         __text__
  *   11    Italic (*)        *text*
  *   12    Italic (_)        _text_   (not inside a word)
  */
@@ -159,8 +159,12 @@ export function applyInlineMarkdown(text: string, keyPrefix: string, _depth = 0)
       // ── Bold: **text** ──
       nodes.push(<strong key={`${keyPrefix}b${key++}`}>{recurse(match[9], "b")}</strong>);
     } else if (match[10] != null) {
-      // ── Italic: __text__ ──
-      nodes.push(<em key={`${keyPrefix}di${key++}`}>{recurse(match[10], "di")}</em>);
+      // ── Underline: __text__ ──
+      nodes.push(
+        <u key={`${keyPrefix}u${key++}`} className="mari-md-underline">
+          {recurse(match[10], "u")}
+        </u>,
+      );
     } else if (match[11] != null) {
       // ── Italic: *text* ──
       nodes.push(<em key={`${keyPrefix}i${key++}`}>{recurse(match[11], "i")}</em>);
@@ -587,6 +591,19 @@ export function renderMarkdownBlocks(
       flushTable();
     }
 
+    // ── Discord-style subtext (must be checked before regular UL) ──
+    const subtextMatch = DISCORD_SUBTEXT_RE.exec(line);
+    if (subtextMatch) {
+      flushText();
+      flushList();
+      segments.push(
+        <small key={`${keyBase}sub${key++}`} className="mari-md-subtext">
+          {renderInline(subtextMatch[1] ?? "", `${keyBase}sub${key}`)}
+        </small>,
+      );
+      continue;
+    }
+
     // ── Task list item (must be checked before regular UL) ──
     const taskMatch = TASK_ITEM_RE.exec(line);
     if (taskMatch) {
@@ -704,8 +721,8 @@ export function applyInlineMarkdownHTML(html: string): string {
       .replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>")
       // Bold: **text**
       .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-      // Italic: __text__
-      .replace(/__(.+?)__/g, "<em>$1</em>")
+      // Underline: __text__
+      .replace(/__(.+?)__/g, '<u class="mari-md-underline">$1</u>')
       // Italic: *text* (single asterisk, not part of **)
       .replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "<em>$1</em>")
       // Italic: _text_ (not inside a word)
@@ -715,5 +732,7 @@ export function applyInlineMarkdownHTML(html: string): string {
         /(?:^|(?<=<br[^>]*>))\s*&gt;\s?(.+?)(?=<br|$)/g,
         '<blockquote class="mari-md-blockquote">$1</blockquote>',
       )
+      // Discord-style subtext: -# text
+      .replace(/(?:^|(?<=<br[^>]*>))\s*-#\s+(.+?)(?=<br|$)/g, '<small class="mari-md-subtext">$1</small>')
   );
 }

--- a/packages/client/src/lib/markdown.tsx
+++ b/packages/client/src/lib/markdown.tsx
@@ -733,6 +733,9 @@ export function applyInlineMarkdownHTML(html: string): string {
         '<blockquote class="mari-md-blockquote">$1</blockquote>',
       )
       // Discord-style subtext: -# text
-      .replace(/(?:^|(?<=<br[^>]*>))\s*-#\s+(.+?)(?=<br|$)/g, '<small class="mari-md-subtext">$1</small>')
+      .replace(
+        /(?:^|(?<=<br[^>]*>))[ \t]*-#(?:[ \t]+(.*?))?(?=<br|$)/g,
+        '<small class="mari-md-subtext">$1</small>',
+      )
   );
 }

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -3520,6 +3520,19 @@ strong {
   opacity: 0.7;
 }
 
+/* Discord-style inline underline and line-level subtext */
+.mari-md-underline {
+  text-decoration: underline;
+  text-underline-offset: 0.12em;
+}
+
+.mari-md-subtext {
+  display: block;
+  color: var(--muted-foreground);
+  font-size: 0.8125em;
+  line-height: 1.35;
+}
+
 /* Fenced code blocks */
 .mari-message-content .mari-md-codeblock {
   position: relative;

--- a/scripts/regressions/assigned-issue-sweep.regression.ts
+++ b/scripts/regressions/assigned-issue-sweep.regression.ts
@@ -24,12 +24,16 @@ assert.equal(innerMarkdownMatch?.[9], "bold", "double-star delimiters remain bol
 const underlineMatch = new RegExp(INLINE_MD_RE.source, INLINE_MD_RE.flags).exec("__underlined__");
 assert.equal(underlineMatch?.[10], "underlined", "double underscores retain the underline span");
 assert.equal(DISCORD_SUBTEXT_RE.exec("-# quiet context")?.[1], "quiet context", "Discord-style subtext is recognized");
+assert.equal(DISCORD_SUBTEXT_RE.exec("-#")?.[1], undefined, "bare Discord-style subtext is recognized");
+assert.equal(DISCORD_SUBTEXT_RE.exec("-# ")?.[1], "", "empty Discord-style subtext with spacing is recognized");
 assert.equal(DISCORD_SUBTEXT_RE.test("- ordinary list item"), false, "ordinary list items remain ordinary lists");
 assert.match(
   applyInlineMarkdownHTML("<span>HTML</span><br>-# quiet context"),
   /<small class="mari-md-subtext">quiet context<\/small>/u,
   "embedded-HTML chat content receives the same Discord-style subtext rendering",
 );
+assert.equal(applyInlineMarkdownHTML("-#"), '<small class="mari-md-subtext"></small>');
+assert.equal(applyInlineMarkdownHTML("-# "), '<small class="mari-md-subtext"></small>');
 
 const markdownSource = readFileSync(join(repositoryRoot, "packages/client/src/lib/markdown.tsx"), "utf8");
 assert.match(

--- a/scripts/regressions/assigned-issue-sweep.regression.ts
+++ b/scripts/regressions/assigned-issue-sweep.regression.ts
@@ -24,7 +24,9 @@ assert.equal(innerMarkdownMatch?.[9], "bold", "double-star delimiters remain bol
 const underlineMatch = new RegExp(INLINE_MD_RE.source, INLINE_MD_RE.flags).exec("__underlined__");
 assert.equal(underlineMatch?.[10], "underlined", "double underscores retain the underline span");
 assert.equal(DISCORD_SUBTEXT_RE.exec("-# quiet context")?.[1], "quiet context", "Discord-style subtext is recognized");
-assert.equal(DISCORD_SUBTEXT_RE.exec("-#")?.[1], undefined, "bare Discord-style subtext is recognized");
+const bareSubtextMatch = DISCORD_SUBTEXT_RE.exec("-#");
+assert.ok(bareSubtextMatch, "bare Discord-style subtext is recognized");
+assert.equal(bareSubtextMatch[1], undefined, "bare Discord-style subtext has no content");
 assert.equal(DISCORD_SUBTEXT_RE.exec("-# ")?.[1], "", "empty Discord-style subtext with spacing is recognized");
 assert.equal(DISCORD_SUBTEXT_RE.test("- ordinary list item"), false, "ordinary list items remain ordinary lists");
 assert.match(

--- a/scripts/regressions/assigned-issue-sweep.regression.ts
+++ b/scripts/regressions/assigned-issue-sweep.regression.ts
@@ -2,7 +2,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { INLINE_MD_RE } from "../../packages/client/src/lib/inline-markdown-regex.js";
+import { DISCORD_SUBTEXT_RE, INLINE_MD_RE } from "../../packages/client/src/lib/inline-markdown-regex.js";
+import { applyInlineMarkdownHTML } from "../../packages/client/src/lib/markdown.js";
 import { mergeUndatedSyncedSettings } from "../../packages/client/src/hooks/use-settings-sync.js";
 import {
   isStockMarinaraUniversalPreset,
@@ -11,12 +12,43 @@ import {
 
 const repositoryRoot = fileURLToPath(new URL("../../", import.meta.url));
 
-const outerMarkdownMatch = new RegExp(INLINE_MD_RE.source, INLINE_MD_RE.flags).exec(
-  "*This is **bold** in italic.*",
+const outerMarkdownMatch = new RegExp(INLINE_MD_RE.source, INLINE_MD_RE.flags).exec("*This is **bold** in italic.*");
+assert.equal(
+  outerMarkdownMatch?.[11],
+  "This is **bold** in italic.",
+  "single-star delimiters keep the full italic span",
 );
-assert.equal(outerMarkdownMatch?.[11], "This is **bold** in italic.", "single-star delimiters keep the full italic span");
 const innerMarkdownMatch = new RegExp(INLINE_MD_RE.source, INLINE_MD_RE.flags).exec(outerMarkdownMatch?.[11] ?? "");
 assert.equal(innerMarkdownMatch?.[9], "bold", "double-star delimiters remain bold inside italic text");
+
+const underlineMatch = new RegExp(INLINE_MD_RE.source, INLINE_MD_RE.flags).exec("__underlined__");
+assert.equal(underlineMatch?.[10], "underlined", "double underscores retain the underline span");
+assert.equal(DISCORD_SUBTEXT_RE.exec("-# quiet context")?.[1], "quiet context", "Discord-style subtext is recognized");
+assert.equal(DISCORD_SUBTEXT_RE.test("- ordinary list item"), false, "ordinary list items remain ordinary lists");
+assert.match(
+  applyInlineMarkdownHTML("<span>HTML</span><br>-# quiet context"),
+  /<small class="mari-md-subtext">quiet context<\/small>/u,
+  "embedded-HTML chat content receives the same Discord-style subtext rendering",
+);
+
+const markdownSource = readFileSync(join(repositoryRoot, "packages/client/src/lib/markdown.tsx"), "utf8");
+assert.match(
+  markdownSource,
+  /<u key=\{`\$\{keyPrefix\}u\$\{key\+\+\}`\} className="mari-md-underline">/u,
+  "the React Markdown path renders double underscores as underline",
+);
+assert.match(
+  markdownSource,
+  /<small key=\{`\$\{keyBase\}sub\$\{key\+\+\}`\} className="mari-md-subtext">/u,
+  "the React Markdown path renders Discord-style subtext as a semantic small block",
+);
+
+const gameNarrationSource = readFileSync(
+  join(repositoryRoot, "packages/client/src/components/game/GameNarration.tsx"),
+  "utf8",
+);
+assert.match(gameNarrationSource, /mari-md-underline/u, "Game chat narration retains underline markup");
+assert.match(gameNarrationSource, /mari-md-subtext/u, "Game chat narration retains Discord-style subtext markup");
 
 const mergedSettings = mergeUndatedSyncedSettings({ accentColor: "local", homeGreetingEnabled: true } as never, {
   accentColor: "server",
@@ -65,6 +97,31 @@ assert.doesNotMatch(
   lorebookCallbacks,
   /if \(!dirtyRef\.current\) return;/u,
   "embedded-lorebook controls reconcile immediately even when the editor is clean",
+);
+
+const presetEditorSource = readFileSync(
+  join(repositoryRoot, "packages/client/src/components/presets/PresetEditor.tsx"),
+  "utf8",
+);
+assert.equal(
+  presetEditorSource.match(/showMarkdownPreview/gu)?.length,
+  3,
+  "Conversation, Game, and section preset content expose Markdown previews",
+);
+
+const professorMariChatSource = readFileSync(
+  join(repositoryRoot, "packages/client/src/components/chat/HomeProfessorMariChat.tsx"),
+  "utf8",
+);
+assert.match(
+  professorMariChatSource,
+  /inputDrafts\.get\(PROFESSOR_MARI_DRAFT_KEY\)/u,
+  "Home Professor Mari restores her composer from the persisted draft store",
+);
+assert.match(
+  professorMariChatSource,
+  /setInputDraft\(PROFESSOR_MARI_DRAFT_KEY,/u,
+  "Home Professor Mari saves composer changes through the persisted draft store",
 );
 
 console.info("Assigned issue-sweep regressions passed.");


### PR DESCRIPTION
## What

- Add Markdown previews to Conversation, Game, and section content in the preset editor by reusing the existing safe `MacroTextarea` preview.
- Persist the Home Professor Mari composer in the existing local draft store, so unsent text survives editor navigation and app restarts and still clears after a successful send or explicit restart.
- Render Discord-style `__underline__` and `-# subtext` through the shared React/HTML Markdown paths and the Game narration/readable paths.

## Why

Preset authors could not preview formatting where they write it, Home Professor Mari kept her draft only in component state and lost it when the view unmounted, and double underscores/subtext behaved differently from Discord despite the chat renderer already supporting adjacent Markdown syntax.

Closes #4914
Closes #4915
Closes #4916

## Validation

- [ ] Run `pnpm check` (automated run passed locally).
- [ ] Run `pnpm localization:check` (automated run passed locally; no new user-facing strings).
- [ ] Run `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/assigned-issue-sweep.regression.ts` (passed locally).
- [ ] Manually verify preset previews, Home Professor Mari draft restoration, and underline/subtext in Conversation, Roleplay, and Game.

## Validation notes

- `pnpm smoke:ui` was attempted. The broad suite entered failures in pre-existing test/environment paths, including stale selectors for `HomeProfessorMariChat.MariPanel` and `Open Characters Library`; the current Home page remained visible in captured output. This is not claimed as passing proof for this patch.
- `pnpm regression:issues` reached and passed this sweep regression, then stopped in the existing granular-preset fixture because `preset.create` omits the now-required `systemKey` column.
- The in-app browser controller could not attach because its bootstrap failed with `Cannot redefine property: process`, so affected browser paths remain listed for manual verification.

> Validation boxes remain unchecked for human verification, per repository policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Markdown previews to preset editor fields.
  * Added Discord-style underlined text and muted subtext formatting across readable content, narration, and chat.
  * Improved styling for underlined text and subtext in rendered content.

* **Bug Fixes**
  * Preserved unsent Professor Mari messages when navigating away or restarting the app.
  * Improved consistency of Markdown formatting across supported content views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->