### PR TITLE
fix: linearize residual content parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept inline Game dialogue and group character macros responsive on malformed or very large generated text without limiting valid authored content (#4984).
 - Removed the 2 GiB application ceiling from automatic and downloadable full backups, using streamed ZIP64 archives so larger local libraries remain restorable without weakening safety limits for ordinary profile imports (#4982).
 - Hardened imported and model-authored content against pathological parsing inputs and reserved metadata keys without removing supported import formats or local tools.
 - Kept automatic and downloadable backups working when local media exceeds the profile importer's ordinary per-file limit, while preserving bounded streaming imports and omitting only an individual unreadable or unarchivable asset instead of failing the whole backup; any omissions are listed in `RESTORE.txt` and automatic-backup status.

--- a/packages/server/src/services/game/segment-edits.ts
+++ b/packages/server/src/services/game/segment-edits.ts
@@ -368,11 +368,11 @@ function replaceDialogueSpeaker(prefix: string, speaker: string): string {
 function normalizeInlineVnDialogueLines(source: string): string {
   return source
     .replace(
-      /([^\n])\s+(\[[^\]]+\]\s*\[(?:main|side|extra|action|thought|whisper(?::[^\]]+)?)\]\s*(?:\[[^\]]+\])?\s*:)/gi,
+      /(\S)[^\S\r\n]+(\[[^\r\n[\]]+\][^\S\r\n]*\[(?:main|side|extra|action|thought|whisper(?::[^\r\n[\]]+)?)\][^\S\r\n]*(?:\[[^\r\n[\]]+\])?[^\S\r\n]*:)/gi,
       "$1\n$2",
     )
     .replace(
-      /(\[[^\]]+\]\s*\[(?:main|side|extra|whisper(?::[^\]]+)?)\]\s*(?:\[[^\]]+\])?\s*:\s*(?:"[^"]*"|“[^”]*”|«[^»]*»))\s+(?=\S)/gi,
+      /(\[[^\r\n[\]]+\][^\S\r\n]*\[(?:main|side|extra|whisper(?::[^\r\n[\]]+)?)\][^\S\r\n]*(?:\[[^\r\n[\]]+\])?[^\S\r\n]*:[^\S\r\n]*(?:"[^"\r\n]*"|“[^”\r\n]*”|«[^»\r\n]*»))[^\S\r\n]+(?=\S)/gi,
       "$1\n",
     );
 }

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -131,6 +131,7 @@ const CHARACTER_MACRO_NAMES = new Set([
   "convo_display",
   "description",
   "example",
+  "group",
   "personality",
   "scenario",
 ]);
