### PR TITLE
fix(chat): keep docked Tracker beside Roleplay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Restored docked Tracker layout so the Roleplay transcript and composer resize beside the panel on either desktop edge instead of being covered by it (#5071).
 - Expanded SwarmUI and ComfyUI LoRA strength controls from `-2..2` to `-100..100` so slider LoRAs can use their required weights (#5072).
 - Regex bundle imports now retain scripts flagged by the pattern-safety heuristic and show a warning instead of reporting those entries as skipped.
 - Kept NanoGPT Illustrator generation within its 4 MB reference-upload limit, preferred immediate hosted-result downloads, and hardened base64 fallback parsing so successful images are stored instead of rendering as broken output (#5058).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -5582,12 +5582,13 @@ test("desktop Tracker docks beside the Roleplay chat on both sides", async ({ pa
     expect(rightTrackerBox!.x + rightTrackerBox!.width).toBeLessThanOrEqual(mainBox!.x + mainBox!.width + 1);
 
     await page.reload();
-    await expect(rightTracker).toBeVisible();
+    const reloadedTracker = page.locator('[data-component^="TrackerDataSidebarDesktop."]');
+    await expect(reloadedTracker).toBeVisible();
 
-    await rightTracker.getByRole("button", { name: "Close tracker panel" }).click();
-    await expect(rightTracker).toBeHidden();
+    await reloadedTracker.getByRole("button", { name: "Close tracker panel" }).click();
+    await expect(reloadedTracker).toBeHidden();
     await page.reload();
-    await expect(rightTracker).toBeHidden();
+    await expect(reloadedTracker).toBeHidden();
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`);
   }

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -5433,8 +5433,8 @@ test("new Roleplay chats seed character Tracker custom-field defaults without re
   }
 });
 
-test("desktop Tracker preserves its controls without shifting the chat column", async ({ page }, testInfo) => {
-  test.skip(!testInfo.project.name.includes("desktop"), "Desktop Tracker overlap behavior is covered on desktop.");
+test("desktop Tracker docks beside the Roleplay chat on both sides", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Desktop Tracker docking is covered on desktop.");
 
   // Keep this device-local layout test isolated from the shared settings
   // record used by the parallel browser project.
@@ -5499,14 +5499,13 @@ test("desktop Tracker preserves its controls without shifting the chat column", 
     expect(mainBox).not.toBeNull();
     expect(chatColumnAfter).not.toBeNull();
     expect(trackerBox).not.toBeNull();
-    expect(Math.abs(chatColumnAfter!.x - chatColumnBefore!.x)).toBeLessThanOrEqual(1);
-    expect(Math.abs(chatColumnAfter!.width - chatColumnBefore!.width)).toBeLessThanOrEqual(1);
-
     const expectedWidth = Math.min(420, Math.floor(mainBox!.width - 8));
     expect(Math.abs(trackerBox!.width - expectedWidth)).toBeLessThanOrEqual(1);
     expect(trackerBox!.x).toBeGreaterThanOrEqual(mainBox!.x - 1);
     expect(trackerBox!.x).toBeLessThanOrEqual(mainBox!.x + 1);
-    expect(trackerBox!.x + trackerBox!.width).toBeGreaterThan(chatColumnAfter!.x);
+    expect(chatColumnAfter!.x).toBeGreaterThan(chatColumnBefore!.x);
+    expect(chatColumnAfter!.width).toBeLessThan(chatColumnBefore!.width);
+    expect(trackerBox!.x + trackerBox!.width).toBeLessThanOrEqual(chatColumnAfter!.x - 7);
 
     const trackerContent = tracker.locator(".mari-tracker-panel-scroll");
     const expectedScale = Math.max(0.65, expectedWidth / 420);
@@ -5563,13 +5562,32 @@ test("desktop Tracker preserves its controls without shifting the chat column", 
     });
     expect(horizontalOverflow).toBeNull();
 
-    await page.reload();
-    await expect(tracker).toBeVisible();
+    await tracker.getByRole("button", { name: /Tracker panel anchored left\. Click to anchor right\./ }).click();
+    const rightTracker = page.locator('[data-component="TrackerDataSidebarDesktop.right"]');
+    await expect(rightTracker).toBeVisible();
+    await rightTracker.evaluate(async (element) => {
+      await Promise.all(
+        element.getAnimations({ subtree: true }).map((animation) => animation.finished.catch(() => undefined)),
+      );
+    });
+    const [rightChatColumn, rightTrackerBox] = await Promise.all([
+      chatColumn.boundingBox(),
+      rightTracker.boundingBox(),
+    ]);
+    expect(rightChatColumn).not.toBeNull();
+    expect(rightTrackerBox).not.toBeNull();
+    expect(rightChatColumn!.x).toBeLessThan(chatColumnBefore!.x);
+    expect(Math.abs(rightChatColumn!.width - chatColumnAfter!.width)).toBeLessThanOrEqual(1);
+    expect(rightChatColumn!.x + rightChatColumn!.width).toBeLessThanOrEqual(rightTrackerBox!.x - 7);
+    expect(rightTrackerBox!.x + rightTrackerBox!.width).toBeLessThanOrEqual(mainBox!.x + mainBox!.width + 1);
 
-    await tracker.getByRole("button", { name: "Close tracker panel" }).click();
-    await expect(tracker).toBeHidden();
     await page.reload();
-    await expect(tracker).toBeHidden();
+    await expect(rightTracker).toBeVisible();
+
+    await rightTracker.getByRole("button", { name: "Close tracker panel" }).click();
+    await expect(rightTracker).toBeHidden();
+    await page.reload();
+    await expect(rightTracker).toBeHidden();
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`);
   }

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -5476,6 +5476,7 @@ test("desktop Tracker docks beside the Roleplay chat on both sides", async ({ pa
 
     const main = page.locator('[data-component="CenterContent"]');
     const chatColumn = page.locator('[data-roleplay-chat-column="true"]');
+    const chatScroll = page.locator("[data-chat-scroll]");
     const trackerToggle = page.locator('[data-tracker-panel-toggle="roleplay-hud"]:visible').first();
     await expect(chatColumn).toBeVisible();
     await expect(trackerToggle).toBeVisible();
@@ -5491,13 +5492,15 @@ test("desktop Tracker docks beside the Roleplay chat on both sides", async ({ pa
       );
     });
 
-    const [mainBox, chatColumnAfter, trackerBox] = await Promise.all([
+    const [mainBox, chatColumnAfter, chatScrollAfter, trackerBox] = await Promise.all([
       main.boundingBox(),
       chatColumn.boundingBox(),
+      chatScroll.boundingBox(),
       tracker.boundingBox(),
     ]);
     expect(mainBox).not.toBeNull();
     expect(chatColumnAfter).not.toBeNull();
+    expect(chatScrollAfter).not.toBeNull();
     expect(trackerBox).not.toBeNull();
     const expectedWidth = Math.min(420, Math.floor(mainBox!.width - 8));
     expect(Math.abs(trackerBox!.width - expectedWidth)).toBeLessThanOrEqual(1);
@@ -5506,6 +5509,7 @@ test("desktop Tracker docks beside the Roleplay chat on both sides", async ({ pa
     expect(chatColumnAfter!.x).toBeGreaterThan(chatColumnBefore!.x);
     expect(chatColumnAfter!.width).toBeLessThan(chatColumnBefore!.width);
     expect(trackerBox!.x + trackerBox!.width).toBeLessThanOrEqual(chatColumnAfter!.x - 7);
+    expect(trackerBox!.x + trackerBox!.width).toBeLessThanOrEqual(chatScrollAfter!.x - 7);
 
     const trackerContent = tracker.locator(".mari-tracker-panel-scroll");
     const expectedScale = Math.max(0.65, expectedWidth / 420);
@@ -5570,15 +5574,18 @@ test("desktop Tracker docks beside the Roleplay chat on both sides", async ({ pa
         element.getAnimations({ subtree: true }).map((animation) => animation.finished.catch(() => undefined)),
       );
     });
-    const [rightChatColumn, rightTrackerBox] = await Promise.all([
+    const [rightChatColumn, rightChatScroll, rightTrackerBox] = await Promise.all([
       chatColumn.boundingBox(),
+      chatScroll.boundingBox(),
       rightTracker.boundingBox(),
     ]);
     expect(rightChatColumn).not.toBeNull();
+    expect(rightChatScroll).not.toBeNull();
     expect(rightTrackerBox).not.toBeNull();
     expect(rightChatColumn!.x).toBeLessThan(chatColumnBefore!.x);
     expect(Math.abs(rightChatColumn!.width - chatColumnAfter!.width)).toBeLessThanOrEqual(1);
     expect(rightChatColumn!.x + rightChatColumn!.width).toBeLessThanOrEqual(rightTrackerBox!.x - 7);
+    expect(rightChatScroll!.x + rightChatScroll!.width).toBeLessThanOrEqual(rightTrackerBox!.x - 7);
     expect(rightTrackerBox!.x + rightTrackerBox!.width).toBeLessThanOrEqual(mainBox!.x + mainBox!.width + 1);
 
     await page.reload();

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -148,6 +148,8 @@ const ActiveLorebookEntriesContent = lazy(async () => {
   return { default: module.ActiveLorebookEntriesContent };
 });
 
+const TRACKER_FOREGROUND_AVOIDANCE_CLASS =
+  "md:pl-[var(--tracker-panel-chat-clear-left)] md:pr-[var(--tracker-panel-chat-clear-right)] md:transition-[padding] md:duration-200 md:ease-[cubic-bezier(0.16,1,0.3,1)]";
 const roleplayNotificationSeenKeys = new Set<string>();
 const MOBILE_FLOATING_PANEL_PADDING = 8;
 
@@ -2145,7 +2147,10 @@ export function ChatRoleplaySurface({
               </Suspense>
             )}
 
-            <div data-chat-resource-drop-surface className="absolute inset-0 z-10 overflow-hidden">
+            <div
+              data-chat-resource-drop-surface
+              className={cn("absolute inset-0 z-10 overflow-hidden", TRACKER_FOREGROUND_AVOIDANCE_CLASS)}
+            >
               <div
                 ref={scrollRef}
                 data-chat-scroll
@@ -2320,7 +2325,13 @@ export function ChatRoleplaySurface({
             </div>
             <PinnedImageOverlay activeChatId={activeChatId} includeSceneVideos />
 
-            <div ref={inputChromeRef} className="pointer-events-none absolute inset-x-0 bottom-0 z-30">
+            <div
+              ref={inputChromeRef}
+              className={cn(
+                "pointer-events-none absolute inset-x-0 bottom-0 z-30",
+                TRACKER_FOREGROUND_AVOIDANCE_CLASS,
+              )}
+            >
               <div
                 data-roleplay-chat-column="true"
                 className="mari-roleplay-input-column pointer-events-auto relative mx-auto px-3 md:px-0"

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -1126,6 +1126,10 @@ export function AppShell() {
     !shellOverlayMode && trackerPanelAnchoredForMotion && trackerPanelSurfaceAvailable
       ? trackerPanelResolvedWidth + TRACKER_PANEL_HUD_GAP
       : 0;
+  const trackerPanelChatClearance =
+    !shellOverlayMode && trackerPanelAnchoredForMotion && trackerPanelSurfaceAvailable
+      ? trackerPanelResolvedWidth + TRACKER_PANEL_CHAT_GAP
+      : 0;
   const trackerPanelHudClearance = trackerPanelHideHudWidgets ? trackerPanelOverlayClearance : 0;
   const trackerPanelContentScale = resolveTrackerPanelContentScale(trackerPanelWidth, trackerPanelResolvedWidth);
   const trackerPanelPortal =
@@ -1340,8 +1344,8 @@ export function AppShell() {
               {
                 "--tracker-panel-hud-clear-left": `${trackerPanelSide === "left" ? trackerPanelHudClearance : 0}px`,
                 "--tracker-panel-hud-clear-right": `${trackerPanelSide === "right" ? trackerPanelHudClearance : 0}px`,
-                "--tracker-panel-chat-clear-left": `${trackerPanelSide === "left" ? trackerPanelOverlayClearance : 0}px`,
-                "--tracker-panel-chat-clear-right": `${trackerPanelSide === "right" ? trackerPanelOverlayClearance : 0}px`,
+                "--tracker-panel-chat-clear-left": `${trackerPanelSide === "left" ? trackerPanelChatClearance : 0}px`,
+                "--tracker-panel-chat-clear-right": `${trackerPanelSide === "right" ? trackerPanelChatClearance : 0}px`,
                 "--tracker-panel-overlay-clearance": `${trackerPanelOverlayClearance}px`,
               } as CSSProperties
             }

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -1340,6 +1340,8 @@ export function AppShell() {
               {
                 "--tracker-panel-hud-clear-left": `${trackerPanelSide === "left" ? trackerPanelHudClearance : 0}px`,
                 "--tracker-panel-hud-clear-right": `${trackerPanelSide === "right" ? trackerPanelHudClearance : 0}px`,
+                "--tracker-panel-chat-clear-left": `${trackerPanelSide === "left" ? trackerPanelOverlayClearance : 0}px`,
+                "--tracker-panel-chat-clear-right": `${trackerPanelSide === "right" ? trackerPanelOverlayClearance : 0}px`,
                 "--tracker-panel-overlay-clearance": `${trackerPanelOverlayClearance}px`,
               } as CSSProperties
             }


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository staging branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5071

## Why this change

- Docked desktop Tracker panels currently cover the Roleplay transcript and composer, making chat content unreadable beneath either dock edge.

## What changed

- Restored side-aware desktop padding for the Roleplay transcript and composer while the Tracker is docked.
- Reused the already resolved panel width, including the existing gap and animation hold.
- Updated the desktop smoke test to require non-overlap on both left and right docking.
- Added the user-facing changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passes, including localization, lint, type-checking, and production builds.
- The isolated desktop Playwright smoke passes and verifies the transcript/composer clear both left and right Tracker edges.
- The same smoke covers panel controls, content overflow, reload, and close persistence.
- Live in-app browser inspection remains an unchecked review item because no in-app browser is attached to this session.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing documentation or release metadata changes are needed. The changelog records the restored behavior.

## UI evidence (if applicable)

The focused desktop smoke verifies non-overlap geometrically on both dock sides at a 1200 × 900 viewport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restored the docked Tracker layout, allowing the Roleplay transcript and composer to resize around the panel on either desktop edge.
  * Improved chat spacing and animated transitions when the Tracker is docked on the left or right.

* **Bug Fixes**
  * Prevented the Tracker panel from overlapping chat content and controls.

* **Tests**
  * Added coverage for Tracker placement, resizing, reload, and close-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->