### PR TITLE
fix: keep avatar scale slider interactive in Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept the Message Avatar Scale and related art-size sliders wide enough to remain visible and repeatedly adjustable in Chrome, including at larger interface display sizes (#4974).
 - Prevented crafted profile archives from retargeting saved credentials, serving active files as trusted app content, escaping asset directories through imported metadata, reconstructing blocked theme CSS, or exhausting the importer with oversized metadata.
 - Hardened local security without removing extension or remote-access capabilities: made Professor Mari filters data-only, encrypted webhook credentials, bounded ZIP extraction and rich-chat network/CSS behavior, restricted automatic network trust to detected runtimes, privatized local data and backups, verified downloads and release commits, and patched audited dependencies.
 - Authenticated APK-managed Android localhost sessions without restricting manual Termux or LAN use, verified the pinned F-Droid Termux APK before install, bound native bridge calls to the exact Engine origin, and made release signing and bootstrap source commits fail closed.

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -319,6 +319,34 @@ test("Appearance distinguishes the square avatar-shape preview from the circular
   expect(squareRadius).toBeLessThan(squareWidth / 3);
 });
 
+test("Message avatar scale stays interactive at the largest display size", async ({ page }) => {
+  await page.goto("/");
+  await page.locator('[data-tour="panel-settings"]').click();
+  await page.getByRole("tab", { name: "Appearance" }).click();
+
+  await page.locator("#settings-control-display-size select").selectOption("22");
+
+  const control = page.locator("#settings-control-roleplay-avatar-scale");
+  const slider = control.locator('input[type="range"]');
+  await control.scrollIntoViewIfNeeded();
+  await expect(slider).toBeVisible();
+
+  const box = await slider.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.width).toBeGreaterThanOrEqual(80);
+
+  for (const fraction of [0.8, 0.25, 0.65]) {
+    await page.mouse.click(box!.x + box!.width * fraction, box!.y + box!.height / 2);
+    const expectedValue = 0.75 + (2.5 - 0.75) * fraction;
+    await expect
+      .poll(async () => Number(await slider.inputValue()))
+      .toBeGreaterThan(expectedValue - 0.12);
+    await expect
+      .poll(async () => Number(await slider.inputValue()))
+      .toBeLessThan(expectedValue + 0.12);
+  }
+});
+
 test("custom theme live preview batches stylesheet updates while typing", async ({ page }) => {
   await page.goto("/");
   await page.locator('[data-tour="panel-settings"]').click();

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -333,6 +333,9 @@ test("Art scale sliders stay interactive at the largest display size", async ({ 
     const box = await slider.boundingBox();
     expect(box).not.toBeNull();
     expect(box!.width).toBeGreaterThanOrEqual(80);
+    const min = Number((await slider.getAttribute("min")) ?? 0);
+    const max = Number((await slider.getAttribute("max")) ?? 100);
+    const midpoint = min + (max - min) / 2;
 
     for (const [fraction, direction] of [
       [0.8, "high"],
@@ -341,9 +344,9 @@ test("Art scale sliders stay interactive at the largest display size", async ({ 
     ] as const) {
       await page.mouse.click(box!.x + box!.width * fraction, box!.y + box!.height / 2);
       if (direction === "high") {
-        await expect.poll(async () => Number(await slider.inputValue())).toBeGreaterThan(1.5);
+        await expect.poll(async () => Number(await slider.inputValue())).toBeGreaterThan(midpoint);
       } else {
-        await expect.poll(async () => Number(await slider.inputValue())).toBeLessThan(1.5);
+        await expect.poll(async () => Number(await slider.inputValue())).toBeLessThan(midpoint);
       }
     }
   };

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -324,27 +324,33 @@ test("Message avatar scale stays interactive at the largest display size", async
   await page.locator('[data-tour="panel-settings"]').click();
   await page.getByRole("tab", { name: "Appearance" }).click();
 
-  await page.locator("#settings-control-display-size select").selectOption("22");
-
   const control = page.locator("#settings-control-roleplay-avatar-scale");
   const slider = control.locator('input[type="range"]');
-  await control.scrollIntoViewIfNeeded();
-  await expect(slider).toBeVisible();
+  const exerciseSlider = async () => {
+    await control.scrollIntoViewIfNeeded();
+    await expect(slider).toBeVisible();
 
-  const box = await slider.boundingBox();
-  expect(box).not.toBeNull();
-  expect(box!.width).toBeGreaterThanOrEqual(80);
+    const box = await slider.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeGreaterThanOrEqual(80);
 
-  for (const fraction of [0.8, 0.25, 0.65]) {
-    await page.mouse.click(box!.x + box!.width * fraction, box!.y + box!.height / 2);
-    const expectedValue = 0.75 + (2.5 - 0.75) * fraction;
-    await expect
-      .poll(async () => Number(await slider.inputValue()))
-      .toBeGreaterThan(expectedValue - 0.12);
-    await expect
-      .poll(async () => Number(await slider.inputValue()))
-      .toBeLessThan(expectedValue + 0.12);
-  }
+    for (const [fraction, direction] of [
+      [0.8, "high"],
+      [0.25, "low"],
+      [0.65, "high"],
+    ] as const) {
+      await page.mouse.click(box!.x + box!.width * fraction, box!.y + box!.height / 2);
+      if (direction === "high") {
+        await expect.poll(async () => Number(await slider.inputValue())).toBeGreaterThan(1.5);
+      } else {
+        await expect.poll(async () => Number(await slider.inputValue())).toBeLessThan(1.5);
+      }
+    }
+  };
+
+  await exerciseSlider();
+  await page.locator("#settings-control-display-size select").selectOption("22");
+  await exerciseSlider();
 });
 
 test("custom theme live preview batches stylesheet updates while typing", async ({ page }) => {

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -5284,7 +5284,7 @@ function AppearanceSettings() {
               ))}
             </div>
             <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/45 p-3">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
                 <div className="flex h-20 w-full shrink-0 items-end justify-center gap-3 overflow-hidden rounded-md bg-black/30 p-2 ring-1 ring-[var(--border)]/70 sm:w-28">
                   {roleplayAvatarStyle === "none" ? (
                     <div
@@ -5320,7 +5320,7 @@ function AppearanceSettings() {
                     }}
                   />
                 </div>
-                <div className="grid min-w-0 flex-1 gap-3">
+                <div className="grid min-w-0 flex-1 gap-3 sm:min-w-[9rem]">
                   <label
                     id={getSettingsControlAnchorId("roleplay-avatar-scale")}
                     className="flex scroll-mt-3 min-w-0 flex-col gap-1"
@@ -5391,7 +5391,7 @@ function AppearanceSettings() {
               />
             </div>
             <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/45 p-3">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
                 <div className="flex h-20 w-full shrink-0 items-end justify-center gap-3 overflow-hidden rounded-md bg-black/30 p-2 ring-1 ring-[var(--border)]/70 sm:w-28">
                   <div
                     className="shrink-0 rounded-lg border border-white/20 bg-gradient-to-b from-sky-300/80 via-cyan-200/65 to-slate-800/90 shadow-lg transition-all"
@@ -5408,7 +5408,7 @@ function AppearanceSettings() {
                     }}
                   />
                 </div>
-                <div className="grid min-w-0 flex-1 gap-3">
+                <div className="grid min-w-0 flex-1 gap-3 sm:min-w-[9rem]">
                   <label
                     id={getSettingsControlAnchorId("game-dialogue-portrait-scale")}
                     className="flex scroll-mt-3 min-w-0 flex-col gap-1"


### PR DESCRIPTION
## Linked issue

Closes #4974

## Why this change

- Chrome users can adjust Message Avatar Scale only once per refresh, and the control disappears at larger interface display sizes.
- The preview and controls were forced side by side from the viewport `sm` breakpoint onward. Inside the fixed-width Settings panel this left the range input only 48 px wide at the default display size and zero width at Huge.

## What changed

- Let the existing roleplay and game art-size rows wrap when their controls need more than the available panel width.
- Give the control group a small minimum width so each slider keeps a usable pointer target.
- Add Chromium desktop and mobile regression coverage that adjusts Message Avatar Scale repeatedly before and after switching to Huge.
- Add an Unreleased changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated proof completed:

- `pnpm check`
- `pnpm --filter @marinara-engine/client lint`
- `pnpm exec playwright test -c playwright.config.ts --project desktop-chromium --grep "Message avatar scale stays interactive"`
- `pnpm exec playwright test -c playwright.config.ts --project mobile-chromium --grep "Message avatar scale stays interactive"`
- `git diff --check`

### Manual verification notes

- The focused Playwright browser proof exercises repeated pointer clicks at Default and Huge in desktop Chromium and mobile Chromium.
- No human manual browser verification was claimed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Automated Chromium proof covers both desktop and mobile layouts at Default and Huge display sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Chrome layout issue that could hide Message Avatar Scale and related art-size sliders.
  * Sliders now remain visible, properly sized, and adjustable across display sizes.
  * Improved responsive wrapping for roleplay and game art previews on smaller screens.

* **Tests**
  * Added coverage confirming avatar scale slider visibility and interaction at default and largest display sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->