@@ -138,7 +139,6 @@ const CHARACTER_CONDITIONAL_OPERAND_NAMES = new Set([
   ...CHARACTER_MACRO_NAMES,
   "character",
   "characterphonetic",
-  "group",
   "speaker",
   "speakerphonetic",
 ]);

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -652,11 +652,15 @@ function resolveDeferredCharacterConditionals(template: string, ctx: MacroContex
 }
 
 function hasCharacterMacro(template: string): boolean {
+  const lowerTemplate = template.toLowerCase();
+  for (const name of CHARACTER_MACRO_NAMES) {
+    if (lowerTemplate.includes(`{{${name}}}`)) return true;
+  }
+
   let searchIndex = 0;
   while (searchIndex < template.length) {
     const tag = readNextMacroTag(template, searchIndex);
     if (!tag) return false;
-    if (CHARACTER_MACRO_NAMES.has(tag.body.toLowerCase())) return true;
 
     const condition = parseIfCondition(tag.body);
     if (condition !== null && conditionDependsOnCharacter(condition)) return true;

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -560,17 +560,17 @@ export function resolveCharacterScopedMacros(
   const scopedContext = macroContextForCharacterProfile(profile, baseContext);
   const scoped = resolveConditionalBlocks(stripMacroComments(template), scopedContext, {});
   return scoped
-    .replace(/\{\{char(?:Name)?\}\}/gi, profile.name)
-    .replace(/\{\{char(?:Name)?Phonetic\}\}/gi, profile.phoneticName ?? profile.name)
-    .replace(/\{\{group\}\}/gi, resolveGroupCharacters(scopedContext))
-    .replace(/\{\{description\}\}/gi, () => resolveCharacterFieldValue(profile, "description", depth, baseContext))
-    .replace(/\{\{personality\}\}/gi, () => resolveCharacterFieldValue(profile, "personality", depth, baseContext))
-    .replace(/\{\{backstory\}\}/gi, () => resolveCharacterFieldValue(profile, "backstory", depth, baseContext))
-    .replace(/\{\{appearance\}\}/gi, () => resolveCharacterFieldValue(profile, "appearance", depth, baseContext))
-    .replace(/\{\{scenario\}\}/gi, () => resolveCharacterFieldValue(profile, "scenario", depth, baseContext))
-    .replace(/\{\{example\}\}/gi, () => resolveCharacterFieldValue(profile, "example", depth, baseContext))
-    .replace(/\{\{charSysInfo\}\}/gi, () => resolveCharacterFieldValue(profile, "systemPrompt", depth, baseContext))
-    .replace(/\{\{charPostHistory\}\}/gi, () =>
+    .replace(/\{\{\s*char(?:Name)?\s*\}\}/gi, profile.name)
+    .replace(/\{\{\s*char(?:Name)?Phonetic\s*\}\}/gi, profile.phoneticName ?? profile.name)
+    .replace(/\{\{\s*group\s*\}\}/gi, resolveGroupCharacters(scopedContext))
+    .replace(/\{\{\s*description\s*\}\}/gi, () => resolveCharacterFieldValue(profile, "description", depth, baseContext))
+    .replace(/\{\{\s*personality\s*\}\}/gi, () => resolveCharacterFieldValue(profile, "personality", depth, baseContext))
+    .replace(/\{\{\s*backstory\s*\}\}/gi, () => resolveCharacterFieldValue(profile, "backstory", depth, baseContext))
+    .replace(/\{\{\s*appearance\s*\}\}/gi, () => resolveCharacterFieldValue(profile, "appearance", depth, baseContext))
+    .replace(/\{\{\s*scenario\s*\}\}/gi, () => resolveCharacterFieldValue(profile, "scenario", depth, baseContext))
+    .replace(/\{\{\s*example\s*\}\}/gi, () => resolveCharacterFieldValue(profile, "example", depth, baseContext))
+    .replace(/\{\{\s*charSysInfo\s*\}\}/gi, () => resolveCharacterFieldValue(profile, "systemPrompt", depth, baseContext))
+    .replace(/\{\{\s*charPostHistory\s*\}\}/gi, () =>
       resolveCharacterFieldValue(profile, "postHistoryInstructions", depth, baseContext),
     );
 }
@@ -707,10 +707,44 @@ function hasCharacterMacro(template: string): boolean {
 
   let searchIndex = 0;
   while (searchIndex < template.length) {
-    const tag = readNextMacroTag(template, searchIndex);
-    if (!tag) return false;
+    const start = template.indexOf("{{", searchIndex);
+    if (start === -1) return false;
+    let bodyStart = start + 2;
+    while (bodyStart < template.length && /\s/u.test(template[bodyStart]!)) bodyStart++;
+    let nameEnd = bodyStart;
+    while (nameEnd < template.length && /[A-Za-z_]/u.test(template[nameEnd]!)) nameEnd++;
+    const name = template.slice(bodyStart, nameEnd).toLowerCase();
+    let directEnd = nameEnd;
+    while (directEnd < template.length && /\s/u.test(template[directEnd]!)) directEnd++;
+    if (template.startsWith("}}", directEnd) && CHARACTER_MACRO_NAMES.has(name)) return true;
 
-    const condition = parseIfCondition(tag.body) ?? parseElseIfCondition(tag.body);
+    const ifEnd = bodyStart + 3;
+    const elseIfEnd = directEnd + 2;
+    const isIf =
+      template.slice(bodyStart, ifEnd).toLowerCase() === "#if" &&
+      (template.startsWith("}}", ifEnd) || (ifEnd < template.length && /\s/u.test(template[ifEnd]!)));
+    const isElseIf =
+      name === "else" &&
+      directEnd > nameEnd &&
+      template.slice(directEnd, elseIfEnd).toLowerCase() === "if" &&
+      (template.startsWith("}}", elseIfEnd) ||
+        (elseIfEnd < template.length && /\s/u.test(template[elseIfEnd]!)));
+    if (!isIf && !isElseIf) {
+      searchIndex = Math.max(start + 2, nameEnd);
+      continue;
+    }
+
+    const end = findBalancedMacroEnd(template, start);
+    if (end === -1) {
+      return (
+        hasCharacterConditionalOperandCandidate(template.slice(bodyStart)) ||
+        [...CHARACTER_MACRO_NAMES].some((macroName) =>
+          lowerTemplate.includes(`{{${macroName}}}`, start + 2),
+        )
+      );
+    }
+    const body = template.slice(start + 2, end - 2).trim();
+    const condition = parseIfCondition(body) ?? parseElseIfCondition(body);
     if (
       condition !== null &&
       hasCharacterConditionalOperandCandidate(condition) &&
@@ -718,7 +752,7 @@ function hasCharacterMacro(template: string): boolean {
     ) {
       return true;
     }
-    searchIndex = tag.end;
+    searchIndex = end;
   }
   return false;
 }
@@ -1029,7 +1063,8 @@ function parseConditionExpression(condition: string): ParsedConditionExpression 
 type ConditionSyntaxNode =
   | { kind: "atom"; value: string }
   | { kind: "and" | "or"; children: ConditionSyntaxNode[] }
-  | { kind: "group"; child: ConditionSyntaxNode };
+  | { kind: "group"; child: ConditionSyntaxNode }
+  | { kind: "adjacent"; children: ConditionSyntaxNode[] };
 
 type ConditionSyntaxFrame = {
   atomStart: number;
@@ -1049,11 +1084,42 @@ function createConditionSyntaxFrame(atomStart: number): ConditionSyntaxFrame {
   };
 }
 
-function appendConditionSyntaxNode(frame: ConditionSyntaxFrame, node: ConditionSyntaxNode): boolean {
-  if (!frame.expectsOperand) return false;
+function appendConditionSyntaxNode(frame: ConditionSyntaxFrame, node: ConditionSyntaxNode): void {
+  if (!frame.expectsOperand) {
+    const previous = frame.andChildren.pop()!;
+    if (previous.kind === "adjacent") {
+      previous.children.push(node);
+      frame.andChildren.push(previous);
+    } else {
+      frame.andChildren.push({ kind: "adjacent", children: [previous, node] });
+    }
+    frame.expectsOperand = false;
+    return;
+  }
   frame.andChildren.push(node);
   frame.expectsOperand = false;
-  return true;
+}
+
+function conditionSyntaxNodeText(node: ConditionSyntaxNode): string {
+  const parts: string[] = [];
+  const pending: Array<ConditionSyntaxNode | string> = [node];
+  while (pending.length > 0) {
+    const part = pending.pop()!;
+    if (typeof part === "string") {
+      parts.push(part);
+    } else if (part.kind === "atom") {
+      parts.push(part.value);
+    } else if (part.kind === "group") {
+      pending.push(")", part.child, "(");
+    } else {
+      const separator = part.kind === "and" ? " && " : part.kind === "or" ? " || " : "";
+      for (let index = part.children.length - 1; index >= 0; index -= 1) {
+        pending.push(part.children[index]!);
+        if (index > 0 && separator) pending.push(separator);
+      }
+    }
+  }
+  return parts.join("");
 }
 
 function appendConditionAtom(
@@ -1061,11 +1127,11 @@ function appendConditionAtom(
   condition: string,
   end: number,
   forceEmpty: boolean,
-): boolean {
+): void {
   const value = condition.slice(frame.atomStart, end).trim();
   frame.atomStart = end;
-  if (!value && !(forceEmpty && frame.expectsOperand)) return true;
-  return appendConditionSyntaxNode(frame, { kind: "atom", value });
+  if (!value && !(forceEmpty && frame.expectsOperand)) return;
+  appendConditionSyntaxNode(frame, { kind: "atom", value });
 }
 
 function combineConditionNodes(kind: "and" | "or", children: ConditionSyntaxNode[]): ConditionSyntaxNode {
@@ -1084,7 +1150,6 @@ function parseConditionSyntax(condition: string): ConditionSyntaxNode {
   let quote: "single" | "double" | null = null;
   let escaped = false;
   let macroDepth = 0;
-  let valid = true;
 
   for (let index = 0; index < condition.length; index += 1) {
     const character = condition[index]!;
@@ -1133,14 +1198,19 @@ function parseConditionSyntax(condition: string): ConditionSyntaxNode {
         frame.literalParenthesisDepth -= 1;
         continue;
       }
-      if (frames.length === 1) continue;
+      if (frames.length === 1) {
+        if (frame.andChildren.length > 0) {
+          appendConditionSyntaxNode(frame, { kind: "atom", value: ")" });
+          frame.atomStart = index + 1;
+        }
+        continue;
+      }
 
-      valid = appendConditionAtom(frame, condition, index, true) && valid;
+      appendConditionAtom(frame, condition, index, true);
       const groupedNode = finishConditionSyntaxFrame(frame);
       frames.pop();
       const parent = frames[frames.length - 1]!;
-      const operand = groupedNode.kind === "atom" ? groupedNode : { kind: "group" as const, child: groupedNode };
-      valid = appendConditionSyntaxNode(parent, operand) && valid;
+      appendConditionSyntaxNode(parent, { kind: "group", child: groupedNode });
       parent.atomStart = index + 1;
       continue;
     }
@@ -1148,7 +1218,7 @@ function parseConditionSyntax(condition: string): ConditionSyntaxNode {
     const operator = frame.literalParenthesisDepth === 0 ? condition.slice(index, index + 2) : "";
     if (operator !== "&&" && operator !== "||") continue;
 
-    valid = appendConditionAtom(frame, condition, index, true) && valid;
+    appendConditionAtom(frame, condition, index, true);
     if (operator === "||") {
       frame.orChildren.push(combineConditionNodes("and", frame.andChildren));
       frame.andChildren = [];
@@ -1158,13 +1228,16 @@ function parseConditionSyntax(condition: string): ConditionSyntaxNode {
     index += 1;
   }
 
-  // An unmatched opening parenthesis is part of the surrounding atom, matching
-  // the legacy parser's malformed-input behavior. Discard any partial frames;
-  // the parent still points at the opening character.
-  if (frames.length !== 1) frames.length = 1;
+  // An unmatched opening parenthesis makes every operator after it nested in
+  // the legacy grammar. Treat that suffix as one atom without rescanning it.
+  if (frames.length !== 1) {
+    const root = frames[0]!;
+    appendConditionAtom(root, condition, condition.length, true);
+    return finishConditionSyntaxFrame(root);
+  }
   const root = frames[0]!;
-  valid = appendConditionAtom(root, condition, condition.length, true) && valid;
-  return valid ? finishConditionSyntaxFrame(root) : { kind: "atom", value: condition.trim() };
+  appendConditionAtom(root, condition, condition.length, true);
+  return finishConditionSyntaxFrame(root);
 }
 
 function parseConditionComparisons(condition: string): ParsedConditionExpression[] {
@@ -1272,6 +1345,11 @@ function parseResolvedConditionAtom(
   return parseConditionExpression(resolveConditionMacros(atom, ctx, options));
 }
 
+function conditionSyntaxAtomValue(node: ConditionSyntaxNode): string | null {
+  if (node.kind === "atom") return node.value;
+  return node.kind === "adjacent" ? conditionSyntaxNodeText(node) : null;
+}
+
 function evaluateOrConditionAtom(
   atom: string,
   equalityShorthand: EqualityShorthand | null,
@@ -1296,8 +1374,12 @@ function evaluateConditionExpression(condition: string, ctx: MacroContext, optio
 
   while (true) {
     if (current) {
-      if (current.kind === "atom") {
-        result = evaluateParsedCondition(parseResolvedConditionAtom(current.value, ctx, options), ctx, options);
+      if (current.kind === "atom" || current.kind === "adjacent") {
+        result = evaluateParsedCondition(
+          parseResolvedConditionAtom(conditionSyntaxAtomValue(current)!, ctx, options),
+          ctx,
+          options,
+        );
         current = null;
       } else if (current.kind === "group") {
         frames.push({ kind: "group" });
@@ -1316,8 +1398,13 @@ function evaluateConditionExpression(condition: string, ctx: MacroContext, optio
         };
         frames.push(frame);
         const child: ConditionSyntaxNode = current.children[0]!;
-        if (child.kind === "atom") {
-          const evaluated = evaluateOrConditionAtom(child.value, frame.equalityShorthand, ctx, options);
+        if (child.kind === "atom" || child.kind === "adjacent") {
+          const evaluated = evaluateOrConditionAtom(
+            conditionSyntaxAtomValue(child)!,
+            frame.equalityShorthand,
+            ctx,
+            options,
+          );
           frame.equalityShorthand = evaluated.equalityShorthand;
           result = evaluated.matches;
           current = null;
@@ -1360,8 +1447,13 @@ function evaluateConditionExpression(condition: string, ctx: MacroContext, optio
       continue;
     }
     const child = frame.children[frame.index]!;
-    if (child.kind === "atom") {
-      const evaluated = evaluateOrConditionAtom(child.value, frame.equalityShorthand, ctx, options);
+    if (child.kind === "atom" || child.kind === "adjacent") {
+      const evaluated = evaluateOrConditionAtom(
+        conditionSyntaxAtomValue(child)!,
+        frame.equalityShorthand,
+        ctx,
+        options,
+      );
       frame.equalityShorthand = evaluated.equalityShorthand;
       result = evaluated.matches;
     } else {

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -967,125 +967,6 @@ function isCharacterConditionalOperand(raw: string): boolean {
 
 type ParsedConditionExpression = { left: string; operator: string; right?: string };
 
-function splitTopLevelCondition(input: string, delimiter: "||" | "&&"): string[] {
-  const parts: string[] = [];
-  let partStart = 0;
-  let quote: "single" | "double" | null = null;
-  let escaped = false;
-  let macroDepth = 0;
-  let parenthesisDepth = 0;
-
-  for (let index = 0; index < input.length; index += 1) {
-    const character = input[index]!;
-
-    if (quote) {
-      if (escaped) {
-        escaped = false;
-      } else if (character === "\\") {
-        escaped = true;
-      } else if (quoteKind(character) === quote) {
-        quote = null;
-      }
-      continue;
-    }
-
-    if (macroDepth > 0) {
-      if (character === "{" && input[index + 1] === "{") {
-        macroDepth += 1;
-        index += 1;
-      } else if (character === "}" && input[index + 1] === "}") {
-        macroDepth -= 1;
-        index += 1;
-      }
-      continue;
-    }
-
-    const nextQuote = quoteKind(character);
-    if (nextQuote) {
-      quote = nextQuote;
-      continue;
-    }
-    if (character === "{" && input[index + 1] === "{") {
-      macroDepth = 1;
-      index += 1;
-      continue;
-    }
-    if (character === "(") {
-      parenthesisDepth += 1;
-      continue;
-    }
-    if (character === ")" && parenthesisDepth > 0) {
-      parenthesisDepth -= 1;
-      continue;
-    }
-    if (parenthesisDepth === 0 && input.startsWith(delimiter, index)) {
-      parts.push(input.slice(partStart, index).trim());
-      partStart = index + delimiter.length;
-      index += delimiter.length - 1;
-    }
-  }
-
-  parts.push(input.slice(partStart).trim());
-  return parts;
-}
-
-function unwrapCondition(input: string): string {
-  let start = 0;
-  let end = input.length;
-  while (start < end && /\s/u.test(input[start]!)) start++;
-  while (end > start && /\s/u.test(input[end - 1]!)) end--;
-
-  let quote: "single" | "double" | null = null;
-  let escaped = false;
-  let macroDepth = 0;
-  const parenthesisStack: number[] = [];
-  const matchingParentheses = new Map<number, number>();
-
-  for (let index = start; index < end; index++) {
-    const character = input[index]!;
-    if (quote) {
-      if (escaped) escaped = false;
-      else if (character === "\\") escaped = true;
-      else if (quoteKind(character) === quote) quote = null;
-      continue;
-    }
-    if (macroDepth > 0) {
-      if (character === "{" && input[index + 1] === "{") {
-        macroDepth += 1;
-        index += 1;
-      } else if (character === "}" && input[index + 1] === "}") {
-        macroDepth -= 1;
-        index += 1;
-      }
-      continue;
-    }
-    const nextQuote = quoteKind(character);
-    if (nextQuote) {
-      quote = nextQuote;
-      continue;
-    }
-    if (character === "{" && input[index + 1] === "{") {
-      macroDepth = 1;
-      index += 1;
-      continue;
-    }
-    if (character === "(") {
-      parenthesisStack.push(index);
-    } else if (character === ")") {
-      const opening = parenthesisStack.pop();
-      if (opening !== undefined) matchingParentheses.set(opening, index);
-    }
-  }
-
-  while (start < end && input[start] === "(" && matchingParentheses.get(start) === end - 1) {
-    start++;
-    end--;
-    while (start < end && /\s/u.test(input[start]!)) start++;
-    while (end > start && /\s/u.test(input[end - 1]!)) end--;
-  }
-  return input.slice(start, end);
-}
-
 function parseConditionExpression(condition: string): ParsedConditionExpression {
   const symbolicOperators = [">=", "<=", "==", "!=", ">", "<", "="] as const;
   let quote: "single" | "double" | null = null;
@@ -1145,13 +1026,161 @@ function parseConditionExpression(condition: string): ParsedConditionExpression 
   return { left: condition.trim(), operator: "truthy" };
 }
 
+type ConditionSyntaxNode =
+  | { kind: "atom"; value: string }
+  | { kind: "and" | "or"; children: ConditionSyntaxNode[] }
+  | { kind: "group"; child: ConditionSyntaxNode };
+
+type ConditionSyntaxFrame = {
+  atomStart: number;
+  andChildren: ConditionSyntaxNode[];
+  orChildren: ConditionSyntaxNode[];
+  expectsOperand: boolean;
+  literalParenthesisDepth: number;
+};
+
+function createConditionSyntaxFrame(atomStart: number): ConditionSyntaxFrame {
+  return {
+    atomStart,
+    andChildren: [],
+    orChildren: [],
+    expectsOperand: true,
+    literalParenthesisDepth: 0,
+  };
+}
+
+function appendConditionSyntaxNode(frame: ConditionSyntaxFrame, node: ConditionSyntaxNode): boolean {
+  if (!frame.expectsOperand) return false;
+  frame.andChildren.push(node);
+  frame.expectsOperand = false;
+  return true;
+}
+
+function appendConditionAtom(
+  frame: ConditionSyntaxFrame,
+  condition: string,
+  end: number,
+  forceEmpty: boolean,
+): boolean {
+  const value = condition.slice(frame.atomStart, end).trim();
+  frame.atomStart = end;
+  if (!value && !(forceEmpty && frame.expectsOperand)) return true;
+  return appendConditionSyntaxNode(frame, { kind: "atom", value });
+}
+
+function combineConditionNodes(kind: "and" | "or", children: ConditionSyntaxNode[]): ConditionSyntaxNode {
+  return children.length === 1 ? children[0]! : { kind, children };
+}
+
+function finishConditionSyntaxFrame(frame: ConditionSyntaxFrame): ConditionSyntaxNode {
+  const andNode = combineConditionNodes("and", frame.andChildren);
+  if (frame.orChildren.length === 0) return andNode;
+  return combineConditionNodes("or", [...frame.orChildren, andNode]);
+}
+
+/** Parse the supported boolean grammar in one quote- and macro-aware pass. */
+function parseConditionSyntax(condition: string): ConditionSyntaxNode {
+  const frames = [createConditionSyntaxFrame(0)];
+  let quote: "single" | "double" | null = null;
+  let escaped = false;
+  let macroDepth = 0;
+  let valid = true;
+
+  for (let index = 0; index < condition.length; index += 1) {
+    const character = condition[index]!;
+    const frame = frames[frames.length - 1]!;
+
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (quoteKind(character) === quote) quote = null;
+      continue;
+    }
+    if (macroDepth > 0) {
+      if (character === "{" && condition[index + 1] === "{") {
+        macroDepth += 1;
+        index += 1;
+      } else if (character === "}" && condition[index + 1] === "}") {
+        macroDepth -= 1;
+        index += 1;
+      }
+      continue;
+    }
+
+    const nextQuote = quoteKind(character);
+    if (nextQuote) {
+      quote = nextQuote;
+      continue;
+    }
+    if (character === "{" && condition[index + 1] === "{") {
+      macroDepth = 1;
+      index += 1;
+      continue;
+    }
+
+    if (character === "(") {
+      const prefix = condition.slice(frame.atomStart, index);
+      if (frame.literalParenthesisDepth === 0 && frame.expectsOperand && prefix.trim().length === 0) {
+        frames.push(createConditionSyntaxFrame(index + 1));
+      } else {
+        frame.literalParenthesisDepth += 1;
+      }
+      continue;
+    }
+
+    if (character === ")") {
+      if (frame.literalParenthesisDepth > 0) {
+        frame.literalParenthesisDepth -= 1;
+        continue;
+      }
+      if (frames.length === 1) continue;
+
+      valid = appendConditionAtom(frame, condition, index, true) && valid;
+      const groupedNode = finishConditionSyntaxFrame(frame);
+      frames.pop();
+      const parent = frames[frames.length - 1]!;
+      const operand = groupedNode.kind === "atom" ? groupedNode : { kind: "group" as const, child: groupedNode };
+      valid = appendConditionSyntaxNode(parent, operand) && valid;
+      parent.atomStart = index + 1;
+      continue;
+    }
+
+    const operator = frame.literalParenthesisDepth === 0 ? condition.slice(index, index + 2) : "";
+    if (operator !== "&&" && operator !== "||") continue;
+
+    valid = appendConditionAtom(frame, condition, index, true) && valid;
+    if (operator === "||") {
+      frame.orChildren.push(combineConditionNodes("and", frame.andChildren));
+      frame.andChildren = [];
+    }
+    frame.expectsOperand = true;
+    frame.atomStart = index + 2;
+    index += 1;
+  }
+
+  // An unmatched opening parenthesis is part of the surrounding atom, matching
+  // the legacy parser's malformed-input behavior. Discard any partial frames;
+  // the parent still points at the opening character.
+  if (frames.length !== 1) frames.length = 1;
+  const root = frames[0]!;
+  valid = appendConditionAtom(root, condition, condition.length, true) && valid;
+  return valid ? finishConditionSyntaxFrame(root) : { kind: "atom", value: condition.trim() };
+}
+
 function parseConditionComparisons(condition: string): ParsedConditionExpression[] {
-  const expression = unwrapCondition(condition);
-  const orParts = splitTopLevelCondition(expression, "||");
-  if (orParts.length > 1) return orParts.flatMap(parseConditionComparisons);
-  const andParts = splitTopLevelCondition(expression, "&&");
-  if (andParts.length > 1) return andParts.flatMap(parseConditionComparisons);
-  return [parseConditionExpression(expression)];
+  const comparisons: ParsedConditionExpression[] = [];
+  const pending = [parseConditionSyntax(condition)];
+  while (pending.length > 0) {
+    const node = pending.pop()!;
+    if (node.kind === "atom") {
+      comparisons.push(parseConditionExpression(node.value));
+    } else if (node.kind === "group") {
+      pending.push(node.child);
+    } else {
+      for (let index = node.children.length - 1; index >= 0; index -= 1) pending.push(node.children[index]!);
+    }
+  }
+  return comparisons;
 }
 
 function conditionDependsOnCharacter(condition: string): boolean {
@@ -1223,50 +1252,122 @@ function evaluateParsedCondition(
   return compareConditionValues(left, parsed.operator, right);
 }
 
-function parseSimpleCondition(
-  condition: string,
+type EqualityShorthand = Pick<ParsedConditionExpression, "left" | "operator">;
+
+type ConditionEvaluationFrame =
+  | { kind: "group" }
+  | { kind: "and"; children: ConditionSyntaxNode[]; index: number }
+  | {
+      kind: "or";
+      children: ConditionSyntaxNode[];
+      index: number;
+      equalityShorthand: EqualityShorthand | null;
+    };
+
+function parseResolvedConditionAtom(
+  atom: string,
   ctx: MacroContext,
   options: ResolveMacroOptions,
-): ParsedConditionExpression | null {
-  const expression = unwrapCondition(condition);
-  if (
-    splitTopLevelCondition(expression, "||").length > 1 ||
-    splitTopLevelCondition(expression, "&&").length > 1
-  ) {
-    return null;
+): ParsedConditionExpression {
+  return parseConditionExpression(resolveConditionMacros(atom, ctx, options));
+}
+
+function evaluateOrConditionAtom(
+  atom: string,
+  equalityShorthand: EqualityShorthand | null,
+  ctx: MacroContext,
+  options: ResolveMacroOptions,
+): { matches: boolean; equalityShorthand: EqualityShorthand | null } {
+  const parsed = parseResolvedConditionAtom(atom, ctx, options);
+  let effective = parsed;
+  let nextShorthand = equalityShorthand;
+  if (["=", "==", "is"].includes(parsed.operator) && parsed.right !== undefined) {
+    nextShorthand = { left: parsed.left, operator: parsed.operator };
+  } else if (equalityShorthand && parsed.operator === "truthy" && stripOuterQuotes(parsed.left) !== null) {
+    effective = { ...equalityShorthand, right: parsed.left };
   }
-  return parseConditionExpression(resolveConditionMacros(expression, ctx, options));
+  return { matches: evaluateParsedCondition(effective, ctx, options), equalityShorthand: nextShorthand };
 }
 
 function evaluateConditionExpression(condition: string, ctx: MacroContext, options: ResolveMacroOptions): boolean {
-  const expression = unwrapCondition(condition);
-  const orParts = splitTopLevelCondition(expression, "||");
-  if (orParts.length > 1) {
-    let equalityShorthand: Pick<ParsedConditionExpression, "left" | "operator"> | null = null;
-    for (const part of orParts) {
-      const parsed = parseSimpleCondition(part, ctx, options);
-      if (parsed) {
-        let effective = parsed;
-        if (["=", "==", "is"].includes(parsed.operator) && parsed.right !== undefined) {
-          equalityShorthand = { left: parsed.left, operator: parsed.operator };
-        } else if (equalityShorthand && parsed.operator === "truthy" && stripOuterQuotes(parsed.left) !== null) {
-          effective = { ...equalityShorthand, right: parsed.left };
+  const frames: ConditionEvaluationFrame[] = [];
+  let current: ConditionSyntaxNode | null = parseConditionSyntax(condition);
+  let result = false;
+
+  while (true) {
+    if (current) {
+      if (current.kind === "atom") {
+        result = evaluateParsedCondition(parseResolvedConditionAtom(current.value, ctx, options), ctx, options);
+        current = null;
+      } else if (current.kind === "group") {
+        frames.push({ kind: "group" });
+        current = current.child;
+        continue;
+      } else if (current.kind === "and") {
+        frames.push({ kind: "and", children: current.children, index: 0 });
+        current = current.children[0]!;
+        continue;
+      } else {
+        const frame: ConditionEvaluationFrame = {
+          kind: "or",
+          children: current.children,
+          index: 0,
+          equalityShorthand: null,
+        };
+        frames.push(frame);
+        const child: ConditionSyntaxNode = current.children[0]!;
+        if (child.kind === "atom") {
+          const evaluated = evaluateOrConditionAtom(child.value, frame.equalityShorthand, ctx, options);
+          frame.equalityShorthand = evaluated.equalityShorthand;
+          result = evaluated.matches;
+          current = null;
+        } else {
+          current = child;
         }
-        if (evaluateParsedCondition(effective, ctx, options)) return true;
-      } else if (evaluateConditionExpression(part, ctx, options)) {
-        return true;
+        continue;
       }
     }
-    return false;
-  }
 
-  const andParts = splitTopLevelCondition(expression, "&&");
-  if (andParts.length > 1) {
-    return andParts.every((part) => evaluateConditionExpression(part, ctx, options));
-  }
+    const frame = frames[frames.length - 1];
+    if (!frame) return result;
+    if (frame.kind === "group") {
+      frames.pop();
+      continue;
+    }
+    if (frame.kind === "and") {
+      if (!result) {
+        frames.pop();
+        continue;
+      }
+      frame.index += 1;
+      if (frame.index >= frame.children.length) {
+        frames.pop();
+        result = true;
+      } else {
+        current = frame.children[frame.index]!;
+      }
+      continue;
+    }
 
-  const parsed = parseSimpleCondition(expression, ctx, options);
-  return parsed ? evaluateParsedCondition(parsed, ctx, options) : false;
+    if (result) {
+      frames.pop();
+      continue;
+    }
+    frame.index += 1;
+    if (frame.index >= frame.children.length) {
+      frames.pop();
+      result = false;
+      continue;
+    }
+    const child = frame.children[frame.index]!;
+    if (child.kind === "atom") {
+      const evaluated = evaluateOrConditionAtom(child.value, frame.equalityShorthand, ctx, options);
+      frame.equalityShorthand = evaluated.equalityShorthand;
+      result = evaluated.matches;
+    } else {
+      current = child;
+    }
+  }
 }
 
 function evaluateCondition(condition: string, ctx: MacroContext, options: ResolveMacroOptions = {}): boolean {

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -966,6 +966,7 @@ function isCharacterConditionalOperand(raw: string): boolean {
 }
 
 type ParsedConditionExpression = { left: string; operator: string; right?: string };
+const CONDITION_WORD_OPERATOR_RE = /(?:is\s+not|not\s+contains|not\s+includes|contains|includes|is)(?=\s|$)/iyu;
 
 function parseConditionExpression(condition: string): ParsedConditionExpression {
   const symbolicOperators = [">=", "<=", "==", "!=", ">", "<", "="] as const;
@@ -1010,9 +1011,8 @@ function parseConditionExpression(condition: string): ParsedConditionExpression 
     }
 
     if (index === 0 || /\s/u.test(condition[index - 1]!)) {
-      const wordMatch = condition
-        .slice(index)
-        .match(/^(is\s+not|not\s+contains|not\s+includes|contains|includes|is)(?=\s|$)/iu);
+      CONDITION_WORD_OPERATOR_RE.lastIndex = index;
+      const wordMatch = CONDITION_WORD_OPERATOR_RE.exec(condition);
       if (wordMatch?.[0]) {
         const left = condition.slice(0, index).trim();
         const right = condition.slice(index + wordMatch[0].length).trim();

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -117,8 +117,23 @@ export interface SupportedMacroDefinition {
 
 export const CHARACTER_REFERENCE_ID_PATTERN = /\{\{([A-Za-z0-9_-]{21})\}\}/g;
 
-const CHARACTER_MACRO_PATTERN =
-  /\{\{(?:char|charName|charNamePhonetic|charPhonetic|description|personality|backstory|appearance|scenario|example|charSysInfo|charPostHistory|convo_display|char_about|convo_behavior)\}\}|\{\{\s*#if\s+[^}]*\b(?:char|charName|charNamePhonetic|charPhonetic|character|speaker|description|personality|backstory|appearance|scenario|example|charSysInfo|charPostHistory|convo_display|char_about|convo_behavior)\b/i;
+const CHARACTER_MACRO_NAMES = new Set([
+  "appearance",
+  "backstory",
+  "char",
+  "char_about",
+  "charname",
+  "charnamephonetic",
+  "charphonetic",
+  "charposthistory",
+  "charsysinfo",
+  "convo_behavior",
+  "convo_display",
+  "description",
+  "example",
+  "personality",
+  "scenario",
+]);
 const MAX_CHARACTER_FIELD_RESOLUTION_DEPTH = 4;
 const MAX_DICE_COUNT = 1000;
 const MAX_DICE_SIDES = 1_000_000;
@@ -636,9 +651,23 @@ function resolveDeferredCharacterConditionals(template: string, ctx: MacroContex
   });
 }
 
+function hasCharacterMacro(template: string): boolean {
+  let searchIndex = 0;
+  while (searchIndex < template.length) {
+    const tag = readNextMacroTag(template, searchIndex);
+    if (!tag) return false;
+    if (CHARACTER_MACRO_NAMES.has(tag.body.toLowerCase())) return true;
+
+    const condition = parseIfCondition(tag.body);
+    if (condition !== null && conditionDependsOnCharacter(condition)) return true;
+    searchIndex = tag.end;
+  }
+  return false;
+}
+
 function expandBracketedCharacterBlocks(template: string, ctx: MacroContext): string {
   const profiles = ctx.characterProfiles ?? [];
-  if (profiles.length <= 1 || !CHARACTER_MACRO_PATTERN.test(template)) {
+  if (profiles.length <= 1 || !hasCharacterMacro(template)) {
     return template;
   }
 
@@ -664,7 +693,7 @@ function expandBracketedCharacterBlocks(template: string, ctx: MacroContext): st
     }
 
     const block = lines.slice(index, endIndex + 1).join("\n");
-    if (!CHARACTER_MACRO_PATTERN.test(block)) {
+    if (!hasCharacterMacro(block)) {
       expandedLines.push(...lines.slice(index, endIndex + 1));
       index = endIndex;
       continue;

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -134,6 +134,14 @@ const CHARACTER_MACRO_NAMES = new Set([
   "personality",
   "scenario",
 ]);
+const CHARACTER_CONDITIONAL_OPERAND_NAMES = new Set([
+  ...CHARACTER_MACRO_NAMES,
+  "character",
+  "characterphonetic",
+  "group",
+  "speaker",
+  "speakerphonetic",
+]);
 const MAX_CHARACTER_FIELD_RESOLUTION_DEPTH = 4;
 const MAX_DICE_COUNT = 1000;
 const MAX_DICE_SIDES = 1_000_000;
@@ -651,6 +659,46 @@ function resolveDeferredCharacterConditionals(template: string, ctx: MacroContex
   });
 }
 
+function hasCharacterConditionalOperandCandidate(condition: string): boolean {
+  let quote: "single" | "double" | null = null;
+  let escaped = false;
+
+  for (let index = 0; index < condition.length; index++) {
+    const character = condition[index]!;
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (quoteKind(character) === quote) quote = null;
+      continue;
+    }
+
+    const nextQuote = quoteKind(character);
+    if (nextQuote) {
+      quote = nextQuote;
+      continue;
+    }
+
+    const candidateStart = character === "@" ? index + 1 : index;
+    let candidateEnd = candidateStart;
+    while (candidateEnd < condition.length) {
+      const code = condition.charCodeAt(candidateEnd);
+      const isIdentifierCharacter =
+        (code >= 48 && code <= 57) ||
+        (code >= 65 && code <= 90) ||
+        code === 95 ||
+        (code >= 97 && code <= 122);
+      if (!isIdentifierCharacter) break;
+      candidateEnd++;
+    }
+    if (candidateEnd === candidateStart) continue;
+    if (CHARACTER_CONDITIONAL_OPERAND_NAMES.has(condition.slice(candidateStart, candidateEnd).toLowerCase())) {
+      return true;
+    }
+    index = candidateEnd - 1;
+  }
+  return false;
+}
+
 function hasCharacterMacro(template: string): boolean {
   const lowerTemplate = template.toLowerCase();
   for (const name of CHARACTER_MACRO_NAMES) {
@@ -662,8 +710,14 @@ function hasCharacterMacro(template: string): boolean {
     const tag = readNextMacroTag(template, searchIndex);
     if (!tag) return false;
 
-    const condition = parseIfCondition(tag.body);
-    if (condition !== null && conditionDependsOnCharacter(condition)) return true;
+    const condition = parseIfCondition(tag.body) ?? parseElseIfCondition(tag.body);
+    if (
+      condition !== null &&
+      hasCharacterConditionalOperandCandidate(condition) &&
+      conditionDependsOnCharacter(condition)
+    ) {
+      return true;
+    }
     searchIndex = tag.end;
   }
   return false;
@@ -975,14 +1029,19 @@ function splitTopLevelCondition(input: string, delimiter: "||" | "&&"): string[]
   return parts;
 }
 
-function isWrappedCondition(input: string): boolean {
-  if (!input.startsWith("(") || !input.endsWith(")")) return false;
+function unwrapCondition(input: string): string {
+  let start = 0;
+  let end = input.length;
+  while (start < end && /\s/u.test(input[start]!)) start++;
+  while (end > start && /\s/u.test(input[end - 1]!)) end--;
+
   let quote: "single" | "double" | null = null;
   let escaped = false;
   let macroDepth = 0;
-  let parenthesisDepth = 0;
+  const parenthesisStack: number[] = [];
+  const matchingParentheses = new Map<number, number>();
 
-  for (let index = 0; index < input.length; index += 1) {
+  for (let index = start; index < end; index++) {
     const character = input[index]!;
     if (quote) {
       if (escaped) escaped = false;
@@ -1010,18 +1069,21 @@ function isWrappedCondition(input: string): boolean {
       index += 1;
       continue;
     }
-    if (character === "(") parenthesisDepth += 1;
-    else if (character === ")") parenthesisDepth -= 1;
-    if (parenthesisDepth === 0 && index < input.length - 1) return false;
+    if (character === "(") {
+      parenthesisStack.push(index);
+    } else if (character === ")") {
+      const opening = parenthesisStack.pop();
+      if (opening !== undefined) matchingParentheses.set(opening, index);
+    }
   }
 
-  return parenthesisDepth === 0;
-}
-
-function unwrapCondition(input: string): string {
-  let unwrapped = input.trim();
-  while (isWrappedCondition(unwrapped)) unwrapped = unwrapped.slice(1, -1).trim();
-  return unwrapped;
+  while (start < end && input[start] === "(" && matchingParentheses.get(start) === end - 1) {
+    start++;
+    end--;
+    while (start < end && /\s/u.test(input[start]!)) start++;
+    while (end > start && /\s/u.test(input[end - 1]!)) end--;
+  }
+  return input.slice(start, end);
 }
 
 function parseConditionExpression(condition: string): ParsedConditionExpression {

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -736,19 +736,14 @@ function hasCharacterMacro(template: string): boolean {
 
     const end = findBalancedMacroEnd(template, start);
     if (end === -1) {
-      return (
-        hasCharacterConditionalOperandCandidate(template.slice(bodyStart)) ||
-        [...CHARACTER_MACRO_NAMES].some((macroName) =>
-          lowerTemplate.includes(`{{${macroName}}}`, start + 2),
-        )
-      );
+      return hasCharacterConditionalOperandCandidate(template.slice(bodyStart));
     }
     const body = template.slice(start + 2, end - 2).trim();
     const condition = parseIfCondition(body) ?? parseElseIfCondition(body);
     if (
       condition !== null &&
       hasCharacterConditionalOperandCandidate(condition) &&
-      conditionDependsOnCharacter(condition)
+      (conditionDependsOnCharacter(condition) || conditionHasLegacyAdjacentCharacterReference(condition))
     ) {
       return true;
     }
@@ -993,10 +988,7 @@ function resolveConditionalOperand(raw: string, ctx: MacroContext, options: Reso
 }
 
 function isCharacterConditionalOperand(raw: string): boolean {
-  const normalized = normalizeConditionKey(raw);
-  return /^(char|charname|charphonetic|charnamephonetic|character|characterphonetic|speaker|speakerphonetic|group|description|personality|backstory|appearance|scenario|example|charsysinfo|charposthistory|convo_display|char_about|convo_behavior)$/.test(
-    normalized,
-  );
+  return CHARACTER_CONDITIONAL_OPERAND_NAMES.has(normalizeConditionKey(raw));
 }
 
 type ParsedConditionExpression = { left: string; operator: string; right?: string };
@@ -1230,11 +1222,6 @@ function parseConditionSyntax(condition: string): ConditionSyntaxNode {
 
   // An unmatched opening parenthesis makes every operator after it nested in
   // the legacy grammar. Treat that suffix as one atom without rescanning it.
-  if (frames.length !== 1) {
-    const root = frames[0]!;
-    appendConditionAtom(root, condition, condition.length, true);
-    return finishConditionSyntaxFrame(root);
-  }
   const root = frames[0]!;
   appendConditionAtom(root, condition, condition.length, true);
   return finishConditionSyntaxFrame(root);
@@ -1249,11 +1236,41 @@ function parseConditionComparisons(condition: string): ParsedConditionExpression
       comparisons.push(parseConditionExpression(node.value));
     } else if (node.kind === "group") {
       pending.push(node.child);
+    } else if (node.kind === "adjacent") {
+      comparisons.push(parseConditionExpression(conditionSyntaxNodeText(node)));
     } else {
       for (let index = node.children.length - 1; index >= 0; index -= 1) pending.push(node.children[index]!);
     }
   }
   return comparisons;
+}
+
+// Bracket expansion historically recognized character operands even in
+// malformed adjacent groups such as `(char)()`. Keep that compatibility local
+// while comparison/deferred-operand consumers match the atom actually evaluated.
+function conditionHasLegacyAdjacentCharacterReference(condition: string): boolean {
+  const pending: Array<{ node: ConditionSyntaxNode; insideAdjacent: boolean }> = [
+    { node: parseConditionSyntax(condition), insideAdjacent: false },
+  ];
+  while (pending.length > 0) {
+    const { node, insideAdjacent } = pending.pop()!;
+    if (node.kind === "atom") {
+      if (!insideAdjacent) continue;
+      const parsed = parseConditionExpression(node.value);
+      if (
+        isCharacterConditionalOperand(parsed.left) ||
+        (parsed.right ? isCharacterConditionalOperand(parsed.right) : false)
+      ) {
+        return true;
+      }
+    } else if (node.kind === "group") {
+      pending.push({ node: node.child, insideAdjacent });
+    } else {
+      const childInsideAdjacent = insideAdjacent || node.kind === "adjacent";
+      for (const child of node.children) pending.push({ node: child, insideAdjacent: childInsideAdjacent });
+    }
+  }
+  return false;
 }
 
 function conditionDependsOnCharacter(condition: string): boolean {

--- a/scripts/regressions/code-scanning-content-parsing.regression.ts
+++ b/scripts/regressions/code-scanning-content-parsing.regression.ts
@@ -167,6 +167,7 @@ assert.equal(
   resolveMacros("[\n{{group}}\n]", groupMacroContext),
   "[\nDottore\n]\n[\nMiko\n]",
 );
+assert.equal(resolveMacros("[\n{{ char }}\n]", groupMacroContext), "[\nMiko\n]\n[\nDottore\n]");
 assert.equal(
   resolveMacros(
     '[\n{{#if user == "Other"}}Other{{else if char == "Miko"}}Miko{{else}}Dottore{{/if}} greets Mari.\n]',
@@ -199,6 +200,47 @@ assert.equal(resolveMacros(nestedAndConditional, groupMacroContext), "[\nMiko\n]
 assert.ok(
   performance.now() - nestedAndStartedAt < 1_000,
   "deeply nested boolean conditions should complete within one second",
+);
+for (const condition of ["(char)) && false", "(char || false)) && false", "()char && false", "(char)() && false"]) {
+  assert.equal(
+    resolveMacros(`[\n{{#if ${condition}}}T{{else}}F{{/if}}\n]`, groupMacroContext),
+    "[\nF\n]\n[\nF\n]",
+  );
+}
+for (const condition of ["(false))", "(false)))", "(false)) && true", "()false", "char && ()false", "false || ()false"]) {
+  assert.equal(resolveMacros(`{{#if ${condition}}}T{{else}}F{{/if}}`, groupMacroContext), "T");
+}
+const adjacentGroupCondition = `(char)${"()".repeat(16_000)} && false`;
+const adjacentGroupStartedAt = performance.now();
+assert.equal(
+  resolveMacros(`[\n{{#if ${adjacentGroupCondition}}}T{{else}}F{{/if}}\n]`, groupMacroContext),
+  "[\nF\n]\n[\nF\n]",
+);
+assert.ok(
+  performance.now() - adjacentGroupStartedAt < 1_000,
+  "adjacent malformed condition groups should complete within one second",
+);
+const malformedMacroPrefix = "{{".repeat(16_000);
+const malformedMacroStartedAt = performance.now();
+const recoveredConditional = resolveMacros(
+  `[\n${malformedMacroPrefix}{{#if char == "Miko"}}M{{else}}D{{/if}}\n]`,
+  groupMacroContext,
+);
+const unresolvedMalformedBlock = `${malformedMacroPrefix}{{#if char == "Miko"}}M{{else}}D{{/if}}`;
+assert.equal(recoveredConditional, `[\n${unresolvedMalformedBlock}\n]\n[\n${unresolvedMalformedBlock}\n]`);
+assert.ok(
+  performance.now() - malformedMacroStartedAt < 1_000,
+  "malformed macro prefixes should be scanned only once",
+);
+const unbalancedConditional = '[\n{{#if broken {{#if char == "Miko"}}M{{else}}D{{/if}}\n]';
+assert.equal(resolveMacros(unbalancedConditional, groupMacroContext), `${unbalancedConditional}\n${unbalancedConditional}`);
+assert.equal(
+  resolveMacros("{{unknown::{{#if false}}A{{else}}B{{/if}}}}", groupMacroContext),
+  "{{unknown::{{#if false}}A{{else}}B{{/if}}}}",
+);
+assert.equal(
+  resolveMacros("{{setvar::nested::{{#if false}}A{{else}}B{{/if}}}}{{getvar::nested}}", groupMacroContext),
+  "B",
 );
 assert.equal(sanitizeFolderSegment("-".repeat(50_000) + "package" + "-".repeat(50_000), "fallback"), "package");
 assert.equal(sanitizeFolderSegment(`${"a".repeat(79)} rest`, "fallback"), "a".repeat(79));

--- a/scripts/regressions/code-scanning-content-parsing.regression.ts
+++ b/scripts/regressions/code-scanning-content-parsing.regression.ts
@@ -164,8 +164,8 @@ assert.equal(
   "[\nMiko greets Mari.\n]\n[\nDottore greets Mari.\n]",
 );
 assert.equal(
-  resolveMacros("[\n{{group}} accompanies {{char}}.\n]", groupMacroContext),
-  "[\nDottore accompanies Miko.\n]\n[\nMiko accompanies Dottore.\n]",
+  resolveMacros("[\n{{group}}\n]", groupMacroContext),
+  "[\nDottore\n]\n[\nMiko\n]",
 );
 assert.equal(
   resolveMacros(

--- a/scripts/regressions/code-scanning-content-parsing.regression.ts
+++ b/scripts/regressions/code-scanning-content-parsing.regression.ts
@@ -7,11 +7,11 @@ import {
 import { parseLorebookWriteApprovalText } from "../../packages/server/src/routes/generate/agent-write-approval.js";
 import { dedupeLastMessageWrappers } from "../../packages/server/src/routes/generate/generate-route-utils.js";
 import { buildImpersonateInstruction } from "../../packages/server/src/services/conversation/impersonate-prompt.js";
-import { stripGmCommandTags } from "../../packages/server/src/services/game/segment-edits.js";
+import { applySegmentEdits, stripGmCommandTags } from "../../packages/server/src/services/game/segment-edits.js";
 import { parseTrustedTimestamp } from "../../packages/server/src/services/import/import-timestamps.js";
 import { extractSetvarAssignments } from "../../packages/server/src/services/import/st-prompt.importer.js";
 import { stripGenerationGuideInstruction } from "../../packages/shared/src/utils/generation-guide.js";
-import { stripMacroComments } from "../../packages/shared/src/utils/macro-engine.js";
+import { resolveMacros, stripMacroComments } from "../../packages/shared/src/utils/macro-engine.js";
 import { sanitizeFolderSegment } from "../../packages/shared/src/features/folder-packages/manifest-package.js";
 import {
   decodeEncodedSpeakerTags,
@@ -124,6 +124,12 @@ assert.equal(stripGmCommandTags("[map_update:x"), "");
 assert.equal(stripGmCommandTags("[map_update:"), "");
 assert.equal(stripGmCommandTags("[party-turn]A[party-chat]B"), "AB");
 assert.equal(stripGmCommandTags("[note: remember the key]\n[book: chapter text]"), "[note: remember the key]\n[book: chapter text]");
+assert.equal(
+  applySegmentEdits('Narration before   [Miko] [main] [smile]: "Hello"   Narration after', {
+    1: { content: "Edited" },
+  }),
+  'Narration before\n\n[Miko] [main] [smile]: "Edited"\n\nNarration after',
+);
 const malformedBracketNoise = "[".repeat(100_000) + ":]";
 assert.equal(stripGmCommandTags(malformedBracketNoise), malformedBracketNoise);
 assert.equal(
@@ -138,12 +144,30 @@ assert.equal(
 );
 assert.equal(stripMacroComments("Before{{//".repeat(20_000) + "comment}}After"), "BeforeAfter");
 assert.equal(stripMacroComments("Before{{// comment with } a lone brace }}After"), "BeforeAfter");
+const groupMacroContext = {
+  user: "Mari",
+  char: "Miko",
+  characters: ["Miko", "Dottore"],
+  characterProfiles: [{ name: "Miko" }, { name: "Dottore" }],
+  variables: {},
+};
+assert.equal(
+  resolveMacros("[\n{{char}} greets Mari.\n]", groupMacroContext),
+  "[\nMiko greets Mari.\n]\n[\nDottore greets Mari.\n]",
+);
+assert.equal(
+  resolveMacros('[\n{{#if char == "Miko"}}Miko{{else}}Dottore{{/if}} greets Mari.\n]', groupMacroContext),
+  "[\nMiko greets Mari.\n]\n[\nDottore greets Mari.\n]",
+);
 assert.equal(sanitizeFolderSegment("-".repeat(50_000) + "package" + "-".repeat(50_000), "fallback"), "package");
 assert.equal(sanitizeFolderSegment(`${"a".repeat(79)} rest`, "fallback"), "a".repeat(79));
 const scopedParsingStartedAt = performance.now();
 extractSetvarAssignments("{{setvar::broken::".repeat(20_000) + "{{setvar::mode::gm}}");
 stripMacroComments("Before{{//".repeat(20_000) + "comment with } a lone brace }}After");
 sanitizeFolderSegment("-".repeat(50_000) + "package" + "-".repeat(50_000), "fallback");
+applySegmentEdits(`Narration${" ".repeat(100_000)}not-a-tag`, { 0: { content: "Edited" } });
+applySegmentEdits(`Narration ${"x [".repeat(50_000)}not-a-tag`, { 0: { content: "Edited" } });
+resolveMacros(`[\n{{#if ${" ".repeat(100_000)}unknown}}text{{/if}}\n]`, groupMacroContext);
 assert.ok(performance.now() - scopedParsingStartedAt < 5_000, "adversarial parsing should complete within five seconds");
 const encodedSpeakerNoise = "&lt;;".repeat(20_000);
 assert.equal(decodeEncodedSpeakerTags(encodedSpeakerNoise), encodedSpeakerNoise);

--- a/scripts/regressions/code-scanning-content-parsing.regression.ts
+++ b/scripts/regressions/code-scanning-content-parsing.regression.ts
@@ -163,6 +163,34 @@ assert.equal(
   resolveMacros('[\n{{#if {{char}} == "Miko"}}Miko{{else}}Dottore{{/if}} greets Mari.\n]', groupMacroContext),
   "[\nMiko greets Mari.\n]\n[\nDottore greets Mari.\n]",
 );
+assert.equal(
+  resolveMacros("[\n{{group}} accompanies {{char}}.\n]", groupMacroContext),
+  "[\nDottore accompanies Miko.\n]\n[\nMiko accompanies Dottore.\n]",
+);
+assert.equal(
+  resolveMacros(
+    '[\n{{#if user == "Other"}}Other{{else if char == "Miko"}}Miko{{else}}Dottore{{/if}} greets Mari.\n]',
+    groupMacroContext,
+  ),
+  "[\nMiko greets Mari.\n]\n[\nDottore greets Mari.\n]",
+);
+const nestedParenthesesConditional = `[\n{{#if ${"(".repeat(10_000)}unknown${")".repeat(10_000)}}}text\n]`;
+const nestedParenthesesStartedAt = performance.now();
+assert.equal(resolveMacros(nestedParenthesesConditional, groupMacroContext), nestedParenthesesConditional);
+assert.ok(
+  performance.now() - nestedParenthesesStartedAt < 1_000,
+  "malformed nested conditional detection should complete within one second",
+);
+const nestedCharacterCondition = `[\n{{#if ${"(".repeat(8_000)}char == "Miko"${")".repeat(8_000)}}}Miko{{else}}Dottore{{/if}}\n]`;
+const nestedCharacterStartedAt = performance.now();
+assert.equal(
+  resolveMacros(nestedCharacterCondition, groupMacroContext),
+  "[\nMiko\n]\n[\nDottore\n]",
+);
+assert.ok(
+  performance.now() - nestedCharacterStartedAt < 1_000,
+  "deeply wrapped character conditions should complete within one second",
+);
 assert.equal(sanitizeFolderSegment("-".repeat(50_000) + "package" + "-".repeat(50_000), "fallback"), "package");
 assert.equal(sanitizeFolderSegment(`${"a".repeat(79)} rest`, "fallback"), "a".repeat(79));
 const scopedParsingStartedAt = performance.now();

--- a/scripts/regressions/code-scanning-content-parsing.regression.ts
+++ b/scripts/regressions/code-scanning-content-parsing.regression.ts
@@ -191,6 +191,15 @@ assert.ok(
   performance.now() - nestedCharacterStartedAt < 1_000,
   "deeply wrapped character conditions should complete within one second",
 );
+let nestedAndCondition = "char";
+for (let depth = 0; depth < 1_600; depth += 1) nestedAndCondition = `char && (${nestedAndCondition})`;
+const nestedAndConditional = `[\n{{#if ${nestedAndCondition}}}{{char}}{{else}}missing{{/if}}\n]`;
+const nestedAndStartedAt = performance.now();
+assert.equal(resolveMacros(nestedAndConditional, groupMacroContext), "[\nMiko\n]\n[\nDottore\n]");
+assert.ok(
+  performance.now() - nestedAndStartedAt < 1_000,
+  "deeply nested boolean conditions should complete within one second",
+);
 assert.equal(sanitizeFolderSegment("-".repeat(50_000) + "package" + "-".repeat(50_000), "fallback"), "package");
 assert.equal(sanitizeFolderSegment(`${"a".repeat(79)} rest`, "fallback"), "a".repeat(79));
 const scopedParsingStartedAt = performance.now();

--- a/scripts/regressions/code-scanning-content-parsing.regression.ts
+++ b/scripts/regressions/code-scanning-content-parsing.regression.ts
@@ -192,8 +192,7 @@ assert.ok(
   performance.now() - nestedCharacterStartedAt < 1_000,
   "deeply wrapped character conditions should complete within one second",
 );
-let nestedAndCondition = "char";
-for (let depth = 0; depth < 1_600; depth += 1) nestedAndCondition = `char && (${nestedAndCondition})`;
+const nestedAndCondition = `${"char && (".repeat(50_000)}char${")".repeat(50_000)}`;
 const nestedAndConditional = `[\n{{#if ${nestedAndCondition}}}{{char}}{{else}}missing{{/if}}\n]`;
 const nestedAndStartedAt = performance.now();
 assert.equal(resolveMacros(nestedAndConditional, groupMacroContext), "[\nMiko\n]\n[\nDottore\n]");
@@ -205,10 +204,23 @@ for (const condition of ["(char)) && false", "(char || false)) && false", "()cha
   assert.equal(
     resolveMacros(`[\n{{#if ${condition}}}T{{else}}F{{/if}}\n]`, groupMacroContext),
     "[\nF\n]\n[\nF\n]",
+    `malformed grouped condition should evaluate false per block: ${condition}`,
   );
 }
+assert.equal(
+  resolveMacros("{{#if (char)() && false}}T{{else}}F{{/if}}", groupMacroContext, {
+    deferCharacterMacros: "all",
+    trimResult: false,
+  }),
+  "F",
+  "malformed adjacent operands should not trigger character deferral",
+);
 for (const condition of ["(false))", "(false)))", "(false)) && true", "()false", "char && ()false", "false || ()false"]) {
-  assert.equal(resolveMacros(`{{#if ${condition}}}T{{else}}F{{/if}}`, groupMacroContext), "T");
+  assert.equal(
+    resolveMacros(`{{#if ${condition}}}T{{else}}F{{/if}}`, groupMacroContext),
+    "T",
+    `malformed condition should keep legacy truthy behavior: ${condition}`,
+  );
 }
 const adjacentGroupCondition = `(char)${"()".repeat(16_000)} && false`;
 const adjacentGroupStartedAt = performance.now();

--- a/scripts/regressions/code-scanning-content-parsing.regression.ts
+++ b/scripts/regressions/code-scanning-content-parsing.regression.ts
@@ -159,6 +159,10 @@ assert.equal(
   resolveMacros('[\n{{#if char == "Miko"}}Miko{{else}}Dottore{{/if}} greets Mari.\n]', groupMacroContext),
   "[\nMiko greets Mari.\n]\n[\nDottore greets Mari.\n]",
 );
+assert.equal(
+  resolveMacros('[\n{{#if {{char}} == "Miko"}}Miko{{else}}Dottore{{/if}} greets Mari.\n]', groupMacroContext),
+  "[\nMiko greets Mari.\n]\n[\nDottore greets Mari.\n]",
+);
 assert.equal(sanitizeFolderSegment("-".repeat(50_000) + "package" + "-".repeat(50_000), "fallback"), "package");
 assert.equal(sanitizeFolderSegment(`${"a".repeat(79)} rest`, "fallback"), "a".repeat(79));
 const scopedParsingStartedAt = performance.now();


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.

## Linked issue

Closes #4984

## Why this change

- CodeQL identified two polynomial-time parsing paths reachable from generated or user-authored text. Large malformed inputs could stall the local server.
- The fix must preserve valid inline VN dialogue syntax and grouped character macros without imposing content-size caps.

## What changed

- Constrained inline VN dialogue normalization to single-line, non-nested tag grammar.
- Replaced the character-macro detection regex with the existing balanced macro and conditional parsers.
- Added behavior and adversarial timing regressions for both paths.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated proof: `pnpm regression:code-scanning-security`
- Automated proof: `git diff --check`
- Manually verify a Game response containing inline `[Speaker] [main]:` dialogue and a multi-character bracketed macro block before release.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not applicable; this changes backend/shared text parsing only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or very large generated text in inline game dialogue and group character macros.
  * Preserved responsiveness for nested, conditional, case-insensitive, and whitespace-tolerant macro expressions.
  * Prevented dialogue parsing from crossing line breaks or incorrectly consuming brackets.
  * Ensured valid authored content remains unrestricted.

* **Tests**
  * Added regression coverage for formatting, content replacement, macro expansion, malformed input, and adversarial parsing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->