### PR TITLE
fix(conversation): left-align generated selfies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Left-aligned generated Conversation selfies with their message text on desktop instead of centering them in the message body (#5042).
 - Treated a literal `CSRF_TRUSTED_ORIGINS=null` as an unset value so it no longer prevents Marinara Engine from opening (#5030).
 - Stopped removed or disabled Example Dialogue markers from silently injecting character examples into prompts (#5031).
 - Restored persona creation through Professor Mari by supplying the persona reference-image default expected by storage validation (#5033).

--- a/packages/client/src/components/chat/ConversationMessageShared.tsx
+++ b/packages/client/src/components/chat/ConversationMessageShared.tsx
@@ -526,7 +526,7 @@ export function ConversationMessageAttachments({
   const { t: localizeUi } = useUiTranslation();
   if (!attachments.length || IMAGE_URL_RE.test(renderedContent.trim())) return null;
   return (
-    <div className="mt-1.5 flex flex-col items-center gap-2">
+    <div className="mt-1.5 flex flex-col items-start gap-2">
       {attachments.map((att, i) =>
         att.type === "image" || att.type?.startsWith("image/") ? (
           <div key={i} className="group/att relative inline-block">


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5042

## Why this change

- Generated Conversation selfies were centered inside the message body on desktop, breaking alignment with the assistant text immediately above them.

## What changed

- Align Conversation message attachment stacks to the start edge.
- Add the user-facing fix to the Unreleased changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Pending desktop Conversation verification while this PR is in draft.
- `git diff --check` passed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Pending browser verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Desktop Conversation selfie images are now left-aligned with their message text.
  - Attachment content is aligned consistently to the start instead of centered.

- **Documentation**
  - Added an unreleased changelog entry describing the alignment improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->