### PR TITLE
Promote expanded editor caret fix to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept the caret at the chosen insertion point when typing quotes or apostrophes in expanded Character and Persona text editors (#4656).
 - Prevented multiple Marinara processes from silently overwriting a shared local data directory; stale diagnostic counts are repaired without hiding stored rows (#5013).
 
 ## [2.4.2]

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -3567,7 +3567,7 @@ test("Matched full-body sprites approve a neutral anchor before using portrait r
   }
 });
 
-test("Convo About Me keeps manual editing and native expanded-editor keyboard behavior", async ({ page }, testInfo) => {
+test("expanded character editors keep native keyboard and quote caret behavior", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "The shared Convo profile fields are covered on desktop.");
 
   const characterName = "About Me Controls Smoke";
@@ -3575,6 +3575,7 @@ test("Convo About Me keeps manual editing and native expanded-editor keyboard be
     data: {
       data: {
         name: characterName,
+        description: "alpha beta",
         personality: "Dryly funny and observant.",
         extensions: { aboutMe: "alpha\nbeta" },
       },
@@ -3584,6 +3585,15 @@ test("Convo About Me keeps manual editing and native expanded-editor keyboard be
   const character = (await createResponse.json()) as { id: string };
 
   try {
+    await page.addInitScript(() => {
+      const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui") ?? '{"state":{},"version":87}') as {
+        state: Record<string, unknown>;
+        version: number;
+      };
+      persisted.state.hasCompletedOnboarding = true;
+      persisted.state.quoteFormat = "typographic";
+      localStorage.setItem("marinara-engine-ui", JSON.stringify(persisted));
+    });
     await page.goto("/");
     await page.locator('[data-tour="panel-characters"]').click();
     await page.getByText(characterName, { exact: true }).first().click();
@@ -3641,6 +3651,44 @@ test("Convo About Me keeps manual editing and native expanded-editor keyboard be
     await page.keyboard.press("Tab");
     await page.keyboard.press("Shift+Tab");
     await expect(expandedEditor).toHaveValue("alpha\nbeta");
+
+    await page.getByRole("button", { name: "Close expanded editor", exact: true }).click();
+    await editorSections.getByRole("button", { name: "Card", exact: true }).click();
+    const descriptionField = page.locator("#character-card-description");
+    await descriptionField.getByRole("button", { name: "Expand editor", exact: true }).click();
+
+    const quoteEditor = page.locator('[data-component="ExpandedMacroEditor"] textarea');
+    const waitForDelayedSelectionRestores = () =>
+      quoteEditor.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+
+    for (const [quote, expected] of [
+      ['"', "alpha “beta"],
+      ["'", "alpha ‘beta"],
+    ] as const) {
+      await quoteEditor.fill("alpha beta");
+      await waitForDelayedSelectionRestores();
+      await quoteEditor.evaluate((textarea) => {
+        textarea.focus();
+        textarea.setSelectionRange(6, 6);
+      });
+      await page.keyboard.type(quote);
+      await waitForDelayedSelectionRestores();
+
+      await expect(quoteEditor).toHaveValue(expected);
+      await expect
+        .poll(() =>
+          quoteEditor.evaluate((textarea) => ({
+            start: textarea.selectionStart,
+            end: textarea.selectionEnd,
+          })),
+        )
+        .toEqual({ start: 7, end: 7 });
+    }
   } finally {
     await page.request.delete(`/api/characters/${character.id}`);
   }

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -112,11 +112,12 @@ function ExpandedMacroEditor({
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
+      const textarea = event.currentTarget;
       const nextValue = formatOnChange
-        ? formatOnChange(event.currentTarget, event.nativeEvent as InputEvent)
-        : event.currentTarget.value;
-      setLocalValue(nextValue);
+        ? formatOnChange(textarea, event.nativeEvent as InputEvent)
+        : textarea.value;
       onChange(nextValue);
+      setLocalValue(textarea.value);
     },
     [formatOnChange, onChange],
   );


### PR DESCRIPTION
## Linked issue

Refs #4656

## Why this change

- Typing a single or double quote in the middle of text in expanded Character and Persona editors could move the caret to the end.
- The focused fix is already reviewed and green on staging.

## What changed

- Promote exact staging commit 7ece372db251a7d5cd0369a99e57ec59b81edff2 to main.
- The production change lets parent quote normalization finish before the expanded editor mirrors the textarea value.
- Includes focused browser coverage for both quote characters and the Unreleased changelog entry.

## Validation

- [ ] pnpm check passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed CONTRIBUTING.md

### Manual verification notes

- Exact staging content passed pnpm check, focused desktop Chromium quote/caret regression, container-build-test, CodeQL, and genuine CodeRabbit review on PR #5018.
- The intermediary ancestry sync PR #5019 changed zero files.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs as needed
- [ ] Translated docs updated or follow-up issue opened
- [ ] Version/release files updated

## UI evidence (if applicable)

- No visual layout or copy changes. This is a focused input-state and caret regression fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed caret positioning when typing quotes or apostrophes in expanded Character and Persona editors.
  * Ensured typographic quote conversion preserves the selected insertion point.
* **Tests**
  * Added coverage for quote conversion and caret preservation in expanded character and description editors.
* **Documentation**
  * Documented the fix in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->