### PR TITLE
Fix Tracker gutter scaling without shifting Roleplay chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
-- Restored docked Tracker layout so the Roleplay transcript and composer resize beside the panel on either desktop edge instead of being covered by it (#5071).
+- Restored docked Tracker gutter scaling so the panel and all of its contents fit beside the centered Roleplay chat on either desktop edge without moving the transcript, composer, or scrollbar (#5071).
 - Expanded SwarmUI and ComfyUI LoRA strength controls from `-2..2` to `-100..100` so slider LoRAs can use their required weights (#5072).
 - Regex bundle imports now retain scripts flagged by the pattern-safety heuristic and show a warning instead of reporting those entries as skipped.
 - Kept NanoGPT Illustrator generation within its 4 MB reference-upload limit, preferred immediate hosted-result downloads, and hardened base64 fallback parsing so successful images are stored instead of rendering as broken output (#5058).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -5511,14 +5511,14 @@ test("desktop Tracker scales into either Roleplay gutter without shifting chat",
     expect(Math.abs(chatScrollAfter!.x - chatScrollBefore!.x)).toBeLessThanOrEqual(1);
     expect(Math.abs(chatScrollAfter!.width - chatScrollBefore!.width)).toBeLessThanOrEqual(1);
 
-    const expectedWidth = Math.min(420, Math.floor(chatColumnAfter!.x - mainBox!.x - 8));
+    const expectedWidth = Math.max(0, Math.min(420, Math.floor(chatColumnAfter!.x - mainBox!.x - 8)));
     expect(Math.abs(trackerBox!.width - expectedWidth)).toBeLessThanOrEqual(1);
     expect(trackerBox!.x).toBeGreaterThanOrEqual(mainBox!.x - 1);
     expect(trackerBox!.x).toBeLessThanOrEqual(mainBox!.x + 1);
     expect(trackerBox!.x + trackerBox!.width).toBeLessThanOrEqual(chatColumnAfter!.x - 7);
 
     const trackerContent = tracker.locator(".mari-tracker-panel-scroll");
-    const expectedScale = Math.max(0.65, expectedWidth / 420);
+    const expectedScale = expectedWidth === 0 ? 1 : Math.max(0.65, expectedWidth / 420);
     const appliedScale = Number(await trackerContent.getAttribute("data-tracker-content-scale"));
     expect(Math.abs(appliedScale - expectedScale)).toBeLessThanOrEqual(0.001);
     const emptyTrackerText = tracker.getByText("No enabled tracker panels.", { exact: true });
@@ -5593,16 +5593,16 @@ test("desktop Tracker scales into either Roleplay gutter without shifting chat",
     expect(Math.abs(rightChatScroll!.x - chatScrollBefore!.x)).toBeLessThanOrEqual(1);
     expect(Math.abs(rightChatScroll!.width - chatScrollBefore!.width)).toBeLessThanOrEqual(1);
 
-    const expectedRightWidth = Math.min(
-      420,
-      Math.floor(mainBox!.x + mainBox!.width - (rightChatColumn!.x + rightChatColumn!.width) - 8),
+    const expectedRightWidth = Math.max(
+      0,
+      Math.min(420, Math.floor(mainBox!.x + mainBox!.width - (rightChatColumn!.x + rightChatColumn!.width) - 8)),
     );
     expect(Math.abs(rightTrackerBox!.width - expectedRightWidth)).toBeLessThanOrEqual(1);
     expect(rightTrackerBox!.x).toBeGreaterThanOrEqual(rightChatColumn!.x + rightChatColumn!.width + 7);
     expect(rightTrackerBox!.x + rightTrackerBox!.width).toBeLessThanOrEqual(mainBox!.x + mainBox!.width + 1);
 
     const rightTrackerContent = rightTracker.locator(".mari-tracker-panel-scroll");
-    const expectedRightScale = Math.max(0.65, expectedRightWidth / 420);
+    const expectedRightScale = expectedRightWidth === 0 ? 1 : Math.max(0.65, expectedRightWidth / 420);
     const appliedRightScale = Number(await rightTrackerContent.getAttribute("data-tracker-content-scale"));
     expect(Math.abs(appliedRightScale - expectedRightScale)).toBeLessThanOrEqual(0.001);
     const rightTrackerContentBox = await rightTrackerContent.boundingBox();

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -5433,8 +5433,8 @@ test("new Roleplay chats seed character Tracker custom-field defaults without re
   }
 });
 
-test("desktop Tracker docks beside the Roleplay chat on both sides", async ({ page }, testInfo) => {
-  test.skip(!testInfo.project.name.includes("desktop"), "Desktop Tracker docking is covered on desktop.");
+test("desktop Tracker scales into either Roleplay gutter without shifting chat", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Desktop Tracker gutter behavior is covered on desktop.");
 
   // Keep this device-local layout test isolated from the shared settings
   // record used by the parallel browser project.
@@ -5480,8 +5480,12 @@ test("desktop Tracker docks beside the Roleplay chat on both sides", async ({ pa
     const trackerToggle = page.locator('[data-tracker-panel-toggle="roleplay-hud"]:visible').first();
     await expect(chatColumn).toBeVisible();
     await expect(trackerToggle).toBeVisible();
-    const chatColumnBefore = await chatColumn.boundingBox();
+    const [chatColumnBefore, chatScrollBefore] = await Promise.all([
+      chatColumn.boundingBox(),
+      chatScroll.boundingBox(),
+    ]);
     expect(chatColumnBefore).not.toBeNull();
+    expect(chatScrollBefore).not.toBeNull();
 
     await trackerToggle.click();
     const tracker = page.locator('[data-component="TrackerDataSidebarDesktop.left"]');
@@ -5502,14 +5506,16 @@ test("desktop Tracker docks beside the Roleplay chat on both sides", async ({ pa
     expect(chatColumnAfter).not.toBeNull();
     expect(chatScrollAfter).not.toBeNull();
     expect(trackerBox).not.toBeNull();
-    const expectedWidth = Math.min(420, Math.floor(mainBox!.width - 8));
+    expect(Math.abs(chatColumnAfter!.x - chatColumnBefore!.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(chatColumnAfter!.width - chatColumnBefore!.width)).toBeLessThanOrEqual(1);
+    expect(Math.abs(chatScrollAfter!.x - chatScrollBefore!.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(chatScrollAfter!.width - chatScrollBefore!.width)).toBeLessThanOrEqual(1);
+
+    const expectedWidth = Math.min(420, Math.floor(chatColumnAfter!.x - mainBox!.x - 8));
     expect(Math.abs(trackerBox!.width - expectedWidth)).toBeLessThanOrEqual(1);
     expect(trackerBox!.x).toBeGreaterThanOrEqual(mainBox!.x - 1);
     expect(trackerBox!.x).toBeLessThanOrEqual(mainBox!.x + 1);
-    expect(chatColumnAfter!.x).toBeGreaterThan(chatColumnBefore!.x);
-    expect(chatColumnAfter!.width).toBeLessThan(chatColumnBefore!.width);
     expect(trackerBox!.x + trackerBox!.width).toBeLessThanOrEqual(chatColumnAfter!.x - 7);
-    expect(trackerBox!.x + trackerBox!.width).toBeLessThanOrEqual(chatScrollAfter!.x - 7);
 
     const trackerContent = tracker.locator(".mari-tracker-panel-scroll");
     const expectedScale = Math.max(0.65, expectedWidth / 420);
@@ -5582,11 +5588,29 @@ test("desktop Tracker docks beside the Roleplay chat on both sides", async ({ pa
     expect(rightChatColumn).not.toBeNull();
     expect(rightChatScroll).not.toBeNull();
     expect(rightTrackerBox).not.toBeNull();
-    expect(rightChatColumn!.x).toBeLessThan(chatColumnBefore!.x);
-    expect(Math.abs(rightChatColumn!.width - chatColumnAfter!.width)).toBeLessThanOrEqual(1);
-    expect(rightChatColumn!.x + rightChatColumn!.width).toBeLessThanOrEqual(rightTrackerBox!.x - 7);
-    expect(rightChatScroll!.x + rightChatScroll!.width).toBeLessThanOrEqual(rightTrackerBox!.x - 7);
+    expect(Math.abs(rightChatColumn!.x - chatColumnBefore!.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(rightChatColumn!.width - chatColumnBefore!.width)).toBeLessThanOrEqual(1);
+    expect(Math.abs(rightChatScroll!.x - chatScrollBefore!.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(rightChatScroll!.width - chatScrollBefore!.width)).toBeLessThanOrEqual(1);
+
+    const expectedRightWidth = Math.min(
+      420,
+      Math.floor(mainBox!.x + mainBox!.width - (rightChatColumn!.x + rightChatColumn!.width) - 8),
+    );
+    expect(Math.abs(rightTrackerBox!.width - expectedRightWidth)).toBeLessThanOrEqual(1);
+    expect(rightTrackerBox!.x).toBeGreaterThanOrEqual(rightChatColumn!.x + rightChatColumn!.width + 7);
     expect(rightTrackerBox!.x + rightTrackerBox!.width).toBeLessThanOrEqual(mainBox!.x + mainBox!.width + 1);
+
+    const rightTrackerContent = rightTracker.locator(".mari-tracker-panel-scroll");
+    const expectedRightScale = Math.max(0.65, expectedRightWidth / 420);
+    const appliedRightScale = Number(await rightTrackerContent.getAttribute("data-tracker-content-scale"));
+    expect(Math.abs(appliedRightScale - expectedRightScale)).toBeLessThanOrEqual(0.001);
+    const rightTrackerContentBox = await rightTrackerContent.boundingBox();
+    expect(rightTrackerContentBox).not.toBeNull();
+    expect(rightTrackerContentBox!.x).toBeGreaterThanOrEqual(rightTrackerBox!.x - 1);
+    expect(rightTrackerContentBox!.x + rightTrackerContentBox!.width).toBeLessThanOrEqual(
+      rightTrackerBox!.x + rightTrackerBox!.width + 1,
+    );
 
     await page.reload();
     const reloadedTracker = page.locator('[data-component^="TrackerDataSidebarDesktop."]');

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -148,8 +148,6 @@ const ActiveLorebookEntriesContent = lazy(async () => {
   return { default: module.ActiveLorebookEntriesContent };
 });
 
-const TRACKER_FOREGROUND_AVOIDANCE_CLASS =
-  "md:pl-[var(--tracker-panel-chat-clear-left)] md:pr-[var(--tracker-panel-chat-clear-right)] md:transition-[padding] md:duration-200 md:ease-[cubic-bezier(0.16,1,0.3,1)]";
 const roleplayNotificationSeenKeys = new Set<string>();
 const MOBILE_FLOATING_PANEL_PADDING = 8;
 
@@ -2147,10 +2145,7 @@ export function ChatRoleplaySurface({
               </Suspense>
             )}
 
-            <div
-              data-chat-resource-drop-surface
-              className={cn("absolute inset-0 z-10 overflow-hidden", TRACKER_FOREGROUND_AVOIDANCE_CLASS)}
-            >
+            <div data-chat-resource-drop-surface className="absolute inset-0 z-10 overflow-hidden">
               <div
                 ref={scrollRef}
                 data-chat-scroll
@@ -2325,13 +2320,7 @@ export function ChatRoleplaySurface({
             </div>
             <PinnedImageOverlay activeChatId={activeChatId} includeSceneVideos />
 
-            <div
-              ref={inputChromeRef}
-              className={cn(
-                "pointer-events-none absolute inset-x-0 bottom-0 z-30",
-                TRACKER_FOREGROUND_AVOIDANCE_CLASS,
-              )}
-            >
+            <div ref={inputChromeRef} className="pointer-events-none absolute inset-x-0 bottom-0 z-30">
               <div
                 data-roleplay-chat-column="true"
                 className="mari-roleplay-input-column pointer-events-auto relative mx-auto px-3 md:px-0"

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -388,6 +388,7 @@ export function AppShell() {
   const liveRightPanelWidth = rightPanelDragWidth ?? sidebarDragWidth ?? sharedSidebarWidth;
   const trackerPanelWidth = getTrackerPanelWidthForProfile(trackerPanelSizeProfile);
   const [trackerPanelResolvedWidth, setTrackerPanelResolvedWidth] = useState(trackerPanelWidth);
+  const [trackerPanelWidthMeasured, setTrackerPanelWidthMeasured] = useState(false);
   const [trackerPanelWindowTarget, setTrackerPanelWindowTarget] = useState<TrackerPanelWindowTarget | null>(null);
   const trackerPanelWindowTargetRef = useRef<TrackerPanelWindowTarget | null>(null);
   const trackerPanelDockingPopupRef = useRef<TrackerPanelWindowTarget["popup"] | null>(null);
@@ -1053,9 +1054,11 @@ export function AppShell() {
   useLayoutEffect(() => {
     if (shellOverlayMode || !trackerPanelSurfaceAvailable || !trackerPanelAnchoredForMotion) {
       setTrackerPanelResolvedWidth(trackerPanelWidth);
+      setTrackerPanelWidthMeasured(false);
       return;
     }
 
+    setTrackerPanelWidthMeasured(false);
     let frame = 0;
     let discoveryObserver: MutationObserver | null = null;
     let observedChatColumn: HTMLElement | null = null;
@@ -1067,7 +1070,7 @@ export function AppShell() {
       const chatColumnRect = chatColumn ? readVisibleElementRect(chatColumn) : null;
 
       if (!mainRect || !chatColumn || !chatColumnRect) {
-        setTrackerPanelResolvedWidth(trackerPanelWidth);
+        setTrackerPanelWidthMeasured(false);
         return false;
       }
 
@@ -1081,6 +1084,7 @@ export function AppShell() {
         gap: TRACKER_PANEL_CHAT_GAP,
       });
       setTrackerPanelResolvedWidth((current) => (current === nextWidth ? current : nextWidth));
+      setTrackerPanelWidthMeasured(true);
 
       if (observedChatColumn !== chatColumn) {
         if (observedChatColumn) observer.unobserve(observedChatColumn);
@@ -1159,7 +1163,7 @@ export function AppShell() {
     );
 
   const trackerPanelDesktop = (side: "left" | "right") =>
-    trackerPanelVisible && trackerPanelSide === side ? (
+    trackerPanelVisible && trackerPanelWidthMeasured && trackerPanelSide === side ? (
       <motion.aside
         key={`tracker-${side}`}
         initial={{

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -1126,10 +1126,6 @@ export function AppShell() {
     !shellOverlayMode && trackerPanelAnchoredForMotion && trackerPanelSurfaceAvailable
       ? trackerPanelResolvedWidth + TRACKER_PANEL_HUD_GAP
       : 0;
-  const trackerPanelChatClearance =
-    !shellOverlayMode && trackerPanelAnchoredForMotion && trackerPanelSurfaceAvailable
-      ? trackerPanelResolvedWidth + TRACKER_PANEL_CHAT_GAP
-      : 0;
   const trackerPanelHudClearance = trackerPanelHideHudWidgets ? trackerPanelOverlayClearance : 0;
   const trackerPanelContentScale = resolveTrackerPanelContentScale(trackerPanelWidth, trackerPanelResolvedWidth);
   const trackerPanelPortal =
@@ -1344,8 +1340,6 @@ export function AppShell() {
               {
                 "--tracker-panel-hud-clear-left": `${trackerPanelSide === "left" ? trackerPanelHudClearance : 0}px`,
                 "--tracker-panel-hud-clear-right": `${trackerPanelSide === "right" ? trackerPanelHudClearance : 0}px`,
-                "--tracker-panel-chat-clear-left": `${trackerPanelSide === "left" ? trackerPanelChatClearance : 0}px`,
-                "--tracker-panel-chat-clear-right": `${trackerPanelSide === "right" ? trackerPanelChatClearance : 0}px`,
                 "--tracker-panel-overlay-clearance": `${trackerPanelOverlayClearance}px`,
               } as CSSProperties
             }

--- a/packages/client/src/lib/tracker-panel-layout.ts
+++ b/packages/client/src/lib/tracker-panel-layout.ts
@@ -8,14 +8,18 @@ interface TrackerPanelDesktopWidthInput {
   gap?: number;
 }
 
-/** Preserve the requested Tracker width, constraining it only to the main viewport. */
+/** Keep the desktop Tracker inside the free gutter beside the centered Roleplay chat column. */
 export function resolveTrackerPanelDesktopWidth({
   preferredWidth,
   mainLeft,
   mainRight,
+  chatColumnLeft,
+  chatColumnRight,
+  side,
   gap = 0,
 }: TrackerPanelDesktopWidthInput) {
-  return Math.max(0, Math.min(preferredWidth, Math.floor(mainRight - mainLeft - gap)));
+  const gutterWidth = side === "left" ? chatColumnLeft - mainLeft : mainRight - chatColumnRight;
+  return Math.max(0, Math.min(preferredWidth, Math.floor(gutterWidth - gap)));
 }
 
 /** Scale constrained Tracker contents while retaining a readable lower bound and responsive reflow. */

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -7514,8 +7514,8 @@ assert.equal(
     side: "left",
     gap: 8,
   }),
-  420,
-  "The Tracker may overlap the chat instead of crushing its controls into a narrow gutter",
+  128,
+  "The Tracker should shrink to the narrower left chat gutter",
 );
 assert.equal(
   resolveTrackerPanelDesktopWidth({
@@ -7527,8 +7527,8 @@ assert.equal(
     side: "right",
     gap: 8,
   }),
-  340,
-  "The right-side Tracker should preserve its selected width when the main viewport can hold it",
+  128,
+  "The Tracker should use the matching right chat gutter",
 );
 assert.equal(resolveTrackerPanelContentScale(340, 340), 1);
 assert.equal(resolveTrackerPanelContentScale(340, 255), 0.75);


### PR DESCRIPTION
## Why

The previous fix for #5071 moved the centered Roleplay transcript, composer, and scrollbar to clear the docked Tracker. The intended behavior is for the Tracker itself—and all of its content—to scale into the free desktop gutter while the chat stays centered.

## What changed

- Restore Tracker width resolution against the actual left or right chat gutter.
- Remove Tracker-driven padding from the Roleplay transcript and composer surfaces.
- Preserve the existing responsive content scale for Tracker text, images, and controls.
- Cover both dock sides and unchanged chat/scroll geometry in the desktop browser regression.
- Correct the changelog entry introduced by the previous fix.

Closes #5071

## Automated evidence

- `pnpm check` — passed
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts` — passed
- Focused desktop Playwright checks for Tracker gutter geometry and Echo Chamber persistence — 2 passed

## Manual verification

- [ ] Manually verify Tracker text, images, and controls at narrow desktop gutter widths.
- [ ] Manually verify the Roleplay scrollbar remains at its normal edge with Tracker and Echo Chamber open.

Manual verification boxes are intentionally left unchecked for maintainers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tracker panel sizing in desktop Roleplay layouts.
  * Tracker panels now fit within the available gutter on either side of centered chat without shifting or resizing the transcript, composer, or scrollbar.
  * Restored proper gutter scaling so panel contents remain within their available space.

* **Tests**
  * Added coverage for left- and right-side Tracker placement, sizing, scaling, and chat stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->