### PR TITLE
fix: preserve caret in expanded editors after quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept the caret at the chosen insertion point when typing quotes or apostrophes in expanded Character and Persona text editors (#4656).
 - Prevented multiple Marinara processes from silently overwriting a shared local data directory; stale diagnostic counts are repaired without hiding stored rows (#5013).
 
 ## [2.4.2]

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -3567,7 +3567,7 @@ test("Matched full-body sprites approve a neutral anchor before using portrait r
   }
 });
 
-test("Convo About Me keeps manual editing and native expanded-editor keyboard behavior", async ({ page }, testInfo) => {
+test("expanded character editors keep native keyboard and quote caret behavior", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "The shared Convo profile fields are covered on desktop.");
 
   const characterName = "About Me Controls Smoke";
@@ -3575,6 +3575,7 @@ test("Convo About Me keeps manual editing and native expanded-editor keyboard be
     data: {
       data: {
         name: characterName,
+        description: "alpha beta",
         personality: "Dryly funny and observant.",
         extensions: { aboutMe: "alpha\nbeta" },
       },
@@ -3584,6 +3585,15 @@ test("Convo About Me keeps manual editing and native expanded-editor keyboard be
   const character = (await createResponse.json()) as { id: string };
 
   try {
+    await page.addInitScript(() => {
+      const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui") ?? '{"state":{},"version":87}') as {
+        state: Record<string, unknown>;
+        version: number;
+      };
+      persisted.state.hasCompletedOnboarding = true;
+      persisted.state.quoteFormat = "typographic";
+      localStorage.setItem("marinara-engine-ui", JSON.stringify(persisted));
+    });
     await page.goto("/");
     await page.locator('[data-tour="panel-characters"]').click();
     await page.getByText(characterName, { exact: true }).first().click();
@@ -3641,6 +3651,44 @@ test("Convo About Me keeps manual editing and native expanded-editor keyboard be
     await page.keyboard.press("Tab");
     await page.keyboard.press("Shift+Tab");
     await expect(expandedEditor).toHaveValue("alpha\nbeta");
+
+    await page.getByRole("button", { name: "Close expanded editor", exact: true }).click();
+    await editorSections.getByRole("button", { name: "Card", exact: true }).click();
+    const descriptionField = page.locator("#character-card-description");
+    await descriptionField.getByRole("button", { name: "Expand editor", exact: true }).click();
+
+    const quoteEditor = page.locator('[data-component="ExpandedMacroEditor"] textarea');
+    const waitForDelayedSelectionRestores = () =>
+      quoteEditor.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+
+    for (const [quote, expected] of [
+      ['"', "alpha “beta"],
+      ["'", "alpha ‘beta"],
+    ] as const) {
+      await quoteEditor.fill("alpha beta");
+      await waitForDelayedSelectionRestores();
+      await quoteEditor.evaluate((textarea) => {
+        textarea.focus();
+        textarea.setSelectionRange(6, 6);
+      });
+      await page.keyboard.type(quote);
+      await waitForDelayedSelectionRestores();
+
+      await expect(quoteEditor).toHaveValue(expected);
+      await expect
+        .poll(() =>
+          quoteEditor.evaluate((textarea) => ({
+            start: textarea.selectionStart,
+            end: textarea.selectionEnd,
+          })),
+        )
+        .toEqual({ start: 7, end: 7 });
+    }
   } finally {
     await page.request.delete(`/api/characters/${character.id}`);
   }

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -112,11 +112,12 @@ function ExpandedMacroEditor({
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
+      const textarea = event.currentTarget;
       const nextValue = formatOnChange
-        ? formatOnChange(event.currentTarget, event.nativeEvent as InputEvent)
-        : event.currentTarget.value;
-      setLocalValue(nextValue);
+        ? formatOnChange(textarea, event.nativeEvent as InputEvent)
+        : textarea.value;
       onChange(nextValue);
+      setLocalValue(textarea.value);
     },
     [formatOnChange, onChange],
   );


### PR DESCRIPTION
## Linked issue

Closes #4656

## Why this change

- Typing an ASCII single or double quote in the middle of text in an expanded Character or Persona editor could move the caret to the end.
- ExpandedMacroEditor stored the raw input before the parent synchronously applied typographic quote formatting, so React restored the raw value and defeated the pending caret restoration.

## What changed

- Let the parent formatter run first, then mirror the resulting textarea value into the expanded editor local state.
- Added focused browser coverage for both quote characters at a mid-text caret position.
- Added the user-facing fix to the Unreleased changelog.

## Validation

- [ ] pnpm check passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed CONTRIBUTING.md

### Manual verification notes

- Automated desktop Chromium proof passes for both ASCII double quote and apostrophe in the middle of an expanded Character description with typographic quote formatting enabled.
- The test asserts the normalized quote value and that selectionStart and selectionEnd remain immediately after the inserted quote.
- pnpm check passes locally.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the docs-i18n branch updated to match, or a docs-i18n follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- No visual layout or copy changes. This is a focused input-state and caret regression fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the caret position when typing single or double quotation marks in expanded Character and Persona editors.
  * Improved text editing so automatic quote formatting no longer moves the cursor unexpectedly.

* **Tests**
  * Added end-to-end coverage for quote replacement and caret placement in expanded character description editors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->