### PR TITLE
fix: resolve assigned Professor Mari, image, agent, and lorebook issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept canceled Professor Mari prompts out of the composer, made the first message edit persist, and retained retry for the latest response (#4947).
+- Preserved the complete provider-ready prompt produced by Game Mode's dynamic image prompt generator through prompt review and image submission (#4948).
+- Stopped Professor Mari's workspace verification guard from treating ordinary task-completion wording as an unverified data mutation (#4949).
+- Enforced each connection's Max Parallel Agent Jobs limit across separate post-processing Agent batches (#4950).
+- Removed deleted lorebooks from the active chat context immediately instead of leaving a stale cached attachment label (#4951).
 - Made turn-game bot move prompts visible when UI debug mode or `DEBUG_AGENTS` is enabled (follow-up to #4945).
 - Included custom world fields and persona inventory in Agent Suite tracker editing without replacing adjacent tracker data (#4937).
 - Exposed active custom image agents in Conversation Gallery's Illustrate picker, matching the existing Roleplay and Game action (#4940).

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -338,6 +338,10 @@ function describeProfessorMariError(error: unknown) {
   return "The request failed before Professor Mari could answer. This message will stay visible long enough to screenshot for troubleshooting.";
 }
 
+function isProfessorMariAbortError(error: unknown) {
+  return typeof error === "object" && error !== null && "name" in error && error.name === "AbortError";
+}
+
 function toMessageExtra(message: Message): Message["extra"] {
   if (typeof message.extra === "string") {
     try {
@@ -4652,7 +4656,7 @@ export function HomeProfessorMariChat({
 
   const handleEditMessage = useCallback(
     async (messageId: string, content: string) => {
-      if (!chatId || isBusy || messageMutationBusyRef.current) return;
+      if (!chatId || isBusy) return;
       messageLoadAbortRef.current?.abort();
       setMessages((current) => current.map((m) => (m.id === messageId ? { ...m, content } : m)));
       try {
@@ -4806,6 +4810,7 @@ export function HomeProfessorMariChat({
         });
       }
     } catch (error) {
+      if (isProfessorMariAbortError(error)) return;
       setDraft(text);
       setAttachments(submittedAttachments);
       console.error("[Professor Mari] Failed to send", error);

--- a/packages/client/src/hooks/use-lorebooks.ts
+++ b/packages/client/src/hooks/use-lorebooks.ts
@@ -223,6 +223,7 @@ export function useDeleteLorebook() {
       qc.removeQueries({ queryKey: lorebookKeys.detail(id) });
       qc.removeQueries({ queryKey: lorebookKeys.entries(id) });
       qc.invalidateQueries({ queryKey: lorebookKeys.all });
+      qc.invalidateQueries({ queryKey: ["chats"] });
       // The server clears `character_book` and the
       // `extensions.importMetadata.embeddedLorebook` pointer for any
       // character this lorebook was linked to. We do not know that

--- a/packages/server/src/services/agents/agent-concurrency.ts
+++ b/packages/server/src/services/agents/agent-concurrency.ts
@@ -29,3 +29,32 @@ export async function settleAgentJobsWithConcurrencyLimit<T, R>(
 
   return results;
 }
+
+export function createAgentConcurrencyLimiter(limit: number) {
+  const normalizedLimit = Number.isFinite(limit) ? Math.max(1, Math.trunc(limit)) : 1;
+  let activeJobs = 0;
+  const waiting: Array<() => void> = [];
+
+  const acquire = () =>
+    new Promise<void>((resolve) => {
+      if (activeJobs < normalizedLimit) {
+        activeJobs += 1;
+        resolve();
+        return;
+      }
+      waiting.push(() => {
+        activeJobs += 1;
+        resolve();
+      });
+    });
+
+  return async function runWithAgentConcurrencyLimit<R>(job: () => Promise<R>): Promise<R> {
+    await acquire();
+    try {
+      return await job();
+    } finally {
+      activeJobs -= 1;
+      waiting.shift()?.();
+    }
+  };
+}

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -1059,8 +1059,12 @@ export async function executeAgentBatch(
   provider: BaseLLMProvider,
   model: string,
   resolveAgentContext?: (config: AgentExecConfig, context: AgentContext) => AgentContext | Promise<AgentContext>,
+  runWithProviderLimit?: <R>(job: () => Promise<R>) => Promise<R>,
 ): Promise<AgentResult[]> {
   if (configs.length === 0) return [];
+  const runProviderJob = <R>(job: () => Promise<R>) => (runWithProviderLimit ? runWithProviderLimit(job) : job());
+  const executeIndividualAgent = async (config: AgentExecConfig, agentContext: AgentContext) =>
+    runProviderJob(() => executeAgent(config, agentContext, provider, model));
   const isolatedConfigs = configs.filter(shouldRunAgentIndividually);
   if (isolatedConfigs.length === configs.length) {
     logger.info(
@@ -1078,7 +1082,8 @@ export async function executeAgentBatch(
     const isolatedSettled = await settleAgentJobsWithConcurrencyLimit(
       isolatedConfigs,
       AGENT_BATCH_FALLBACK_MAX_CONCURRENT,
-      async (config) => executeAgent(config, resolveAgentContext ? await resolveAgentContext(config, context) : context, provider, model),
+      async (config) =>
+        executeIndividualAgent(config, resolveAgentContext ? await resolveAgentContext(config, context) : context),
     );
     return isolatedSettled.map((entry, index) =>
       entry.status === "fulfilled"
@@ -1098,13 +1103,13 @@ export async function executeAgentBatch(
     );
     const batchedConfigs = configs.filter((config) => !shouldRunAgentIndividually(config));
     const [batchedResults, isolatedSettled] = await Promise.all([
-      executeAgentBatch(batchedConfigs, context, provider, model, resolveAgentContext),
+      executeAgentBatch(batchedConfigs, context, provider, model, resolveAgentContext, runWithProviderLimit),
       settleAgentJobsWithConcurrencyLimit(isolatedConfigs, AGENT_BATCH_FALLBACK_MAX_CONCURRENT, (config) =>
         resolveAgentContext
           ? Promise.resolve(resolveAgentContext(config, context)).then((agentContext) =>
-              executeAgent(config, agentContext, provider, model),
+              executeIndividualAgent(config, agentContext),
             )
-          : executeAgent(config, context, provider, model),
+          : executeIndividualAgent(config, context),
       ),
     ]);
     const isolatedResults = isolatedSettled.map((entry, index) =>
@@ -1121,7 +1126,7 @@ export async function executeAgentBatch(
   if (configs.length === 1) {
     logger.info(`[agent-batch] Only 1 agent (${configs[0]!.type}), running individually`);
     const agentContext = resolveAgentContext ? await resolveAgentContext(configs[0]!, context) : context;
-    return [await executeAgent(configs[0]!, agentContext, provider, model)];
+    return [await executeIndividualAgent(configs[0]!, agentContext)];
   }
 
   const requestOptionGroups = new Map<string, AgentExecConfig[]>();
@@ -1139,7 +1144,9 @@ export async function executeAgentBatch(
     );
     const groupedResults: AgentResult[] = [];
     for (const group of requestOptionGroups.values()) {
-      groupedResults.push(...(await executeAgentBatch(group, context, provider, model, resolveAgentContext)));
+      groupedResults.push(
+        ...(await executeAgentBatch(group, context, provider, model, resolveAgentContext, runWithProviderLimit)),
+      );
     }
     return groupedResults;
   }
@@ -1219,27 +1226,29 @@ export async function executeAgentBatch(
     // Use streaming (onToken) to keep the connection alive — avoids proxy
     // timeouts (e.g. Cloudflare 524) on large batch responses.
     let responseText = "";
-    const result = await provider.chatComplete(messages, {
-      model,
-      temperature,
-      maxTokens: batchMaxTokens,
-      enableCaching,
-      anthropicExtendedCacheTtl,
-      cachingAtDepth,
-      customParameters,
-      enabledParameters: configs[0]!.enabledParameters,
-      suppressModelParameters: configs[0]!.suppressModelParameters,
-      stream: streamResponses,
-      onToken: streamResponses
-        ? (chunk) => {
-            responseText += chunk;
-          }
-        : undefined,
-      signal: agentCallSignal(
-        context.signal,
-        configs.some((config) => config.type === "illustrator") ? "illustrator" : undefined,
-      ),
-    });
+    const result = await runProviderJob(() =>
+      provider.chatComplete(messages, {
+        model,
+        temperature,
+        maxTokens: batchMaxTokens,
+        enableCaching,
+        anthropicExtendedCacheTtl,
+        cachingAtDepth,
+        customParameters,
+        enabledParameters: configs[0]!.enabledParameters,
+        suppressModelParameters: configs[0]!.suppressModelParameters,
+        stream: streamResponses,
+        onToken: streamResponses
+          ? (chunk) => {
+              responseText += chunk;
+            }
+          : undefined,
+        signal: agentCallSignal(
+          context.signal,
+          configs.some((config) => config.type === "illustrator") ? "illustrator" : undefined,
+        ),
+      }),
+    );
 
     // chatComplete also accumulates content, but streaming via onToken is
     // the primary path — use whichever is populated.
@@ -1290,7 +1299,8 @@ export async function executeAgentBatch(
       const retrySettled = await settleAgentJobsWithConcurrencyLimit(
         failed,
         AGENT_BATCH_FALLBACK_MAX_CONCURRENT,
-        async (config) => executeAgent(config, resolveAgentContext ? await resolveAgentContext(config, context) : context, provider, model),
+        async (config) =>
+          executeIndividualAgent(config, resolveAgentContext ? await resolveAgentContext(config, context) : context),
       );
       const retries: AgentResult[] = [];
       for (let i = 0; i < retrySettled.length; i++) {

--- a/packages/server/src/services/agents/agent-pipeline.ts
+++ b/packages/server/src/services/agents/agent-pipeline.ts
@@ -20,7 +20,7 @@ import {
   type AgentToolContext,
 } from "./agent-executor.js";
 import { logger } from "../../lib/logger.js";
-import { settleAgentJobsWithConcurrencyLimit } from "./agent-concurrency.js";
+import { createAgentConcurrencyLimiter, settleAgentJobsWithConcurrencyLimit } from "./agent-concurrency.js";
 export { settleAgentJobsWithConcurrencyLimit } from "./agent-concurrency.js";
 
 /** A fully resolved agent ready for execution. */
@@ -169,6 +169,7 @@ function buildAgentContext(agent: ResolvedAgent, context: AgentContext): AgentCo
 async function executeGroup(
   group: AgentGroup,
   context: AgentContext,
+  runWithConnectionLimit: <R>(job: () => Promise<R>) => Promise<R>,
   onResult?: AgentResultCallback,
   resolveAgentContext?: AgentContextResolver,
 ): Promise<AgentResult[]> {
@@ -197,7 +198,9 @@ async function executeGroup(
 
   const batchResultsPromise =
     batchAgents.length > 0
-      ? executeAgentBatch(batchAgents, groupContext, group.provider, group.model, resolveAgentContext).then((results) => {
+      ? runWithConnectionLimit(() =>
+          executeAgentBatch(batchAgents, groupContext, group.provider, group.model, resolveAgentContext),
+        ).then((results) => {
           for (const result of results) {
             safeOnResult(result);
           }
@@ -218,10 +221,16 @@ async function executeGroup(
       (resolveAgentContext
         ? Promise.resolve(resolveAgentContext(agent, buildAgentContext(agent, context)))
         : Promise.resolve(buildAgentContext(agent, context))
-      ).then((agentContext) => executeAgent(agent, agentContext, agent.provider, agent.model, agent.toolContext)).then((result) => {
-        safeOnResult(result);
-        return result;
-      }),
+      )
+        .then((agentContext) =>
+          runWithConnectionLimit(() =>
+            executeAgent(agent, agentContext, agent.provider, agent.model, agent.toolContext),
+          ),
+        )
+        .then((result) => {
+          safeOnResult(result);
+          return result;
+        }),
   ).then((settled) =>
     settled.map((entry, index) => {
       if (entry.status === "fulfilled") return entry.value;
@@ -266,6 +275,14 @@ async function executePhase(
   if (phaseAgents.length === 0) return [];
 
   const groups = groupByProviderModel(phaseAgents).flatMap(splitGroupForParallelJobs);
+  const connectionLimits = new Map<number, number>();
+  for (const group of groups) {
+    const key = providerKey(group.provider);
+    connectionLimits.set(key, Math.min(connectionLimits.get(key) ?? group.maxParallelJobs, group.maxParallelJobs));
+  }
+  const connectionLimiters = new Map(
+    Array.from(connectionLimits, ([key, limit]) => [key, createAgentConcurrencyLimiter(limit)]),
+  );
 
   logger.debug(
     '[agent-pipeline] Phase "%s": %d agents → %d job group(s) %j',
@@ -284,10 +301,8 @@ async function executePhase(
     );
   }
 
-  const settled = await settleAgentJobsWithConcurrencyLimit(
-    groups,
-    AGENT_PHASE_MAX_CONCURRENT_GROUPS,
-    (group) => executeGroup(group, context, onResult, resolveAgentContext),
+  const settled = await settleAgentJobsWithConcurrencyLimit(groups, AGENT_PHASE_MAX_CONCURRENT_GROUPS, (group) =>
+    executeGroup(group, context, connectionLimiters.get(providerKey(group.provider))!, onResult, resolveAgentContext),
   );
 
   const results: AgentResult[] = [];

--- a/packages/server/src/services/agents/agent-pipeline.ts
+++ b/packages/server/src/services/agents/agent-pipeline.ts
@@ -198,8 +198,13 @@ async function executeGroup(
 
   const batchResultsPromise =
     batchAgents.length > 0
-      ? runWithConnectionLimit(() =>
-          executeAgentBatch(batchAgents, groupContext, group.provider, group.model, resolveAgentContext),
+      ? executeAgentBatch(
+          batchAgents,
+          groupContext,
+          group.provider,
+          group.model,
+          resolveAgentContext,
+          runWithConnectionLimit,
         ).then((results) => {
           for (const result of results) {
             safeOnResult(result);

--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -582,7 +582,7 @@ export async function buildNpcPortraitProviderPrompt(req: NpcPortraitRequest): P
     ],
   });
   return compileGameImagePrompt(
-    req.dynamicPromptGenerator ? { ...req, appearance: null } : req,
+    req.dynamicPromptGenerator ? { ...req, appearance: null, preserveFullSourcePrompt: true } : req,
     "portrait",
     prompt,
     1400,
@@ -602,6 +602,7 @@ function compileGameImagePrompt(
     appearance?: string | null;
     preserveFullBackgroundPrompt?: boolean;
     preserveFullScenePrompt?: boolean;
+    preserveFullSourcePrompt?: boolean;
     omitProfileStyleText?: boolean;
     omitProfileSubjectTags?: boolean;
   },
@@ -628,7 +629,10 @@ function compileGameImagePrompt(
       negativePrompt: [negativePrompt, hardNegative].filter(Boolean).join(", "),
     };
   }
-  if ((kind === "illustration" || kind === "background") && req.preserveFullScenePrompt) {
+  if (
+    req.preserveFullSourcePrompt ||
+    ((kind === "illustration" || kind === "background") && req.preserveFullScenePrompt)
+  ) {
     const compilePrefix = (dedupeAgainstPrompt: string) =>
       compileImagePrompt({
         kind,
@@ -1063,7 +1067,11 @@ export async function buildBackgroundProviderPrompt(req: BackgroundGenRequest): 
     ],
   });
   return compileGameImagePrompt(
-    req.mapsArtworkContext ? { ...req, artStyle: undefined } : req,
+    req.dynamicPromptGenerator
+      ? { ...req, artStyle: req.mapsArtworkContext ? undefined : req.artStyle, preserveFullSourcePrompt: true }
+      : req.mapsArtworkContext
+        ? { ...req, artStyle: undefined }
+        : req,
     "background",
     prompt,
     req.preserveFullBackgroundPrompt || req.preserveFullScenePrompt ? 7000 : 1000,
@@ -1251,7 +1259,13 @@ export async function buildSceneIllustrationProviderPrompt(
         ]
       : [],
   });
-  return compileGameImagePrompt(req, "illustration", prompt, 7000, GAME_ILLUSTRATION_NEGATIVE_PROMPT);
+  return compileGameImagePrompt(
+    req.dynamicPromptGenerator ? { ...req, preserveFullSourcePrompt: true } : req,
+    "illustration",
+    prompt,
+    7000,
+    GAME_ILLUSTRATION_NEGATIVE_PROMPT,
+  );
 }
 
 export async function buildSceneIllustrationImagePrompt(req: SceneIllustrationGenRequest): Promise<string> {

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -1645,7 +1645,6 @@ export function resolveWorkspaceMutationVerification(
 export function workspaceTextClaimsMutationCompletion(text: string): boolean {
   const normalized = text.trim().replace(/\s+/gu, " ");
   if (!normalized) return false;
-  if (/^(?:all\s+)?(?:done|complete|completed|finished)\b/iu.test(normalized)) return true;
   const completedMutation =
     "created|updated|changed|deleted|removed|renamed|wrote|written|fixed|implemented|built|installed|imported|exported|saved|enabled|disabled|assigned|linked|unlinked|generated|moved|copied|replaced|verified";
   return (

--- a/scripts/regressions/agent-runtime.regression.ts
+++ b/scripts/regressions/agent-runtime.regression.ts
@@ -349,6 +349,31 @@ assert.equal(
   "Max Parallel Agent Jobs must apply across every post-processing group sharing a connection",
 );
 
+const isolatedConnectionLimitedProvider = new ConcurrencyRecordingProvider();
+const isolatedConnectionLimitedAgents: ResolvedAgent[] = [
+  {
+    ...makeAgent("illustrator"),
+    id: "illustrator-limited-a",
+    provider: isolatedConnectionLimitedProvider,
+    maxParallelJobs: 1,
+  },
+  {
+    ...makeAgent("illustrator"),
+    id: "illustrator-limited-b",
+    provider: isolatedConnectionLimitedProvider,
+    maxParallelJobs: 1,
+  },
+];
+await createAgentPipeline(isolatedConnectionLimitedAgents, context).postGenerate(
+  "Isolated jobs in one batch group must share the connection limit.",
+);
+assert.equal(isolatedConnectionLimitedProvider.calls, 2, "isolated agents should still make separate requests");
+assert.equal(
+  isolatedConnectionLimitedProvider.maxActiveCalls,
+  1,
+  "Max Parallel Agent Jobs must also serialize isolated configs inside one batch group",
+);
+
 const parallelLlamaArgs = buildLlamaArgs({
   modelPath: "/tmp/model.gguf",
   gpuLayers: 0,

--- a/scripts/regressions/agent-runtime.regression.ts
+++ b/scripts/regressions/agent-runtime.regression.ts
@@ -40,6 +40,22 @@ class RecordingProvider extends BaseLLMProvider {
   }
 }
 
+class ConcurrencyRecordingProvider extends RecordingProvider {
+  activeCalls = 0;
+  maxActiveCalls = 0;
+
+  override async chatComplete(messages: ChatMessage[], options: ChatOptions): Promise<ChatCompletionResult> {
+    this.activeCalls += 1;
+    this.maxActiveCalls = Math.max(this.maxActiveCalls, this.activeCalls);
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return await super.chatComplete(messages, options);
+    } finally {
+      this.activeCalls -= 1;
+    }
+  }
+}
+
 const makeAgent = (type: string, resultType = "context_injection"): ResolvedAgent => ({
   id: type,
   type,
@@ -307,6 +323,31 @@ await createAgentPipeline([spotifyAgent], context).postGenerate("The room settle
 assert.equal(spotifyProvider.calls, 1, "Spotify Music DJ should make one planning request");
 assert.equal(spotifyProvider.options[0]?.tools, undefined, "Spotify planning should not enter the LLM tool loop");
 assert.equal(spotifyToolExecutions, 0, "Spotify tools should run later in the deterministic playback stage");
+
+const connectionLimitedProvider = new ConcurrencyRecordingProvider();
+const connectionLimitedAgents: ResolvedAgent[] = [
+  {
+    ...makeAgent("tracker-limited"),
+    provider: connectionLimitedProvider,
+    maxParallelJobs: 1,
+    settings: { ...makeAgent("tracker-limited").settings, includeParallelResults: false },
+  },
+  {
+    ...makeAgent("illustrator-limited"),
+    provider: connectionLimitedProvider,
+    maxParallelJobs: 1,
+    settings: { ...makeAgent("illustrator-limited").settings, includeParallelResults: true },
+  },
+];
+await createAgentPipeline(connectionLimitedAgents, context).postGenerate(
+  "A shared connection must serialize its jobs.",
+);
+assert.equal(connectionLimitedProvider.calls, 2, "separate post-processing groups should still make separate requests");
+assert.equal(
+  connectionLimitedProvider.maxActiveCalls,
+  1,
+  "Max Parallel Agent Jobs must apply across every post-processing group sharing a connection",
+);
 
 const parallelLlamaArgs = buildLlamaArgs({
   modelPath: "/tmp/model.gguf",

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -4095,6 +4095,10 @@ const professorMariHomeSource = readFileSync(
   new URL("../../packages/client/src/components/chat/HomeProfessorMariChat.tsx", import.meta.url),
   "utf8",
 );
+const lorebookHooksSource = readFileSync(
+  new URL("../../packages/client/src/hooks/use-lorebooks.ts", import.meta.url),
+  "utf8",
+);
 const professorMariContextBudget = resolveProfessorMariContextBudget(
   [
     {
@@ -4136,6 +4140,21 @@ assert.equal(
 );
 assert.match(professorMariHomeSource, /toggleProfessorChatSelection/u);
 assert.match(professorMariHomeSource, /handleBulkDeleteProfessorChats/u);
+assert.match(
+  professorMariHomeSource,
+  /const handleEditMessage = useCallback\([\s\S]{0,180}if \(!chatId \|\| isBusy\) return;/u,
+  "Professor Mari's first edit after generation must not be rejected by a stale busy ref",
+);
+assert.match(
+  professorMariHomeSource,
+  /catch \(error\) \{\s*if \(isProfessorMariAbortError\(error\)\) return;\s*setDraft\(text\)/u,
+  "Stopping Professor Mari must not restore an already-submitted prompt to the composer",
+);
+assert.match(
+  lorebookHooksSource,
+  /useDeleteLorebook\(\)[\s\S]{0,900}invalidateQueries\(\{ queryKey: \["chats"\] \}\)/u,
+  "Deleting a lorebook must refresh cached chat metadata so it leaves active context immediately",
+);
 assert.match(
   professorMariHomeSource,
   /handleDeleteProfessorChat[\s\S]{0,500}showConfirmDialog/u,

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -6577,6 +6577,16 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       });
       assert.equal(countAppearance(dynamicPreserved.prompt), 1);
 
+      const providerReadyDynamicPrompt =
+        "1girl, elphelt_valentine, guilty_gear, solo, portrait, upper_body, pink_hair, blue_eyes, white_background, masterpiece, best_quality";
+      const providerReadyDynamic = await buildNpcPortraitProviderPrompt({
+        ...request,
+        styleProfiles: createDefaultImageStyleProfileSettings(),
+        styleProfileId: "danbooru",
+        dynamicPromptGenerator: async () => providerReadyDynamicPrompt,
+      });
+      assert.match(providerReadyDynamic.prompt, new RegExp(providerReadyDynamicPrompt));
+
       const dynamicOmitted = await buildNpcPortraitProviderPrompt({
         ...request,
         dynamicPromptGenerator: async () => "Centered portrait of Lyra with a readable expression and clean lighting.",
@@ -9534,6 +9544,12 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       );
       assert.equal(workspaceTextClaimsMutationCompletion(unsupportedCompletion.visibleText), true);
       assert.equal(workspaceActionNeedsVerification(unsupportedCompletion, []), "none");
+
+      const completedSupportReply = parseAssistantWorkspaceAction(
+        '{"say":"Done. Shell commands are unavailable here, so use these manual steps.","commands":[],"stop":true}',
+      );
+      assert.equal(workspaceTextClaimsMutationCompletion(completedSupportReply.visibleText), false);
+      assert.equal(workspaceActionNeedsVerification(completedSupportReply, []), null);
 
       const mutationResult: WorkspaceCommandResult = {
         id: "create-lorebook",


### PR DESCRIPTION
## Linked issues

Closes #4947
Closes #4948
Closes #4949
Closes #4950
Closes #4951

## Why this change

This assigned-issue sweep fixes five user-visible regressions in Professor Mari, Game image prompting, Agent scheduling, and lorebook context cleanup. The changes preserve existing behavior while correcting the narrow boundaries where canceled state, provider-ready prompt data, connection limits, or deleted context were lost.

## What changed

- Keep canceled Professor Mari prompts out of the composer and accept the first message edit after generation; the existing latest-response retry remains available.
- Preserve complete LLM-directed Game image prompts through style compilation and prompt review.
- Require a concrete mutation claim before the Professor Mari workspace verification guard can fire.
- Share the saved Max Parallel Agent Jobs ceiling across every provider request on the same connection, including isolated and mixed batch execution.
- Refresh cached chat metadata after lorebook deletion so Active Context removes the deleted attachment immediately.
- Add focused regressions and Unreleased changelog entries for all five issues.

## Validation

- [ ] pnpm check passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed CONTRIBUTING.md

Automated evidence:

- pnpm check
- pnpm regression:prompt
- pnpm regression:agent-runtime
- pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts
- GitHub pnpm-validate
- GitHub container-build-test
- CodeRabbit review, including follow-up review with no new actionable comments

### Manual verification notes

- Manually verify cancel, edit, and latest-response retry in embedded and floating Professor Mari.
- Manually review a complete dynamic Game image prompt with a tagged style profile.
- Manually verify same-connection post-processing agents do not exceed their saved parallel limit.
- Manually delete an active chat lorebook and inspect Active Context.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the docs-i18n branch updated to match, or a docs-i18n follow-up issue opened
- [ ] Version/release files updated

Unreleased changelog entries are included. No user-facing documentation pages or release metadata changed.

## UI evidence

No visual design changed; UI screenshots are not applicable to this behavior and state-management sweep.