### PR TITLE
perf(client): cache repeated checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Changed
 
+- Repeated local checks now reuse native TypeScript and ESLint caches for unchanged client files (#ISSUE).
 - Manual Agent retries now resolve the same current settings, custom tools, and permitted built-in tools as normal Agent generation while retaining retry-specific historical context and Spotify playback verification (#4894).
 - Localized achievement definitions and official capability-package Home metadata through stable locale-aware contracts with English fallback, and refreshed Home's welcome copy (#4803, #4806).
 - Positioned Professor Mari's navigation helper at the bottom-left on her first appearance while preserving every remembered user placement.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Changed
 
-- Repeated local checks now reuse native TypeScript and ESLint caches for unchanged client files (#ISSUE).
+- Repeated local checks now reuse native TypeScript and ESLint caches for unchanged client files (#4938).
 - Manual Agent retries now resolve the same current settings, custom tools, and permitted built-in tools as normal Agent generation while retaining retry-specific historical context and Spotify playback verification (#4894).
 - Localized achievement definitions and official capability-package Home metadata through stable locale-aware contracts with English fallback, and refreshed Home's welcome copy (#4803, #4806).
 - Positioned Professor Mari's navigation helper at the bottom-left on her first appearance while preserving every remembered user placement.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "node ./scripts/build.mjs",
-    "clean": "node -e \"const fs=require('fs');['dist','tsconfig.tsbuildinfo'].forEach(p=>{try{fs.rmSync(p,{recursive:true,force:true})}catch{}})\"",
+    "clean": "node -e \"const fs=require('fs');['dist','tsconfig.tsbuildinfo','node_modules/.cache/eslint'].forEach(p=>{try{fs.rmSync(p,{recursive:true,force:true})}catch{}})\"",
     "preview": "vite preview",
-    "lint": "eslint ."
+    "lint": "eslint . --cache --cache-strategy content --cache-location node_modules/.cache/eslint/.eslintcache"
   },
   "dependencies": {
     "@dnd-kit/core": "6.3.1",

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -13,6 +13,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
+    "incremental": true,
     "declaration": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #4938

## Why this change

Repeated local checks reprocess the complete client TypeScript and ESLint inputs even when those files are unchanged. Reusing the tools' native caches shortens iterative validation while keeping every existing diagnostic and production-build lane.

## What changed

- Enabled TypeScript incremental state for the no-emit client project.
- Enabled ESLint content caching at `packages/client/node_modules/.cache/eslint/.eslintcache` without changing `eslint .` file selection or rules.
- Made explicit client clean remove the ESLint cache alongside `dist` and TypeScript build state; ordinary `pnpm check` continues to retain caches.
- Added an `[Unreleased]` changelog entry without promising a universal timing result.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Cache-cold `pnpm check` passed in 2m22s on one Windows machine.
- Immediate unchanged `pnpm check` passed in 28s; a final warm implementation run also passed in 28s.
- Post-commit PR-readiness `pnpm check` passed in 82s after the explicit-clean proof had removed TypeScript's warm state. These timings are machine-specific.
- A disposable client TypeScript error failed with `TS2322` before Vite, and a disposable ESLint syntax error failed with a parsing diagnostic; both files were restored exactly and their normal commands passed afterward.
- With `dist`, TypeScript build state, and the ESLint cache present, explicit client clean removed all three; the next client lint passed and recreated its cache.
- No browser or container check was performed because this changes validation tooling only, not runtime or UI behavior.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

The required changelog entry is included. No user documentation, translation, or version change is needed.

## UI evidence (if applicable)

Not applicable; this changes local validation tooling and clean behavior only.

## Risks and limitations

- Cold checks still perform all work; the benefit applies to repeated runs with unchanged or narrowly changed client inputs.
- Vite/PWA production builds remain uncached and continue to set a runtime floor.
- Cache invalidation remains owned by TypeScript and ESLint; explicit clean provides a deliberate cold reset.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Repeated local checks now run faster by reusing caches for unchanged client files.

* **Maintenance**
  * Cleaning the client project now also removes cached lint data.
  * Added a changelog entry documenting the improved local check performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->