### PR TITLE
Address the current Engine issue sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Kept the caret at the chosen insertion point when typing quotes or apostrophes in expanded Character and Persona text editors (#4656).
 - Prevented multiple Marinara processes from silently overwriting a shared local data directory; stale diagnostic counts are repaired without hiding stored rows (#5013).
+- Let Termux recover its app-private storage lease after an Android restart instead of blocking launch on an exited process (#5029).
 - Omitted runtime Agent prompt sections when their Agent produced no output (#5023).
 
 ## [2.4.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,20 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Added
 
 - Added the one-time v2.4.3 beta What's New message to the Home experience.
+- Added `{{addnumvar::name::value}}` for numeric variable addition without changing `{{addvar}}` string concatenation (#5024).
+- Added a Personal Extension authoring guide with importable Browser and Server examples, package/API references, lifecycle guidance, and troubleshooting (#5026).
 
 ### Changed
 
 - Advanced the staging version identity to v2.4.3 across the Engine, Home page, PWA manifest, Windows installer, Android bootstrap metadata, update checks, and release references. Android now uses `versionName` `2.4.3` with `versionCode` `44`.
 - Kept README's stable-release pointer tied to the latest published tag instead of rewriting it during staging version preparation.
+- Removed the shared 1 MiB JavaScript field limit from Browser and Server Personal Extensions while preserving their separate archive, CSS, storage, request, and sandbox boundaries (#5025).
 
 ### Fixed
 
 - Kept the caret at the chosen insertion point when typing quotes or apostrophes in expanded Character and Persona text editors (#4656).
 - Prevented multiple Marinara processes from silently overwriting a shared local data directory; stale diagnostic counts are repaired without hiding stored rows (#5013).
+- Omitted runtime Agent prompt sections when their Agent produced no output (#5023).
 
 ## [2.4.2]
 

--- a/docs/examples/personal-extensions/browser-minimal/extension.css
+++ b/docs/examples/personal-extensions/browser-minimal/extension.css
@@ -1,3 +1,3 @@
-#marinara-personal-extension-root {
+[data-ext-root] {
   font-size: 16px;
 }

--- a/docs/examples/personal-extensions/browser-minimal/extension.css
+++ b/docs/examples/personal-extensions/browser-minimal/extension.css
@@ -1,0 +1,3 @@
+#marinara-personal-extension-root {
+  font-size: 16px;
+}

--- a/docs/examples/personal-extensions/browser-minimal/extension.js
+++ b/docs/examples/personal-extensions/browser-minimal/extension.js
@@ -1,0 +1,25 @@
+const saved = await marinara.storage.get();
+let count = Number(saved.count) || 0;
+
+const elements = () => [
+  { kind: "text", text: `Button pressed ${count} time${count === 1 ? "" : "s"}.` },
+  { kind: "button", id: "increment", label: "Count one" },
+];
+
+const panel = marinara.ui.registerContribution({
+  id: "hello-panel",
+  kind: "panel",
+  label: "Hello Panel",
+  description: "Minimal Personal Extension example",
+  icon: "hand",
+  elements: elements(),
+  onEvent: async ({ elementId }) => {
+    if (elementId !== "increment") return;
+    count += 1;
+    await marinara.storage.patch({ count });
+    panel.update({ elements: elements() });
+  },
+});
+
+marinara.log.info("Hello Panel loaded");
+marinara.onCleanup(() => panel.remove());

--- a/docs/examples/personal-extensions/browser-minimal/extension.js
+++ b/docs/examples/personal-extensions/browser-minimal/extension.js
@@ -1,8 +1,12 @@
 const saved = await marinara.storage.get();
 let count = Number(saved.count) || 0;
 
+const statusElement = () => ({
+  kind: "text",
+  text: `Button pressed ${count} time${count === 1 ? "" : "s"}.`,
+});
 const elements = () => [
-  { kind: "text", text: `Button pressed ${count} time${count === 1 ? "" : "s"}.` },
+  statusElement(),
   { kind: "button", id: "increment", label: "Count one" },
 ];
 
@@ -18,7 +22,7 @@ const panel = marinara.ui.registerContribution({
     count += 1;
     await marinara.storage.patch({ count });
     panel.update({ elements: elements() });
-    marinara.ui.showWindow({ title: "Hello Panel", elements: elements() });
+    marinara.ui.showWindow({ title: "Hello Panel", elements: [statusElement()] });
   },
 });
 

--- a/docs/examples/personal-extensions/browser-minimal/extension.js
+++ b/docs/examples/personal-extensions/browser-minimal/extension.js
@@ -18,6 +18,7 @@ const panel = marinara.ui.registerContribution({
     count += 1;
     await marinara.storage.patch({ count });
     panel.update({ elements: elements() });
+    marinara.ui.showWindow({ title: "Hello Panel", elements: elements() });
   },
 });
 

--- a/docs/examples/personal-extensions/browser-minimal/manifest.json
+++ b/docs/examples/personal-extensions/browser-minimal/manifest.json
@@ -1,0 +1,12 @@
+{
+  "kind": "marinara.personal-extension",
+  "version": 1,
+  "config": {
+    "name": "Hello Panel",
+    "version": "1.0.0",
+    "description": "A minimal sandboxed Browser Extension.",
+    "runtime": "client",
+    "capabilities": [],
+    "jsPath": "extension.js"
+  }
+}

--- a/docs/examples/personal-extensions/browser-minimal/manifest.json
+++ b/docs/examples/personal-extensions/browser-minimal/manifest.json
@@ -7,6 +7,7 @@
     "description": "A minimal sandboxed Browser Extension.",
     "runtime": "client",
     "capabilities": [],
-    "jsPath": "extension.js"
+    "jsPath": "extension.js",
+    "cssPath": "extension.css"
   }
 }

--- a/docs/examples/personal-extensions/server-minimal/manifest.json
+++ b/docs/examples/personal-extensions/server-minimal/manifest.json
@@ -1,0 +1,12 @@
+{
+  "kind": "marinara.personal-server-extension",
+  "version": 1,
+  "config": {
+    "name": "Server Counter",
+    "version": "1.0.0",
+    "description": "A minimal sandboxed Server Extension.",
+    "runtime": "server",
+    "capabilities": [],
+    "serverJsPath": "server-extension.js"
+  }
+}

--- a/docs/examples/personal-extensions/server-minimal/server-extension.js
+++ b/docs/examples/personal-extensions/server-minimal/server-extension.js
@@ -1,0 +1,11 @@
+const saved = await marinara.storage.get();
+const starts = (Number(saved.starts) || 0) + 1;
+await marinara.storage.patch({ starts });
+
+marinara.log.info(`Server Counter started ${starts} time${starts === 1 ? "" : "s"}`);
+
+const timer = marinara.setInterval(() => {
+  marinara.log.debug("Server Counter heartbeat");
+}, 60_000);
+
+marinara.onCleanup(() => marinara.clearInterval(timer));

--- a/docs/extending/personal-extensions.md
+++ b/docs/extending/personal-extensions.md
@@ -8,6 +8,8 @@ The default message is:
 
 There is no New Draft action and there are no import controls in this section. Ask Professor Mari to create or revise a draft. She can save code, but she cannot approve or enable it.
 
+To write and import your own package, use the [Personal Extension authoring guide](writing-personal-extensions.md). Self-authored packages use the separately gated External Extensions flow.
+
 ## Review and enable
 
 Every draft starts disabled. Marinara fingerprints the exact executable code with SHA-256. Open the draft, inspect the code, compare the displayed hash, then choose **Review and Run** only if you accept that exact version. Any executable edit or restored revision disables the extension and requires a fresh approval.
@@ -206,6 +208,7 @@ If an extension misbehaves, choose **Disable**. If the interface is unavailable,
 
 ## Related guides
 
+- [Writing Personal Extensions](writing-personal-extensions.md)
 - [Professor Mari](../home/professor-mari.md)
 - [Server Configuration](../CONFIGURATION.md)
 - [Backup and Restore](../data/backup-and-restore.md)

--- a/docs/extending/writing-personal-extensions.md
+++ b/docs/extending/writing-personal-extensions.md
@@ -86,7 +86,7 @@ marinara.onCleanup(() => panel.remove());
 Use this `extension.css` to style the constrained iframe window opened by the button:
 
 ```css
-#marinara-personal-extension-root {
+[data-ext-root] {
   font-size: 16px;
 }
 ```

--- a/docs/extending/writing-personal-extensions.md
+++ b/docs/extending/writing-personal-extensions.md
@@ -58,8 +58,12 @@ Use this `extension.js`:
 const saved = await marinara.storage.get();
 let count = Number(saved.count) || 0;
 
+const statusElement = () => ({
+  kind: "text",
+  text: `Button pressed ${count} time${count === 1 ? "" : "s"}.`,
+});
 const elements = () => [
-  { kind: "text", text: `Button pressed ${count} time${count === 1 ? "" : "s"}.` },
+  statusElement(),
   { kind: "button", id: "increment", label: "Count one" },
 ];
 
@@ -75,7 +79,7 @@ const panel = marinara.ui.registerContribution({
     count += 1;
     await marinara.storage.patch({ count });
     panel.update({ elements: elements() });
-    marinara.ui.showWindow({ title: "Hello Panel", elements: elements() });
+    marinara.ui.showWindow({ title: "Hello Panel", elements: [statusElement()] });
   },
 });
 

--- a/docs/extending/writing-personal-extensions.md
+++ b/docs/extending/writing-personal-extensions.md
@@ -19,7 +19,7 @@ Choose the least-powerful runtime that can do the job:
 | ---------------------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | Sandboxed Browser Extension  | Private state, active-chat context, buttons, menu actions, and Marinara-rendered panels | No Marinara DOM, cookies, browser storage, network, or arbitrary HTML                        |
 | Server Extension             | Background logic that needs managed timers and private extension storage                | Separate OS sandbox; no Marinara files, secrets, network, child processes, or native modules |
-| Full page External Extension | Legacy code that genuinely needs Marinara's page or same-origin APIs                    | Not sandboxed; use only for exact code you fully trust                                       |
+| Full-page External Extension | Legacy code that genuinely needs Marinara's page or same-origin APIs                    | Not sandboxed; use only for exact code you fully trust                                       |
 
 Browser Extensions work on every supported platform. Server Extensions require macOS Seatbelt or Linux Bubblewrap. See the [platform table](personal-extensions.md#platform-support) before choosing a Server Extension.
 
@@ -128,7 +128,7 @@ Use [Marinara-rendered panels](personal-extensions.md#add-a-marinara-rendered-pa
 
 `showWindow({ title, elements, onEvent, onClose })` returns a handle with `update({ title?, elements? })` and `close()`. Package CSS styles these sandboxed iframe windows; host-rendered contributions always use Marinara's own theme and controls.
 
-The safe Browser runtime has no DOM or network API. Do not work around that boundary. If a useful capability is missing, request a narrow host capability rather than switching to full page access by default.
+The safe Browser runtime has no DOM or network API. Do not work around that boundary. If a useful capability is missing, request a narrow host capability rather than switching to full-page access by default.
 
 ### Context capabilities
 
@@ -233,7 +233,7 @@ The ZIP, request, sandbox-message, and storage limits protect separate transport
 - Re-importing the same name updates the existing record after confirmation. A byte-identical re-import keeps its current hash and approval; changed executable content clears approval. Marinara warns when numeric versions indicate a downgrade.
 - **Export** writes the current manifest and source files to a portable package. Approval is never exported.
 - Restoring a revision, importing a profile, or restoring a backup leaves the extension disabled until reviewed again.
-- **Disable** stops the runtime and registered cleanup. Full page code may require a page reload if it created unregistered side effects.
+- **Disable** stops the runtime and registered cleanup. Full-page code may require a page reload if it created unregistered side effects.
 - **Delete** removes the installed record. Export first if you may need the source later.
 
 ## Debugging

--- a/docs/extending/writing-personal-extensions.md
+++ b/docs/extending/writing-personal-extensions.md
@@ -1,0 +1,197 @@
+# Writing Personal Extensions
+
+This guide is for people writing their own Marinara Engine extensions. For installing, reviewing, and safely running an extension, start with [Personal Extensions](personal-extensions.md).
+
+Code you write and import yourself is treated as an **External Extension**. It starts disabled and cannot run until you inspect it and approve its exact SHA-256 hash.
+
+## Before you start
+
+External Extensions are hidden until both safety gates are open:
+
+1. Set `ENABLE_EXTERNAL_EXTENSIONS=true` in the Marinara host's `.env` file.
+2. Open **Settings** > **Advanced** > **Danger Zone** and enable **Allow third-party extension imports**.
+
+Importing and managing extensions also requires localhost access or configured **Admin Access**. If you use Marinara from a phone, LAN address, or remote browser, set `ADMIN_SECRET` on the server and enter the same value under **Settings** > **Advanced** > **Admin Access**.
+
+Choose the least-powerful runtime that can do the job:
+
+| Runtime                      | Use it for                                                                              | Important boundary                                                                           |
+| ---------------------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Sandboxed Browser Extension  | Private state, active-chat context, buttons, menu actions, and Marinara-rendered panels | No Marinara DOM, cookies, browser storage, network, or arbitrary HTML                        |
+| Server Extension             | Background logic that needs managed timers and private extension storage                | Separate OS sandbox; no Marinara files, secrets, network, child processes, or native modules |
+| Full page External Extension | Legacy code that genuinely needs Marinara's page or same-origin APIs                    | Not sandboxed; use only for exact code you fully trust                                       |
+
+Browser Extensions work on every supported platform. Server Extensions require macOS Seatbelt or Linux Bubblewrap. See the [platform table](personal-extensions.md#platform-support) before choosing a Server Extension.
+
+## Browser Extension quickstart
+
+Create a folder with this layout:
+
+```text
+Hello Panel/
+  manifest.json
+  extension.js
+```
+
+Use this `manifest.json`:
+
+```json
+{
+  "kind": "marinara.personal-extension",
+  "version": 1,
+  "config": {
+    "name": "Hello Panel",
+    "version": "1.0.0",
+    "description": "A minimal sandboxed Browser Extension.",
+    "runtime": "client",
+    "capabilities": [],
+    "jsPath": "extension.js"
+  }
+}
+```
+
+Use this `extension.js`:
+
+```js
+const saved = await marinara.storage.get();
+let count = Number(saved.count) || 0;
+
+const elements = () => [
+  { kind: "text", text: `Button pressed ${count} time${count === 1 ? "" : "s"}.` },
+  { kind: "button", id: "increment", label: "Count one" },
+];
+
+const panel = marinara.ui.registerContribution({
+  id: "hello-panel",
+  kind: "panel",
+  label: "Hello Panel",
+  description: "Minimal Personal Extension example",
+  icon: "hand",
+  elements: elements(),
+  onEvent: async ({ elementId }) => {
+    if (elementId !== "increment") return;
+    count += 1;
+    await marinara.storage.patch({ count });
+    panel.update({ elements: elements() });
+  },
+});
+
+marinara.log.info("Hello Panel loaded");
+marinara.onCleanup(() => panel.remove());
+```
+
+Then import and run it:
+
+1. Open **Settings** > **Addons** > **External Extensions**.
+2. Choose **Import Folder** and select `Hello Panel`, or zip the folder and import the ZIP.
+3. Open the disabled draft and inspect its manifest and JavaScript.
+4. Choose **Review and Run** and approve the exact displayed hash.
+5. Open the Extensions menu and select **Hello Panel**.
+
+The same runnable example lives at `docs/examples/personal-extensions/browser-minimal/` in the repository.
+
+## Browser API reference
+
+Sandboxed Browser Extensions receive one frozen global named `marinara`:
+
+| API                                                          | Purpose                                                              |
+| ------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `runtime`, `version`                                         | Runtime name (`client`) and current Browser API version              |
+| `extensionId`, `extensionName`, `capabilities`               | Identity and approved capabilities for this exact extension revision |
+| `log.debug/info/warn/error(...)`                             | Write a tagged entry to the browser console                          |
+| `storage.get()`                                              | Read this extension's private JSON object                            |
+| `storage.patch(object)`                                      | Merge values into private storage and return the new object          |
+| `storage.delete()`                                           | Clear private storage                                                |
+| `context.get()`                                              | Read the current active-chat snapshot                                |
+| `context.subscribe(listener)`                                | Receive context changes; returns an unsubscribe function             |
+| `ui.registerContribution(options)`                           | Add a safe button, Extensions-menu item, or Marinara-rendered panel  |
+| `ui.showWindow(options)`                                     | Open the older constrained iframe window                             |
+| `setTimeout`, `setInterval`, `clearTimeout`, `clearInterval` | Managed timers removed when the extension stops                      |
+| `onCleanup(callback)`                                        | Register additional cleanup logic                                    |
+
+Use [Marinara-rendered panels](personal-extensions.md#add-a-marinara-rendered-panel) for normal UI and [active chat context](personal-extensions.md#use-active-chat-context) for chat-aware behavior. Extension state belongs in `marinara.storage`, not browser storage.
+
+The safe Browser runtime has no DOM or network API. Do not work around that boundary. If a useful capability is missing, request a narrow host capability rather than switching to full page access by default.
+
+### Context capabilities
+
+Declare optional record access in `config.capabilities`:
+
+```json
+{
+  "capabilities": ["read_active_characters", "read_active_persona"]
+}
+```
+
+- `read_active_characters` populates bounded fields for Character cards in the active chat.
+- `read_active_persona` populates bounded fields for the selected Persona.
+- `full_page_access` selects the unsandboxed compatibility runtime and is available only to External Extensions.
+
+Changing capabilities changes the executable hash, disables the extension, and requires a new review.
+
+## Server Extension quickstart
+
+Create this folder:
+
+```text
+Server Counter/
+  manifest.json
+  server-extension.js
+```
+
+Use `kind: "marinara.personal-server-extension"`, `runtime: "server"`, and `serverJsPath` in the manifest. A complete example is available at `docs/examples/personal-extensions/server-minimal/`.
+
+Server code receives `marinara.runtime`, `marinara.version`, extension identity, `log`, `storage`, managed timers, and `onCleanup`. It does not receive filesystem, process, network, module-loading, or Marinara database access.
+
+Server Extensions remain disabled when the host cannot establish Seatbelt or Bubblewrap. This is a platform restriction, not an extension error.
+
+## Package and manifest reference
+
+| Field                                        | Notes                                                                                                  |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `kind`                                       | `marinara.personal-extension` or `marinara.personal-server-extension`                                  |
+| top-level `version`                          | Package envelope version; currently `1`                                                                |
+| `config.name`                                | Required display name, 1-200 characters                                                                |
+| `config.version`                             | Optional extension version such as `1.2.0`; numeric dotted versions support upgrade/downgrade warnings |
+| `config.description`                         | Optional description, up to 2,000 characters                                                           |
+| `config.runtime`                             | `client` or `server`; defaults to `client`                                                             |
+| `config.capabilities`                        | Approved Browser capabilities; Server Extensions must use an empty list                                |
+| `config.jsPath` / `config.serverJsPath`      | JavaScript file path or ordered array of paths, relative to the manifest                               |
+| `config.cssPath`                             | Optional CSS file path or ordered array; CSS remains inside the sandboxed iframe                       |
+| `config.js`, `config.serverJs`, `config.css` | Inline alternatives when separate files are unnecessary                                                |
+
+Use plain JavaScript. Marinara does not compile TypeScript or install extension dependencies. Bundle dependencies into your JavaScript before importing when necessary.
+
+Loose `.js`, `.mjs`, `.cjs`, `.server.js`, `.server.mjs`, `.server.cjs`, and `.css` files can also be imported directly. A manifest is preferred because it records identity, runtime, version, capabilities, and file order explicitly.
+
+## Update and recovery lifecycle
+
+- Every import starts disabled and unapproved.
+- Editing code, CSS, runtime, or capabilities clears approval and disables the extension.
+- Re-importing the same name updates the existing draft after confirmation. Marinara warns when numeric versions indicate a downgrade.
+- **Export** writes the current manifest and source files to a portable package. Approval is never exported.
+- Restoring a revision, importing a profile, or restoring a backup leaves the extension disabled until reviewed again.
+- **Disable** stops the runtime and registered cleanup. Full page code may require a page reload if it created unregistered side effects.
+- **Delete** removes the installed record. Export first if you may need the source later.
+
+## Debugging
+
+| Symptom                                                                 | Check                                                                                              |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| External import controls are missing                                    | Open both External Extension gates described above                                                 |
+| Management says localhost or Admin Access is required                   | Configure `ADMIN_SECRET` and save it under **Admin Access**                                        |
+| Import finds no extension                                               | Check `manifest.json`, its relative source paths, and the selected runtime's required JavaScript   |
+| The extension disables after an edit                                    | Expected: inspect and approve the new exact hash                                                   |
+| Browser code cannot use `document`, `window`, `fetch`, or local storage | Expected in the safe sandbox; use the documented broker APIs                                       |
+| Server Extension is unavailable                                         | Use macOS Seatbelt or Linux with Bubblewrap, or switch to a Browser Extension                      |
+| Browser Extension throws                                                | Open browser developer tools; `marinara.log` and startup errors are tagged with the extension name |
+| Server Extension throws                                                 | Check its status in **Settings** > **Addons** and the Marinara server log                          |
+
+CSS, private storage, import archives, and runtime messages retain separate safety limits. Marinara should report the boundary that rejected a package instead of presenting it as an execution failure.
+
+## Related guides
+
+- [Personal Extensions](personal-extensions.md)
+- [Server Configuration](../CONFIGURATION.md)
+- [Troubleshooting](../TROUBLESHOOTING.md)
+- [Personal Extension Architecture](../development/personal-extensions.md)

--- a/docs/extending/writing-personal-extensions.md
+++ b/docs/extending/writing-personal-extensions.md
@@ -31,6 +31,7 @@ Create a folder with this layout:
 Hello Panel/
   manifest.json
   extension.js
+  extension.css
 ```
 
 Use this `manifest.json`:
@@ -45,7 +46,8 @@ Use this `manifest.json`:
     "description": "A minimal sandboxed Browser Extension.",
     "runtime": "client",
     "capabilities": [],
-    "jsPath": "extension.js"
+    "jsPath": "extension.js",
+    "cssPath": "extension.css"
   }
 }
 ```
@@ -73,11 +75,20 @@ const panel = marinara.ui.registerContribution({
     count += 1;
     await marinara.storage.patch({ count });
     panel.update({ elements: elements() });
+    marinara.ui.showWindow({ title: "Hello Panel", elements: elements() });
   },
 });
 
 marinara.log.info("Hello Panel loaded");
 marinara.onCleanup(() => panel.remove());
+```
+
+Use this `extension.css` to style the constrained iframe window opened by the button:
+
+```css
+#marinara-personal-extension-root {
+  font-size: 16px;
+}
 ```
 
 Then import and run it:
@@ -105,11 +116,13 @@ Sandboxed Browser Extensions receive one frozen global named `marinara`:
 | `context.get()`                                              | Read the current active-chat snapshot                                |
 | `context.subscribe(listener)`                                | Receive context changes; returns an unsubscribe function             |
 | `ui.registerContribution(options)`                           | Add a safe button, Extensions-menu item, or Marinara-rendered panel  |
-| `ui.showWindow(options)`                                     | Open the older constrained iframe window                             |
+| `ui.showWindow(options)`                                     | Open a constrained iframe window                                     |
 | `setTimeout`, `setInterval`, `clearTimeout`, `clearInterval` | Managed timers removed when the extension stops                      |
 | `onCleanup(callback)`                                        | Register additional cleanup logic                                    |
 
 Use [Marinara-rendered panels](personal-extensions.md#add-a-marinara-rendered-panel) for normal UI and [active chat context](personal-extensions.md#use-active-chat-context) for chat-aware behavior. Extension state belongs in `marinara.storage`, not browser storage.
+
+`showWindow({ title, elements, onEvent, onClose })` returns a handle with `update({ title?, elements? })` and `close()`. Package CSS styles these sandboxed iframe windows; host-rendered contributions always use Marinara's own theme and controls.
 
 The safe Browser runtime has no DOM or network API. Do not work around that boundary. If a useful capability is missing, request a narrow host capability rather than switching to full page access by default.
 
@@ -139,7 +152,40 @@ Server Counter/
   server-extension.js
 ```
 
-Use `kind: "marinara.personal-server-extension"`, `runtime: "server"`, and `serverJsPath` in the manifest. A complete example is available at `docs/examples/personal-extensions/server-minimal/`.
+Use this `manifest.json`:
+
+```json
+{
+  "kind": "marinara.personal-server-extension",
+  "version": 1,
+  "config": {
+    "name": "Server Counter",
+    "version": "1.0.0",
+    "description": "A minimal sandboxed Server Extension.",
+    "runtime": "server",
+    "capabilities": [],
+    "serverJsPath": "server-extension.js"
+  }
+}
+```
+
+Use this `server-extension.js`:
+
+```js
+const saved = await marinara.storage.get();
+const starts = (Number(saved.starts) || 0) + 1;
+await marinara.storage.patch({ starts });
+
+marinara.log.info(`Server Counter started ${starts} time${starts === 1 ? "" : "s"}`);
+
+const timer = marinara.setInterval(() => {
+  marinara.log.debug("Server Counter heartbeat");
+}, 60_000);
+
+marinara.onCleanup(() => marinara.clearInterval(timer));
+```
+
+The same runnable package is available at `docs/examples/personal-extensions/server-minimal/`.
 
 Server code receives `marinara.runtime`, `marinara.version`, extension identity, `log`, `storage`, managed timers, and `onCleanup`. It does not receive filesystem, process, network, module-loading, or Marinara database access.
 
@@ -147,28 +193,40 @@ Server Extensions remain disabled when the host cannot establish Seatbelt or Bub
 
 ## Package and manifest reference
 
-| Field                                        | Notes                                                                                                  |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `kind`                                       | `marinara.personal-extension` or `marinara.personal-server-extension`                                  |
-| top-level `version`                          | Package envelope version; currently `1`                                                                |
-| `config.name`                                | Required display name, 1-200 characters                                                                |
-| `config.version`                             | Optional extension version such as `1.2.0`; numeric dotted versions support upgrade/downgrade warnings |
-| `config.description`                         | Optional description, up to 2,000 characters                                                           |
-| `config.runtime`                             | `client` or `server`; defaults to `client`                                                             |
-| `config.capabilities`                        | Approved Browser capabilities; Server Extensions must use an empty list                                |
-| `config.jsPath` / `config.serverJsPath`      | JavaScript file path or ordered array of paths, relative to the manifest                               |
-| `config.cssPath`                             | Optional CSS file path or ordered array; CSS remains inside the sandboxed iframe                       |
-| `config.js`, `config.serverJs`, `config.css` | Inline alternatives when separate files are unnecessary                                                |
+| Field                                        | Notes                                                                                          |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `kind`                                       | `marinara.personal-extension` or `marinara.personal-server-extension`                          |
+| top-level `version`                          | Package envelope version; currently `1`                                                        |
+| `config.name`                                | Required display name, 1-200 characters                                                        |
+| `config.version`                             | Optional extension version such as `1.2.0`; numeric dotted versions support downgrade warnings |
+| `config.description`                         | Optional description, up to 2,000 characters                                                   |
+| `config.runtime`                             | `client` or `server`; defaults to `client`                                                     |
+| `config.capabilities`                        | Requested Browser capabilities; Server Extensions must use an empty list                       |
+| `config.jsPath` / `config.serverJsPath`      | JavaScript file path or ordered array of paths, relative to the manifest                       |
+| `config.cssPath`                             | Optional CSS file path or ordered array; safe-runtime CSS stays in the sandboxed iframe        |
+| `config.js`, `config.serverJs`, `config.css` | Inline alternatives when separate files are unnecessary                                        |
 
 Use plain JavaScript. Marinara does not compile TypeScript or install extension dependencies. Bundle dependencies into your JavaScript before importing when necessary.
 
 Loose `.js`, `.mjs`, `.cjs`, `.server.js`, `.server.mjs`, `.server.cjs`, and `.css` files can also be imported directly. A manifest is preferred because it records identity, runtime, version, capabilities, and file order explicitly.
 
+### Validation limits
+
+| Content                      | Current boundary                                                                        |
+| ---------------------------- | --------------------------------------------------------------------------------------- |
+| Name / version / description | 200 characters / 64 characters / 2,000 characters                                       |
+| Browser or Server JS         | No per-field source cap; the enclosing file, archive, or request boundary still applies |
+| CSS                          | 256 KiB                                                                                 |
+| Imported ZIP                 | 32 MiB compressed, 2 MiB per text entry, and 16 MiB total extracted text                |
+| Private storage              | 1,000,000 bytes of serialized JSON per extension                                        |
+
+The ZIP, request, sandbox-message, and storage limits protect separate transport or runtime boundaries; they are not executable-source policy.
+
 ## Update and recovery lifecycle
 
-- Every import starts disabled and unapproved.
+- Every new import starts disabled and unapproved.
 - Editing code, CSS, runtime, or capabilities clears approval and disables the extension.
-- Re-importing the same name updates the existing draft after confirmation. Marinara warns when numeric versions indicate a downgrade.
+- Re-importing the same name updates the existing record after confirmation. A byte-identical re-import keeps its current hash and approval; changed executable content clears approval. Marinara warns when numeric versions indicate a downgrade.
 - **Export** writes the current manifest and source files to a portable package. Approval is never exported.
 - Restoring a revision, importing a profile, or restoring a backup leaves the extension disabled until reviewed again.
 - **Disable** stops the runtime and registered cleanup. Full page code may require a page reload if it created unregistered side effects.
@@ -180,7 +238,7 @@ Loose `.js`, `.mjs`, `.cjs`, `.server.js`, `.server.mjs`, `.server.cjs`, and `.c
 | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | External import controls are missing                                    | Open both External Extension gates described above                                                 |
 | Management says localhost or Admin Access is required                   | Configure `ADMIN_SECRET` and save it under **Admin Access**                                        |
-| Import finds no extension                                               | Check `manifest.json`, its relative source paths, and the selected runtime's required JavaScript   |
+| Import finds no extension                                               | Check `manifest.json` and its relative paths; Server needs JS, while Browser needs CSS or JS       |
 | The extension disables after an edit                                    | Expected: inspect and approve the new exact hash                                                   |
 | Browser code cannot use `document`, `window`, `fetch`, or local storage | Expected in the safe sandbox; use the documented broker APIs                                       |
 | Server Extension is unavailable                                         | Use macOS Seatbelt or Linux with Bubblewrap, or switch to a Browser Extension                      |

--- a/docs/prompts/macros.md
+++ b/docs/prompts/macros.md
@@ -188,6 +188,7 @@ Variables let one part of your prompt store a value and let a later part read it
 | `{{setvar::name::value}}` | Stores a value and leaves nothing in the text. |
 | `{{getvar::name}}` | Reads a stored value (nothing if it was never set). |
 | `{{addvar::name::value}}` | Adds text to the end of a stored value. |
+| `{{addnumvar::name::value}}` | Adds a number to a stored numeric value. Missing or invalid numbers count as 0. |
 | `{{incvar::name}}` | Adds 1 to a numeric variable. |
 | `{{decvar::name}}` | Takes 1 away from a numeric variable. |
 

--- a/docs/prompts/macros.md
+++ b/docs/prompts/macros.md
@@ -188,7 +188,7 @@ Variables let one part of your prompt store a value and let a later part read it
 | `{{setvar::name::value}}` | Stores a value and leaves nothing in the text. |
 | `{{getvar::name}}` | Reads a stored value (nothing if it was never set). |
 | `{{addvar::name::value}}` | Adds text to the end of a stored value. |
-| `{{addnumvar::name::value}}` | Adds a number to a stored numeric value. Missing or invalid numbers count as 0. |
+| `{{addnumvar::name::value}}` | Adds a number to a stored numeric value. Missing or invalid numbers count as 0; an overflowing addition is ignored. |
 | `{{incvar::name}}` | Adds 1 to a numeric variable. |
 | `{{decvar::name}}` | Takes 1 away from a numeric variable. |
 

--- a/packages/client/src/lib/chat-macros.ts
+++ b/packages/client/src/lib/chat-macros.ts
@@ -199,7 +199,7 @@ export function resolveMessageMacros(
  * Variable-op macros make resolution order-dependent (writes mutate the shared
  * context; reads observe them), so templates containing them are never cached.
  */
-const VARIABLE_OP_MACRO_RE = /\{\{\s*(?:setvar|addvar|incvar|decvar|getvar)\b/i;
+const VARIABLE_OP_MACRO_RE = /\{\{\s*(?:setvar|addvar|addnumvar|incvar|decvar|getvar)\b/i;
 /** Only short templates (regex replacements, trims, patterns) are worth caching. */
 const RESOLVER_CACHE_MAX_TEMPLATE_LENGTH = 2048;
 

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -12,6 +12,7 @@ import {
   closeSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   readSync,
   renameSync,
   rmSync,
@@ -20,7 +21,7 @@ import {
 } from "node:fs";
 import { chmod, copyFile, open, rename, unlink, writeFile } from "node:fs/promises";
 import { createHash, randomUUID } from "node:crypto";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import { hostname, networkInterfaces } from "node:os";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { STORAGE_MIGRATION_NOTICE_SETTINGS_KEY, type StorageMigrationNotice } from "@marinara-engine/shared";
@@ -1045,6 +1046,17 @@ function pidDefinitelyExited(pid: number) {
   }
 }
 
+function isTermuxPrivateHomeStorage(rootDir: string) {
+  if (process.platform !== "android" || !process.env.HOME) return false;
+  try {
+    const home = realpathSync(resolve(process.env.HOME));
+    const storage = realpathSync(resolve(rootDir));
+    return storage === home || storage.startsWith(`${home}${sep}`);
+  } catch {
+    return false;
+  }
+}
+
 function fileStoreManifestExists(rootDir: string) {
   return existsSync(manifestPath(rootDir));
 }
@@ -1385,7 +1397,9 @@ class FileTableStore {
         }
         throw err;
       }
-      const sameHost = Boolean(CURRENT_HOST_ID && existing.record.hostId === CURRENT_HOST_ID);
+      const sameHost =
+        Boolean(CURRENT_HOST_ID && existing.record.hostId === CURRENT_HOST_ID) ||
+        isTermuxPrivateHomeStorage(this.rootDir);
       if (!sameHost || !pidDefinitelyExited(existing.record.pid)) {
         throw new StorageWriterLeaseError(
           `Another Marinara Engine process (PID ${existing.record.pid}, host ${existing.record.hostname}) may be using ${this.rootDir}. ` +

--- a/packages/server/src/routes/docs.routes.ts
+++ b/packages/server/src/routes/docs.routes.ts
@@ -187,7 +187,7 @@ const DOC_ORDER: Record<string, string[]> = {
   noodle: ["overview.md", "settings.md"],
   appearance: ["appearance-settings.md", "fonts.md", "chat-backgrounds.md", "custom-css-themes.md", "card-css-theming.md"],
   data: ["importing-from-sillytavern.md", "backup-and-restore.md", "where-data-is-stored.md", "clearing-data.md"],
-  extending: ["regex-scripts.md", "custom-tools.md"],
+  extending: ["personal-extensions.md", "writing-personal-extensions.md", "regex-scripts.md", "custom-tools.md"],
   integrations: ["home-assistant.md", "discord-mirror.md", "message-translation.md", "haptic-feedback.md"],
   development: [
     "architecture-map.md",

--- a/packages/server/src/services/generation/runtime-agent-sections.ts
+++ b/packages/server/src/services/generation/runtime-agent-sections.ts
@@ -197,7 +197,7 @@ export function clearUnusedRuntimeAgentSections(
       const message = messages[i]!;
       if (!message.content.includes(tokens.start) && !message.content.includes(tokens.placeholder)) continue;
       const content = message.content
-        .replace(sectionPattern, (_match, sectionContent: string) => sectionContent.split(tokens.placeholder).join(""))
+        .replace(sectionPattern, "")
         .split(tokens.start)
         .join("")
         .split(tokens.end)

--- a/packages/shared/src/schemas/personal-extension.schema.ts
+++ b/packages/shared/src/schemas/personal-extension.schema.ts
@@ -5,8 +5,6 @@ import { z } from "zod";
 import { PERSONAL_EXTENSION_CAPABILITIES } from "../types/personal-extension.js";
 import { cssByteLimit, cssByteMessage } from "./css-size.js";
 
-const MAX_EXTENSION_JS_BYTES = 1024 * 1024;
-
 function utf8ByteLength(value: string): number {
   let bytes = 0;
   for (let index = 0; index < value.length; index += 1) {
@@ -28,9 +26,6 @@ function utf8ByteLength(value: string): number {
   return bytes;
 }
 
-const jsByteLimit = (value: string | null | undefined) =>
-  value == null || utf8ByteLength(value) <= MAX_EXTENSION_JS_BYTES;
-const jsByteMessage = `JavaScript must be at most ${MAX_EXTENSION_JS_BYTES} bytes`;
 const extensionRuntimeSchema = z.enum(["client", "server"]);
 const extensionCapabilitySchema = z.enum(PERSONAL_EXTENSION_CAPABILITIES);
 const extensionVersionSchema = z
@@ -44,8 +39,8 @@ const personalExtensionPayloadSchema = z.object({
   runtime: extensionRuntimeSchema.optional().default("client"),
   capabilities: z.array(extensionCapabilitySchema).max(PERSONAL_EXTENSION_CAPABILITIES.length).default([]),
   css: z.string().nullable().optional().refine(cssByteLimit, { message: cssByteMessage }),
-  js: z.string().nullable().optional().refine(jsByteLimit, { message: jsByteMessage }),
-  serverJs: z.string().nullable().optional().refine(jsByteLimit, { message: jsByteMessage }),
+  js: z.string().nullable().optional(),
+  serverJs: z.string().nullable().optional(),
 });
 
 function validateRuntimePayload(

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -453,6 +453,7 @@ export const SUPPORTED_MACROS: readonly SupportedMacroDefinition[] = [
   { category: "Variables", syntax: "{{getvar::name}}", description: "Read a dynamic variable" },
   { category: "Variables", syntax: "{{setvar::name::value}}", description: "Set a dynamic variable" },
   { category: "Variables", syntax: "{{addvar::name::value}}", description: "Append to a dynamic variable" },
+  { category: "Variables", syntax: "{{addnumvar::name::value}}", description: "Add to a numeric variable" },
   {
     category: "Variables",
     syntax: "{{incvar::name}} / {{decvar::name}}",
@@ -974,7 +975,7 @@ function resolveConditionalOperand(raw: string, ctx: MacroContext, options: Reso
       //     plain word or number still compares as itself — unchanged behavior;
       //   • force concrete resolution (deferCharacterMacros off) so a group chat
       //     compares the real value, not a deferred per-character placeholder.
-      if (!/^(setvar|addvar|incvar|decvar)\b/i.test(token)) {
+      if (!/^(setvar|addvar|addnumvar|incvar|decvar)\b/i.test(token)) {
         const braced = `{{${token}}}`;
         const resolved = resolveMacros(braced, ctx, {
           ...nestedMacroOptions(options),
@@ -1655,7 +1656,7 @@ export function selectConditionalPayloadBranch(
 function resolveVariableOperationMacros(input: string, ctx: MacroContext, options: ResolveMacroOptions): string {
   return replaceBalancedMacros(input, (body, original) => {
     const readMatch = body.match(/^(getvar|incvar|decvar)::([\w.-]+)$/i);
-    const writeMatch = body.match(/^(setvar|addvar)::([\w.-]+)::([\s\S]*)$/i);
+    const writeMatch = body.match(/^(setvar|addvar|addnumvar)::([\w.-]+)::([\s\S]*)$/i);
     const op = String(readMatch?.[1] ?? writeMatch?.[1] ?? "").toLowerCase();
     const name = readMatch?.[2] ?? writeMatch?.[2];
     if (!op || !name) return undefined;
@@ -1675,6 +1676,16 @@ function resolveVariableOperationMacros(input: string, ctx: MacroContext, option
           (ctx.variables[name] ?? "") +
           resolveMacros(writeMatch?.[3] ?? "", ctx, { ...nestedMacroOptions(options), trimResult: false });
         return "";
+      case "addnumvar": {
+        const currentValue = Number(ctx.variables[name] ?? "0");
+        const addedValue = Number(
+          resolveMacros(writeMatch?.[3] ?? "", ctx, { ...nestedMacroOptions(options), trimResult: false }),
+        );
+        ctx.variables[name] = String(
+          (Number.isFinite(currentValue) ? currentValue : 0) + (Number.isFinite(addedValue) ? addedValue : 0),
+        );
+        return "";
+      }
       case "incvar":
         ctx.variables[name] = String((parseInt(ctx.variables[name] ?? "0", 10) || 0) + 1);
         return "";
@@ -1954,6 +1965,7 @@ function formatMacroDateTime(now: Date, requestedTimeZone?: string): MacroDateTi
  *  - {{getvar::name}} — read a dynamic variable
  *  - {{setvar::name::value}} — set a variable
  *  - {{addvar::name::value}} — append to a variable
+ *  - {{addnumvar::name::value}} — add to a numeric variable
  *  - {{incvar::name}} — increment numeric variable by 1
  *  - {{decvar::name}} — decrement numeric variable by 1
  *  - {{input}} — last user message

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -1681,9 +1681,10 @@ function resolveVariableOperationMacros(input: string, ctx: MacroContext, option
         const addedValue = Number(
           resolveMacros(writeMatch?.[3] ?? "", ctx, { ...nestedMacroOptions(options), trimResult: false }),
         );
-        ctx.variables[name] = String(
-          (Number.isFinite(currentValue) ? currentValue : 0) + (Number.isFinite(addedValue) ? addedValue : 0),
-        );
+        const currentNumber = Number.isFinite(currentValue) ? currentValue : 0;
+        const addedNumber = Number.isFinite(addedValue) ? addedValue : 0;
+        const sum = currentNumber + addedNumber;
+        ctx.variables[name] = String(Number.isFinite(sum) ? sum : currentNumber);
         return "";
       }
       case "incvar":

--- a/scripts/regressions/extension-security.regression.ts
+++ b/scripts/regressions/extension-security.regression.ts
@@ -3,7 +3,10 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runInNewContext } from "node:vm";
-import { createPersonalExtensionSchema } from "../../packages/shared/src/schemas/personal-extension.schema.js";
+import {
+  createPersonalExtensionSchema,
+  updatePersonalExtensionSchema,
+} from "../../packages/shared/src/schemas/personal-extension.schema.js";
 import type { DB } from "../../packages/server/src/db/connection.js";
 import { createFileNativeDB } from "../../packages/server/src/db/file-backed-store.js";
 import { appSettings, installedExtensions } from "../../packages/server/src/db/schema/index.js";
@@ -176,6 +179,19 @@ const manifestWithEnabled = createPersonalExtensionSchema.parse({
 });
 assert.equal("enabled" in manifestWithEnabled, false);
 
+const sourceOverOneMiB = `/*${"x".repeat(1024 * 1024)}*/`;
+assert.equal(
+  createPersonalExtensionSchema.parse({ name: "Large browser draft", runtime: "client", js: sourceOverOneMiB }).js,
+  sourceOverOneMiB,
+);
+assert.equal(
+  createPersonalExtensionSchema.parse({ name: "Large server draft", runtime: "server", serverJs: sourceOverOneMiB })
+    .serverJs,
+  sourceOverOneMiB,
+);
+assert.equal(updatePersonalExtensionSchema.parse({ js: sourceOverOneMiB }).js, sourceOverOneMiB);
+assert.equal(updatePersonalExtensionSchema.parse({ serverJs: sourceOverOneMiB }).serverJs, sourceOverOneMiB);
+
 const storageDir = mkdtempSync(join(tmpdir(), "marinara-personal-extension-security-"));
 const previousFileStorageDir = process.env.FILE_STORAGE_DIR;
 const previousExternalGate = process.env.ENABLE_EXTERNAL_EXTENSIONS;
@@ -216,6 +232,20 @@ try {
   assert.equal(migratedRows[0]!.source, "legacy");
 
   const storage = createPersonalExtensionsStorage(db);
+  const largeDraft = await storage.create({
+    name: "Large source draft",
+    runtime: "client",
+    js: sourceOverOneMiB,
+  });
+  assert.ok(largeDraft);
+  assert.equal(largeDraft.js, sourceOverOneMiB);
+  const largeServerUpdate = await storage.update(largeDraft.id, {
+    runtime: "server",
+    serverJs: sourceOverOneMiB,
+  });
+  assert.equal(largeServerUpdate?.serverJs, sourceOverOneMiB);
+  assert.equal(largeServerUpdate?.revisions[0]?.js, sourceOverOneMiB);
+
   const externalDraft = await storage.create(
     {
       name: "Dropped external extension",
@@ -354,6 +384,7 @@ try {
         name: "Sandbox capability proof",
         runtime: "server",
         serverJs: `
+          ${sourceOverOneMiB}
           const escapedProcess = globalThis.constructor.constructor("return process")();
           const fs = escapedProcess.getBuiltinModule("node:fs");
           const childProcess = escapedProcess.getBuiltinModule("node:child_process");
@@ -800,8 +831,11 @@ try {
 }
 
 {
-  const { normalizePersonalExtensionImportEntry, personalExtensionEntriesFromJson } =
-    await import("../../packages/client/src/lib/personal-extension-import.js");
+  const {
+    normalizePersonalExtensionImportEntry,
+    personalExtensionEntriesFromJson,
+    personalExtensionEntryFromSourceFile,
+  } = await import("../../packages/client/src/lib/personal-extension-import.js");
   const [legacyEntry] = personalExtensionEntriesFromJson(
     {
       kind: "marinara.extension",
@@ -825,6 +859,17 @@ try {
   assert.ok(explicitSandboxEntry);
   const explicitSandboxDraft = normalizePersonalExtensionImportEntry(explicitSandboxEntry, "Safe");
   assert.deepEqual(explicitSandboxDraft?.capabilities, []);
+
+  for (const [fileName, runtime, sourceField] of [
+    ["large-browser.js", "client", "js"],
+    ["large-server.server.js", "server", "serverJs"],
+  ] as const) {
+    const entry = personalExtensionEntryFromSourceFile(fileName, sourceOverOneMiB);
+    assert.ok(entry);
+    const draft = normalizePersonalExtensionImportEntry(entry, fileName);
+    assert.equal(draft?.runtime, runtime);
+    assert.equal(draft?.[sourceField], sourceOverOneMiB);
+  }
 }
 
 {

--- a/scripts/regressions/profile-import-data-security.regression.ts
+++ b/scripts/regressions/profile-import-data-security.regression.ts
@@ -59,6 +59,7 @@ try {
 
   try {
     const timestamp = new Date(0).toISOString();
+    const sourceOverOneMiB = `/*${"x".repeat(1024 * 1024)}*/`;
     const connectionFixture = (id: string, overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
       id,
       name: id,
@@ -169,7 +170,7 @@ try {
       runtime: "client",
       capabilities: "[]",
       css: null,
-      js: "globalThis.profileExtensionRan = true;",
+      js: sourceOverOneMiB,
       serverJs: null,
       enabled: "true",
       contentHash: "foreign-hash",
@@ -179,6 +180,14 @@ try {
       installedAt: timestamp,
       createdAt: timestamp,
       updatedAt: timestamp,
+    };
+    const importedServerExtension = {
+      ...importedExtension,
+      id: "profile-server-extension",
+      name: "Profile Server Extension",
+      runtime: "server",
+      js: null,
+      serverJs: sourceOverOneMiB,
     };
     const modernPayload = {
       type: "marinara_profile",
@@ -192,7 +201,7 @@ try {
             mari_instructions: [importedInstruction],
             custom_themes: [importedTheme],
             custom_tools: [importedTool],
-            installed_extensions: [importedExtension],
+            installed_extensions: [importedExtension, importedServerExtension],
           },
           files: [],
         },
@@ -209,7 +218,7 @@ try {
     assert.equal(preview.imported.connections, 6);
     assert.equal(preview.imported.customTools, 1);
     assert.equal(preview.imported.mariInstructions, 1);
-    assert.equal(preview.imported.personalExtensions, 1);
+    assert.equal(preview.imported.personalExtensions, 2);
     const previewWarnings = new Map(
       (preview.warnings as Array<{ type: string; message: string }>).map((warning) => [warning.type, warning.message]),
     );
@@ -311,9 +320,16 @@ try {
     const [tool] = await db.select().from(schema.customTools);
     assert.equal(tool?.enabled, "false");
     assert.equal(tool?.includeHiddenContext, "false");
-    const [extension] = await db.select().from(schema.installedExtensions);
-    assert.equal(extension?.enabled, "false");
-    assert.equal(extension?.approvedHash, null);
+    const extensions = await db.select().from(schema.installedExtensions);
+    assert.equal(extensions.length, 2);
+    const browserExtension = extensions.find((candidate) => candidate.id === importedExtension.id);
+    const serverExtension = extensions.find((candidate) => candidate.id === importedServerExtension.id);
+    assert.equal(browserExtension?.js, sourceOverOneMiB);
+    assert.equal(serverExtension?.serverJs, sourceOverOneMiB);
+    for (const extension of extensions) {
+      assert.equal(extension.enabled, "false");
+      assert.equal(extension.approvedHash, null);
+    }
 
     const themes = themesModule.createThemesStorage(db);
     const localTheme = await themes.create({ name: "Local active theme", css: ":root { --background: blue; }" });

--- a/scripts/regressions/profile-import-data-security.regression.ts
+++ b/scripts/regressions/profile-import-data-security.regression.ts
@@ -324,6 +324,8 @@ try {
     assert.equal(extensions.length, 2);
     const browserExtension = extensions.find((candidate) => candidate.id === importedExtension.id);
     const serverExtension = extensions.find((candidate) => candidate.id === importedServerExtension.id);
+    assert.equal(browserExtension?.runtime, "client");
+    assert.equal(serverExtension?.runtime, "server");
     assert.equal(browserExtension?.js, sourceOverOneMiB);
     assert.equal(serverExtension?.serverJs, sourceOverOneMiB);
     for (const extension of extensions) {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -2711,7 +2711,21 @@ const cases: RegressionCase[] = [
       assert.equal(resolve("{{addnumvar::score::4}}{{getvar::score}}"), "4");
       assert.equal(resolve("{{setvar::score::invalid}}{{addnumvar::score::5}}{{getvar::score}}"), "5");
       assert.equal(resolve("{{setvar::score::7}}{{addnumvar::score::invalid}}{{getvar::score}}"), "7");
+      assert.equal(resolve("{{setvar::score::1e308}}{{addnumvar::score::1e308}}{{getvar::score}}"), "1e+308");
+      assert.equal(
+        resolve("{{setvar::score::1e308}}{{addnumvar::score::1e308}}{{addnumvar::score::-1e308}}{{getvar::score}}"),
+        "0",
+      );
       assert.equal(resolve("{{setvar::score::20}}{{addvar::score::-2}}{{getvar::score}}"), "20-2");
+
+      const conditionalVariables = { score: "10" };
+      resolveMacros("{{#if addnumvar::score::5}}unchanged{{/if}}", {
+        user: "Mari",
+        char: "Dottore",
+        characters: ["Dottore"],
+        variables: conditionalVariables,
+      });
+      assert.equal(conditionalVariables.score, "10", "conditional operands must not execute numeric writes");
 
       const variables = { score: "0" };
       const resolveMessage = createMessageMacroResolver({ variables });

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -8472,7 +8472,7 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
     },
   },
   {
-    name: "unused runtime agent sections preserve surrounding prompt text",
+    name: "unused runtime agent sections omit surrounding prompt text",
     run() {
       const tokens = makeRuntimeAgentSectionTokens("knowledge-router", "regression");
       const messages = [
@@ -8483,11 +8483,7 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
 
       clearUnusedRuntimeAgentSectionsForTest(messages, [["knowledge-router", tokens]]);
 
-      assert.equal(messages.length, 1);
-      assert.match(messages[0]?.content ?? "", /This is where additional lore will be:/);
-      assert.equal(messages[0]?.content.includes(tokens.placeholder), false);
-      assert.equal(messages[0]?.content.includes(tokens.start), false);
-      assert.equal(messages[0]?.content.includes(tokens.end), false);
+      assert.equal(messages.length, 0);
     },
   },
   {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -284,6 +284,7 @@ import {
 } from "../../packages/server/src/services/video/video-generation.js";
 import { loadGameStoryboardImagePrompt } from "../../packages/server/src/services/image/game-storyboard-image-prompt.js";
 import { formatAgentFailuresToast, toAgentFailure } from "../../packages/client/src/lib/agent-failures.js";
+import { createMessageMacroResolver } from "../../packages/client/src/lib/chat-macros.js";
 import { formatGenerationParameterError } from "../../packages/client/src/lib/generation-parameter-errors.js";
 import { normalizeCustomMusicSource } from "../../packages/client/src/components/chat/AgentAddSetupFields.js";
 import {
@@ -2688,6 +2689,35 @@ const cases: RegressionCase[] = [
         "untouched",
       );
       assert.equal(context.variables.personaTouched, undefined);
+    },
+  },
+  {
+    name: "addnumvar adds numbers without changing addvar concatenation",
+    run() {
+      const resolve = (template: string) =>
+        resolveMacros(template, {
+          user: "Mari",
+          char: "Dottore",
+          characters: ["Dottore"],
+          variables: {},
+        });
+
+      assert.equal(
+        resolve("{{setvar::modifier::2}}{{setvar::score::20}}{{addnumvar::score::{{modifier}}}}{{getvar::score}}"),
+        "22",
+      );
+      assert.equal(resolve("{{setvar::score::20}}{{addnumvar::score::-2}}{{getvar::score}}"), "18");
+      assert.equal(resolve("{{setvar::score::1.5}}{{addnumvar::score::2.25}}{{getvar::score}}"), "3.75");
+      assert.equal(resolve("{{addnumvar::score::4}}{{getvar::score}}"), "4");
+      assert.equal(resolve("{{setvar::score::invalid}}{{addnumvar::score::5}}{{getvar::score}}"), "5");
+      assert.equal(resolve("{{setvar::score::7}}{{addnumvar::score::invalid}}{{getvar::score}}"), "7");
+      assert.equal(resolve("{{setvar::score::20}}{{addvar::score::-2}}{{getvar::score}}"), "20-2");
+
+      const variables = { score: "0" };
+      const resolveMessage = createMessageMacroResolver({ variables });
+      resolveMessage("{{addnumvar::score::1}}");
+      resolveMessage("{{addnumvar::score::1}}");
+      assert.equal(variables.score, "2", "repeated numeric writes must not be served from the display macro cache");
     },
   },
   {

--- a/scripts/regressions/storage-writer-lock.regression.ts
+++ b/scripts/regressions/storage-writer-lock.regression.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDB, getDB } from "../../packages/server/src/db/connection.js";
@@ -108,6 +108,57 @@ try {
       assert.notEqual(readJson<LeaseRecord>(ownerPath(dir)).token, "stale-owner-token");
       await afterCrash._fileStore.close();
     }
+
+    // Termux has no stable machine ID on some Android devices. Its HOME is
+    // app-private, so an exited lease there is safe to reclaim after reboot;
+    // the same fallback must not apply to storage outside that HOME.
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+    const previousHome = process.env.HOME;
+    const termuxHome = mkdtempSync(join(tmpdir(), "marinara-termux-home-"));
+    tempDirs.push(termuxHome);
+    const termuxStorage = join(termuxHome, "Marinara-Engine", "packages", "server", "data", "storage");
+    process.env.FILE_STORAGE_DIR = termuxStorage;
+    mkdirSync(leasePath(termuxStorage), { recursive: true });
+    writeFileSync(
+      ownerPath(termuxStorage),
+      JSON.stringify({
+        ...leaseTemplate,
+        pid: await exitedPid(),
+        hostId: null,
+        token: "stale-termux-token",
+      }),
+    );
+    let termuxDb: Awaited<ReturnType<typeof createFileNativeDB>> | undefined;
+    try {
+      Object.defineProperty(process, "platform", { ...platformDescriptor, value: "android" });
+      process.env.HOME = termuxHome;
+      termuxDb = await createFileNativeDB();
+      assert.notEqual(readJson<LeaseRecord>(ownerPath(termuxStorage)).token, "stale-termux-token");
+      await termuxDb._fileStore.close();
+      termuxDb = undefined;
+
+      const outsideHome = useTempStorage("termux-outside-home");
+      mkdirSync(leasePath(outsideHome));
+      writeFileSync(
+        ownerPath(outsideHome),
+        JSON.stringify({
+          ...leaseTemplate,
+          pid: await exitedPid(),
+          hostId: null,
+          token: "outside-termux-home-token",
+        }),
+      );
+      const linkedOutsideHome = join(termuxHome, "shared-storage");
+      symlinkSync(outsideHome, linkedOutsideHome, "dir");
+      process.env.FILE_STORAGE_DIR = linkedOutsideHome;
+      await assert.rejects(createFileNativeDB(), StorageWriterLeaseError);
+    } finally {
+      if (termuxDb) await termuxDb._fileStore.close();
+      Object.defineProperty(process, "platform", platformDescriptor);
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+    }
+    process.env.FILE_STORAGE_DIR = dir;
 
     // Counts are diagnostics only: a stale value cannot hide a valid row and
     // startup heals it from the rows actually loaded from disk.


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.

## Linked issues

Closes #5023
Closes #5024
Closes #5025
Closes #5026
Closes #5029

Follow-up: #5028 tracks the required translated-doc synchronization.

## Why this change

Resolve the Engine issue sweep, including the Termux launch regression reported while the PR was in review, with focused fixes and no unrelated refactors.

## What changed

- Omit a token-bounded runtime Agent section when its Agent produces no output.
- Add `{{addnumvar::name::value}}` while preserving `{{addvar}}` string concatenation.
- Remove only the shared 1 MiB `js`/`serverJs` schema refinement; keep separate ZIP, CSS, storage, request, protocol, approval, and sandbox boundaries.
- Add a practical Personal Extension authoring guide with importable Browser and Server examples, API/manifest/limit references, lifecycle guidance, and troubleshooting.
- Let Termux reclaim a dead writer lease only for canonical storage paths inside its app-private HOME; keep live PIDs and outside/shared paths blocked.
- Record all user-facing changes under v2.4.3.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Automated evidence

- `pnpm check`
- `pnpm regression:prompt`
- `pnpm regression:extensions-security` (including macOS Seatbelt runtime proof)
- `pnpm regression:docs`
- `pnpm regression:storage-writer-lock`
- `pnpm version:check`
- `pnpm credits:check`
- `pnpm release:notes -- 2.4.3`
- Example manifests normalize as runnable `client` and `server` packages; JavaScript syntax checks pass.
- `git diff --check`

### Manual verification notes

- No new Engine UI component or visual styling behavior is introduced. Review should focus on prompt output, macro arithmetic, extension import/runtime boundaries, and the rendered documentation.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- No new UI surface; not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `addnumvar` macro for numeric variable updates.
  * Removed the 1 MiB source-size limit for Personal Extensions.
  * Added browser and server Personal Extension examples.

* **Bug Fixes**
  * Fixed editor caret placement and shared local data handling.
  * Improved empty Agent prompt sections.
  * Improved Termux storage recovery after Android restarts.

* **Documentation**
  * Added comprehensive Personal Extension authoring, API, validation, and troubleshooting guidance.
  * Documented the new `addnumvar` macro.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->