### PR TITLE
fix(mari): sync an embedded character's lorebook on Mari's generic mutations (#4927)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept a character's embedded lorebook in sync when Professor Mari edits it: adding, updating, or deleting an entry (or restoring one of those changes) in a lorebook embedded in a character card now rebuilds that character's copy, instead of leaving it stale as only her edits did before (#4927).
 - Gave Professor Mari a safe way to delete a single lorebook entry (`lorebook.deleteEntry`) and told her to use it instead of a raw `mari db delete`, which previously let her remove far more entries than intended when asked to delete just one (#4924).
 - Preserved unsent Home Professor Mari messages across editor navigation and app restarts until they are sent or explicitly cleared (#4915).
 - Taught workspace Professor Mari to revise an existing saved memory when asked, instead of declining that a matching memory "already exists": her guidance now includes a read-then-rewrite recipe and worked example for editing a memory's content in place (the same pattern she uses for preset sections), which also works on an enabled or persistent memory without turning it off (#4917).

--- a/packages/server/src/services/mari-db/mari-db.service.ts
+++ b/packages/server/src/services/mari-db/mari-db.service.ts
@@ -16,6 +16,7 @@ import * as schema from "../../db/schema/index.js";
 import { getFileStorageDir, getMonorepoRoot, isCustomToolScriptEnabled } from "../../config/runtime-config.js";
 import { logger } from "../../lib/logger.js";
 import { createCharactersStorage } from "../storage/characters.storage.js";
+import { syncCharacterBookFromLorebook } from "../lorebook/character-book-sync.js";
 import {
   createMariInstructionsStorage,
   MAX_INSTRUCTION_CONTENT_LENGTH,
@@ -4702,6 +4703,9 @@ export class MariDbService {
       }
       throw err;
     }
+    // #4927: the restore reverted the lorebook rows, so rebuild any embedded character_book from the
+    // restored state (no-op for standalone lorebooks).
+    await this.syncAffectedCharacterBooks(record.plan.changes);
     this.pending.delete(id);
     await this.deletePendingSidecar(id);
     const history = await this.recordHistory({
@@ -6385,6 +6389,37 @@ export class MariDbService {
     return { kind, table, scriptPath, apply, cascade: true, reason, cwd };
   }
 
+  // #4927: keep an embedded character's data.character_book in sync after Mari mutates a lorebook
+  // through the generic mutation path — which, unlike the HTTP routes, never called the sync, so
+  // add/update/delete of an embedded lorebook's entries left the derived copy stale. Safe for
+  // standalone lorebooks: syncCharacterBookFromLorebook no-ops when the lorebook isn't embedded, and
+  // swallows its own errors, so a sync failure never breaks the mutation.
+  private async syncAffectedCharacterBooks(changes: PlanChange[]): Promise<void> {
+    const lorebookIds = new Set<string>();
+    const collect = (value: unknown) => {
+      if (typeof value === "string" && value) lorebookIds.add(value);
+    };
+    for (const change of changes) {
+      if (!change.apply) continue;
+      if (change.table === "lorebook_entries") {
+        // Collect BOTH sides: an entry reparented between lorebooks (a raw patch of its
+        // lorebookId) leaves its former lorebook stale too, not just the destination.
+        collect(change.before?.lorebookId);
+        collect(change.after?.lorebookId);
+      } else if (change.table === "lorebooks" && change.action !== "delete" && change.id) {
+        // A rename/metadata update rebuilds the embedded copy from the live row. A whole-lorebook
+        // DELETE is skipped here: syncCharacterBookFromLorebook rebuilds from the (now-gone) row and
+        // no-ops, so it would neither clear the character's stale character_book nor drop the
+        // dangling embed pointer. That clear + restore-re-embed parity with the HTTP DELETE route is
+        // tracked separately (#4932).
+        collect(change.id);
+      }
+    }
+    for (const lorebookId of lorebookIds) {
+      await syncCharacterBookFromLorebook(this.db, lorebookId);
+    }
+  }
+
   private async executeMutation(
     request: ParsedMutationRequest,
     command: string,
@@ -6418,6 +6453,7 @@ export class MariDbService {
 
     try {
       const journalPath = await this.applyPlan(plan);
+      await this.syncAffectedCharacterBooks(plan.changes);
       const history = await this.recordHistory({ plan, command, sessionId, status: "approved", journalPath });
       const review = await this.createAppliedReview(plan, command, sessionId, journalPath, history.id);
       return {

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -2187,7 +2187,11 @@ try {
 
     const embeddedSyncApproval = mariDb.getPendingApprovals().find((approval) => !beforeEmbeddedSync.has(approval.id));
     assert.ok(embeddedSyncApproval, "the entry edit produced a reviewable approval");
-    await mariDb.restoreAppliedReview(embeddedSyncApproval.id);
+    const embeddedSyncRestore = await mariDb.restoreAppliedReview(embeddedSyncApproval.id);
+    assert.ok(
+      embeddedSyncRestore && "history" in embeddedSyncRestore,
+      `restoring the entry edit must succeed (not null / state_changed): ${JSON.stringify(embeddedSyncRestore)}`,
+    );
     assert.ok(
       (await readEmbeddedBookContent()).includes("original content"),
       "restoring the edit resyncs the embedded character_book back",

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -2142,6 +2142,90 @@ try {
     await lorebookStorage.remove(professorMariDeleteLorebookId);
   }
 
+  // #4927: a Mari lorebook entry mutation resyncs an embedded character's data.character_book on
+  // both apply and Restore. The generic mari-db mutation path used to skip
+  // syncCharacterBookFromLorebook, so add/update/delete of an embedded lorebook's entries left the
+  // character's derived copy stale.
+  const embeddedSyncLorebook = await lorebookStorage.create({ name: "Embedded sync book" });
+  const embeddedSyncCharacter = await characterStorage.create(
+    characterDataSchema.parse({
+      name: "Embedded sync host",
+      character_book: { name: "Embedded sync book", entries: [] },
+      extensions: { importMetadata: { embeddedLorebook: { lorebookId: embeddedSyncLorebook.id } } },
+    }),
+  );
+  assert.ok(embeddedSyncCharacter, "embedded host character created");
+  let embeddedReparentTargetId: string | null = null;
+  try {
+    await lorebookStorage.update(embeddedSyncLorebook.id, { characterId: embeddedSyncCharacter.id });
+    const embeddedSyncEntry = await lorebookStorage.createEntry({
+      lorebookId: embeddedSyncLorebook.id,
+      name: "Embedded entry",
+      content: "original content",
+      keys: ["embed"],
+    });
+    const readEmbeddedBookContent = async () => {
+      const row = await characterStorage.getById(embeddedSyncCharacter.id);
+      const data = JSON.parse(String(row?.data ?? "{}")) as {
+        character_book?: { entries?: Array<{ content?: string }> };
+      };
+      return (data.character_book?.entries ?? []).map((entry) => entry.content ?? "");
+    };
+
+    const beforeEmbeddedSync = new Set(mariDb.getPendingApprovals().map((approval) => approval.id));
+    const embeddedSyncUpdate = await mariDb.executeAction({
+      action: "lorebook.updateEntry",
+      entryId: embeddedSyncEntry.id,
+      patch: { content: "edited content" },
+      apply: true,
+    });
+    assert.equal(embeddedSyncUpdate.ok, true);
+    assert.ok(
+      (await readEmbeddedBookContent()).includes("edited content"),
+      "applying a Mari entry edit resyncs the embedded character_book",
+    );
+
+    const embeddedSyncApproval = mariDb.getPendingApprovals().find((approval) => !beforeEmbeddedSync.has(approval.id));
+    assert.ok(embeddedSyncApproval, "the entry edit produced a reviewable approval");
+    await mariDb.restoreAppliedReview(embeddedSyncApproval.id);
+    assert.ok(
+      (await readEmbeddedBookContent()).includes("original content"),
+      "restoring the edit resyncs the embedded character_book back",
+    );
+
+    // #4927 (reparent): moving an entry to a DIFFERENT lorebook must resync the entry's FORMER
+    // lorebook too, not just the destination. syncAffectedCharacterBooks collects both sides of a
+    // lorebook_entries change, so the embedded book the entry LEFT rebuilds without it. (The old
+    // `after ?? before` collection synced only the destination and left this book stale.)
+    const embeddedReparentTarget = await lorebookStorage.create({ name: "Reparent target book" });
+    embeddedReparentTargetId = embeddedReparentTarget.id;
+    const embeddedReparent = await mariDb.executeCli({
+      argv: [
+        "db",
+        "patch",
+        "lorebook_entries",
+        embeddedSyncEntry.id,
+        "--json",
+        JSON.stringify({ lorebookId: embeddedReparentTarget.id }),
+        "--apply",
+      ],
+    });
+    assert.equal(
+      embeddedReparent.ok,
+      true,
+      `reparenting an entry to another lorebook must succeed: ${JSON.stringify(embeddedReparent)}`,
+    );
+    assert.deepEqual(
+      await readEmbeddedBookContent(),
+      [],
+      "reparenting an entry OUT of the embedded lorebook resyncs the former lorebook (the moved entry no longer appears)",
+    );
+  } finally {
+    await lorebookStorage.remove(embeddedSyncLorebook.id);
+    await characterStorage.remove(embeddedSyncCharacter.id);
+    if (embeddedReparentTargetId) await lorebookStorage.remove(embeddedReparentTargetId);
+  }
+
   const professorMariCliLorebookId = "professor-mari-cli-lorebook-create-regression";
   const professorMariCliLorebookResult = await mariDb.executeCli({
     argv: [


### PR DESCRIPTION
## Linked issue

Closes #4927

## Why this change

When a lorebook is embedded in a character card, the card keeps a derived copy at `data.character_book`, and the character editor's Lorebook tab reads from that copy directly. The HTTP lorebook routes keep it fresh by calling `syncCharacterBookFromLorebook` after every entry mutation.

Professor Mari's edits do **not** go through those routes — her `app_data` actions and `mari db` / `mari lorebooks` CLI both run through the generic mari-db mutation path (`executeMutation` → `applyPlan`, and `restoreAppliedReview` → `restorePlan`), which never called the sync. So when Mari added, edited, or deleted an entry in a lorebook embedded in a character, the character's `data.character_book` was left stale: the change looked applied, but reopening the character editor's Lorebook tab showed the old entries (the edit appeared to roll back). Restoring one of her edits had the same gap in reverse.

This is the systemic counterpart to the per-route sync — surfaced by CodeRabbit on #4926 and split out here so #4926 (the safe single-entry delete) could stay focused.

## What changed

- Added `syncAffectedCharacterBooks`, which collects the lorebook ids touched by an applied plan and rebuilds each embedded character's `data.character_book` via the existing `syncCharacterBookFromLorebook`. It is a no-op for standalone (non-embedded) lorebooks and swallows its own errors, so a sync failure can never fail the underlying mutation.
- Called it after `applyPlan` (apply) and after a **successful** `restorePlan` (Restore) — so it never fires on the `#4852` state-changed early-return that leaves data and the pending review intact.
- For `lorebook_entries` changes it collects **both** `before.lorebookId` and `after.lorebookId`, so an entry reparented from one lorebook to another resyncs the lorebook it left, not just the destination.
- Skips whole-lorebook **deletes**: `syncCharacterBookFromLorebook` rebuilds from the live row, which is already gone by the time the hook runs, so it would silently no-op. Clearing a deleted embedded lorebook's footprint (and re-embedding it on Restore), to match the HTTP `DELETE` route, is tracked as a follow-up in #4932.
- Regression in `open-issues.regression.ts` covering the entry edit + Restore resync and the cross-lorebook reparent.

## Validation

<!-- Boxes left unchecked intentionally: this PR was prepared with AI assistance, so the manual/browser items are a TO-DO list for the human contributor, not proof of completion. See notes below. -->

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated (already run locally, boxes above left for the human to confirm per repo policy):

- `pnpm check` passes (TypeScript + ESLint + client build) with exit 0.
- `scripts/regressions/open-issues.regression.ts` passes, including the new embedded-sync case: an entry edited via `lorebook.updateEntry` rebuilds the embedded character's `character_book`; `restoreAppliedReview` reverts it; and a cross-lorebook reparent (`mari db patch lorebook_entries … --json '{"lorebookId":…}'`) resyncs the source lorebook.

Still to verify in a real browser (not yet done):

- Import a lorebook into a character card (so `data.character_book` + the `embeddedLorebook` pointer are set), then ask Professor Mari to add / edit / delete an entry in that lorebook. Reopen the character editor's Lorebook tab and confirm the change is reflected (previously it appeared to roll back).
- Use the review card's **Restore** on one of those edits and confirm the character's Lorebook tab reverts to match.
- Confirm a Mari edit to a **standalone** (non-embedded) lorebook still behaves exactly as before (no character touched).

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

Notes: adds a `CHANGELOG.md` entry under `### Fixed`. No user-facing docs under `docs/` changed, so no `docs-i18n` update is required. No version bump.

## UI evidence (if applicable)

Not applicable — this is a server-side data-coherence fix with no UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Professor Mari lorebook edits now stay synchronized with embedded character-card lorebooks when entries are added, updated, deleted, restored, or moved.
  * Restoring a prior review correctly restores the embedded lorebook content.
  * Standalone lorebooks remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->