### PR TITLE
Remove dead capability prompt-context assignments

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3078,10 +3078,6 @@ export async function generateRoutes(app: FastifyInstance) {
         }
 
         let canonicalGamePartyNames: string[] = [];
-        let capabilityPromptContext: Awaited<ReturnType<typeof collectCapabilityPromptContext>> = {
-          blocks: [],
-          provides: {},
-        };
         const injectCapabilityContexts = async ({
           messages,
           chatMetadata,
@@ -3211,7 +3207,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
           // A package holding `prompt-context` appends its live state to the system message, the same way
           // the lorebook block above does. Nothing registered (the normal case) ⇒ no effect on the prompt.
-          capabilityPromptContext = await injectCapabilityContexts({
+          const capabilityPromptContext = await injectCapabilityContexts({
             messages: finalMessages,
             chatMetadata: chatMeta,
             mode: "game",
@@ -3301,7 +3297,7 @@ export async function generateRoutes(app: FastifyInstance) {
         }
 
         if (chatMode !== "game") {
-          capabilityPromptContext = await injectCapabilityContexts({
+          await injectCapabilityContexts({
             messages: finalMessages,
             chatMetadata: chatMeta,
             mode: chatMode,


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository staging branch or a same-repository `hotfix/*` branch to `main`.

## Linked issue

Closes #4996

## Why this change

GitHub native Code Quality identified an always-overwritten initial capability prompt-context value and an unused non-game assignment. The cleanup preserves the context-injection side effects and game capability-provider behavior while clearing both release-quality findings.

## What changed

- Scope the collected prompt-context result to the game branch, where `buildGmFormatReminder` consumes its `provides` map.
- Keep non-game context and roleplay-event injection awaited for side effects without storing its unused return value.
- Remove the default result that every chat-mode path overwrote before use.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated proof on exact head `667d3aba6f48ada359b5a30bf0474937a68884ef`:

- `pnpm check` passed (Impeccable context, localization, workspace lint/type checks, and production builds).
- `pnpm --filter @marinara-engine/server lint` passed.
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/capability-package-lifecycle.regression.ts` passed; its intentional failure-fixture logs were emitted as expected.
- The final diff changes only result binding: both conditional `await injectCapabilityContexts(...)` calls, their arguments, call order, injected message mutation, roleplay-event collection, and the game `.provides` consumer remain intact.

No browser or container pass was run because this patch is a mechanical TypeScript scoping cleanup with no runtime branch, output, UI, or built artifact contract change.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs, localization, version, or changelog changes are needed because behavior and user-visible output are unchanged.

## UI evidence (if applicable)

Not applicable; no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of capability context during generation.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->