### PR TITLE
fix: refresh stale staging clients and keep Termux awake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Refreshed stale same-version browser clients when the server commit changes, so staging fixes such as NovelAI generation-setting saves and connection imports no longer remain hidden behind an older cached interface (#4957).
+- Kept the Termux-hosted server awake while the launcher is running and released the Android wake lock when it stops, preventing backgrounded Termux sessions from freezing until the terminal is reopened (#4956).
 - Kept Professor Mari's generated continuation suggestions available after opening and closing a lorebook (#4953).
 - Made SwarmUI image requests honor the configured ComfyUI timeout instead of inheriting a shorter transport timeout (#4954).
 - Kept canceled Professor Mari prompts out of the composer, made the first message edit persist, and retained retry for the latest response (#4947).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1878,6 +1878,151 @@ test("NovelAI style plate upload keeps the connection editor mounted", async ({ 
   if (cleanupFailure !== undefined) throw cleanupFailure;
 });
 
+test("NovelAI generation defaults survive save and editor navigation", async ({ page, request }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Desktop connection-default editing is covered here.");
+
+  const suffix = Date.now().toString(36);
+  const connectionName = `NovelAI Defaults ${suffix}`;
+  const personaName = `NovelAI Navigation Persona ${suffix}`;
+  const connectionResponse = await request.post("/api/connections", {
+    data: {
+      name: connectionName,
+      provider: "image_generation",
+      imageGenerationSource: "novelai",
+      imageService: "novelai",
+      model: "nai-diffusion-4-5-full",
+    },
+  });
+  const personaResponse = await request.post("/api/characters/personas", { data: { name: personaName } });
+  expect(connectionResponse.ok()).toBeTruthy();
+  expect(personaResponse.ok()).toBeTruthy();
+  const connection = (await connectionResponse.json()) as { id: string };
+  const persona = (await personaResponse.json()) as { id: string };
+
+  try {
+    await page.goto("/");
+    await page.locator('[data-tour="panel-connections"]').click();
+    const rightPanel = page.locator('[data-component="RightPanelDesktop"]');
+    await rightPanel
+      .getByText(connectionName, { exact: true })
+      .first()
+      .evaluate((element) => (element as HTMLElement).click());
+
+    let editor = page.locator(".mari-editor-shell");
+    await expect(editor).toBeVisible();
+    await editor.getByRole("button", { name: /NovelAI generation setup/iu }).click();
+    const seedInput = editor.getByRole("spinbutton", { name: "Seed" });
+    await seedInput.fill("50");
+    await editor.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(editor.getByText("Saved", { exact: true })).toBeVisible();
+
+    await expect
+      .poll(async () => {
+        const response = await request.get(`/api/connections/${connection.id}`);
+        const stored = (await response.json()) as { defaultParameters?: string | null };
+        const params = JSON.parse(stored.defaultParameters ?? "{}") as {
+          imageGeneration?: { seed?: number };
+        };
+        return params.imageGeneration?.seed;
+      })
+      .toBe(50);
+
+    await page.locator('[data-tour="panel-personas"]').click();
+    await rightPanel
+      .getByText(personaName, { exact: true })
+      .first()
+      .evaluate((element) => (element as HTMLElement).click());
+    await expect
+      .poll(() =>
+        page.evaluate(async () => {
+          const { useUIStore } = await import("/src/stores/ui.store.ts");
+          return useUIStore.getState().personaDetailId;
+        }),
+      )
+      .toBe(persona.id);
+
+    await page.locator('[data-tour="panel-connections"]').click();
+    await rightPanel
+      .getByText(connectionName, { exact: true })
+      .first()
+      .evaluate((element) => (element as HTMLElement).click());
+    editor = page.locator(".mari-editor-shell");
+    const reopenedSeedInput = editor.getByRole("spinbutton", { name: "Seed" });
+    if (!(await reopenedSeedInput.isVisible())) {
+      await editor.getByRole("button", { name: /NovelAI generation setup/iu }).click();
+    }
+    await expect(reopenedSeedInput).toHaveValue("50");
+  } finally {
+    await Promise.all([
+      request.delete(`/api/connections/${connection.id}`).catch(() => undefined),
+      request.delete(`/api/characters/personas/${persona.id}`).catch(() => undefined),
+    ]);
+  }
+});
+
+test("NovelAI generation defaults survive connection import", async ({ page, request }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Desktop connection import is covered here.");
+
+  const connectionName = `Imported NovelAI Defaults ${Date.now().toString(36)}`;
+  let importedConnectionId: string | null = null;
+
+  try {
+    await page.goto("/");
+    await page.locator('[data-tour="panel-connections"]').click();
+    const rightPanel = page.locator('[data-component="RightPanelDesktop"]');
+    await rightPanel.getByRole("button", { name: "Import connection" }).click();
+    const importDialog = page.getByRole("dialog", { name: "Import Connections" });
+    await importDialog.locator('input[type="file"]').setInputFiles({
+      name: "novelai-defaults.connection.json",
+      mimeType: "application/json",
+      buffer: Buffer.from(
+        JSON.stringify({
+          kind: "marinara.connections",
+          version: 1,
+          exportedAt: new Date().toISOString(),
+          connections: [
+            {
+              name: connectionName,
+              provider: "image_generation",
+              baseUrl: "https://image.novelai.net",
+              model: "nai-diffusion-4-5-full",
+              imageGenerationSource: "novelai",
+              imageService: "novelai",
+              defaultParameters: {
+                imageGeneration: {
+                  version: 1,
+                  service: "novelai",
+                  seed: 73,
+                  styleProfileId: null,
+                },
+              },
+            },
+          ],
+        }),
+      ),
+    });
+    await expect(importDialog).toContainText("1 succeeded");
+
+    const connectionsResponse = await request.get("/api/connections");
+    const connections = (await connectionsResponse.json()) as Array<{
+      id: string;
+      name: string;
+      defaultParameters?: string | null;
+    }>;
+    const imported = connections.find((connection) => connection.name === connectionName);
+    expect(imported).toBeTruthy();
+    importedConnectionId = imported?.id ?? null;
+    const params = JSON.parse(imported?.defaultParameters ?? "{}") as {
+      imageGeneration?: { seed?: number };
+    };
+    expect(params.imageGeneration?.seed).toBe(73);
+  } finally {
+    if (importedConnectionId) {
+      await request.delete(`/api/connections/${importedConnectionId}`).catch(() => undefined);
+    }
+  }
+});
+
 test("Connection image captioning defaults persist with a dedicated captioning connection", async ({
   page,
   request,

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1884,22 +1884,26 @@ test("NovelAI generation defaults survive save and editor navigation", async ({ 
   const suffix = Date.now().toString(36);
   const connectionName = `NovelAI Defaults ${suffix}`;
   const personaName = `NovelAI Navigation Persona ${suffix}`;
-  const connectionResponse = await request.post("/api/connections", {
-    data: {
-      name: connectionName,
-      provider: "image_generation",
-      imageGenerationSource: "novelai",
-      imageService: "novelai",
-      model: "nai-diffusion-4-5-full",
-    },
-  });
-  const personaResponse = await request.post("/api/characters/personas", { data: { name: personaName } });
-  expect(connectionResponse.ok()).toBeTruthy();
-  expect(personaResponse.ok()).toBeTruthy();
-  const connection = (await connectionResponse.json()) as { id: string };
-  const persona = (await personaResponse.json()) as { id: string };
+  let connectionId: string | null = null;
+  let personaId: string | null = null;
 
   try {
+    const connectionResponse = await request.post("/api/connections", {
+      data: {
+        name: connectionName,
+        provider: "image_generation",
+        imageGenerationSource: "novelai",
+        imageService: "novelai",
+        model: "nai-diffusion-4-5-full",
+      },
+    });
+    expect(connectionResponse.ok()).toBeTruthy();
+    connectionId = ((await connectionResponse.json()) as { id: string }).id;
+
+    const personaResponse = await request.post("/api/characters/personas", { data: { name: personaName } });
+    expect(personaResponse.ok()).toBeTruthy();
+    personaId = ((await personaResponse.json()) as { id: string }).id;
+
     await page.goto("/");
     await page.locator('[data-tour="panel-connections"]').click();
     const rightPanel = page.locator('[data-component="RightPanelDesktop"]');
@@ -1918,7 +1922,7 @@ test("NovelAI generation defaults survive save and editor navigation", async ({ 
 
     await expect
       .poll(async () => {
-        const response = await request.get(`/api/connections/${connection.id}`);
+        const response = await request.get(`/api/connections/${connectionId}`);
         const stored = (await response.json()) as { defaultParameters?: string | null };
         const params = JSON.parse(stored.defaultParameters ?? "{}") as {
           imageGeneration?: { seed?: number };
@@ -1939,7 +1943,7 @@ test("NovelAI generation defaults survive save and editor navigation", async ({ 
           return useUIStore.getState().personaDetailId;
         }),
       )
-      .toBe(persona.id);
+      .toBe(personaId);
 
     await page.locator('[data-tour="panel-connections"]').click();
     await rightPanel
@@ -1953,10 +1957,8 @@ test("NovelAI generation defaults survive save and editor navigation", async ({ 
     }
     await expect(reopenedSeedInput).toHaveValue("50");
   } finally {
-    await Promise.all([
-      request.delete(`/api/connections/${connection.id}`).catch(() => undefined),
-      request.delete(`/api/characters/personas/${persona.id}`).catch(() => undefined),
-    ]);
+    if (connectionId) await request.delete(`/api/connections/${connectionId}`).catch(() => undefined);
+    if (personaId) await request.delete(`/api/characters/personas/${personaId}`).catch(() => undefined);
   }
 });
 
@@ -2016,6 +2018,20 @@ test("NovelAI generation defaults survive connection import", async ({ page, req
       imageGeneration?: { seed?: number };
     };
     expect(params.imageGeneration?.seed).toBe(73);
+
+    await importDialog.getByRole("button", { name: "Close Import Connections" }).click();
+    await expect(importDialog).toHaveCount(0);
+    await rightPanel
+      .getByText(connectionName, { exact: true })
+      .first()
+      .evaluate((element) => (element as HTMLElement).click());
+    const editor = page.locator(".mari-editor-shell");
+    await expect(editor).toBeVisible();
+    const seedInput = editor.getByRole("spinbutton", { name: "Seed" });
+    if (!(await seedInput.isVisible())) {
+      await editor.getByRole("button", { name: /NovelAI generation setup/iu }).click();
+    }
+    await expect(seedInput).toHaveValue("73");
   } finally {
     if (importedConnectionId) {
       await request.delete(`/api/connections/${importedConnectionId}`).catch(() => undefined);

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1931,6 +1931,19 @@ test("NovelAI generation defaults survive save and editor navigation", async ({ 
       })
       .toBe(50);
 
+    const downloadPromise = page.waitForEvent("download");
+    await editor.getByRole("button", { name: "Export connection" }).click();
+    const exportDialog = page.getByRole("dialog", { name: "Export Connection Data" });
+    await expect(exportDialog).toBeVisible();
+    await exportDialog.getByRole("button", { name: "Export", exact: true }).click();
+    const download = await downloadPromise;
+    const downloadPath = await download.path();
+    expect(downloadPath).not.toBeNull();
+    const exported = JSON.parse(readFileSync(downloadPath!, "utf8")) as {
+      connections?: Array<{ defaultParameters?: { imageGeneration?: { seed?: number } } }>;
+    };
+    expect(exported.connections?.[0]?.defaultParameters?.imageGeneration?.seed).toBe(50);
+
     await page.locator('[data-tour="panel-personas"]').click();
     await rightPanel
       .getByText(personaName, { exact: true })

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -37,6 +37,11 @@ import { useDialogStore } from "./stores/dialog.store";
 import { api } from "./lib/api-client";
 import { forceRefreshSpa } from "./lib/browser-runtime";
 import {
+  formatRuntimeBuild,
+  getServerRuntimeBuild,
+  isRuntimeBuildCurrent,
+} from "./lib/runtime-build";
+import {
   getCssColorFallback,
   getCssGradientColorStops,
   isCssGradient,
@@ -53,6 +58,7 @@ import { setCustomNotificationSoundUrl } from "./lib/notification-sound";
 
 const VERSION_RECOVERY_KEY = "marinara:pwa-version-recovery";
 const VERSION_CHECK_INTERVAL_MS = 5 * 60_000;
+const CLIENT_BUILD = formatRuntimeBuild(APP_VERSION, __MARINARA_BUILD_COMMIT__);
 const LazyModalRenderer = lazy(() =>
   import("./components/layout/ModalRenderer").then((module) => ({ default: module.ModalRenderer })),
 );
@@ -64,6 +70,7 @@ type HealthResponse = {
   status: string;
   timestamp: string;
   version: string;
+  build?: string | null;
 };
 
 type CustomFontFace = {
@@ -951,12 +958,13 @@ export function App() {
           return;
         }
 
-        if (health.version === APP_VERSION) {
+        const serverBuild = getServerRuntimeBuild(health);
+        if (isRuntimeBuildCurrent(APP_VERSION, CLIENT_BUILD, health)) {
           sessionStorage.removeItem(VERSION_RECOVERY_KEY);
           return;
         }
 
-        await recoverFromVersionSkew(health.version);
+        await recoverFromVersionSkew(serverBuild);
       } catch {
         // Ignore version checks when the network is unavailable.
       }

--- a/packages/client/src/build-env.d.ts
+++ b/packages/client/src/build-env.d.ts
@@ -1,0 +1,1 @@
+declare const __MARINARA_BUILD_COMMIT__: string | null;

--- a/packages/client/src/lib/runtime-build.ts
+++ b/packages/client/src/lib/runtime-build.ts
@@ -1,0 +1,21 @@
+export type RuntimeHealth = {
+  version: string;
+  build?: string | null;
+};
+
+export function formatRuntimeBuild(version: string, commit: string | null) {
+  return commit ? `${version}+${commit}` : version;
+}
+
+export function getServerRuntimeBuild(health: RuntimeHealth) {
+  return health.build?.trim() || health.version;
+}
+
+export function isRuntimeBuildCurrent(clientVersion: string, clientBuild: string, health: RuntimeHealth) {
+  const serverBuild = health.build?.trim();
+  if (!serverBuild || serverBuild === health.version) {
+    return health.version === clientVersion;
+  }
+
+  return serverBuild === clientBuild;
+}

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -18,9 +18,10 @@ function normalizeBuildCommit(value: string | undefined) {
 }
 
 function resolveBuildCommit() {
-  const environmentCommit = normalizeBuildCommit(
-    process.env.MARINARA_GIT_COMMIT ?? process.env.GITHUB_SHA ?? process.env.BUILD_COMMIT,
-  );
+  const environmentCommit =
+    normalizeBuildCommit(process.env.MARINARA_GIT_COMMIT) ??
+    normalizeBuildCommit(process.env.GITHUB_SHA) ??
+    normalizeBuildCommit(process.env.BUILD_COMMIT);
   if (environmentCommit) return environmentCommit;
 
   try {

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { VitePWA } from "vite-plugin-pwa";
+import { execFileSync } from "node:child_process";
 import path from "path";
 
 const ENABLE_SOURCE_MAPS = process.env.VITE_ENABLE_SOURCEMAP === "true";
@@ -9,6 +10,33 @@ const PWA_DISABLED = Boolean(process.env.SKIP_PWA);
 const DEV_SERVER_PORT = Number.parseInt(process.env.VITE_PORT ?? "5173", 10);
 const DEV_SERVER_HOST = process.env.VITE_HOST?.trim() || undefined;
 const DEV_SERVER_OPEN = process.env.VITE_OPEN_BROWSER !== "false" && process.env.AUTO_OPEN_BROWSER !== "false";
+const BUILD_COMMIT_LENGTH = 12;
+
+function normalizeBuildCommit(value: string | undefined) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.slice(0, BUILD_COMMIT_LENGTH) : null;
+}
+
+function resolveBuildCommit() {
+  const environmentCommit = normalizeBuildCommit(
+    process.env.MARINARA_GIT_COMMIT ?? process.env.GITHUB_SHA ?? process.env.BUILD_COMMIT,
+  );
+  if (environmentCommit) return environmentCommit;
+
+  try {
+    return normalizeBuildCommit(
+      execFileSync("git", ["rev-parse", `--short=${BUILD_COMMIT_LENGTH}`, "HEAD"], {
+        cwd: path.resolve(__dirname, "../.."),
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }),
+    );
+  } catch {
+    return null;
+  }
+}
+
+const BUILD_COMMIT = resolveBuildCommit();
 
 function manualChunks(id: string) {
   if (!id.includes("node_modules")) return undefined;
@@ -85,6 +113,9 @@ function pwaStub(): Plugin {
 }
 
 export default defineConfig({
+  define: {
+    __MARINARA_BUILD_COMMIT__: JSON.stringify(BUILD_COMMIT),
+  },
   plugins: [
     react({
       babel: {

--- a/scripts/regressions/assigned-issue-sweep.regression.ts
+++ b/scripts/regressions/assigned-issue-sweep.regression.ts
@@ -5,6 +5,11 @@ import { fileURLToPath } from "node:url";
 import { DISCORD_SUBTEXT_RE, INLINE_MD_RE } from "../../packages/client/src/lib/inline-markdown-regex.js";
 import { applyInlineMarkdownHTML } from "../../packages/client/src/lib/markdown.js";
 import { mergeUndatedSyncedSettings } from "../../packages/client/src/hooks/use-settings-sync.js";
+import {
+  formatRuntimeBuild,
+  getServerRuntimeBuild,
+  isRuntimeBuildCurrent,
+} from "../../packages/client/src/lib/runtime-build.js";
 import { useAgentStore } from "../../packages/client/src/stores/agent.store.js";
 import {
   isStockMarinaraUniversalPreset,
@@ -12,6 +17,29 @@ import {
 } from "../../packages/shared/src/types/prompt.js";
 
 const repositoryRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+const clientBuild = formatRuntimeBuild("2.4.2", "aaaaaaaaaaaa");
+assert.equal(clientBuild, "2.4.2+aaaaaaaaaaaa");
+assert.equal(
+  isRuntimeBuildCurrent("2.4.2", clientBuild, { version: "2.4.2", build: "2.4.2+aaaaaaaaaaaa" }),
+  true,
+  "matching same-version builds do not refresh",
+);
+assert.equal(
+  isRuntimeBuildCurrent("2.4.2", clientBuild, { version: "2.4.2", build: "2.4.2+bbbbbbbbbbbb" }),
+  false,
+  "a newer commit with the same release version refreshes the stale client",
+);
+assert.equal(
+  isRuntimeBuildCurrent("2.4.2", clientBuild, { version: "2.4.2" }),
+  true,
+  "older servers without build metadata retain version-only compatibility",
+);
+assert.equal(
+  getServerRuntimeBuild({ version: "2.4.2", build: " 2.4.2+bbbbbbbbbbbb " }),
+  "2.4.2+bbbbbbbbbbbb",
+  "the server build identity is normalized for the recovery key",
+);
 
 const outerMarkdownMatch = new RegExp(INLINE_MD_RE.source, INLINE_MD_RE.flags).exec("*This is **bold** in italic.*");
 assert.equal(

--- a/scripts/regressions/launcher-format-guard.regression.mjs
+++ b/scripts/regressions/launcher-format-guard.regression.mjs
@@ -80,8 +80,17 @@ assert.match(
   /trap release_termux_wake_lock EXIT/u,
   "the Termux launcher must release its wake lock whenever the server exits",
 );
+const wakeLockTrapIndex = termuxLauncherSource.search(/^[ \t]*trap release_termux_wake_lock EXIT[ \t]*$/mu);
+const wakeLockAcquireIndex = termuxLauncherSource.search(
+  /^[ \t]*if[ \t]+termux-wake-lock\b[^\n]*;[ \t]*then[ \t]*$/mu,
+);
+const serverStartIndex = termuxLauncherSource.lastIndexOf("node dist/index.js");
 assert.ok(
-  termuxLauncherSource.indexOf("termux-wake-lock") < termuxLauncherSource.lastIndexOf("node dist/index.js"),
+  wakeLockTrapIndex >= 0 && wakeLockAcquireIndex >= 0 && wakeLockTrapIndex < wakeLockAcquireIndex,
+  "the Termux launcher must register wake-lock cleanup before acquiring the lock",
+);
+assert.ok(
+  wakeLockAcquireIndex >= 0 && serverStartIndex >= 0 && wakeLockAcquireIndex < serverStartIndex,
   "the Termux launcher must acquire its wake lock before starting the server",
 );
 assert.doesNotMatch(

--- a/scripts/regressions/launcher-format-guard.regression.mjs
+++ b/scripts/regressions/launcher-format-guard.regression.mjs
@@ -70,6 +70,25 @@ for (const launcherPath of ["start.sh", "start-termux.sh", "start.bat"]) {
     );
   }
 }
+const termuxLauncherSource = readFileSync(join(repositoryRoot, "start-termux.sh"), "utf8");
+assert.ok(
+  termuxLauncherSource.includes("termux-wake-lock") && termuxLauncherSource.includes("termux-wake-unlock"),
+  "the Termux launcher must hold an Android wake lock while the server runs",
+);
+assert.match(
+  termuxLauncherSource,
+  /trap release_termux_wake_lock EXIT/u,
+  "the Termux launcher must release its wake lock whenever the server exits",
+);
+assert.ok(
+  termuxLauncherSource.indexOf("termux-wake-lock") < termuxLauncherSource.lastIndexOf("node dist/index.js"),
+  "the Termux launcher must acquire its wake lock before starting the server",
+);
+assert.doesNotMatch(
+  termuxLauncherSource,
+  /exec node dist\/index\.js/u,
+  "the Termux launcher must retain its shell so the EXIT cleanup trap can run",
+);
 const installerSource = readFileSync(join(repositoryRoot, "win/installer/install.bat"), "utf8");
 assert.ok(
   installerSource.includes("check-target") && installerSource.includes("if errorlevel 2"),

--- a/start-termux.sh
+++ b/start-termux.sh
@@ -570,11 +570,11 @@ release_termux_wake_lock() {
         fi
     fi
 }
+trap release_termux_wake_lock EXIT
 
 if command -v termux-wake-lock &> /dev/null && command -v termux-wake-unlock &> /dev/null; then
     if termux-wake-lock >/dev/null 2>&1; then
         TERMUX_WAKE_LOCK_ACQUIRED=1
-        trap release_termux_wake_lock EXIT
         echo "  [OK] Android wake lock acquired for background reliability"
     else
         echo "  [WARN] Could not acquire an Android wake lock; background execution may pause."

--- a/start-termux.sh
+++ b/start-termux.sh
@@ -560,6 +560,29 @@ elif [ "$AUTO_OPEN_BROWSER_ENABLED" != "1" ]; then
     echo "  [OK] Auto-open disabled (AUTO_OPEN_BROWSER=${AUTO_OPEN_BROWSER_VALUE})"
 fi
 
+# Keep Android from suspending the Termux process while the local server is
+# running. Release the lock on every launcher exit, including Ctrl+C.
+TERMUX_WAKE_LOCK_ACQUIRED=0
+release_termux_wake_lock() {
+    if [ "$TERMUX_WAKE_LOCK_ACQUIRED" = "1" ]; then
+        if ! termux-wake-unlock >/dev/null 2>&1; then
+            echo "  [WARN] Could not release the Android wake lock."
+        fi
+    fi
+}
+
+if command -v termux-wake-lock &> /dev/null && command -v termux-wake-unlock &> /dev/null; then
+    if termux-wake-lock >/dev/null 2>&1; then
+        TERMUX_WAKE_LOCK_ACQUIRED=1
+        trap release_termux_wake_lock EXIT
+        echo "  [OK] Android wake lock acquired for background reliability"
+    else
+        echo "  [WARN] Could not acquire an Android wake lock; background execution may pause."
+    fi
+else
+    echo "  [WARN] Termux wake-lock commands are unavailable; background execution may pause."
+fi
+
 # Start server
 cd packages/server
-exec node dist/index.js
+node dist/index.js


### PR DESCRIPTION
## Linked issues

Closes #4957
Closes #4956

## Why this change

NovelAI default parameters already survive the current save, navigation, and import paths, but staging commits keep the same release version. A browser still running an older same-version bundle therefore could not detect that the server had moved to a newer commit and could keep exhibiting the pre-fix behavior.

Android may also suspend a backgrounded Termux process unless its wake lock is active, which makes the local Marinara server appear frozen until Termux is foregrounded again.

## What changed

- Embed the client build commit and compare it with `/api/health` so same-version staging updates clear stale browser runtime caches and reload once.
- Preserve version-only compatibility for servers that do not expose build metadata.
- Acquire a Termux wake lock immediately before starting the server and release it on launcher exit.
- Add browser regressions covering NovelAI defaults after Save/persona navigation and connection JSON import.
- Add focused runtime-build and launcher contract regressions.
- Document both user-facing fixes under `CHANGELOG.md` Unreleased.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Automated evidence

- `pnpm check`
- `bash -n start-termux.sh`
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/assigned-issue-sweep.regression.ts`
- `node scripts/regressions/launcher-format-guard.regression.mjs`
- `pnpm exec playwright test -c playwright.config.ts e2e/core-flows.e2e.ts --project=desktop-chromium --grep 'NovelAI generation defaults survive'` (2 passed)
- Production build inspection confirmed the client bundle and server build metadata contain the same 12-character commit.

### Manual verification still required

- Manually verify a browser left open across two same-version staging commits reloads to the new build without looping.
- Manually verify NovelAI settings persist after Save, persona navigation, reopening, export, and import in LibreWolf.
- Manually verify a Termux-hosted client remains responsive while Android backgrounds Termux, and that stopping the launcher releases the wake lock.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated

No user-facing documentation page changed; `CHANGELOG.md` contains the release-note entries. No version metadata changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Same-version browser clients now refresh when the server build changes, reducing stale-session issues.
  - Termux-hosted servers keep Android awake while running and release the wake lock cleanly on shutdown.
  - Servers without build metadata remain compatible with version recovery.

- **Tests**
  - Added coverage for NovelAI seed persistence and imported connection defaults.
  - Added regression checks for build mismatch handling and Termux wake-lock behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->