### PR TITLE
Fix preset regex imports and Spotify fallback playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Imported preset regex entries even when they contain unsupported SillyTavern placements, warning about ignored placement values instead of discarding the entire regex, and let Music DJ try the next candidate when Spotify accepts but cannot verify the first selected track (#4959, #4960).
 - Refreshed stale same-version browser clients when the server commit changes, so staging fixes such as NovelAI generation-setting saves and connection imports no longer remain hidden behind an older cached interface (#4957).
 - Kept the Termux-hosted server awake while the launcher is running and released the Android wake lock when it stops, preventing backgrounded Termux sessions from freezing until the terminal is reopened (#4956).
 - Kept Professor Mari's generated continuation suggestions available after opening and closing a lorebook (#4953).

--- a/packages/client/src/components/panels/PresetsPanel.tsx
+++ b/packages/client/src/components/panels/PresetsPanel.tsx
@@ -576,14 +576,6 @@ export function PresetsPanel() {
         const orderBase = getNextRegexOrderBase((regexScripts ?? []) as RegexScriptRow[]);
         for (const [index, entry] of entries.entries()) {
           const unsupportedPlacements = getUnsupportedStRegexPlacements(entry);
-          if (unsupportedPlacements.length > 0) {
-            warnings.push(
-              localizeUi("ui.panels.presetspanel.ignoredUnsupportedRegexPlacements", {
-                value1: index + 1,
-                value2: unsupportedPlacements.join(", "),
-              }),
-            );
-          }
           const normalized = normalizeRegexImportEntry(entry, orderBase + index);
           if (!normalized) {
             failed.push(`Entry ${index + 1}: missing name or find pattern.`);
@@ -592,6 +584,14 @@ export function PresetsPanel() {
           try {
             await createRegexScript.mutateAsync(normalized);
             imported++;
+            if (unsupportedPlacements.length > 0) {
+              warnings.push(
+                localizeUi("ui.panels.presetspanel.ignoredUnsupportedRegexPlacements", {
+                  value1: index + 1,
+                  value2: unsupportedPlacements.join(", "),
+                }),
+              );
+            }
           } catch (error) {
             failed.push(`Entry ${index + 1} (${normalized.name}): ${describeImportError(error)}`);
           }

--- a/packages/client/src/components/panels/PresetsPanel.tsx
+++ b/packages/client/src/components/panels/PresetsPanel.tsx
@@ -315,6 +315,7 @@ export function PresetsPanel() {
   const [selectedPresetIds, setSelectedPresetIds] = useState<Set<string>>(new Set());
   const [exportingSelected, setExportingSelected] = useState(false);
   const [regexImportError, setRegexImportError] = useState<string | null>(null);
+  const [regexImportWarning, setRegexImportWarning] = useState<string | null>(null);
   const [regexImportSuccess, setRegexImportSuccess] = useState<string | null>(null);
   const [functionImportError, setFunctionImportError] = useState<string | null>(null);
   const [functionImportSuccess, setFunctionImportSuccess] = useState<string | null>(null);
@@ -558,6 +559,7 @@ export function PresetsPanel() {
   const handleImportRegex = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
       setRegexImportError(null);
+      setRegexImportWarning(null);
       setRegexImportSuccess(null);
       const file = event.target.files?.[0];
       if (!file) return;
@@ -570,14 +572,17 @@ export function PresetsPanel() {
 
         let imported = 0;
         const failed: string[] = [];
+        const warnings: string[] = [];
         const orderBase = getNextRegexOrderBase((regexScripts ?? []) as RegexScriptRow[]);
         for (const [index, entry] of entries.entries()) {
           const unsupportedPlacements = getUnsupportedStRegexPlacements(entry);
           if (unsupportedPlacements.length > 0) {
-            failed.push(
-              `Entry ${index + 1}: unsupported SillyTavern placement ${unsupportedPlacements.join(", ")} was skipped.`,
+            warnings.push(
+              localizeUi("ui.panels.presetspanel.ignoredUnsupportedRegexPlacements", {
+                value1: index + 1,
+                value2: unsupportedPlacements.join(", "),
+              }),
             );
-            continue;
           }
           const normalized = normalizeRegexImportEntry(entry, orderBase + index);
           if (!normalized) {
@@ -598,6 +603,9 @@ export function PresetsPanel() {
         if (failed.length > 0) {
           setRegexImportError(`Skipped ${failed.length} regex script${failed.length === 1 ? "" : "s"}. ${failed[0]}`);
         }
+        if (warnings.length > 0) {
+          setRegexImportWarning(warnings[0]!);
+        }
         if (imported === 0 && failed.length === 0) {
           setRegexImportError("No valid regex scripts found in file.");
         }
@@ -607,7 +615,7 @@ export function PresetsPanel() {
 
       event.target.value = "";
     },
-    [createRegexScript, regexScripts],
+    [createRegexScript, localizeUi, regexScripts],
   );
 
   const handleExportFunctions = useCallback(() => {
@@ -1453,6 +1461,7 @@ export function PresetsPanel() {
         handleImportRegex={handleImportRegex}
         handleExportRegex={handleExportRegex}
         regexImportError={regexImportError}
+        regexImportWarning={regexImportWarning}
         regexImportSuccess={regexImportSuccess}
         sortedRegexScripts={sortedRegexScripts}
         draggedRegexId={draggedRegexId}
@@ -1519,6 +1528,7 @@ function RegexSection({
   handleImportRegex,
   handleExportRegex,
   regexImportError,
+  regexImportWarning,
   regexImportSuccess,
   sortedRegexScripts,
   draggedRegexId,
@@ -1535,6 +1545,7 @@ function RegexSection({
   handleImportRegex: (event: ChangeEvent<HTMLInputElement>) => void;
   handleExportRegex: () => void;
   regexImportError: string | null;
+  regexImportWarning: string | null;
   regexImportSuccess: string | null;
   sortedRegexScripts: RegexScriptRow[];
   draggedRegexId: string | null;
@@ -1616,6 +1627,7 @@ function RegexSection({
           {regexImportError}
         </div>
       )}
+      {regexImportWarning && <div className="mb-1 px-1 text-xs text-amber-500">{regexImportWarning}</div>}
       {regexImportSuccess && <div className="mb-1 px-1 text-xs text-green-500">{regexImportSuccess}</div>}
       {sortedRegexScripts.length === 0 ? (
         <p className="mari-chrome-text-muted px-1 py-2 text-[0.625rem]">

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -7424,6 +7424,7 @@
   "ui.panels.presetspanel.failedToDeleteValue1PresetValue2": "Failed to delete {{value1}} preset{{value2}}",
   "ui.panels.presetspanel.failedToExportPresets": "Failed to export presets",
   "ui.panels.presetspanel.failedToUploadPresetPicture": "Failed to upload preset picture",
+  "ui.panels.presetspanel.ignoredUnsupportedRegexPlacements": "Entry {{value1}}: ignored unsupported SillyTavern placement(s) {{value2}} and imported the regex with its supported placement settings.",
   "ui.panels.presetspanel.importPreset": "Import preset",
   "ui.panels.presetspanel.noFunctionsToExport": "No functions to export",
   "ui.panels.presetspanel.noMatchingPresets": "No matching presets",

--- a/packages/server/src/services/generation/spotify-agent-runtime.ts
+++ b/packages/server/src/services/generation/spotify-agent-runtime.ts
@@ -353,13 +353,27 @@ async function playSpotifyFallbackCandidates(args: {
   }
 
   const queueSize = context.chatMode === "game" ? 1 : 5;
-  const picked = candidates.tracks.slice(0, queueSize);
-  const uris = picked.map((track) => track.uri);
-  const play = await executeSpotifyAgentToolJson(
+  let picked = candidates.tracks.slice(0, queueSize);
+  let uris = picked.map((track) => track.uri);
+  let play = await executeSpotifyAgentToolJson(
     agent,
     "spotify_play",
     uris.length === 1 ? { uri: uris[0], reason } : { uris, reason },
   );
+  if (
+    play.applied !== true &&
+    play.verification === "failed" &&
+    readSpotifyPlaybackTrackUri(play) !== uris[0] &&
+    candidates.tracks.length > 1
+  ) {
+    picked = candidates.tracks.slice(1, queueSize + 1);
+    uris = picked.map((track) => track.uri);
+    play = await executeSpotifyAgentToolJson(
+      agent,
+      "spotify_play",
+      uris.length === 1 ? { uri: uris[0], reason } : { uris, reason },
+    );
+  }
   if (play.applied !== true) {
     const playError = typeof play.error === "string" ? play.error : "Spotify play did not apply playback.";
     return { ...result, success: false, error: playError };

--- a/packages/server/src/services/generation/spotify-agent-runtime.ts
+++ b/packages/server/src/services/generation/spotify-agent-runtime.ts
@@ -360,10 +360,12 @@ async function playSpotifyFallbackCandidates(args: {
     "spotify_play",
     uris.length === 1 ? { uri: uris[0], reason } : { uris, reason },
   );
+  const activeUri = readSpotifyPlaybackTrackUri(play);
   if (
     play.applied !== true &&
     play.verification === "failed" &&
-    readSpotifyPlaybackTrackUri(play) !== uris[0] &&
+    typeof activeUri === "string" &&
+    activeUri !== uris[0] &&
     candidates.tracks.length > 1
   ) {
     picked = candidates.tracks.slice(1, queueSize + 1);

--- a/scripts/regressions/agent-runtime.regression.ts
+++ b/scripts/regressions/agent-runtime.regression.ts
@@ -18,7 +18,11 @@ import {
   type ChatOptions,
 } from "../../packages/server/src/services/llm/base-provider.js";
 import { agentResultTypeSchema } from "../../packages/shared/src/schemas/agent.schema.js";
-import { AGENT_RESULT_TYPE_VALUES, type AgentContext } from "../../packages/shared/src/types/agent.js";
+import {
+  AGENT_RESULT_TYPE_VALUES,
+  type AgentContext,
+  type AgentResult,
+} from "../../packages/shared/src/types/agent.js";
 
 class RecordingProvider extends BaseLLMProvider {
   calls = 0;
@@ -329,6 +333,7 @@ assert.equal(spotifyProvider.options[0]?.tools, undefined, "Spotify planning sho
 assert.equal(spotifyToolExecutions, 0, "Spotify tools should run later in the deterministic playback stage");
 
 const spotifyFallbackCalls: string[] = [];
+let spotifyFallbackReportsActiveUri = true;
 const spotifyFallbackAgent = {
   ...makeAgent("spotify", "spotify_control"),
   __spotifyCandidateTracks: [
@@ -344,7 +349,7 @@ const spotifyFallbackAgent = {
         return JSON.stringify({
           error: "Spotify playback failed to start the selected track on Regression device.",
           verification: "failed",
-          currentUri: "spotify:track:previous",
+          ...(spotifyFallbackReportsActiveUri ? { currentUri: "spotify:track:previous" } : {}),
         });
       }
       return JSON.stringify({
@@ -356,25 +361,24 @@ const spotifyFallbackAgent = {
     },
   },
 } as SpotifyRuntimeAgent;
+const spotifyFallbackPlannerResult: AgentResult = {
+  agentId: "spotify",
+  agentType: "spotify",
+  type: "spotify_control",
+  data: {
+    action: "play",
+    mood: "tense",
+    searchQuery: "game soundtrack",
+    trackUris: [],
+    trackNames: [],
+  },
+  tokensUsed: 12,
+  durationMs: 1,
+  success: true,
+  error: null,
+};
 const [spotifyFallbackResult] = await applySpotifyAgentPlaybackFallbacks(
-  [
-    {
-      agentId: "spotify",
-      agentType: "spotify",
-      type: "spotify_control",
-      data: {
-        action: "play",
-        mood: "tense",
-        searchQuery: "game soundtrack",
-        trackUris: [],
-        trackNames: [],
-      },
-      tokensUsed: 12,
-      durationMs: 1,
-      success: true,
-      error: null,
-    },
-  ],
+  [spotifyFallbackPlannerResult],
   [spotifyFallbackAgent],
   { ...context, chatMode: "game" },
 );
@@ -385,6 +389,20 @@ assert.deepEqual(
 );
 assert.equal(spotifyFallbackResult?.success, true);
 assert.deepEqual((spotifyFallbackResult?.data as Record<string, unknown>).trackUris, ["spotify:track:fallback"]);
+
+spotifyFallbackReportsActiveUri = false;
+spotifyFallbackCalls.length = 0;
+const [spotifyMissingUriResult] = await applySpotifyAgentPlaybackFallbacks(
+  [spotifyFallbackPlannerResult],
+  [spotifyFallbackAgent],
+  { ...context, chatMode: "game" },
+);
+assert.deepEqual(
+  spotifyFallbackCalls,
+  ["spotify:track:unavailable"],
+  "Music DJ must not switch candidates when Spotify verification reports no active URI",
+);
+assert.equal(spotifyMissingUriResult?.success, false);
 
 const connectionLimitedProvider = new ConcurrencyRecordingProvider();
 const connectionLimitedAgents: ResolvedAgent[] = [

--- a/scripts/regressions/agent-runtime.regression.ts
+++ b/scripts/regressions/agent-runtime.regression.ts
@@ -6,6 +6,10 @@ import {
 } from "../../packages/server/src/services/agents/agent-executor.js";
 import { createAgentPipeline, type ResolvedAgent } from "../../packages/server/src/services/agents/agent-pipeline.js";
 import { resolveAgentPipelineAgents } from "../../packages/server/src/services/generation/agent-resolution.js";
+import {
+  applySpotifyAgentPlaybackFallbacks,
+  type SpotifyRuntimeAgent,
+} from "../../packages/server/src/services/generation/spotify-agent-runtime.js";
 import { buildLlamaArgs } from "../../packages/server/src/services/sidecar/sidecar-launch-plan.js";
 import {
   BaseLLMProvider,
@@ -323,6 +327,64 @@ await createAgentPipeline([spotifyAgent], context).postGenerate("The room settle
 assert.equal(spotifyProvider.calls, 1, "Spotify Music DJ should make one planning request");
 assert.equal(spotifyProvider.options[0]?.tools, undefined, "Spotify planning should not enter the LLM tool loop");
 assert.equal(spotifyToolExecutions, 0, "Spotify tools should run later in the deterministic playback stage");
+
+const spotifyFallbackCalls: string[] = [];
+const spotifyFallbackAgent = {
+  ...makeAgent("spotify", "spotify_control"),
+  __spotifyCandidateTracks: [
+    { uri: "spotify:track:unavailable", name: "Unavailable", artist: "Regression Artist" },
+    { uri: "spotify:track:fallback", name: "Fallback", artist: "Regression Artist" },
+  ],
+  toolContext: {
+    tools: [],
+    executeToolCall: async (call) => {
+      const args = JSON.parse(call.function.arguments) as { uri?: string };
+      spotifyFallbackCalls.push(args.uri ?? "");
+      if (args.uri === "spotify:track:unavailable") {
+        return JSON.stringify({
+          error: "Spotify playback failed to start the selected track on Regression device.",
+          verification: "failed",
+          currentUri: "spotify:track:previous",
+        });
+      }
+      return JSON.stringify({
+        applied: true,
+        currentUri: "spotify:track:fallback",
+        device: "Regression device",
+        queued: 1,
+      });
+    },
+  },
+} as SpotifyRuntimeAgent;
+const [spotifyFallbackResult] = await applySpotifyAgentPlaybackFallbacks(
+  [
+    {
+      agentId: "spotify",
+      agentType: "spotify",
+      type: "spotify_control",
+      data: {
+        action: "play",
+        mood: "tense",
+        searchQuery: "game soundtrack",
+        trackUris: [],
+        trackNames: [],
+      },
+      tokensUsed: 12,
+      durationMs: 1,
+      success: true,
+      error: null,
+    },
+  ],
+  [spotifyFallbackAgent],
+  { ...context, chatMode: "game" },
+);
+assert.deepEqual(
+  spotifyFallbackCalls,
+  ["spotify:track:unavailable", "spotify:track:fallback"],
+  "Music DJ should try the next deterministic candidate after Spotify accepts but cannot verify the first",
+);
+assert.equal(spotifyFallbackResult?.success, true);
+assert.deepEqual((spotifyFallbackResult?.data as Record<string, unknown>).trackUris, ["spotify:track:fallback"]);
 
 const connectionLimitedProvider = new ConcurrencyRecordingProvider();
 const connectionLimitedAgents: ResolvedAgent[] = [

--- a/scripts/regressions/assigned-issue-sweep.regression.ts
+++ b/scripts/regressions/assigned-issue-sweep.regression.ts
@@ -202,4 +202,24 @@ assert.match(
   "chat navigation uses the continuation-preserving Agent reset",
 );
 
+const presetsPanelSource = readFileSync(
+  join(repositoryRoot, "packages/client/src/components/panels/PresetsPanel.tsx"),
+  "utf8",
+);
+const unsupportedRegexPlacementBranch =
+  /const unsupportedPlacements = getUnsupportedStRegexPlacements\(entry\);[\s\S]*?const normalized =/u.exec(
+    presetsPanelSource,
+  )?.[0];
+assert.ok(unsupportedRegexPlacementBranch, "the preset regex placement import branch remains discoverable");
+assert.doesNotMatch(
+  unsupportedRegexPlacementBranch,
+  /continue;/u,
+  "unsupported SillyTavern placements must not discard the entire preset regex entry",
+);
+assert.match(
+  unsupportedRegexPlacementBranch,
+  /warnings\.push/u,
+  "ignored SillyTavern placements remain visible as an import warning",
+);
+
 console.info("Assigned issue-sweep regressions passed.");

--- a/scripts/regressions/assigned-issue-sweep.regression.ts
+++ b/scripts/regressions/assigned-issue-sweep.regression.ts
@@ -206,20 +206,30 @@ const presetsPanelSource = readFileSync(
   join(repositoryRoot, "packages/client/src/components/panels/PresetsPanel.tsx"),
   "utf8",
 );
-const unsupportedRegexPlacementBranch =
+const unsupportedRegexPlacementGate =
   /const unsupportedPlacements = getUnsupportedStRegexPlacements\(entry\);[\s\S]*?const normalized =/u.exec(
     presetsPanelSource,
   )?.[0];
-assert.ok(unsupportedRegexPlacementBranch, "the preset regex placement import branch remains discoverable");
+assert.ok(unsupportedRegexPlacementGate, "the preset regex placement import branch remains discoverable");
 assert.doesNotMatch(
-  unsupportedRegexPlacementBranch,
+  unsupportedRegexPlacementGate,
   /continue;/u,
   "unsupported SillyTavern placements must not discard the entire preset regex entry",
 );
+const successfulRegexImportWarning =
+  /await createRegexScript\.mutateAsync\(normalized\);[\s\S]*?warnings\.push\([\s\S]*?ignoredUnsupportedRegexPlacements"/u.exec(
+    presetsPanelSource,
+  )?.[0];
+assert.ok(successfulRegexImportWarning, "the successful preset regex import warning remains discoverable");
 assert.match(
-  unsupportedRegexPlacementBranch,
-  /warnings\.push/u,
-  "ignored SillyTavern placements remain visible as an import warning",
+  successfulRegexImportWarning,
+  /await createRegexScript\.mutateAsync\(normalized\);[\s\S]*?warnings\.push/u,
+  "ignored SillyTavern placements produce a warning only after the regex imports successfully",
+);
+assert.match(
+  successfulRegexImportWarning,
+  /localizeUi\("ui\.panels\.presetspanel\.ignoredUnsupportedRegexPlacements"/u,
+  "unsupported placement warnings must use the localized message",
 );
 
 console.info("Assigned issue-sweep regressions passed.");

--- a/scripts/regressions/assigned-issue-sweep.regression.ts
+++ b/scripts/regressions/assigned-issue-sweep.regression.ts
@@ -216,6 +216,16 @@ assert.doesNotMatch(
   /continue;/u,
   "unsupported SillyTavern placements must not discard the entire preset regex entry",
 );
+const regexBeforeSuccessfulImport =
+  /const unsupportedPlacements = getUnsupportedStRegexPlacements\(entry\);[\s\S]*?await createRegexScript\.mutateAsync\(normalized\);/u.exec(
+    presetsPanelSource,
+  )?.[0];
+assert.ok(regexBeforeSuccessfulImport, "the preset regex pre-import path remains discoverable");
+assert.doesNotMatch(
+  regexBeforeSuccessfulImport,
+  /warnings\.push/u,
+  "unsupported placement warnings must not be emitted before the regex imports successfully",
+);
 const successfulRegexImportWarning =
   /await createRegexScript\.mutateAsync\(normalized\);[\s\S]*?warnings\.push\([\s\S]*?ignoredUnsupportedRegexPlacements"/u.exec(
     presetsPanelSource,


### PR DESCRIPTION
## Linked issues

Closes #4959
Closes #4960

Related: #4922 is already handled by draft PR #4923, so this sweep deliberately does not duplicate it.

## Why this change

Two assigned bug reports shared a small user-facing failure mode: valid work was discarded after one unsupported or unavailable choice.

- Preset regex import rejected an entire regex entry when its SillyTavern placement array contained an unsupported value, even though the supported placements could still be normalized.
- Music DJ stopped after Spotify accepted a selected track but continued reporting the previous URI, so a single unavailable or otherwise unstartable candidate ended the deterministic fallback.

## What changed

- Preserve preset regex entries with unsupported SillyTavern placement values, ignore only those values, and show a localized warning.
- Keep malformed regex entries and actual API failures on the existing skipped-entry path.
- Give Music DJ one bounded alternate-candidate attempt after a Spotify URI-verification failure.
- Do not broaden retries for authentication, device, or repeat-mode failures.
- Add focused regressions and an Unreleased changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Commands run:

- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm localization:check`
- `pnpm regression:agent-runtime`
- `pnpm regression:prompt`
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/assigned-issue-sweep.regression.ts`

### Manual verification notes

Manual verification still required before marking this PR ready:

1. Import a preset regex containing both supported and unsupported SillyTavern placement values; confirm the regex is created and the ignored placement warning appears.
2. Trigger Music DJ with a first Spotify candidate that is accepted but does not become the active URI; confirm exactly one alternate selection is attempted.
3. Confirm authentication, missing-device, and repeat-mode failures do not trigger candidate switching.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated

An Unreleased changelog entry and the canonical English localization key are included. No user-facing documentation pages or version files changed.

## UI evidence

Not attached. The UI change is limited to the existing regex import status area.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preset regex imports now retain entries with unsupported SillyTavern placements and show a localized warning.
  * Spotify playback now retries with the next available candidate when track verification fails, while preserving successful playback behavior.
* **Tests**
  * Added regression coverage for preset import warnings, retained regex entries, and Spotify fallback playback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->