### PR TITLE
fix(image): expand ComfyUI LoRA strength range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Expanded SwarmUI and ComfyUI LoRA strength controls from `-2..2` to `-100..100` so slider LoRAs can use their required weights (#5072).
 - Regex bundle imports now retain scripts flagged by the pattern-safety heuristic and show a warning instead of reporting those entries as skipped.
 - Kept NanoGPT Illustrator generation within its 4 MB reference-upload limit, preferred immediate hosted-result downloads, and hardened base64 fallback parsing so successful images are stored instead of rendering as broken output (#5058).
 - Kept Windows launcher updates from failing while protecting data by excluding the generated capability-package `node_modules` junction from update snapshots (#5052).

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -83,6 +83,8 @@ import {
   VIDEO_DEFAULTS_STORAGE_KEY,
   COMFYUI_SAMPLER_OPTIONS,
   COMFYUI_SCHEDULER_OPTIONS,
+  COMFYUI_LORA_STRENGTH_MIN,
+  COMFYUI_LORA_STRENGTH_MAX,
   NOVELAI_NOISE_SCHEDULE_OPTIONS,
   NOVELAI_SAMPLER_OPTIONS,
   SD_WEBUI_SAMPLER_OPTIONS,
@@ -3780,8 +3782,8 @@ function ComfyUiLoraSettings({
           <NumberSetting
             label={localizeUi("ui.connections.comfyuilorasettings.strength")}
             value={slot.strength}
-            min={-2}
-            max={2}
+            min={COMFYUI_LORA_STRENGTH_MIN}
+            max={COMFYUI_LORA_STRENGTH_MAX}
             integer={false}
             onCommit={(strength) => updateSlot(index, { strength })}
           />

--- a/packages/shared/src/constants/image-generation-defaults.ts
+++ b/packages/shared/src/constants/image-generation-defaults.ts
@@ -8,6 +8,8 @@ import type {
 
 export const IMAGE_DEFAULTS_STORAGE_KEY = "imageGeneration";
 export const IMAGE_GENERATION_DEFAULTS_VERSION = 1 as const;
+export const COMFYUI_LORA_STRENGTH_MIN = -100;
+export const COMFYUI_LORA_STRENGTH_MAX = 100;
 
 export const IMAGE_DEFAULTS_SERVICES: ImageDefaultsService[] = ["automatic1111", "comfyui", "novelai"];
 
@@ -319,7 +321,7 @@ export function normalizeComfyUiLoraSettings(rawLoras: unknown): ComfyUiDefaults
     const raw = isRecord(entry) ? entry : {};
     return {
       model: readString(raw.model, "").trim(),
-      strength: readNumber(raw.strength, 1, -2, 2),
+      strength: readNumber(raw.strength, 1, COMFYUI_LORA_STRENGTH_MIN, COMFYUI_LORA_STRENGTH_MAX),
     };
   });
 }

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -7827,8 +7827,9 @@ assert.equal(({} as { tags?: string[] }).tags, undefined, "Background metadata m
   assert.equal(explicitlyRequestsTextRewrite(undefined), false);
 }
 
-// Issue #4118 — ComfyUI exposes up to five LoRAs consistently to image and
-// video API-format workflows.
+// Issues #4118 and #5072 — ComfyUI exposes up to five LoRAs consistently to
+// image and video API-format workflows without clipping slider LoRA strengths
+// to the legacy -2..2 range.
 {
   const normalized = normalizeComfyUiLoraSettings([
     { model: "style-a.safetensors", strength: 1.25 },
@@ -7840,15 +7841,15 @@ assert.equal(({} as { tags?: string[] }).tags, undefined, "Background metadata m
   ]);
   assert.equal(normalized.length, 5);
   assert.equal(normalized[0]?.strength, 1.25);
-  assert.equal(normalized[1]?.strength, 2);
-  assert.equal(normalized[2]?.strength, -2);
+  assert.equal(normalized[1]?.strength, 99);
+  assert.equal(normalized[2]?.strength, -99);
   assert.deepEqual(buildComfyUiLoraWorkflowReplacements(normalized), {
     "%LORA_1%": "style-a.safetensors",
     "%LORA_1_strength%": 1.25,
     "%LORA_2%": "style-b.safetensors",
-    "%LORA_2_strength%": 2,
+    "%LORA_2_strength%": 99,
     "%LORA_3%": "style-c.safetensors",
-    "%LORA_3_strength%": -2,
+    "%LORA_3_strength%": -99,
     "%LORA_4%": "style-d.safetensors",
     "%LORA_4_strength%": 0.5,
     "%LORA_5%": "style-e.safetensors",

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -7831,6 +7831,17 @@ assert.equal(({} as { tags?: string[] }).tags, undefined, "Background metadata m
 // image and video API-format workflows without clipping slider LoRA strengths
 // to the legacy -2..2 range.
 {
+  const normalizedBounds = normalizeComfyUiLoraSettings([
+    { model: "upper-endpoint.safetensors", strength: 100 },
+    { model: "lower-endpoint.safetensors", strength: -100 },
+    { model: "above-range.safetensors", strength: 101 },
+    { model: "below-range.safetensors", strength: -101 },
+  ]);
+  assert.deepEqual(
+    normalizedBounds.map(({ strength }) => strength),
+    [100, -100, 100, -100],
+  );
+
   const normalized = normalizeComfyUiLoraSettings([
     { model: "style-a.safetensors", strength: 1.25 },
     { model: "style-b.safetensors", strength: 99 },


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository staging branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5072

## Why this change

- SwarmUI and ComfyUI slider LoRAs can require weights outside the legacy `-2..2` range, but both saved normalization and the editor silently clamped them.

## What changed

- Defined one shared `-100..100` LoRA strength range.
- Reused it in profile normalization and the connection editor.
- Updated the existing ComfyUI LoRA regression and changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passes.
- The focused open-issues regression passes and confirms `99` and `-99` survive normalization and workflow substitution.
- The connection-editor smoke paths pass in the broader UI suite; live browser verification remains for review because no in-app browser is attached to this session.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing docs or release metadata changes are expected; the existing connection control now accepts the wider backend-supported range.

## UI evidence (if applicable)

The shared range is consumed by the existing number control, so the UI and saved normalization cannot diverge. Manual field entry above `2` remains an unchecked review item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded ComfyUI and SwarmUI LoRA strength controls to support values from **-100 to 100**.
  * LoRA settings now preserve higher positive and negative strength values.

* **Documentation**
  * Added a changelog entry describing the expanded LoRA strength range.

* **Tests**
  * Updated regression coverage to verify strengths such as `99` and `-99` are retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->