### PR TITLE
fix: log turn-game move prompts in debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Made turn-game bot move prompts visible when UI debug mode or `DEBUG_AGENTS` is enabled (follow-up to #4945).
 - Included custom world fields and persona inventory in Agent Suite tracker editing without replacing adjacent tracker data (#4937).
 - Exposed active custom image agents in Conversation Gallery's Illustrate picker, matching the existing Roleplay and Game action (#4940).
 - Resumed pending turn-game bot seats after a regular Conversation reply so UNO cannot remain frozen when a chat send wins the per-chat generation lock (#4941).

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -419,7 +419,7 @@ import {
   resolveChatSummaryPrompt,
   withoutRetiredChatSummaryAgentIds,
 } from "../services/generation/roleplay-summary-runtime.js";
-import { getChatGenerationTimeoutMs, getMaxToolRounds } from "../config/runtime-config.js";
+import { getChatGenerationTimeoutMs, getMaxToolRounds, isDebugAgentsEnabled } from "../config/runtime-config.js";
 import {
   isReviewableWriterAgentType,
   buildRuntimeAgentSectionEligibleTypes,
@@ -768,6 +768,9 @@ export async function generateRoutes(app: FastifyInstance) {
     const requestDebug = input.debugMode === true;
     const debugLog = (message: string, ...args: any[]) => {
       logDebugOverride(requestDebug, message, ...args);
+    };
+    const turnGameDebugLog = (message: string, ...args: any[]) => {
+      logDebugOverride(requestDebug || isDebugAgentsEnabled(), message, ...args);
     };
 
     // Resolve the chat
@@ -1255,6 +1258,7 @@ export async function generateRoutes(app: FastifyInstance) {
           baseUrl,
           reply,
           signal: abortController.signal,
+          debugLog: turnGameDebugLog,
         });
         generationComplete = true;
         sendSseEvent(reply, { type: "done", data: "" });
@@ -9682,6 +9686,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   baseUrl,
                   reply,
                   signal: abortController.signal,
+                  debugLog: turnGameDebugLog,
                 });
 
                 const professorMariResult = await handleProfessorMariCommand({
@@ -9836,6 +9841,7 @@ export async function generateRoutes(app: FastifyInstance) {
             baseUrl,
             reply,
             signal: abortController.signal,
+            debugLog: turnGameDebugLog,
           });
         } catch (turnGameErr) {
           if (abortController.signal.aborted || isAbortLikeError(turnGameErr)) return;

--- a/packages/server/src/services/generation/turn-game-command-runtime.ts
+++ b/packages/server/src/services/generation/turn-game-command-runtime.ts
@@ -19,6 +19,7 @@ interface TurnGameCommandArgs {
   baseUrl: string;
   reply: FastifyReply;
   signal: AbortSignal;
+  debugLog?: (message: string, ...args: unknown[]) => void;
 }
 
 function normalizeGameType(commandType: string) {
@@ -93,6 +94,7 @@ export async function handleTurnGameCommand(args: TurnGameCommandArgs): Promise<
       baseUrl: args.baseUrl,
       reply: args.reply,
       signal: args.signal,
+      debugLog: args.debugLog,
     });
     return true;
   } catch (error) {

--- a/packages/server/src/services/turn-games/turn-game-bot-runner.service.ts
+++ b/packages/server/src/services/turn-games/turn-game-bot-runner.service.ts
@@ -42,6 +42,7 @@ interface RunBotTurnsArgs {
   baseUrl?: string;
   reply: FastifyReply;
   signal?: AbortSignal;
+  debugLog?: (message: string, ...args: unknown[]) => void;
   /** Test/override hooks — production passes conn+baseUrl and builds the provider here. */
   provider?: BaseLLMProvider;
   model?: string;
@@ -369,6 +370,13 @@ export async function runTurnGameBotTurns(args: RunBotTurnsArgs): Promise<void> 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let proposed: any = null;
     try {
+      args.debugLog?.(
+        "[debug/turn-game/move] chatId=%s seatId=%s model=%s prompt messages:\n%s",
+        chatId,
+        seatId,
+        model,
+        JSON.stringify(moveMessages, null, 2),
+      );
       const res = await provider.chatComplete(moveMessages, {
         model,
         tools,

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -8196,6 +8196,14 @@ try {
     join(REPOSITORY_ROOT, "packages/server/src/routes/generate.routes.ts"),
     "utf8",
   );
+  const turnGameBotRunnerSource = readFileSync(
+    join(REPOSITORY_ROOT, "packages/server/src/services/turn-games/turn-game-bot-runner.service.ts"),
+    "utf8",
+  );
+  const turnGameCommandRuntimeSource = readFileSync(
+    join(REPOSITORY_ROOT, "packages/server/src/services/generation/turn-game-command-runtime.ts"),
+    "utf8",
+  );
 
   assert.match(
     chatAreaSource,
@@ -8236,6 +8244,22 @@ try {
     "Turn-game recovery must re-check cancellation after a bot runner resolves",
   );
   assert.match(turnGameResumeBlock, /logger\.warn\(turnGameErr/u);
+  assert.match(
+    generateRouteSource,
+    /logDebugOverride\(requestDebug \|\| isDebugAgentsEnabled\(\), message, \.\.\.args\)/u,
+    "Turn-game prompt logging must honor both UI debug mode and DEBUG_AGENTS",
+  );
+  assert.equal(
+    (generateRouteSource.match(/debugLog: turnGameDebugLog/gu) ?? []).length,
+    3,
+    "Every production turn-game runner path must receive the request-aware debug logger",
+  );
+  assert.match(turnGameCommandRuntimeSource, /debugLog: args\.debugLog/u);
+  assert.match(
+    turnGameBotRunnerSource,
+    /args\.debugLog\?\.\([\s\S]*?JSON\.stringify\(moveMessages, null, 2\)[\s\S]*?provider\.chatComplete\(moveMessages/u,
+    "Turn-game bot moves must log the final provider prompt immediately before submission",
+  );
 }
 
 console.info("Open-issue regressions passed.");


### PR DESCRIPTION
## Linked issue

Related to #4941 and follow-up to #4945.

## Why this change

CodeRabbit identified in its final outside-diff review on #4945 that the automatic turn-game recovery path did not forward request-aware debug logging into the bot runner. The final move-selection prompt was therefore invisible under UI debug mode.

## What changed

- Forwarded a turn-game debug callback through explicit bot turns, command-started games, and automatic recovery.
- Honored both the request `debugMode` flag and `DEBUG_AGENTS`.
- Logged the final move-selection message array immediately before provider submission.
- Added focused source regressions and an Unreleased changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated evidence:

- `pnpm check`
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts`
- `git diff --check`

### Manual verification notes

- [ ] Enable UI debug mode and verify the final turn-game move prompt appears.
- [ ] Enable `DEBUG_AGENTS` without UI debug mode and verify the same prompt appears.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

Added a user-facing entry under `CHANGELOG.md` `[Unreleased]`; no documentation pages or version files changed.

## UI evidence (if applicable)

Not applicable; server debug logging only.