### PR TITLE
fix: keep Noodle visible while update awaits restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept an already-installed Noodle Agent visible and usable after downloading an update while its replacement waits for the required Marinara Engine restart (#4976).
 - Prevented crafted profile archives from retargeting saved credentials, serving active files as trusted app content, escaping asset directories through imported metadata, reconstructing blocked theme CSS, or exhausting the importer with oversized metadata.
 - Hardened local security without removing extension or remote-access capabilities: made Professor Mari filters data-only, encrypted webhook credentials, bounded ZIP extraction and rich-chat network/CSS behavior, restricted automatic network trust to detected runtimes, privatized local data and backups, verified downloads and release commits, and patched audited dependencies.
 - Authenticated APK-managed Android localhost sessions without restricting manual Termux or LAN use, verified the pinned F-Droid Termux APK before install, bound native bridge calls to the exact Engine origin, and made release signing and bootstrap source commits fail closed.

--- a/packages/client/src/hooks/use-capability-packages.ts
+++ b/packages/client/src/hooks/use-capability-packages.ts
@@ -77,13 +77,18 @@ export function selectGameExperiencePackages(
   );
 }
 
+/** A restart-required update can keep using the version already loaded by this browser session. */
+export function isCapabilityPackageAvailableUntilRestart(installed: InstalledCapabilityPackage): boolean {
+  return installed.status === "restart-required" && Boolean(installed.previousVersion);
+}
+
 /** Installed destinations that Home can safely expose as browser tabs. */
 export function selectHomeBrowserPackages(
   installed: InstalledCapabilityPackage[] | undefined,
 ): InstalledCapabilityPackage[] {
   return (installed ?? []).filter(
     (pkg) =>
-      isInstalledCapabilityReady(pkg) &&
+      (isInstalledCapabilityReady(pkg) || isCapabilityPackageAvailableUntilRestart(pkg)) &&
       pkg.manifest.contributions?.slots?.includes("home-browser-tab") &&
       Boolean(pkg.manifest.entrypoints.client?.trim()) &&
       Boolean(pkg.manifest.contributions.homeBrowserTab),
@@ -208,7 +213,15 @@ export function useCapabilityClientModules() {
   useEffect(() => {
     const eligiblePackageIds = new Set<string>();
     for (const item of installed.data ?? []) {
-      if (!isInstalledCapabilityReady(item) || !item.manifest.entrypoints.client) continue;
+      if (!item.manifest.entrypoints.client) continue;
+      if (isCapabilityPackageAvailableUntilRestart(item)) {
+        // The old client module is still loaded and paired with the old server
+        // runtime until Marinara restarts. Keep its state mounted while the new
+        // package version waits on disk.
+        eligiblePackageIds.add(item.id);
+        continue;
+      }
+      if (!isInstalledCapabilityReady(item)) continue;
       eligiblePackageIds.add(item.id);
       const current = getCapabilityClientModuleState(item.id);
       const attempt = current.version === item.version ? current.attempt : 0;

--- a/packages/server/src/routes/capability-packages.routes.ts
+++ b/packages/server/src/routes/capability-packages.routes.ts
@@ -109,7 +109,10 @@ export async function capabilityPackagesRoutes(app: FastifyInstance) {
           ? await capabilityModuleRuntime.activatePackage(app, id)
           : installed;
       } finally {
-        await refreshCapabilityAgentRegistry();
+        // A restart-required update leaves the prior runtime active in this
+        // process. Keep its agent definitions visible until startup activates
+        // the replacement; refreshing now would make the package disappear.
+        if (installed.status !== "restart-required") await refreshCapabilityAgentRegistry();
       }
     },
   );

--- a/scripts/regressions/agent-registry-hydration.regression.ts
+++ b/scripts/regressions/agent-registry-hydration.regression.ts
@@ -1,8 +1,16 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
-import { replaceBuiltInAgentDefinitions, type BuiltInAgentManifest } from "../../packages/shared/dist/index.js";
+import {
+  replaceBuiltInAgentDefinitions,
+  type BuiltInAgentManifest,
+  type InstalledCapabilityPackage,
+} from "../../packages/shared/dist/index.js";
 import { buildRoleplayAgentSettingsOrder } from "../../packages/client/src/lib/agent-settings-order.js";
-import { selectVisibleTrackerCapabilityAgents } from "../../packages/client/src/hooks/use-capability-packages.js";
+import {
+  isCapabilityPackageAvailableUntilRestart,
+  selectHomeBrowserPackages,
+  selectVisibleTrackerCapabilityAgents,
+} from "../../packages/client/src/hooks/use-capability-packages.js";
 import { isReviewableWriterAgentType } from "../../packages/server/src/services/generation/runtime-agent-sections.js";
 
 const manifests: BuiltInAgentManifest[] = [
@@ -135,6 +143,32 @@ assert.deepEqual(
   "Connections must use refreshed capability-agent definitions while it remains mounted",
 );
 
+const pendingNoodleUpdate = {
+  id: "noodle",
+  version: "1.0.9",
+  manifest: {
+    entrypoints: { client: "client.js" },
+    contributions: {
+      slots: ["home-browser-tab"],
+      homeBrowserTab: { label: "Noodle", ariaLabel: "Open Noodle" },
+    },
+  },
+  status: "restart-required",
+  readiness: "pending",
+  previousVersion: "1.0.8",
+} as unknown as InstalledCapabilityPackage;
+assert.equal(isCapabilityPackageAvailableUntilRestart(pendingNoodleUpdate), true);
+assert.deepEqual(
+  selectHomeBrowserPackages([pendingNoodleUpdate]).map((item) => item.id),
+  ["noodle"],
+  "A Noodle update waiting for restart must keep the already-loaded Home tab visible",
+);
+assert.deepEqual(
+  selectHomeBrowserPackages([{ ...pendingNoodleUpdate, previousVersion: undefined }]).map((item) => item.id),
+  [],
+  "A first install waiting for restart must not expose a client module that has never loaded",
+);
+
 const connectionsPanelSource = await readFile(
   new URL("../../packages/client/src/components/panels/ConnectionsPanel.tsx", import.meta.url),
   "utf8",
@@ -158,9 +192,22 @@ assert.match(
   /const trackerLocalCount = useMemo\(\(\) => \{[\s\S]*?return trackerAgents\.filter\([\s\S]*?\}, \[agentConfigs, trackerAgents\]\);/u,
   "the Sidecar count must consume the reactive tracker list",
 );
+
+const capabilityPackageRoutesSource = await readFile(
+  new URL("../../packages/server/src/routes/capability-packages.routes.ts", import.meta.url),
+  "utf8",
+);
+assert.match(
+  capabilityPackageRoutesSource,
+  /if \(installed\.status !== "restart-required"\) await refreshCapabilityAgentRegistry\(\);/u,
+  "A restart-required update must retain the current session's agent registry until restart",
+);
 const assignHandlerStart = sidecarCardSource.indexOf("const handleAssignTrackersToLocal = async () => {");
 const assignHandlerEnd = sidecarCardSource.indexOf("\n  const handleModelLoadToggle", assignHandlerStart);
-assert.ok(assignHandlerStart >= 0 && assignHandlerEnd > assignHandlerStart, "Connections must retain assign-all handling");
+assert.ok(
+  assignHandlerStart >= 0 && assignHandlerEnd > assignHandlerStart,
+  "Connections must retain assign-all handling",
+);
 assert.match(
   sidecarCardSource.slice(assignHandlerStart, assignHandlerEnd),
   /trackerAgents\.map\(async \(agent\) => \{/u,


### PR DESCRIPTION
## Linked issue

Closes #4976

## Why this change

- Updating Noodle marks the replacement package `restart-required`, which made both its Agents-pane definition and Home browser tab disappear even though the already-loaded Noodle runtime remains usable until Marinara Engine restarts.

## What changed

- Keep the existing capability-agent registry in place while a restart-required replacement waits on disk.
- Keep an already-loaded Home browser package eligible when its installed record has a `previousVersion`; first-time installs remain hidden until their required restart.
- Preserve the loaded client-module state through that update window and add regression coverage for both update and first-install behavior.
- Add an Unreleased changelog note.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated: `pnpm check`
- Automated: `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/agent-registry-hydration.regression.ts`
- Automated: `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/capability-package-lifecycle.regression.ts`
- Automated: `pnpm version:check`
- Automated: Prettier and `git diff --check`
- Manual Noodle package-update click-through remains for the maintainer because this checkout has no separate disposable installed-profile fixture.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- No visual redesign; this preserves the existing Noodle destinations during the pre-restart update window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Installed agents remain visible and usable while an updated version awaits a required engine restart.
  - Existing runtime definitions stay active during restart-required updates.

- **Bug Fixes**
  - Prevented restart-required updates from prematurely hiding installed packages or refreshing active agent assignments.
  - Pending first-time installations remain hidden until ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->