### PR TITLE
Fix CSRF, prompt, persona, and regex import regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+### Fixed
+
+- Treated a literal `CSRF_TRUSTED_ORIGINS=null` as an unset value so it no longer prevents Marinara Engine from opening (#5030).
+- Stopped removed or disabled Example Dialogue markers from silently injecting character examples into prompts (#5031).
+- Restored persona creation through Professor Mari by supplying the persona reference-image default expected by storage validation (#5033).
+- Kept supported placement settings when importing character-scoped SillyTavern regexes that also contain unsupported placements, with a warning for the ignored values (#5036).
+
 ## [2.4.3]
 
 ### Added

--- a/packages/client/src/components/characters/CharacterRegexSection.tsx
+++ b/packages/client/src/components/characters/CharacterRegexSection.tsx
@@ -192,6 +192,7 @@ export function CharacterRegexSection({
   const openRegexDetail = useUIStore((s) => s.openRegexDetail);
   const editorDirty = useUIStore((s) => s.editorDirty);
   const [importError, setImportError] = useState<string | null>(null);
+  const [importWarning, setImportWarning] = useState<string | null>(null);
   const [importSuccess, setImportSuccess] = useState<string | null>(null);
 
   const scopedScripts = useMemo(() => {
@@ -252,6 +253,7 @@ export function CharacterRegexSection({
   const handleImport = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
       setImportError(null);
+      setImportWarning(null);
       setImportSuccess(null);
       const file = event.target.files?.[0];
       if (!file || !characterId) return;
@@ -264,15 +266,10 @@ export function CharacterRegexSection({
 
         let imported = 0;
         const failed: string[] = [];
+        const warnings: string[] = [];
         const orderBase = getNextRegexOrderBase((regexScripts ?? []) as RegexScriptRow[]);
         for (const [index, entry] of entries.entries()) {
           const unsupportedPlacements = getUnsupportedStRegexPlacements(entry);
-          if (unsupportedPlacements.length > 0) {
-            failed.push(
-              `Entry ${index + 1}: unsupported SillyTavern placement ${unsupportedPlacements.join(", ")} was skipped.`,
-            );
-            continue;
-          }
           const normalized = normalizeRegexImportEntry(entry, orderBase + index);
           if (!normalized) {
             failed.push(`Entry ${index + 1}: missing name or find pattern.`);
@@ -282,6 +279,14 @@ export function CharacterRegexSection({
             // Force-scope every imported script to this character.
             await createRegex.mutateAsync({ ...normalized, targetCharacterIds: [characterId] });
             imported++;
+            if (unsupportedPlacements.length > 0) {
+              warnings.push(
+                localizeUi("ui.panels.presetspanel.ignoredUnsupportedRegexPlacements", {
+                  value1: index + 1,
+                  value2: unsupportedPlacements.join(", "),
+                }),
+              );
+            }
           } catch (error) {
             failed.push(`Entry ${index + 1} (${normalized.name}): ${describeImportError(error)}`);
           }
@@ -293,6 +298,9 @@ export function CharacterRegexSection({
         if (failed.length > 0) {
           setImportError(`Skipped ${failed.length} regex script${failed.length === 1 ? "" : "s"}. ${failed[0]}`);
         }
+        if (warnings.length > 0) {
+          setImportWarning(warnings[0]!);
+        }
         if (imported === 0 && failed.length === 0) {
           setImportError("No valid regex scripts found in file.");
         }
@@ -302,7 +310,7 @@ export function CharacterRegexSection({
 
       event.target.value = "";
     },
-    [characterId, createRegex, regexScripts],
+    [characterId, createRegex, regexScripts, localizeUi],
   );
 
   const handleDelete = useCallback(
@@ -363,6 +371,7 @@ export function CharacterRegexSection({
       ) : (
         <>
           {importError && <div className="text-xs text-red-500">{importError}</div>}
+          {importWarning && <div className="text-xs text-amber-500">{importWarning}</div>}
           {importSuccess && <div className="text-xs text-green-500">{importSuccess}</div>}
           {scopedScripts.length === 0 ? (
             <p className="py-1 text-[0.6875rem] text-[var(--muted-foreground)]">{localizeUi("ui.characters.characterregexsection.noRegexScriptsForThisCharacterYet")}</p>

--- a/packages/server/src/config/runtime-config.ts
+++ b/packages/server/src/config/runtime-config.ts
@@ -460,7 +460,7 @@ export function isAdminSecretRequiredOnLoopback() {
 }
 
 export function getCsrfTrustedOrigins() {
-  return parseCsv(process.env.CSRF_TRUSTED_ORIGINS);
+  return parseCsv(process.env.CSRF_TRUSTED_ORIGINS).filter((origin) => origin.toLowerCase() !== "null");
 }
 
 export function isUpdatesApplyEnabled() {

--- a/packages/server/src/services/mari-db/mari-db.service.ts
+++ b/packages/server/src/services/mari-db/mari-db.service.ts
@@ -1194,6 +1194,7 @@ export function buildPersonaCreateRow(data: Row, id: string, timestamp: string):
     scenario: firstString(data, ["scenario"]) ?? "",
     backstory: firstString(data, ["backstory"]) ?? "",
     appearance: firstString(data, ["appearance"]) ?? "",
+    useCharacterSheetAsReference: "false",
     isActive: "false",
     nameColor: "",
     dialogueColor: "",

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -318,19 +318,6 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
   // Build lookup maps
   const sectionMap = new Map(input.sections.map((s) => [s.id, s]));
   const groupMap = new Map(input.groups.map((g) => [g.id, g]));
-  const hasDialogueExamplesMarker = sectionOrder.some((sectionId) => {
-    const section = sectionMap.get(sectionId);
-    if (!section || section.enabled !== "true" || section.isMarker !== "true" || !section.markerConfig) return false;
-    if (section.groupId) {
-      const group = groupMap.get(section.groupId);
-      if (group && group.enabled !== "true") return false;
-    }
-    try {
-      return (JSON.parse(section.markerConfig) as MarkerConfig).type === "dialogue_examples";
-    } catch {
-      return false;
-    }
-  });
 
   // Inject choice variable values into variableValues
   // chatChoices is { variableName: value | value[] } — resolve and merge into variables so {{varName}} resolves
@@ -484,7 +471,6 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
     resolveLorebookContent: (value) => resolveMacrosWithVariableSnapshot(value, macroCtx, deferNameMacroOptions),
     onLorebookScan: addActivatedLorebookCharacterReferences,
     groupScenarioOverrideText: input.groupScenarioOverrideText ?? null,
-    hasDialogueExamplesMarker,
     macroCtx,
   };
 

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -103,8 +103,6 @@ export interface MarkerContext {
   lorebookScanResultApplied?: boolean;
   /** When set, replaces all individual character scenario fields with this shared group scenario. */
   groupScenarioOverrideText?: string | null;
-  /** Whether the preset has an enabled marker that owns Example Dialogue placement. */
-  hasDialogueExamplesMarker?: boolean;
 }
 
 /** Expanded marker result. */
@@ -151,16 +149,9 @@ export function orderCharacterMarkerFields(fields: readonly string[]): string[] 
     .map(({ field }) => field);
 }
 
-/** Append Example Dialogue to Character Info when no dedicated marker owns it. */
-export function resolveCharacterMarkerFields(
-  configuredFields: readonly string[] | undefined,
-  hasDialogueExamplesMarker: boolean,
-): string[] {
-  const fields = [...(configuredFields ?? DEFAULT_CHARACTER_MARKER_FIELDS)];
-  if (!hasDialogueExamplesMarker && !fields.includes("mes_example") && !fields.includes("example_dialogue")) {
-    fields.push("mes_example");
-  }
-  return orderCharacterMarkerFields(fields);
+/** Resolve only the card fields explicitly owned by the Character Info marker. */
+export function resolveCharacterMarkerFields(configuredFields: readonly string[] | undefined): string[] {
+  return orderCharacterMarkerFields(configuredFields ?? DEFAULT_CHARACTER_MARKER_FIELDS);
 }
 
 /**
@@ -205,7 +196,7 @@ async function expandCharacter(config: MarkerConfig, ctx: MarkerContext): Promis
     const profile = characterMacroProfileFromData(data);
     const characterMacroContext = macroContextForCharacterProfile(ctx.macroCtx, profile);
 
-    const fields = resolveCharacterMarkerFields(config.characterFields, ctx.hasDialogueExamplesMarker === true);
+    const fields = resolveCharacterMarkerFields(config.characterFields);
 
     const charParts: string[] = [];
     for (const field of fields) {

--- a/scripts/regressions/assigned-issue-sweep.regression.ts
+++ b/scripts/regressions/assigned-issue-sweep.regression.ts
@@ -402,6 +402,15 @@ assert.doesNotMatch(
   /warnings\.push/u,
   "character-scoped placement warnings must not be emitted before the regex imports successfully",
 );
+const scopedSupportedImportPath = scopedRegexBeforeSuccessfulImport.replace(
+  /if \(!normalized\) \{[\s\S]*?continue;\s*\}/u,
+  "",
+);
+assert.doesNotMatch(
+  scopedSupportedImportPath,
+  /continue;/u,
+  "supported character-scoped regex entries must reach the import even when some placements are unsupported",
+);
 const successfulScopedRegexImportWarning =
   /await createRegex\.mutateAsync\(\{ \.\.\.normalized, targetCharacterIds: \[characterId\] \}\);[\s\S]*?warnings\.push\([\s\S]*?ignoredUnsupportedRegexPlacements"/u.exec(
     characterRegexSectionSource,

--- a/scripts/regressions/assigned-issue-sweep.regression.ts
+++ b/scripts/regressions/assigned-issue-sweep.regression.ts
@@ -378,6 +378,44 @@ assert.match(
   "unsupported placement warnings must use the localized message",
 );
 
+const characterRegexSectionSource = readFileSync(
+  join(repositoryRoot, "packages/client/src/components/characters/CharacterRegexSection.tsx"),
+  "utf8",
+);
+const scopedUnsupportedRegexPlacementGate =
+  /const unsupportedPlacements = getUnsupportedStRegexPlacements\(entry\);[\s\S]*?const normalized =/u.exec(
+    characterRegexSectionSource,
+  )?.[0];
+assert.ok(scopedUnsupportedRegexPlacementGate, "the character-scoped regex placement branch remains discoverable");
+assert.doesNotMatch(
+  scopedUnsupportedRegexPlacementGate,
+  /continue;/u,
+  "unsupported SillyTavern placements must not discard an entire character-scoped regex entry",
+);
+const scopedRegexBeforeSuccessfulImport =
+  /const unsupportedPlacements = getUnsupportedStRegexPlacements\(entry\);[\s\S]*?await createRegex\.mutateAsync\(\{ \.\.\.normalized, targetCharacterIds: \[characterId\] \}\);/u.exec(
+    characterRegexSectionSource,
+  )?.[0];
+assert.ok(scopedRegexBeforeSuccessfulImport, "the character-scoped regex pre-import path remains discoverable");
+assert.doesNotMatch(
+  scopedRegexBeforeSuccessfulImport,
+  /warnings\.push/u,
+  "character-scoped placement warnings must not be emitted before the regex imports successfully",
+);
+const successfulScopedRegexImportWarning =
+  /await createRegex\.mutateAsync\(\{ \.\.\.normalized, targetCharacterIds: \[characterId\] \}\);[\s\S]*?warnings\.push\([\s\S]*?ignoredUnsupportedRegexPlacements"/u.exec(
+    characterRegexSectionSource,
+  )?.[0];
+assert.ok(
+  successfulScopedRegexImportWarning,
+  "the successful character-scoped regex import warning remains discoverable",
+);
+assert.match(
+  successfulScopedRegexImportWarning,
+  /localizeUi\("ui\.panels\.presetspanel\.ignoredUnsupportedRegexPlacements"/u,
+  "character-scoped imports use the localized unsupported-placement warning",
+);
+
 const gameSetupWizardSource = readFileSync(
   join(repositoryRoot, "packages/client/src/components/game/GameSetupWizard.tsx"),
   "utf8",

--- a/scripts/regressions/mari-db-review-durability.regression.ts
+++ b/scripts/regressions/mari-db-review-durability.regression.ts
@@ -30,6 +30,35 @@ const previousFileStorageDir = process.env.FILE_STORAGE_DIR;
 const sidecarPath = (dir: string, id: string) => join(dir, "journal", "pending", `${id}.json`);
 
 try {
+  // ── Professor Mari can create a persona with every required storage default ──
+  {
+    const dir = tempStorageDir();
+    const db = await createFileNativeDB();
+    try {
+      const mari = new MariDbService(db);
+      const created = await mari.executeAction({
+        action: "persona.create",
+        personaId: "created-persona",
+        data: { name: "Created Persona", description: "A durable identity." },
+        apply: true,
+      });
+      assert.equal(created.ok, true, "Professor Mari's persona.create action passes storage validation");
+      assert.equal(created.mode, "apply");
+      assert.equal(created.approval?.status, "pending", "the applied persona still receives a review card");
+
+      const fetched = await mari.executeAction({ action: "persona.get", personaId: "created-persona" });
+      assert.equal(fetched.ok, true, "the created persona is persisted");
+      assert.equal(
+        (fetched.output as Record<string, unknown>).useCharacterSheetAsReference,
+        "false",
+        "the persona stores the required character-sheet reference default",
+      );
+    } finally {
+      await db._fileStore.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
   // ── A pending review persists to a sidecar, rehydrates after a restart, and Restore works ──
   {
     const dir = tempStorageDir();

--- a/scripts/regressions/mari-db-review-durability.regression.ts
+++ b/scripts/regressions/mari-db-review-durability.regression.ts
@@ -8,7 +8,7 @@
 //   - a sidecar past its retention deadline is pruned on load,
 //   - the persisted set is capped so it cannot grow without bound.
 import assert from "node:assert/strict";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createFileNativeDB } from "../../packages/server/src/db/file-backed-store.js";
@@ -32,9 +32,11 @@ const sidecarPath = (dir: string, id: string) => join(dir, "journal", "pending",
 try {
   // ── Professor Mari can create a persona with every required storage default ──
   {
+    const previousBlockStorageDir = process.env.FILE_STORAGE_DIR;
     const dir = tempStorageDir();
-    const db = await createFileNativeDB();
+    let db: Awaited<ReturnType<typeof createFileNativeDB>> | null = null;
     try {
+      db = await createFileNativeDB();
       const mari = new MariDbService(db);
       const created = await mari.executeAction({
         action: "persona.create",
@@ -45,6 +47,15 @@ try {
       assert.equal(created.ok, true, "Professor Mari's persona.create action passes storage validation");
       assert.equal(created.mode, "apply");
       assert.equal(created.approval?.status, "pending", "the applied persona still receives a review card");
+      const reviewId = created.approval?.id;
+      assert.ok(reviewId, "the applied persona review has an id");
+      const reviewPath = sidecarPath(dir, reviewId);
+      assert.ok(existsSync(reviewPath), "the persona review is persisted to a sidecar");
+      assert.equal(
+        (JSON.parse(readFileSync(reviewPath, "utf8")) as { id?: string }).id,
+        reviewId,
+        "the sidecar contains the registered persona review",
+      );
 
       const fetched = await mari.executeAction({ action: "persona.get", personaId: "created-persona" });
       assert.equal(fetched.ok, true, "the created persona is persisted");
@@ -54,7 +65,9 @@ try {
         "the persona stores the required character-sheet reference default",
       );
     } finally {
-      await db._fileStore.close();
+      if (db) await db._fileStore.close();
+      if (previousBlockStorageDir === undefined) delete process.env.FILE_STORAGE_DIR;
+      else process.env.FILE_STORAGE_DIR = previousBlockStorageDir;
       rmSync(dir, { recursive: true, force: true });
     }
   }

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -7904,7 +7904,11 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         }),
       } as unknown as DB;
 
-      const assemble = (wrapFormat: "xml" | "markdown" | "none", dialogueMarker: "absent" | "enabled" | "disabled") =>
+      const assemble = (
+        wrapFormat: "xml" | "markdown" | "none",
+        dialogueMarker: "absent" | "enabled" | "disabled",
+        characterFields?: string[],
+      ) =>
         assemblePrompt({
           db,
           preset: {
@@ -7923,7 +7927,7 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
               identifier: "characterInfo",
               name: "Character Info",
               isMarker: "true",
-              markerConfig: JSON.stringify({ type: "character" }),
+              markerConfig: JSON.stringify({ type: "character", ...(characterFields ? { characterFields } : {}) }),
             }),
             ...(dialogueMarker !== "absent"
               ? [
@@ -7958,6 +7962,11 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
           assert.equal(promptText.includes("dialogue_examples"), false);
         }
       }
+
+      const explicitCharacterField = await assemble("xml", "absent", ["mes_example"]);
+      const explicitCharacterFieldText = explicitCharacterField.messages.map((message) => message.content).join("\n");
+      assert.equal(explicitCharacterFieldText.match(/CHARACTER_EXAMPLE_DIALOGUE/g)?.length, 1);
+      assert.match(explicitCharacterFieldText, /<mes_example>/);
 
       const explicitMarker = await assemble("xml", "enabled");
       const explicitPromptText = explicitMarker.messages.map((message) => message.content).join("\n");

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -7853,27 +7853,23 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         ]),
         ["description", "personality", "backstory", "appearance", "scenario", "mes_example", "system_prompt", "stats"],
       );
-      assert.deepEqual(resolveCharacterMarkerFields(undefined, false), [
+      assert.deepEqual(resolveCharacterMarkerFields(undefined), [
         "description",
         "personality",
         "backstory",
         "appearance",
         "scenario",
-        "mes_example",
         "system_prompt",
       ]);
-      assert.deepEqual(resolveCharacterMarkerFields(undefined, true), [
+      assert.deepEqual(resolveCharacterMarkerFields(["scenario", "mes_example", "description"]), [
         "description",
-        "personality",
-        "backstory",
-        "appearance",
         "scenario",
-        "system_prompt",
+        "mes_example",
       ]);
     },
   },
   {
-    name: "character markers append Example Dialogue only when no enabled dialogue marker owns it",
+    name: "character markers omit removed or disabled Example Dialogue sections",
     async run() {
       const characterRow = {
         id: "char-example-fallback",
@@ -7908,13 +7904,13 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         }),
       } as unknown as DB;
 
-      const assemble = (wrapFormat: "xml" | "markdown" | "none", withDialogueMarker: boolean) =>
+      const assemble = (wrapFormat: "xml" | "markdown" | "none", dialogueMarker: "absent" | "enabled" | "disabled") =>
         assemblePrompt({
           db,
           preset: {
             id: `preset-example-fallback-${wrapFormat}`,
             name: "Example Dialogue Fallback Fixture",
-            sectionOrder: JSON.stringify(withDialogueMarker ? ["character", "examples"] : ["character"]),
+            sectionOrder: JSON.stringify(dialogueMarker === "absent" ? ["character"] : ["character", "examples"]),
             groupOrder: JSON.stringify([]),
             wrapFormat,
             parameters: JSON.stringify({}),
@@ -7929,7 +7925,7 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
               isMarker: "true",
               markerConfig: JSON.stringify({ type: "character" }),
             }),
-            ...(withDialogueMarker
+            ...(dialogueMarker !== "absent"
               ? [
                   promptSection({
                     id: "examples",
@@ -7938,6 +7934,7 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
                     isMarker: "true",
                     markerConfig: JSON.stringify({ type: "dialogue_examples" }),
                     injectionOrder: 1,
+                    enabled: dialogueMarker === "disabled" ? "false" : "true",
                   }),
                 ]
               : []),
@@ -7953,17 +7950,16 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         });
 
       for (const wrapFormat of ["xml", "markdown", "none"] as const) {
-        const result = await assemble(wrapFormat, false);
-        const promptText = result.messages.map((message) => message.content).join("\n");
-        assert.equal(promptText.match(/CHARACTER_EXAMPLE_DIALOGUE/g)?.length, 1);
-        assert.ok(promptText.indexOf("CHARACTER_SCENARIO") < promptText.indexOf("CHARACTER_EXAMPLE_DIALOGUE"));
-        assert.ok(promptText.indexOf("CHARACTER_EXAMPLE_DIALOGUE") < promptText.indexOf("CHARACTER_SYSTEM_PROMPT"));
-        if (wrapFormat === "xml") assert.match(promptText, /<mes_example>/);
-        if (wrapFormat === "markdown") assert.match(promptText, /#### mes_example/);
-        if (wrapFormat === "none") assert.equal(promptText.includes("mes_example"), false);
+        for (const dialogueMarker of ["absent", "disabled"] as const) {
+          const result = await assemble(wrapFormat, dialogueMarker);
+          const promptText = result.messages.map((message) => message.content).join("\n");
+          assert.equal(promptText.includes("CHARACTER_EXAMPLE_DIALOGUE"), false);
+          assert.equal(promptText.includes("mes_example"), false);
+          assert.equal(promptText.includes("dialogue_examples"), false);
+        }
       }
 
-      const explicitMarker = await assemble("xml", true);
+      const explicitMarker = await assemble("xml", "enabled");
       const explicitPromptText = explicitMarker.messages.map((message) => message.content).join("\n");
       assert.equal(explicitPromptText.match(/CHARACTER_EXAMPLE_DIALOGUE/g)?.length, 1);
       assert.match(explicitPromptText, /<dialogue_examples>/);

--- a/scripts/regressions/request-host-security.regression.ts
+++ b/scripts/regressions/request-host-security.regression.ts
@@ -13,10 +13,21 @@ delete process.env.CORS_ORIGINS;
 delete process.env.MARINARA_E2E_DISABLE_RATE_LIMIT;
 
 const { corsDelegate } = await import("../../packages/server/src/config/cors-config.js");
+const { getCsrfTrustedOrigins } = await import("../../packages/server/src/config/runtime-config.js");
 const { hostValidationHook, parseRequestHostname } =
   await import("../../packages/server/src/middleware/host-validation.js");
 const { rateLimitHook, resetRateLimitBucketsForTests } =
   await import("../../packages/server/src/middleware/rate-limit.js");
+
+process.env.CSRF_TRUSTED_ORIGINS = "null";
+assert.deepEqual(getCsrfTrustedOrigins(), [], "a literal null CSRF origin is treated as unset");
+process.env.CSRF_TRUSTED_ORIGINS = "NULL, https://proxy.example.com";
+assert.deepEqual(
+  getCsrfTrustedOrigins(),
+  ["https://proxy.example.com"],
+  "a null sentinel does not discard configured trusted origins",
+);
+delete process.env.CSRF_TRUSTED_ORIGINS;
 
 assert.equal(parseRequestHostname("192.168.1.50:7860"), "192.168.1.50");
 assert.equal(parseRequestHostname("[fd7a:115c:a1e0::1]:7860"), "fd7a:115c:a1e0::1");


### PR DESCRIPTION
## Linked issues

Closes #5030
Closes #5031
Closes #5033
Closes #5036

Issue #5032 is already fixed on staging by #5027 and will be closed separately with that proof.

## Why this change

The remaining open Engine reports came from four narrow regressions: a deployment sentinel treated as an origin, a prompt fallback overriding preset intent, a missing required persona default, and character-scoped regex imports rejecting otherwise usable entries.

## What changed

- Treat case-insensitive `null` values in `CSRF_TRUSTED_ORIGINS` as unset while retaining real origins.
- Include Example Dialogue only through an enabled Dialogue Examples marker or an explicit Character Info field selection.
- Supply `useCharacterSheetAsReference: "false"` when Professor Mari creates a persona.
- Import character-scoped SillyTavern regexes with their supported placements and show the existing localized warning for ignored placements.
- Add focused regressions and Unreleased changelog entries for each behavior.

## Validation

- [ ] pnpm check passes locally
- [ ] Container build completed
- [ ] Manual browser verification completed
- [ ] Edge cases checked
- [ ] Read and followed CONTRIBUTING.md

### Automated evidence

- `pnpm check` — passed
- `pnpm regression:request-security` — passed
- `pnpm regression:prompt` — passed
- `pnpm regression:mari-review-durability` — passed
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/assigned-issue-sweep.regression.ts` — passed
- `pnpm localization:check` — passed
- `git diff --check` — passed
- `pnpm smoke:ui` — non-gating run stopped after 143 passes because unrelated existing navigation, catalog, Noodle-tour, and Professor Mari mobile tests timed out or failed under the two-worker run; no failure exercised a changed path.

### Manual verification notes

- Manually verify startup with `CSRF_TRUSTED_ORIGINS=null`.
- Manually verify removed and disabled Example Dialogue sections stay out of generated prompts.
- Manually create a persona through Professor Mari and retain it from the review card.
- Manually import a character-scoped SillyTavern regex containing supported and unsupported placement values and confirm the import plus warning.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs as needed
- [ ] Translated docs updated or follow-up issue opened
- [ ] Version/release files updated if applicable

No user-facing documentation or release metadata changes are required. The Unreleased changelog is updated.

## UI evidence

The scoped regex importer reuses the existing amber localized warning treatment from the global regex importer; no visual redesign or new copy was introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CSRF trusted-origin handling by ignoring `null` values while preserving valid origins.
  - Fixed Example Dialogue behavior so it appears only when explicitly enabled.
  - Newly created personas now use the correct default reference setting.
  - SillyTavern regex imports now succeed despite unsupported placements, with clear warnings shown afterward.

- **Tests**
  - Added regression coverage for security settings, dialogue markers, persona creation, and regex import behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->