### PR TITLE
Fix Windows gallery media containment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept valid Gallery images visible on Windows when canonical paths differ only by drive-letter or directory casing, without weakening traversal and symlink containment checks (#5099).
 - Honored each image style profile's selected prompt grammar for character avatars, portraits, and sprites instead of silently forcing compact tags (#5083).
 - Game checkpoints now capture and restore the turn-game engine state, so loading a checkpoint rewinds an active turn-game (UNO, Chess, Poker, Eight Ball) along with the story and map instead of leaving it on its post-checkpoint state (#5077).
 - Routed Game Mode time-advance and weather-update through the queued per-chat metadata patch path so they no longer silently revert a concurrent metadata write, which could permanently lock World Map movement as a stale definition (#5076).

--- a/packages/server/src/utils/media-file-security.ts
+++ b/packages/server/src/utils/media-file-security.ts
@@ -1,5 +1,5 @@
 import { open, realpath, type FileHandle } from "node:fs/promises";
-import { basename, extname, join, resolve, sep } from "node:path";
+import { basename, extname, join, posix, resolve, win32 } from "node:path";
 import type { FastifyReply } from "fastify";
 import { getDataDir, getFileStorageDir } from "../config/runtime-config.js";
 import { assertInsideDir, isAllowedImageBuffer } from "./security.js";
@@ -242,6 +242,21 @@ function hasUnsafeSvgHref(source: string): boolean {
   return false;
 }
 
+/** Compare canonical paths using the host filesystem's case and separator rules. */
+export function isCanonicalMediaPathInsideRoot(
+  canonicalPath: string,
+  canonicalRoot: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  const pathApi = platform === "win32" ? win32 : posix;
+  const normalizeCase = (value: string) => (platform === "win32" ? value.toLowerCase() : value);
+  const relativePath = pathApi.relative(normalizeCase(canonicalRoot), normalizeCase(canonicalPath));
+  return (
+    relativePath === "" ||
+    (relativePath !== ".." && !relativePath.startsWith(`..${pathApi.sep}`) && !pathApi.isAbsolute(relativePath))
+  );
+}
+
 /** Resolve symlinks and permit reads only from Marinara's configured media roots. */
 async function resolveAllowedMediaPath(filePath: string, additionalRoot?: string): Promise<string | null> {
   let canonicalPath: string;
@@ -256,8 +271,7 @@ async function resolveAllowedMediaPath(filePath: string, additionalRoot?: string
   )) {
     try {
       const canonicalRoot = await realpath(resolve(configuredRoot));
-      const rootPrefix = canonicalRoot.endsWith(sep) ? canonicalRoot : `${canonicalRoot}${sep}`;
-      if (canonicalPath === canonicalRoot || canonicalPath.startsWith(rootPrefix)) return canonicalPath;
+      if (isCanonicalMediaPathInsideRoot(canonicalPath, canonicalRoot)) return canonicalPath;
     } catch {
       // A configured root may not exist yet; it cannot contain this file.
     }

--- a/scripts/regressions/profile-import-asset-security.regression.ts
+++ b/scripts/regressions/profile-import-asset-security.regression.ts
@@ -37,7 +37,13 @@ const [
     promoteStagedProfileAssets,
     stageProfileImportAssets,
   },
-  { sendValidatedMediaFile, validateImageAssetBuffer, validateImageAssetFile, validateVideoAssetFile },
+  {
+    isCanonicalMediaPathInsideRoot,
+    sendValidatedMediaFile,
+    validateImageAssetBuffer,
+    validateImageAssetFile,
+    validateVideoAssetFile,
+  },
 ] = await Promise.all([
   import("../../packages/server/src/db/file-backed-store.js"),
   import("../../packages/server/src/db/schema/index.js"),
@@ -92,6 +98,39 @@ const validMp4 = Buffer.from([0, 0, 0, 20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0
 const videoManifest = Buffer.from('{"version":1,"videos":[]}', "utf8");
 
 try {
+  assert.equal(
+    isCanonicalMediaPathInsideRoot(
+      "F:\\MarinaraEngine2\\packages\\server\\data\\gallery\\chat-1\\selfie.png",
+      "f:\\marinaraengine2\\packages\\server\\data",
+      "win32",
+    ),
+    true,
+    "Windows media containment must ignore canonical drive and directory casing",
+  );
+  assert.equal(
+    isCanonicalMediaPathInsideRoot(
+      "F:\\MarinaraEngine2\\packages\\server\\data-escape\\selfie.png",
+      "f:\\marinaraengine2\\packages\\server\\data",
+      "win32",
+    ),
+    false,
+    "Windows media containment must still reject sibling-prefix escapes",
+  );
+  assert.equal(
+    isCanonicalMediaPathInsideRoot(
+      "G:\\MarinaraEngine2\\packages\\server\\data\\gallery\\selfie.png",
+      "F:\\MarinaraEngine2\\packages\\server\\data",
+      "win32",
+    ),
+    false,
+    "Windows media containment must reject a different drive",
+  );
+  assert.equal(
+    isCanonicalMediaPathInsideRoot("/srv/Marinara/data/gallery/selfie.png", "/srv/marinara/data", "linux"),
+    false,
+    "case-sensitive hosts must retain case-sensitive media containment",
+  );
+
   assert.ok(validateImageAssetBuffer(validPng, "valid.png"));
   assert.equal(validateImageAssetBuffer(html, "payload.png"), null);
   assert.equal(validateImageAssetBuffer(javascript, "payload.js"), null);


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5099

## Why this change

Valid Gallery images could return 404 on Windows when `realpath` canonicalized their drive letter or directory casing differently from the configured media root. The file was safe and present, but the case-sensitive prefix check rejected it.

## What changed

- Replaced string-prefix containment with a platform-aware canonical relative-path check.
- Made Windows canonical containment case-insensitive while retaining POSIX case sensitivity.
- Preserved traversal, sibling-prefix, symlink, image-signature, and validated-descriptor protections.
- Added regression cases for Windows case differences, sibling escapes, different drives, and POSIX case sensitivity.
- Added the user-facing fix to the Unreleased changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated verification performed:

- `pnpm --filter @marinara-engine/server lint`
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/profile-import-asset-security.regression.ts`
- `git diff --check`

A real Windows install with drive-case, junction, or OneDrive canonicalization remains a maintainer/manual verification item.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing documentation page or release metadata changed. `CHANGELOG.md` includes the fix.

## UI evidence (if applicable)

Not applicable; this is a server file-serving regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media path matching for Windows Gallery locations, including paths with differing letter casing.
  * Strengthened protection against similarly named sibling folders, alternate drives, traversal attempts, and symlink-based escapes.
  * Preserved case-sensitive path behavior on Linux.

* **Documentation**
  * Added a changelog entry describing the Windows path-matching improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->