### PR TITLE
feat(game): Experience combat seam — combatActive, combatStyle, requestCombat (Capability API 1.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added capability API 1.11 Experience combat seam: `game-surface` packages receive `combatActive` (true the instant the built-in combat UI mounts, unlike the lagging narrative scene state), the effective `combatStyle`, and `requestCombat()` — which routes into the same encounter-generation pass as the manual Start Combat button, minus the confirm dialog; packages still cannot supply combatants or combat state (#5094).
 - Added capability API 1.10 package assets: an Agent package manifest may declare `contributions.assets.paths`, and the Engine serves those image and JSON files over `/api/capability-packages/<id>/assets/<path>` with per-request hash verification, a passive content-type allowlist, and cheap `ETag`/`304` revalidation — so a package (for example a Game experience) can ship tilesets and sprite atlases instead of inlining art into its client bundle (#5091).
 - Agent package client bundles and assets now carry strong ETags derived from their manifest hashes and answer revalidations with `304 Not Modified`, so an unchanged package no longer re-downloads in full on every app load (#5082).
 - Let Professor Mari read your chat history: attach a chat from the composer's attach menu — sharing all, a range, or the last N messages — so Mari can see your roleplay and give grounded feedback, with a Context Viewer to review and remove what's attached to free up tokens (#5073).

--- a/docs/development/optional-agent-packages.md
+++ b/docs/development/optional-agent-packages.md
@@ -113,6 +113,28 @@ asset URLs as `/api/capability-packages/<packageId>/assets/<path>` (optionally k
 `?v=<packageVersion>` so a version bump busts any intermediary cache) without re-fetching the
 installed list or scraping its own import URL.
 
+### Capability API 1.11 Experience combat seam
+
+Capability API 1.11 adds a combat seam to the `game-surface` capability props. `combatActive`
+reports the instant the built-in combat UI actually mounts — unlike `chatMeta.gameActiveState`,
+the GM's narrative scene state, which lags the flip and can say "combat" without any encounter
+existing — and `combatStyle` carries the effective style (`classic` or `tactical`).
+`requestCombat()` asks the Engine to generate an encounter through the exact pass the manual
+Start Combat button uses, minus the confirm dialog, since the Experience's own interface already
+expressed the intent; the Engine's generation pass still decides what the encounter is.
+Deliberately absent: any way for a package to supply combatants or combat state directly —
+combat stays Engine-owned.
+
+`requestCombat()` is identity-stable, silent on the package path, and returns a code the
+Experience renders its own feedback from: `"started"`, or a refusal — `"combat-active"`,
+`"pending"` (a generation is already in flight), `"no-turn"` (the GM has not written a turn
+yet), or `"unavailable"` (concluded session or replay). `combatPending` and `combatError`
+mirror the generation's progress and failure so a package is never left waiting on
+`combatActive` after a failed generation. Like the 1.7/1.8 seams (and unlike the hard-gated
+1.10 `contributions.assets`), these props are delivered to every `game-surface` package
+regardless of the `capabilityApi` it declares — the 1.11 label marks when they appeared, so a
+package that *requires* them declares 1.11 and older Engines refuse it cleanly.
+
 ## Initial packages
 
 - all currently built-in agents;

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -6582,63 +6582,8 @@ function GameSurfaceComponent({
     [clearPendingInteractiveCommands, sendMessage],
   );
 
-  // Engine state handed to the slot, recomputed per turn so the surface tracks streaming and new
-  // messages. Builds nothing unless the surface is mounted, so a Classic game never pays for it.
-  const experienceSurfaceProps = useMemo(
-    () =>
-      !experienceSurfaceActive
-        ? undefined
-        : {
-            chatId: activeChatId,
-            chatMeta,
-            messages,
-            latestAssistant: latestAssistantMsg,
-            isStreaming,
-            scopedAssetMap,
-            sendMessage: sendExperienceMessage,
-            setExperienceBackgroundTag: pushExperienceBackground,
-            setExperienceSpeakerAvatars,
-            setExperienceChrome,
-            // Who is speaking RIGHT NOW, as the narration plays. Deriving it from the turn text instead yields
-            // only the LAST speaker of the turn, which leaves a VN sprite stuck on whoever spoke last.
-            activeSpeaker: activeSpeaker
-              ? { name: activeSpeaker.name, expression: activeSpeaker.expression ?? null }
-              : null,
-            experienceChoiceSlotEl,
-            // Per-turn state, so the surface can hold its menu until the narration finishes.
-            narrationDone,
-            latestNarrationText,
-            scenePreparing,
-            directionsPlaying,
-            assetGenerationBlocksScene,
-            replayActive,
-            sessionInteractive: (chatMeta.gameSessionStatus as string) !== "concluded",
-            // The host's sprite-size setting, so the player's slider keeps working in this mode.
-            spriteScale: gameFullBodySpriteScale,
-          },
-    [
-      experienceSurfaceActive,
-      activeChatId,
-      chatMeta,
-      messages,
-      latestAssistantMsg,
-      isStreaming,
-      scopedAssetMap,
-      sendExperienceMessage,
-      pushExperienceBackground,
-      setExperienceSpeakerAvatars,
-      setExperienceChrome,
-      activeSpeaker,
-      experienceChoiceSlotEl,
-      narrationDone,
-      latestNarrationText,
-      scenePreparing,
-      directionsPlaying,
-      assetGenerationBlocksScene,
-      replayActive,
-      gameFullBodySpriteScale,
-    ],
-  );
+  // experienceSurfaceProps (the engine state handed to the surface slot) is declared further down,
+  // after the combat seam it now carries — see the memo next to classicCombatStarter.
 
   // Game mutations
   const createGame = useCreateGame();
@@ -8060,6 +8005,18 @@ function GameSurfaceComponent({
     (chatMeta.gameCombatStyle as GameCombatStyle | undefined) ??
     (combatSetupConfig?.combatStyle as GameCombatStyle | undefined) ??
     "classic";
+  // Live snapshot for the identity-stable combat seam (#5094): a package may
+  // cache requestCombat at mount, so the callback must read CURRENT values, not
+  // its creation render's closure. messageId rides latestAssistantMsgRef.
+  const combatSeamRef = useRef({ combatUiActive: false, concluded: false, replayActive: false });
+  useEffect(() => {
+    combatSeamRef.current.combatUiActive = combatUiActive;
+    combatSeamRef.current.concluded = (chatMeta.gameSessionStatus as string) === "concluded";
+    combatSeamRef.current.replayActive = replayActive;
+  });
+  /** Synchronous in-flight flag beside the async combatGenerationPending state:
+   *  same-frame double requests all read the stale state, the ref does not. */
+  const combatGenerationInFlightRef = useRef(false);
   const tacticalCombatActive = combatUiActive && effectiveCombatStyle === "tactical";
   const topOverlayOffsetClass = "top-3";
   const queuedCombatMatchesLatest =
@@ -8174,11 +8131,15 @@ function GameSurfaceComponent({
 
   const generateCombatStateForMessage = useCallback(
     (messageId: string) => {
-      if (combatGenerationPending) return;
+      // Both guards: the state flag drives rendering, but it is stale within a
+      // frame — same-frame double calls (a package spamming requestCombat, #5094)
+      // all read false. The ref flips synchronously and clears with the request.
+      if (combatGenerationPending || combatGenerationInFlightRef.current) return;
       const debugMode = useUIStore.getState().debugMode;
       if (debugMode) {
         console.warn("[game-combat] Starting combat state generation", { chatId: activeChatId, messageId });
       }
+      combatGenerationInFlightRef.current = true;
       setCombatGenerationError(null);
       setCombatGenerationPending(true);
       api
@@ -8303,7 +8264,10 @@ function GameSurfaceComponent({
           setCombatGenerationError(message);
           toast.error(localizeUi("ui.game.gamesurfacecomponent.value1UseTheCombatButtonToRetry", { value1: message }));
         })
-        .finally(() => setCombatGenerationPending(false));
+        .finally(() => {
+          combatGenerationInFlightRef.current = false;
+          setCombatGenerationPending(false);
+        });
     },
     [
       activeChatId,
@@ -8490,7 +8454,49 @@ function GameSurfaceComponent({
     generateCombatStateForMessage(messageId);
   }, [generateCombatStateForMessage, latestAssistantMsg?.id, queuedCombatGeneration?.messageId, localizeUi]);
 
+  /** Keeps the identity-stable combat seam pointing at the CURRENT generator
+   *  (whose own identity tracks its render-state deps). */
+  const generateCombatRef = useRef(generateCombatStateForMessage);
+  useEffect(() => {
+    generateCombatRef.current = generateCombatStateForMessage;
+  });
+
+  /** Shared combat-start core (#5094): the manual button (after its confirm dialog) and an
+   *  Experience's requestCombat both funnel through here — ONE path into the vanilla
+   *  generation pass, so a package can never trigger side effects the button would not.
+   *  The vanilla LLM pass still decides what the encounter is. Reads everything through
+   *  refs so the identity-stable package callback can never act on a stale closure;
+   *  `notify` keeps Engine toasts off the package path (the Experience renders its own
+   *  feedback from the returned refusal code). */
+  const startCombatGeneration = useCallback(
+    (notify: boolean): "started" | "combat-active" | "pending" | "no-turn" | "unavailable" => {
+      const seam = combatSeamRef.current;
+      if (seam.concluded || seam.replayActive) return "unavailable";
+      if (seam.combatUiActive) {
+        if (notify) toast("Combat is already active.");
+        return "combat-active";
+      }
+      if (combatGenerationInFlightRef.current) {
+        if (notify) toast("Combat is already being prepared.");
+        return "pending";
+      }
+      const messageId = latestAssistantMsgRef.current?.id;
+      if (!messageId) {
+        if (notify) toast.error(localizeUi("ui.game.gamesurfacecomponent.theGmNeedsToWriteAtLeastOneTurn"));
+        return "no-turn";
+      }
+      setQueuedCombatGeneration({ messageId });
+      setPreparedCombatState(null);
+      setCombatGenerationError(null);
+      generateCombatRef.current(messageId);
+      return "started";
+    },
+    [localizeUi],
+  );
+
   const handleRequestManualCombatStart = useCallback(async () => {
+    // Pre-dialog guards so the player is never asked to confirm a request that
+    // must fail — the core re-checks all of them (fresh, via refs) afterwards.
     if (combatUiActive) {
       toast("Combat is already active.");
       return;
@@ -8499,8 +8505,7 @@ function GameSurfaceComponent({
       toast("Combat is already being prepared.");
       return;
     }
-    const messageId = latestAssistantMsg?.id;
-    if (!messageId) {
+    if (!latestAssistantMsg?.id) {
       toast.error(localizeUi("ui.game.gamesurfacecomponent.theGmNeedsToWriteAtLeastOneTurn"));
       return;
     }
@@ -8511,16 +8516,95 @@ function GameSurfaceComponent({
       cancelLabel: "No",
     });
     if (!confirmed) return;
-    setQueuedCombatGeneration({ messageId });
-    setPreparedCombatState(null);
-    setCombatGenerationError(null);
-    generateCombatStateForMessage(messageId);
-  }, [combatGenerationPending, combatUiActive, generateCombatStateForMessage, latestAssistantMsg?.id, localizeUi]);
+    startCombatGeneration(true);
+  }, [combatGenerationPending, combatUiActive, latestAssistantMsg?.id, startCombatGeneration, localizeUi]);
+
+  /** Handed to Experience surfaces as requestCombat (#5094). Identity-stable (matching
+   *  every other function in the surface props), silent (returns the refusal code
+   *  instead of Engine toasts over the package's UI), and confirm-free — the
+   *  Experience's own interface already expressed the intent. Deliberately takes no
+   *  combatant data: startCombat(party, enemies) would let a package construct combat
+   *  outside the vanilla generation path, and combat stays vanilla. */
+  const requestExperienceCombat = useCallback(() => startCombatGeneration(false), [startCombatGeneration]);
 
   // The narration renders these buttons only when the props are supplied, so withholding them beats
   // hiding: no dead button, and no way to reach the Classic flow underneath the surface.
   const classicInventoryOpener = activeExperienceChrome?.providesInventory ? undefined : () => setInventoryOpen(true);
   const classicCombatStarter = activeExperienceChrome?.providesCombat ? undefined : handleRequestManualCombatStart;
+
+  // Engine state handed to the surface slot, recomputed per turn so the surface tracks streaming and
+  // new messages. Builds nothing unless the surface is mounted, so a Classic game never pays for it.
+  // Declared here (not with the other seams) because it carries the combat seam computed above.
+  const experienceSurfaceProps = useMemo(
+    () =>
+      !experienceSurfaceActive
+        ? undefined
+        : {
+            chatId: activeChatId,
+            chatMeta,
+            messages,
+            latestAssistant: latestAssistantMsg,
+            isStreaming,
+            scopedAssetMap,
+            sendMessage: sendExperienceMessage,
+            setExperienceBackgroundTag: pushExperienceBackground,
+            setExperienceSpeakerAvatars,
+            setExperienceChrome,
+            // Who is speaking RIGHT NOW, as the narration plays. Deriving it from the turn text instead yields
+            // only the LAST speaker of the turn, which leaves a VN sprite stuck on whoever spoke last.
+            activeSpeaker: activeSpeaker
+              ? { name: activeSpeaker.name, expression: activeSpeaker.expression ?? null }
+              : null,
+            experienceChoiceSlotEl,
+            // Per-turn state, so the surface can hold its menu until the narration finishes.
+            narrationDone,
+            latestNarrationText,
+            scenePreparing,
+            directionsPlaying,
+            assetGenerationBlocksScene,
+            replayActive,
+            sessionInteractive: (chatMeta.gameSessionStatus as string) !== "concluded",
+            // The host's sprite-size setting, so the player's slider keeps working in this mode.
+            spriteScale: gameFullBodySpriteScale,
+            // Combat seam (#5094): the instant the combat UI actually mounts — unlike
+            // chatMeta.gameActiveState, the GM's narrative scene state, which lags the
+            // flip and can say "combat" without any combat UI existing.
+            combatActive: combatUiActive,
+            combatStyle: effectiveCombatStyle,
+            requestCombat: requestExperienceCombat,
+            // Generation progress/outcome mirrors, so a package that requested combat can
+            // show its own feedback instead of waiting on combatActive forever.
+            combatPending: combatGenerationPending,
+            combatError: combatGenerationError,
+          },
+    [
+      experienceSurfaceActive,
+      activeChatId,
+      chatMeta,
+      messages,
+      latestAssistantMsg,
+      isStreaming,
+      scopedAssetMap,
+      sendExperienceMessage,
+      pushExperienceBackground,
+      setExperienceSpeakerAvatars,
+      setExperienceChrome,
+      activeSpeaker,
+      experienceChoiceSlotEl,
+      narrationDone,
+      latestNarrationText,
+      scenePreparing,
+      directionsPlaying,
+      assetGenerationBlocksScene,
+      replayActive,
+      gameFullBodySpriteScale,
+      combatUiActive,
+      effectiveCombatStyle,
+      requestExperienceCombat,
+      combatGenerationPending,
+      combatGenerationError,
+    ],
+  );
 
   useEffect(() => {
     if (!queuedQte || !latestAssistantMsg?.id) return;

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -8017,6 +8017,13 @@ function GameSurfaceComponent({
   /** Synchronous in-flight flag beside the async combatGenerationPending state:
    *  same-frame double requests all read the stale state, the ref does not. */
   const combatGenerationInFlightRef = useRef(false);
+  // #5094: on chat switch, clear the in-flight lock (the [activeChatId] reset above only clears the
+  // pending STATE). Otherwise a combat generation left in flight by the previous chat keeps this ref
+  // true, and the new chat's generateCombatStateForMessage guard bails, leaving it stuck as "pending".
+  // The request itself is chat-scoped via requestChatId, so a stale completion never clears the lock.
+  useEffect(() => {
+    combatGenerationInFlightRef.current = false;
+  }, [activeChatId]);
   const tacticalCombatActive = combatUiActive && effectiveCombatStyle === "tactical";
   const topOverlayOffsetClass = "top-3";
   const queuedCombatMatchesLatest =
@@ -8142,6 +8149,11 @@ function GameSurfaceComponent({
       combatGenerationInFlightRef.current = true;
       setCombatGenerationError(null);
       setCombatGenerationPending(true);
+      // #5094: scope the async completion to the chat that started it. If the user switches chats while
+      // this is in flight, activeChatIdRef diverges from requestChatId and every handler bails, so a
+      // stale Chat A response can't apply combat state to Chat B, set B's error, or clear B's lock. The
+      // chat-switch cleanup (the [activeChatId] effect) clears the in-flight ref so the new chat can start.
+      const requestChatId = activeChatId;
       api
         .post<EncounterInitResponse>("/encounter/init", {
           chatId: activeChatId,
@@ -8151,6 +8163,7 @@ function GameSurfaceComponent({
           debugMode,
         })
         .then(async (response) => {
+          if (activeChatIdRef.current !== requestChatId) return; // chat switched; ignore stale completion
           const combatants = hydrateGeneratedCombatState(response.combatState);
           if (!combatants) {
             throw new Error("Combat generator returned an empty party or enemy list.");
@@ -8259,12 +8272,14 @@ function GameSurfaceComponent({
           });
         })
         .catch((err) => {
+          if (activeChatIdRef.current !== requestChatId) return; // chat switched; don't set stale error
           const message = err instanceof Error ? err.message : "Combat generation failed.";
           console.warn("[game-combat] Failed to generate combat state", err);
           setCombatGenerationError(message);
           toast.error(localizeUi("ui.game.gamesurfacecomponent.value1UseTheCombatButtonToRetry", { value1: message }));
         })
         .finally(() => {
+          if (activeChatIdRef.current !== requestChatId) return; // chat switched; don't clear the new chat's lock
           combatGenerationInFlightRef.current = false;
           setCombatGenerationPending(false);
         });

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -2684,6 +2684,13 @@ function GameSurfaceComponent({
   const [preparedCombatState, setPreparedCombatState] = useState<PreparedCombatState | null>(null);
   const [combatGenerationPending, setCombatGenerationPending] = useState(false);
   const [combatGenerationError, setCombatGenerationError] = useState<string | null>(null);
+  /** Synchronous in-flight flag beside the async combatGenerationPending state: same-frame double
+   *  requests all read the stale state, the ref does not. Declared early so the turn-retry handler,
+   *  which must abandon an in-flight generation, can reach it. #5094. */
+  const combatGenerationInFlightRef = useRef(false);
+  /** Monotonic id for the CURRENT combat request; a stale completion whose id no longer matches bails.
+   *  Bumped on every new request, on chat switch, and when a turn retry abandons a generation. #5094. */
+  const combatGenerationRequestIdRef = useRef(0);
   const [combatItemEffects, setCombatItemEffects] = useState<CombatItemEffect[]>([]);
   const [combatMechanics, setCombatMechanics] = useState<CombatMechanic[]>([]);
   const [combatDialogueCues, setCombatDialogueCues] = useState<CombatDialogueCue[]>([]);
@@ -3067,6 +3074,11 @@ function GameSurfaceComponent({
     setQueuedQte(null);
     setQueuedEncounter(null);
     setQueuedCombatGeneration(null);
+    // #5094: abandon any in-flight combat generation here — clear the lock so a fresh request isn't
+    // blocked by it, and bump the request id so the old generation's stale completion can't re-queue
+    // combat, apply state, or set an error against the reset combat state.
+    combatGenerationInFlightRef.current = false;
+    combatGenerationRequestIdRef.current += 1;
     setCombatGenerationPending(false);
     setCombatItemEffects([]);
     setCombatMechanics([]);
@@ -6343,6 +6355,11 @@ function GameSurfaceComponent({
     setPendingEncounter(null);
     setQueuedEncounter(null);
     setQueuedCombatGeneration(null);
+    // #5094: abandon any in-flight combat generation here — clear the lock so a fresh request isn't
+    // blocked by it, and bump the request id so the old generation's stale completion can't re-queue
+    // combat, apply state, or set an error against the reset combat state.
+    combatGenerationInFlightRef.current = false;
+    combatGenerationRequestIdRef.current += 1;
     setCombatGenerationPending(false);
     setCombatItemEffects([]);
     setCombatMechanics([]);
@@ -8016,16 +8033,16 @@ function GameSurfaceComponent({
     combatSeamRef.current.concluded = (chatMeta.gameSessionStatus as string) === "concluded";
     combatSeamRef.current.replayActive = replayActive;
   });
-  /** Synchronous in-flight flag beside the async combatGenerationPending state:
-   *  same-frame double requests all read the stale state, the ref does not. */
-  const combatGenerationInFlightRef = useRef(false);
   // #5094: on chat switch, clear the in-flight lock AND the error (the [activeChatId] reset above only
-  // clears the pending state). Otherwise a combat generation left in flight by the previous chat keeps
-  // this ref true — so the new chat's generateCombatStateForMessage guard bails, leaving it stuck as
-  // "pending" — and the previous chat's error stays visible. The request itself is chat-scoped via
-  // requestChatId, so a stale completion never clears the lock or writes the new chat's error.
+  // clears the pending state) and invalidate any in-flight request (bump the request id), so a
+  // generation left in flight by the previous chat can't keep the new chat stuck as "pending", leak its
+  // error, or have a stale completion touch the new chat. (Both refs are declared with the combat state
+  // above so the turn-retry handler can reach them too.) The requestId check is why a same-chat retry
+  // is also covered; the requestChatId check is a synchronous belt (activeChatIdRef updates during
+  // render, ahead of this effect's bump), so a chat switch is caught even before the bump lands.
   useEffect(() => {
     combatGenerationInFlightRef.current = false;
+    combatGenerationRequestIdRef.current += 1;
     setCombatGenerationError(null);
   }, [activeChatId]);
   const tacticalCombatActive = combatUiActive && effectiveCombatStyle === "tactical";
@@ -8153,11 +8170,13 @@ function GameSurfaceComponent({
       combatGenerationInFlightRef.current = true;
       setCombatGenerationError(null);
       setCombatGenerationPending(true);
-      // #5094: scope the async completion to the chat that started it. If the user switches chats while
-      // this is in flight, activeChatIdRef diverges from requestChatId and every handler bails, so a
-      // stale Chat A response can't apply combat state to Chat B, set B's error, or clear B's lock. The
-      // chat-switch cleanup (the [activeChatId] effect) clears the in-flight ref so the new chat can start.
+      // #5094: scope the async completion to THIS request. requestId is bumped by any newer request, a
+      // chat switch, or a turn retry that abandons this one; requestChatId is the synchronous belt for a
+      // chat switch (activeChatIdRef updates during render, ahead of the effect that bumps requestId).
+      // Every handler below bails unless BOTH still match, so a stale completion can't apply combat
+      // state, set an error, or clear the lock for a different request, turn, or chat.
       const requestChatId = activeChatId;
+      const requestId = ++combatGenerationRequestIdRef.current;
       api
         .post<EncounterInitResponse>("/encounter/init", {
           chatId: activeChatId,
@@ -8167,7 +8186,7 @@ function GameSurfaceComponent({
           debugMode,
         })
         .then(async (response) => {
-          if (activeChatIdRef.current !== requestChatId) return; // chat switched; ignore stale completion
+          if (combatGenerationRequestIdRef.current !== requestId || activeChatIdRef.current !== requestChatId) return; // superseded
           const combatants = hydrateGeneratedCombatState(response.combatState);
           if (!combatants) {
             throw new Error("Combat generator returned an empty party or enemy list.");
@@ -8226,7 +8245,8 @@ function GameSurfaceComponent({
             };
             void requestAssetGeneration(assetPayload, { allowPromptReview: false })
               .then((assetResult) => {
-                if (activeChatIdRef.current !== requestChatId) return; // chat switched; don't update it
+                if (combatGenerationRequestIdRef.current !== requestId || activeChatIdRef.current !== requestChatId)
+                  return; // superseded; don't apply avatars to a different request/turn/chat
                 if (!assetResult?.generatedNpcAvatars?.length) return;
                 const avatarByName = new Map(
                   assetResult.generatedNpcAvatars.map(
@@ -8277,7 +8297,7 @@ function GameSurfaceComponent({
           });
         })
         .catch((err) => {
-          if (activeChatIdRef.current !== requestChatId) return; // chat switched; don't set stale error
+          if (combatGenerationRequestIdRef.current !== requestId || activeChatIdRef.current !== requestChatId) return; // superseded; don't set stale error
           const message = err instanceof Error ? err.message : "Combat generation failed.";
           console.warn("[game-combat] Failed to generate combat state", err);
           setCombatGenerationError(message);
@@ -8289,7 +8309,7 @@ function GameSurfaceComponent({
           }
         })
         .finally(() => {
-          if (activeChatIdRef.current !== requestChatId) return; // chat switched; don't clear the new chat's lock
+          if (combatGenerationRequestIdRef.current !== requestId || activeChatIdRef.current !== requestChatId) return; // superseded; don't clear another request's lock
           combatGenerationInFlightRef.current = false;
           setCombatGenerationPending(false);
         });
@@ -9599,6 +9619,11 @@ function GameSurfaceComponent({
     setViewedMapId(null);
     setCombatStartMessageId(null);
     setQueuedCombatGeneration(null);
+    // #5094: abandon any in-flight combat generation here — clear the lock so a fresh request isn't
+    // blocked by it, and bump the request id so the old generation's stale completion can't re-queue
+    // combat, apply state, or set an error against the reset combat state.
+    combatGenerationInFlightRef.current = false;
+    combatGenerationRequestIdRef.current += 1;
     setCombatGenerationPending(false);
     setCombatItemEffects([]);
     setCombatMechanics([]);
@@ -9727,6 +9752,11 @@ function GameSurfaceComponent({
     setPendingEncounter(null);
     setQueuedEncounter(null);
     setQueuedCombatGeneration(null);
+    // #5094: abandon any in-flight combat generation here — clear the lock so a fresh request isn't
+    // blocked by it, and bump the request id so the old generation's stale completion can't re-queue
+    // combat, apply state, or set an error against the reset combat state.
+    combatGenerationInFlightRef.current = false;
+    combatGenerationRequestIdRef.current += 1;
     setCombatGenerationPending(false);
     setCombatItemEffects([]);
     setCombatMechanics([]);

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -369,6 +369,11 @@ type GameAssetGenerationOptions = {
   /** Keep narration / queued interactions waiting for this asset job. */
   blocksScene?: boolean;
   showSuccessToast?: boolean;
+  /** #5094: called after generation resolves; if it returns false the caller's request was superseded
+   *  (chat switch, turn retry, or a newer combat request), so the result is discarded instead of being
+   *  applied. Keeps a stale combat visual job from overwriting the current chat's background/avatars or
+   *  clobbering the current asset-generation state. */
+  isCurrent?: () => boolean;
 };
 
 type ApplyGeneratedAssetsOptions = {
@@ -5602,6 +5607,13 @@ function GameSurfaceComponent({
       try {
         const res = await runGameAssetGeneration(assetPayload, { allowPromptReview: options?.allowPromptReview });
 
+        // #5094: the caller's request may have been superseded (chat switch, turn retry, or a newer combat
+        // request) while generation was in flight. Bail before touching asset state or applying assets so a
+        // stale job can't overwrite the current chat's background/avatars or clear the live request's state.
+        if (options?.isCurrent && !options.isCurrent()) {
+          return null;
+        }
+
         setPendingAssetGeneration(null);
         setAssetGenerationBlocksScene(false);
         if (!res) return null;
@@ -5615,6 +5627,10 @@ function GameSurfaceComponent({
 
         return res;
       } catch {
+        // #5094: don't surface a superseded request's failure on the current chat's asset state.
+        if (options?.isCurrent && !options.isCurrent()) {
+          return null;
+        }
         setAssetGenerationFailed(true);
         setAssetGenerationBlocksScene(false);
         return null;
@@ -8243,7 +8259,13 @@ function GameSurfaceComponent({
               npcsNeedingAvatars: shouldGenerateEnemyAvatars ? enemyAvatarRequests : undefined,
               debugMode: useUIStore.getState().debugMode,
             };
-            void requestAssetGeneration(assetPayload, { allowPromptReview: false })
+            void requestAssetGeneration(assetPayload, {
+              allowPromptReview: false,
+              // #5094: gate the internal asset apply (background + avatars + asset state) on this combat
+              // request still being current, since requestAssetGeneration applies before the .then below runs.
+              isCurrent: () =>
+                combatGenerationRequestIdRef.current === requestId && activeChatIdRef.current === requestChatId,
+            })
               .then((assetResult) => {
                 if (combatGenerationRequestIdRef.current !== requestId || activeChatIdRef.current !== requestChatId)
                   return; // superseded; don't apply avatars to a different request/turn/chat

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -2678,7 +2678,9 @@ function GameSurfaceComponent({
   const [queuedEncounter, setQueuedEncounter] = useState<{ encounter: CombatEncounterTag; messageId: string } | null>(
     null,
   );
-  const [queuedCombatGeneration, setQueuedCombatGeneration] = useState<{ messageId: string } | null>(null);
+  const [queuedCombatGeneration, setQueuedCombatGeneration] = useState<{ messageId: string; notify: boolean } | null>(
+    null,
+  );
   const [preparedCombatState, setPreparedCombatState] = useState<PreparedCombatState | null>(null);
   const [combatGenerationPending, setCombatGenerationPending] = useState(false);
   const [combatGenerationError, setCombatGenerationError] = useState<string | null>(null);
@@ -4272,7 +4274,7 @@ function GameSurfaceComponent({
         if (tags.combatEncounter && !hasCombatResultAfterMessage(latestAssistantMsg.id)) {
           setQueuedEncounter({ encounter: tags.combatEncounter, messageId: latestAssistantMsg.id });
         } else if (tags.stateChange === "combat" && !hasCombatResultAfterMessage(latestAssistantMsg.id)) {
-          setQueuedCombatGeneration({ messageId: latestAssistantMsg.id });
+          setQueuedCombatGeneration({ messageId: latestAssistantMsg.id, notify: true });
         }
       }
       lastProcessedMsgRef.current = latestAssistantMsg.id;
@@ -4733,7 +4735,7 @@ function GameSurfaceComponent({
       if (tags.combatEncounter) {
         setQueuedEncounter({ encounter: tags.combatEncounter, messageId: msg.id });
       } else if (tags.stateChange === "combat") {
-        setQueuedCombatGeneration({ messageId: msg.id });
+        setQueuedCombatGeneration({ messageId: msg.id, notify: true });
       }
     }
 
@@ -8017,12 +8019,14 @@ function GameSurfaceComponent({
   /** Synchronous in-flight flag beside the async combatGenerationPending state:
    *  same-frame double requests all read the stale state, the ref does not. */
   const combatGenerationInFlightRef = useRef(false);
-  // #5094: on chat switch, clear the in-flight lock (the [activeChatId] reset above only clears the
-  // pending STATE). Otherwise a combat generation left in flight by the previous chat keeps this ref
-  // true, and the new chat's generateCombatStateForMessage guard bails, leaving it stuck as "pending".
-  // The request itself is chat-scoped via requestChatId, so a stale completion never clears the lock.
+  // #5094: on chat switch, clear the in-flight lock AND the error (the [activeChatId] reset above only
+  // clears the pending state). Otherwise a combat generation left in flight by the previous chat keeps
+  // this ref true — so the new chat's generateCombatStateForMessage guard bails, leaving it stuck as
+  // "pending" — and the previous chat's error stays visible. The request itself is chat-scoped via
+  // requestChatId, so a stale completion never clears the lock or writes the new chat's error.
   useEffect(() => {
     combatGenerationInFlightRef.current = false;
+    setCombatGenerationError(null);
   }, [activeChatId]);
   const tacticalCombatActive = combatUiActive && effectiveCombatStyle === "tactical";
   const topOverlayOffsetClass = "top-3";
@@ -8137,7 +8141,7 @@ function GameSurfaceComponent({
   ]);
 
   const generateCombatStateForMessage = useCallback(
-    (messageId: string) => {
+    (messageId: string, notify: boolean) => {
       // Both guards: the state flag drives rendering, but it is stale within a
       // frame — same-frame double calls (a package spamming requestCombat, #5094)
       // all read false. The ref flips synchronously and clears with the request.
@@ -8222,6 +8226,7 @@ function GameSurfaceComponent({
             };
             void requestAssetGeneration(assetPayload, { allowPromptReview: false })
               .then((assetResult) => {
+                if (activeChatIdRef.current !== requestChatId) return; // chat switched; don't update it
                 if (!assetResult?.generatedNpcAvatars?.length) return;
                 const avatarByName = new Map(
                   assetResult.generatedNpcAvatars.map(
@@ -8276,7 +8281,12 @@ function GameSurfaceComponent({
           const message = err instanceof Error ? err.message : "Combat generation failed.";
           console.warn("[game-combat] Failed to generate combat state", err);
           setCombatGenerationError(message);
-          toast.error(localizeUi("ui.game.gamesurfacecomponent.value1UseTheCombatButtonToRetry", { value1: message }));
+          // Only the Engine paths (manual button, retry, auto-queue) toast. An Experience/package
+          // request passes notify=false and renders its own feedback from combatError, so a failed
+          // package request must not surface an Engine toast over the package's UI. #5094.
+          if (notify) {
+            toast.error(localizeUi("ui.game.gamesurfacecomponent.value1UseTheCombatButtonToRetry", { value1: message }));
+          }
         })
         .finally(() => {
           if (activeChatIdRef.current !== requestChatId) return; // chat switched; don't clear the new chat's lock
@@ -8312,7 +8322,7 @@ function GameSurfaceComponent({
     if (preparedCombatState?.messageId === queuedCombatGeneration.messageId) return;
     if (isStreaming || scenePreparing || assetGenerationBlocksScene) return;
 
-    generateCombatStateForMessage(queuedCombatGeneration.messageId);
+    generateCombatStateForMessage(queuedCombatGeneration.messageId, queuedCombatGeneration.notify);
   }, [
     activeChatId,
     combatGenerationPending,
@@ -8463,10 +8473,10 @@ function GameSurfaceComponent({
       toast.error(localizeUi("ui.game.gamesurfacecomponent.noCurrentTurnIsAvailableForCombatGeneration"));
       return;
     }
-    setQueuedCombatGeneration({ messageId });
+    setQueuedCombatGeneration({ messageId, notify: true });
     setPreparedCombatState(null);
     setCombatGenerationError(null);
-    generateCombatStateForMessage(messageId);
+    generateCombatStateForMessage(messageId, true);
   }, [generateCombatStateForMessage, latestAssistantMsg?.id, queuedCombatGeneration?.messageId, localizeUi]);
 
   /** Keeps the identity-stable combat seam pointing at the CURRENT generator
@@ -8500,10 +8510,10 @@ function GameSurfaceComponent({
         if (notify) toast.error(localizeUi("ui.game.gamesurfacecomponent.theGmNeedsToWriteAtLeastOneTurn"));
         return "no-turn";
       }
-      setQueuedCombatGeneration({ messageId });
+      setQueuedCombatGeneration({ messageId, notify });
       setPreparedCombatState(null);
       setCombatGenerationError(null);
-      generateCombatRef.current(messageId);
+      generateCombatRef.current(messageId, notify);
       return "started";
     },
     [localizeUi],

--- a/packages/shared/src/schemas/capability-package.schema.ts
+++ b/packages/shared/src/schemas/capability-package.schema.ts
@@ -172,7 +172,9 @@ const capabilityPackageManifestBaseSchema = z
   .strict();
 
 // 1.10: contributions.assets — general package-owned static asset delivery.
-export const supportedCapabilityApi = Object.freeze({ major: 1, minor: 10 } as const);
+// 1.11: Experience combat seam — combatActive/combatStyle/requestCombat on the
+//        game-surface capabilityProps.
+export const supportedCapabilityApi = Object.freeze({ major: 1, minor: 11 } as const);
 
 const capabilityApiVersionSchema = z
   .object({

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -104,7 +104,7 @@ try {
   const legacyManifest = capabilityPackageManifestSchema.parse(installedPackage("legacy", ["agent"]).manifest);
   assert.equal(legacyManifest.schemaVersion, 1, "Existing manifest v1 packages must remain readable");
   assert.equal(getCapabilityApiCompatibilityIssue(legacyManifest), null);
-  assert.deepEqual(supportedCapabilityApi, { major: 1, minor: 10 });
+  assert.deepEqual(supportedCapabilityApi, { major: 1, minor: 11 });
 
   const manifestV2 = capabilityPackageManifestSchema.parse({
     ...legacyManifest,
@@ -140,20 +140,20 @@ try {
   });
   assert.match(
     getCapabilityApiCompatibilityIssue(unsupportedMajorManifest) ?? "",
-    /requires capability API 2\.0; this Engine supports 1\.10/,
+    /requires capability API 2\.0; this Engine supports 1\.11/,
   );
   const currentMinorManifest = capabilityPackageManifestSchema.parse({
     ...manifestV2,
-    capabilityApi: { major: 1, minor: 10 },
+    capabilityApi: { major: 1, minor: 11 },
   });
   assert.equal(getCapabilityApiCompatibilityIssue(currentMinorManifest), null);
   const unsupportedMinorManifest = capabilityPackageManifestSchema.parse({
     ...manifestV2,
-    capabilityApi: { major: 1, minor: 11 },
+    capabilityApi: { major: 1, minor: 12 },
   });
   assert.match(
     getCapabilityApiCompatibilityIssue(unsupportedMinorManifest) ?? "",
-    /requires capability API 1\.11; this Engine supports 1\.10/,
+    /requires capability API 1\.12; this Engine supports 1\.11/,
   );
 
   const forwardCompatibleCatalog = capabilityCatalogSchema.parse({


### PR DESCRIPTION
Closes #5094

## Why

A `game-surface` Experience has no trustworthy combat signal: the only thing a package can watch is `chatMeta.gameActiveState`, the GM's *narrative* scene state — it lags the actual combat-UI flip (written by a separate metadata transition) and can say "combat" when no encounter was generated at all. And an Experience with its own world (an encounter tile in a pixel RPG) cannot request a fight without the player re-confirming through a modal that duplicates the intent they just expressed in the Experience's own UI.

## What changed (Capability API 1.11 — client-only, additive, zero combat mechanics touched)

`packages/client/src/components/game/GameSurface.tsx`:

- `experienceSurfaceProps` gains **`combatActive`** (the already-computed `combatUiActive` — true the instant the combat UI actually mounts), **`combatStyle`** (the effective style, `classic`/`tactical`), and **`requestCombat()`**.
- The manual Start Combat handler is refactored so the confirm dialog wraps a shared core (`startCombatGeneration`), and `requestCombat` calls that **same core** — one path into the vanilla `generateCombatStateForMessage` pass, so a package can never trigger side effects the button would not. The confirm dialog is skipped on the package path because the Experience's own interface already expressed the intent; the guards (combat already active, generation pending, no turn yet) still apply.
- **Deliberately absent:** `startCombat(party, enemies)` or any way to inject combat state — the vanilla LLM pass still decides what the encounter is. Combat stays Engine-owned.
- The `experienceSurfaceProps` memo moved below the combat declarations it now consumes (its only consumer is the surface mount further down; nothing between the old and new positions referenced it). The Classic-game guard is untouched: the props are still not built at all unless the surface is active.
- `requestCombat()` is **identity-stable** (reads current state through refs, matching the stability contract of every other function in the props — a package may safely cache it), **silent on the package path** (returns `"started" | "combat-active" | "pending" | "no-turn" | "unavailable"` instead of painting Engine toasts over the package UI), and **gated**: concluded sessions and replay refuse with `"unavailable"`, mirroring the sendMessage seam.
- A synchronous in-flight ref guards the generation alongside the async React state, so same-frame double calls (a package spamming `requestCombat`) cannot fan out concurrent `/encounter/init` generations.
- `combatPending`/`combatError` mirror generation progress and failure, so a package is never left waiting on `combatActive` after a failed generation.
- The manual button keeps its pre-dialog guards (including the no-turn check, which the first review round caught moving behind the confirm).

`packages/shared/src/schemas/capability-package.schema.ts`: `supportedCapabilityApi` → `{1, 11}` (a package *requiring* the seam declares 1.11 and older engines refuse it with the versioned message; packages that feature-detect keep working everywhere). Lifecycle-regression pins updated.

Docs: Capability API 1.11 section in `docs/development/optional-agent-packages.md`; CHANGELOG entry under Unreleased.

Note on `requestCombat(opts)`: the issue sketched a `hint` parameter; it is deferred — the encounter generator (`/encounter/init`) takes no steering context today, so accepting-and-ignoring a hint would be dishonest. If steering lands server-side later, the callback can grow the option compatibly.

## Validation

- [x] `pnpm check`
- [x] capability-package-lifecycle + capability-package-cache regressions (1.11 pins)
- [x] `pnpm version:check`
- [x] Manually verify a Classic game: Start Combat button shows the confirm, generates, enters and exits combat exactly as before.
- [x] Manually verify an Experience game: the package sees `combatActive` flip the instant combat mounts, and `requestCombat()` generates an encounter through the same vanilla pass (no confirm dialog).
- [x] Manually verify a Classic game still builds no `experienceSurfaceProps` at all.

Docs note: the `docs/development/optional-agent-packages.md` edit needs a docs-i18n mirror — batched with the pending round-8 catch-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Game-surface experiences can display live combat activity and style information.
  * Experiences can request Engine-generated combat encounters and receive pending, success, and error status updates.
  * Combat controls prevent duplicate or invalid encounter requests.
  * Experiences that manage their own combat can hide the standard combat controls.
  * Tactical combat can automatically generate battlefield backgrounds.
  * Updated support for Capability API version 1.11.

* **Documentation**
  * Added guidance for integrating combat capabilities into optional game-surface packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->