### PR TITLE
fix(server): give Professor Mari a safe lorebook.deleteEntry action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Gave Professor Mari a safe way to delete a single lorebook entry (`lorebook.deleteEntry`) and told her to use it instead of a raw `mari db delete`, which previously let her remove far more entries than intended when asked to delete just one (#4924).
 - Preserved unsent Home Professor Mari messages across editor navigation and app restarts until they are sent or explicitly cleared (#4915).
 - Taught workspace Professor Mari to revise an existing saved memory when asked, instead of declining that a matching memory "already exists": her guidance now includes a read-then-rewrite recipe and worked example for editing a memory's content in place (the same pattern she uses for preset sections), which also works on an enabled or persistent memory without turning it off (#4917).
 - Made Force To Call Tool serialize native required-tool controls for Google Gemini, Vertex AI, and compatible Anthropic requests, while safely falling back to automatic choice for manual Claude extended thinking and Mythos (#4907).

--- a/packages/server/src/services/mari-db/mari-db.service.ts
+++ b/packages/server/src/services/mari-db/mari-db.service.ts
@@ -822,6 +822,11 @@ function normalizeAppDataActionName(action: string): string {
     "lorebook.entries.get": "lorebook.getentry",
     "lorebook.entry.update": "lorebook.updateentry",
     "lorebook.entries.update": "lorebook.updateentry",
+    "lorebook.entry.delete": "lorebook.deleteentry",
+    "lorebook.entries.delete": "lorebook.deleteentry",
+    "lorebook.entry.remove": "lorebook.deleteentry",
+    "lorebook.entries.remove": "lorebook.deleteentry",
+    "lorebook.removeentry": "lorebook.deleteentry",
     "theme.set": "theme.setactive",
     "theme.activate": "theme.setactive",
     "promptpreset.list": "preset.list",
@@ -3556,6 +3561,26 @@ export class MariDbService {
             table: "lorebook_entries",
             id: entryId,
             patch,
+            apply: firstBoolean(args, ["apply"]) === true,
+            cascade: false,
+            reason: firstString(args, ["reason"]) ?? null,
+            cwd: context.cwd,
+          },
+          context.command,
+          context.sessionId,
+        );
+      }
+      case "deleteentry": {
+        // A safe, scoped single-entry delete so Mari never reaches for a raw `mari db delete --where`
+        // (which can match — and remove — far more rows than intended).
+        const entryId = requiredString(args, ["entryId", "id"], "lorebook entry id");
+        const entryExists = await this.getRawById(getMeta("lorebook_entries"), entryId);
+        if (!entryExists) throw new Error(`Lorebook entry ${entryId} not found`);
+        return this.executeMutation(
+          {
+            kind: "delete",
+            table: "lorebook_entries",
+            id: entryId,
             apply: firstBoolean(args, ["apply"]) === true,
             cascade: false,
             reason: firstString(args, ["reason"]) ?? null,

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -207,6 +207,7 @@ export const PROFESSOR_MARI_APP_DATA_ACTIONS = [
   "lorebook.update",
   "lorebook.addEntry",
   "lorebook.updateEntry",
+  "lorebook.deleteEntry",
   "theme.list",
   "theme.active",
   "theme.get",
@@ -641,7 +642,7 @@ ${MARI_GUIDED_SEQUENCES}
 
 \`app_data\` quick reference:
 - Reads: \`character.list|get|search|folder.list\`, \`persona.list|active|get|search\`, \`lorebook.list|get|entries|getEntry|search\`, \`theme.list|active|get\`, \`personal_extension.list|get|search\`, \`agent.list|get|search\`, \`preset.list|get|search|sections|getSection|groups|getGroup|choiceBlocks|getChoiceBlock\`, \`home_widget.list|get\`, \`instruction.list|get\`.
-- Writes: \`character.create|update|moveToFolder\`, \`persona.create|update\`, \`lorebook.create|update|addEntry|updateEntry\`, \`theme.create|update|setActive\`, \`personal_extension.create|update\`, \`agent.create|update\`, \`preset.create|update|addSection|updateSection|deleteSection|addGroup|updateGroup|deleteGroup|addChoiceBlock|updateChoiceBlock|deleteChoiceBlock\`, \`home_widget.create|update|delete\`, \`instruction.remember|update|forget\`.
+- Writes: \`character.create|update|moveToFolder\`, \`persona.create|update\`, \`lorebook.create|update|addEntry|updateEntry|deleteEntry\`, \`theme.create|update|setActive\`, \`personal_extension.create|update\`, \`agent.create|update\`, \`preset.create|update|addSection|updateSection|deleteSection|addGroup|updateGroup|deleteGroup|addChoiceBlock|updateChoiceBlock|deleteChoiceBlock\`, \`home_widget.create|update|delete\`, \`instruction.remember|update|forget\`.
 - Character folders: call \`character.folder.list\` to resolve the destination, then \`character.moveToFolder\` with \`characterId\` and either \`folderId\` or \`folderName\`. A move removes the character from its previous folder. When the user explicitly asks for the move, set \`apply:true\`, then verify with \`character.folder.list\`.
 - Put write fields in \`data\` for creates and \`patch\` for updates. Use \`entryId\` for \`lorebook.updateEntry\`; use \`lorebookId\` only for a lorebook or for \`lorebook.addEntry\`.
 - New creates: use \`apply:true\` immediately for \`character.create\`, \`persona.create\`, \`lorebook.create\`, \`lorebook.addEntry\`, \`agent.create\`, \`preset.create\`, and non-activating \`theme.create\` when the user asked you to create it. Verify with a read before claiming success.
@@ -661,6 +662,7 @@ ${MARI_GUIDED_SEQUENCES}
   - Unsure what a field does? \`docs_read docs/lorebooks/entries.md\` at the heading "Entry types: Normal, Constant, Selective" or "Keyword matching rules".
 - Lorebook fidelity pass: after creating a lorebook, OFFER the user a second-pass review (do not run it unprompted). If they accept, read the entries back (\`lorebook.entries\` then \`lorebook.getEntry\`) and fix weak spots with \`lorebook.updateEntry\`: narrow an over-broad key or add \`matchWholeWords\`, mark always-relevant lore \`constant\`, group alternates, or fill a missing \`description\`.
 - Lorebook reading: \`lorebook.entries\` is a compact index with entry IDs and content previews. Call \`lorebook.getEntry\` with each relevant \`entryId\` before reviewing or rewriting its full content.
+- Deleting a lorebook entry: use \`lorebook.deleteEntry\` with the entry's \`entryId\` and \`apply:true\` — it removes that one entry and shows a Keep/Restore card. NEVER delete a lorebook entry with a raw \`mari db delete\`: its \`--where\` selector can match and permanently remove far more rows than you intend. If a raw \`mari db delete\` is ever unavoidable, dry-run it first (\`apply:false\`) and confirm the exact affected-row count before applying.
 - For \`preset.create\`, put prompt sections in \`data.sections\` and preset variables in \`data.choiceBlocks\`. Each choice block needs \`variableName\`, \`question\`, and \`options\` with \`label\`/\`value\` pairs.
 - Editing part of a preset: \`preset.sections\` is a compact index (section IDs, names, content previews); call \`preset.getSection\` before rewriting one. To add a line at a specific spot, read the section's full content with \`preset.getSection\`, splice your change into it, then \`preset.updateSection\` with the whole new content — the section is the finest editable unit (there is no line/offset addressing). \`preset.addSection\`/\`addGroup\` place the new item and wire it into the preset's order; \`preset.deleteGroup\` keeps the group's member sections (they just lose the grouping).
 - Custom image agents are supported by the live runtime. Use \`data.resultType: "image_prompt"\`, enable \`settings.customCapabilities.trigger_image_generation\`, and have the agent return \`shouldGenerate\` plus \`prompt\`. Marker-triggered agents should also set \`activationKeywords\`. Do not claim that only Illustrator can generate image prompts.
@@ -699,6 +701,7 @@ Revising a saved memory (read its full text, edit it, then write the whole new c
 {"say":"","commands":[{"name":"app_data","arguments":{"action":"instruction.update","id":"memory-id","data":{"content":"...the full memory text with the requested change applied..."},"reason":"User asked to reword this memory","apply":true}}],"stop":false}
 {"say":"","commands":[{"name":"app_data","arguments":{"action":"agent.create","data":{"name":"Image Marker","description":"Turns IMG_PROMPT markers into image prompts.","resultType":"image_prompt","activationKeywords":["IMG_PROMPT:"],"activationScanDepth":4,"settings":{"customCapabilities":{"trigger_image_generation":true}}},"reason":"User requested a marker-triggered image agent","apply":true}}],"stop":false}
 {"say":"","commands":[{"name":"app_data","arguments":{"action":"lorebook.updateEntry","entryId":"entry-id","patch":{"content":"new content"},"reason":"Update requested by user","apply":false}}],"stop":false}
+{"say":"","commands":[{"name":"app_data","arguments":{"action":"lorebook.deleteEntry","entryId":"entry-id","reason":"User asked to delete this entry","apply":true}}],"stop":false}
 
 Available command schemas:
 ${toolDocs}

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -2097,47 +2097,50 @@ try {
   // #4924: lorebook.deleteEntry removes exactly ONE entry (scoped), so Mari never needs a raw
   // `mari db delete --where` that can mass-delete unrelated rows.
   const professorMariDeleteLorebookId = "professor-mari-delete-entry-regression";
-  const professorMariDeleteCreate = await mariDb.executeAction({
-    action: "lorebook.create",
-    lorebookId: professorMariDeleteLorebookId,
-    data: {
-      name: "Delete-entry regression",
-      entries: [
-        { name: "Keep me", content: "This entry must survive." },
-        { name: "Remove me", content: "This entry gets deleted." },
-      ],
-    },
-    apply: true,
-  });
-  assert.equal(professorMariDeleteCreate.ok, true);
-  const professorMariDeleteEntries = await lorebookStorage.listEntries(professorMariDeleteLorebookId);
-  assert.equal(professorMariDeleteEntries.length, 2, "both entries were created");
-  const professorMariEntryToDelete = professorMariDeleteEntries.find((entry) => entry.name === "Remove me");
-  const professorMariEntryToKeep = professorMariDeleteEntries.find((entry) => entry.name === "Keep me");
-  assert.ok(professorMariEntryToDelete && professorMariEntryToKeep, "both named entries are present before delete");
+  try {
+    const professorMariDeleteCreate = await mariDb.executeAction({
+      action: "lorebook.create",
+      lorebookId: professorMariDeleteLorebookId,
+      data: {
+        name: "Delete-entry regression",
+        entries: [
+          { name: "Keep me", content: "This entry must survive." },
+          { name: "Remove me", content: "This entry gets deleted." },
+        ],
+      },
+      apply: true,
+    });
+    assert.equal(professorMariDeleteCreate.ok, true);
+    const professorMariDeleteEntries = await lorebookStorage.listEntries(professorMariDeleteLorebookId);
+    assert.equal(professorMariDeleteEntries.length, 2, "both entries were created");
+    const professorMariEntryToDelete = professorMariDeleteEntries.find((entry) => entry.name === "Remove me");
+    const professorMariEntryToKeep = professorMariDeleteEntries.find((entry) => entry.name === "Keep me");
+    assert.ok(professorMariEntryToDelete && professorMariEntryToKeep, "both named entries are present before delete");
 
-  // Deleting a non-existent entry is rejected, not a silent no-op.
-  const professorMariDeleteMissing = await mariDb.executeAction({
-    action: "lorebook.deleteEntry",
-    entryId: "no-such-entry-id",
-    apply: true,
-  });
-  assert.equal(professorMariDeleteMissing.ok, false, "deleting a missing entry is rejected");
+    // Deleting a non-existent entry is rejected, not a silent no-op.
+    const professorMariDeleteMissing = await mariDb.executeAction({
+      action: "lorebook.deleteEntry",
+      entryId: "no-such-entry-id",
+      apply: true,
+    });
+    assert.equal(professorMariDeleteMissing.ok, false, "deleting a missing entry is rejected");
 
-  const professorMariDeleteResult = await mariDb.executeAction({
-    action: "lorebook.deleteEntry",
-    entryId: professorMariEntryToDelete.id,
-    apply: true,
-  });
-  assert.equal(
-    professorMariDeleteResult.ok,
-    true,
-    `lorebook.deleteEntry must succeed: ${JSON.stringify(professorMariDeleteResult)}`,
-  );
-  const professorMariAfterDelete = await lorebookStorage.listEntries(professorMariDeleteLorebookId);
-  assert.equal(professorMariAfterDelete.length, 1, "exactly one entry was removed (scoped, not a mass delete)");
-  assert.equal(professorMariAfterDelete[0]?.id, professorMariEntryToKeep.id, "the untargeted entry survives");
-  await lorebookStorage.remove(professorMariDeleteLorebookId);
+    const professorMariDeleteResult = await mariDb.executeAction({
+      action: "lorebook.deleteEntry",
+      entryId: professorMariEntryToDelete.id,
+      apply: true,
+    });
+    assert.equal(
+      professorMariDeleteResult.ok,
+      true,
+      `lorebook.deleteEntry must succeed: ${JSON.stringify(professorMariDeleteResult)}`,
+    );
+    const professorMariAfterDelete = await lorebookStorage.listEntries(professorMariDeleteLorebookId);
+    assert.equal(professorMariAfterDelete.length, 1, "exactly one entry was removed (scoped, not a mass delete)");
+    assert.equal(professorMariAfterDelete[0]?.id, professorMariEntryToKeep.id, "the untargeted entry survives");
+  } finally {
+    await lorebookStorage.remove(professorMariDeleteLorebookId);
+  }
 
   const professorMariCliLorebookId = "professor-mari-cli-lorebook-create-regression";
   const professorMariCliLorebookResult = await mariDb.executeCli({

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -2094,6 +2094,51 @@ try {
   );
   await lorebookStorage.remove(professorMariParamLorebookId);
 
+  // #4924: lorebook.deleteEntry removes exactly ONE entry (scoped), so Mari never needs a raw
+  // `mari db delete --where` that can mass-delete unrelated rows.
+  const professorMariDeleteLorebookId = "professor-mari-delete-entry-regression";
+  const professorMariDeleteCreate = await mariDb.executeAction({
+    action: "lorebook.create",
+    lorebookId: professorMariDeleteLorebookId,
+    data: {
+      name: "Delete-entry regression",
+      entries: [
+        { name: "Keep me", content: "This entry must survive." },
+        { name: "Remove me", content: "This entry gets deleted." },
+      ],
+    },
+    apply: true,
+  });
+  assert.equal(professorMariDeleteCreate.ok, true);
+  const professorMariDeleteEntries = await lorebookStorage.listEntries(professorMariDeleteLorebookId);
+  assert.equal(professorMariDeleteEntries.length, 2, "both entries were created");
+  const professorMariEntryToDelete = professorMariDeleteEntries.find((entry) => entry.name === "Remove me");
+  const professorMariEntryToKeep = professorMariDeleteEntries.find((entry) => entry.name === "Keep me");
+  assert.ok(professorMariEntryToDelete && professorMariEntryToKeep, "both named entries are present before delete");
+
+  // Deleting a non-existent entry is rejected, not a silent no-op.
+  const professorMariDeleteMissing = await mariDb.executeAction({
+    action: "lorebook.deleteEntry",
+    entryId: "no-such-entry-id",
+    apply: true,
+  });
+  assert.equal(professorMariDeleteMissing.ok, false, "deleting a missing entry is rejected");
+
+  const professorMariDeleteResult = await mariDb.executeAction({
+    action: "lorebook.deleteEntry",
+    entryId: professorMariEntryToDelete.id,
+    apply: true,
+  });
+  assert.equal(
+    professorMariDeleteResult.ok,
+    true,
+    `lorebook.deleteEntry must succeed: ${JSON.stringify(professorMariDeleteResult)}`,
+  );
+  const professorMariAfterDelete = await lorebookStorage.listEntries(professorMariDeleteLorebookId);
+  assert.equal(professorMariAfterDelete.length, 1, "exactly one entry was removed (scoped, not a mass delete)");
+  assert.equal(professorMariAfterDelete[0]?.id, professorMariEntryToKeep.id, "the untargeted entry survives");
+  await lorebookStorage.remove(professorMariDeleteLorebookId);
+
   const professorMariCliLorebookId = "professor-mari-cli-lorebook-create-regression";
   const professorMariCliLorebookResult = await mariDb.executeCli({
     argv: [


### PR DESCRIPTION
## Linked issue

Closes #4924

## Why this change

Professor Mari had **no safe way to delete a single lorebook entry**: her `app_data` toolkit exposes `lorebook.addEntry` and `lorebook.updateEntry` but no `deleteEntry`. When a user asked her to delete one entry, `lorebook.deleteEntry` failed (not a real action), so she fell back to the raw `mari db delete <table> --where <expr>` command — a bulk delete with no row-count guard — and removed **77 entries across unrelated lorebooks** instead of the one. (The deletion was recoverable via the Keep/Restore card, but the blast radius was the whole matched set.)

## What changed

- **`packages/server/src/services/mari-db/mari-db.service.ts`** — added a `lorebook.deleteEntry` `app_data` action: it takes `entryId`, verifies the entry exists (throws otherwise), and deletes exactly that one row (`{ kind: "delete", table: "lorebook_entries", id, cascade: false }`) through the same `executeMutation` → Keep/Restore review as add/update. This is the identical shape the CLI's `mari lorebooks delete-entry <id>` already uses. Also registered delete aliases (`lorebook.entry.delete`, `lorebook.entries.delete`, `lorebook.entry.remove`, `lorebook.removeentry`, …).
- **`packages/server/src/services/professor-mari/workspace-agent.service.ts`** — registered `lorebook.deleteEntry` in the action catalog and the Writes quick-ref, added a prompt bullet ("to delete a lorebook entry use `lorebook.deleteEntry`; **never** a raw `mari db delete`, whose `--where` can remove far more rows than intended; if a raw `mari db delete` is ever unavoidable, dry-run and confirm the row count first"), and a worked example.
- **`scripts/regressions/open-issues.regression.ts`** — new test that creates a lorebook with two entries, deletes one via `lorebook.deleteEntry`, and asserts **exactly one** is removed, the other survives, and deleting a missing id is rejected.
- **`CHANGELOG.md`** — one Fixed entry.

Note on classification: `lorebook.deleteEntry` is correctly treated as **mutating** (its suffix isn't in the read-only whitelist), so it can't bypass the review and produces a recoverable Keep/Restore card.

Out of scope (deliberately, per the issue): a broader guardrail on raw `mari db delete --where` bulk deletes (dry-run-and-confirm before applying) — can be tracked separately.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated, done by me:

- `pnpm check` passes (TypeScript + ESLint + build, exit 0).
- The full `open-issues` regression passes, including the new scoping test (delete one of two entries → exactly one removed, the other survives, missing id rejected).

Still needs a human (please verify in a real browser, don't trust the boxes above):

- Ask Mari to delete one lorebook entry; confirm she uses `lorebook.deleteEntry`, only that entry is removed, and a Keep/Restore card appears (Restore puts it back).
- Confirm she no longer reaches for `mari db delete` for a single-entry delete.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

`CHANGELOG.md` updated. No `docs/` change and no version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a safer tool for deleting individual lorebook entries.
  - Supports deletion by entry ID with an explicit apply step.
  - Prevents unintended removal of other entries in the same lorebook.

- **Bug Fixes**
  - Deleting a nonexistent lorebook entry now reports a failure instead of proceeding.

- **Documentation**
  - Updated guidance and examples to recommend targeted entry deletion over broad database deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->