### PR TITLE
Fix vectorized lorebook recall compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Kept valid Gallery images visible on Windows when canonical paths differ only by drive-letter or directory casing, without weakening traversal and symlink containment checks (#5099).
+- Made vectorized lorebook recall use model-appropriate query/document formatting, prioritize recent user turns, and reject incompatible stored vector spaces with useful debug diagnostics (#5104).
 - Honored each image style profile's selected prompt grammar for character avatars, portraits, and sprites instead of silently forcing compact tags (#5083).
 - Game checkpoints now capture and restore the turn-game engine state, so loading a checkpoint rewinds an active turn-game (UNO, Chess, Poker, Eight Ball) along with the story and map instead of leaving it on its post-checkpoint state (#5077).
 - Routed Game Mode time-advance and weather-update through the queued per-chat metadata patch path so they no longer silently revert a concurrent metadata write, which could permanently lock World Map movement as a stale definition (#5076).

--- a/packages/server/src/db/schema/chats.ts
+++ b/packages/server/src/db/schema/chats.ts
@@ -113,6 +113,8 @@ export const memoryChunks = fileTable("memory_chunks", {
   content: text("content").notNull(),
   /** JSON-serialized float[] embedding (null until vectorized) */
   embedding: text("embedding"),
+  /** Stable provider/model/profile identity for the stored embedding */
+  embeddingSpaceId: text("embedding_space_id"),
   /** How many messages were grouped into this chunk */
   messageCount: integer("message_count").notNull(),
   /** Non-null for imported chunks; they should not advance local chunk cursors. */

--- a/packages/server/src/db/schema/lorebooks.ts
+++ b/packages/server/src/db/schema/lorebooks.ts
@@ -181,6 +181,8 @@ export const lorebookEntries = fileTable("lorebook_entries", {
 
   /** Pre-computed embedding vector (JSON array of floats) for semantic matching */
   embedding: text("embedding"),
+  /** Stable provider/model/profile identity for the stored embedding */
+  embeddingSpaceId: text("embedding_space_id"),
 
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -270,6 +270,10 @@ function normalizeMemoryRecallImportChunk(value: unknown, importedAt: string): C
   return {
     content: value.content,
     embedding: normalizeMemoryEmbedding(value.embedding),
+    embeddingSpaceId:
+      typeof value.embeddingSpaceId === "string" && value.embeddingSpaceId.trim()
+        ? value.embeddingSpaceId.trim()
+        : null,
     messageCount,
     firstMessageAt,
     lastMessageAt,
@@ -1783,6 +1787,7 @@ export async function chatsRoutes(app: FastifyInstance) {
       .select({
         content: memoryChunks.content,
         embedding: memoryChunks.embedding,
+        embeddingSpaceId: memoryChunks.embeddingSpaceId,
         messageCount: memoryChunks.messageCount,
         firstMessageAt: memoryChunks.firstMessageAt,
         lastMessageAt: memoryChunks.lastMessageAt,
@@ -1802,6 +1807,7 @@ export async function chatsRoutes(app: FastifyInstance) {
       chunks: chunks.map((chunk) => ({
         content: chunk.content,
         embedding: parseMemoryEmbedding(chunk.embedding),
+        embeddingSpaceId: chunk.embeddingSpaceId,
         messageCount: chunk.messageCount,
         firstMessageAt: chunk.firstMessageAt,
         lastMessageAt: chunk.lastMessageAt,
@@ -1877,6 +1883,7 @@ export async function chatsRoutes(app: FastifyInstance) {
           chatId: req.params.id,
           content: chunk.content,
           embedding: chunk.embedding ? JSON.stringify(chunk.embedding) : null,
+          embeddingSpaceId: chunk.embedding ? (chunk.embeddingSpaceId ?? null) : null,
           messageCount: chunk.messageCount,
           sourceChatId: importedSourceChatId,
           firstMessageAt: chunk.firstMessageAt,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1972,6 +1972,7 @@ export async function generateRoutes(app: FastifyInstance) {
             tokenBudget: resolveLorebookTokenBudget(chatMeta),
             chatEmbedding: chatContextEmbedding,
             semanticEmbeddingsByLorebookId: lorebookSemanticEmbeddingsById,
+            semanticEmbeddingSpaceId: lorebookSemanticEmbeddingSpaceId,
             semanticSimilarityBaseline: lorebookSemanticSimilarityBaseline,
             entryStateOverrides: options.previewOnly
               ? deferredLorebookEntryStateBaseline
@@ -2051,6 +2052,7 @@ export async function generateRoutes(app: FastifyInstance) {
         let chatContextEmbedding: number[] | null = null;
         let lorebookSemanticEmbeddingsById: Map<string, number[] | null> | undefined;
         let lorebookSemanticSimilarityBaseline = 0;
+        let lorebookSemanticEmbeddingSpaceId: string | null = null;
         const knowledgeRouterActivatedLorebookEntryIds = new Set<string>();
         const knowledgeRouterExcludedLorebookEntryIds = new Set<string>();
         let knowledgeRouterActivationPassCompleted = false;
@@ -2082,6 +2084,7 @@ export async function generateRoutes(app: FastifyInstance) {
             chatContextEmbedding = semanticEmbeddings.defaultEmbedding;
             lorebookSemanticEmbeddingsById = semanticEmbeddings.embeddingsByLorebookId;
             lorebookSemanticSimilarityBaseline = semanticEmbeddings.similarityBaseline;
+            lorebookSemanticEmbeddingSpaceId = semanticEmbeddings.embeddingSpaceId;
           }
         } catch {
           // Embedding generation is optional — if it fails, fall back to keyword-only matching
@@ -2163,6 +2166,7 @@ export async function generateRoutes(app: FastifyInstance) {
             lorebookTokenBudget: resolveLorebookTokenBudget(chatMeta),
             chatEmbedding: chatContextEmbedding,
             semanticEmbeddingsByLorebookId: lorebookSemanticEmbeddingsById,
+            semanticEmbeddingSpaceId: lorebookSemanticEmbeddingSpaceId,
             semanticSimilarityBaseline: lorebookSemanticSimilarityBaseline,
             entryStateOverrides:
               (chatMeta.entryStateOverrides as Record<string, { ephemeral?: number | null; enabled?: boolean }>) ??
@@ -2720,6 +2724,7 @@ export async function generateRoutes(app: FastifyInstance) {
             tokenBudget: resolveLorebookTokenBudget(chatMeta),
             chatEmbedding: chatContextEmbedding,
             semanticEmbeddingsByLorebookId: lorebookSemanticEmbeddingsById,
+            semanticEmbeddingSpaceId: lorebookSemanticEmbeddingSpaceId,
             semanticSimilarityBaseline: lorebookSemanticSimilarityBaseline,
             entryStateOverrides:
               (chatMeta.entryStateOverrides as Record<string, { ephemeral?: number | null; enabled?: boolean }>) ??
@@ -3158,6 +3163,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 tokenBudget: resolveLorebookTokenBudget(chatMeta),
                 chatEmbedding: chatContextEmbedding,
                 semanticEmbeddingsByLorebookId: lorebookSemanticEmbeddingsById,
+                semanticEmbeddingSpaceId: lorebookSemanticEmbeddingSpaceId,
                 semanticSimilarityBaseline: lorebookSemanticSimilarityBaseline,
                 entryStateOverrides:
                   (chatMeta.entryStateOverrides as Record<string, { ephemeral?: number | null; enabled?: boolean }>) ??

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -29,7 +29,10 @@ import { createCharactersStorage } from "../services/storage/characters.storage.
 import { createGameStateStorage } from "../services/storage/game-state.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 import { filterRelevantLorebooks, processLorebooks } from "../services/lorebook/index.js";
-import { buildLorebookSemanticEmbeddingsById } from "../services/lorebook/embeddings.js";
+import {
+  buildLorebookEntryEmbeddingText,
+  buildLorebookSemanticEmbeddingsById,
+} from "../services/lorebook/embeddings.js";
 import { resolveOwnerSpatialProjection } from "../services/spatial-context/projection.js";
 import { resolveLorebookScopeExclusions } from "../services/lorebook/game-lorebook-scope.js";
 import {
@@ -46,7 +49,12 @@ import {
 } from "../services/lorebook/character-book-sync.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../services/llm/local-sidecar.js";
-import { resolveMemoryRecallEmbeddingSource } from "../services/memory-recall-embedding.js";
+import {
+  createMemoryRecallEmbeddingSpaceId,
+  formatMemoryRecallEmbeddingTexts,
+  resolveMemoryRecallEmbeddingSource,
+} from "../services/memory-recall-embedding.js";
+import { sidecarModelService } from "../services/sidecar/sidecar-model.service.js";
 import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
 import { DATA_DIR } from "../utils/data-dir.js";
 import { assertInsideDir, extensionFromImageMime, isAllowedImageBuffer } from "../utils/security.js";
@@ -1056,6 +1064,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
     let chatEmbedding: number[] | null = null;
     let semanticEmbeddingsByLorebookId: Map<string, number[] | null> | undefined;
     let semanticSimilarityBaseline = 0;
+    let semanticEmbeddingSpaceId: string | null = null;
     try {
       const activeEntries = (await storage.listActiveEntries(lorebookScopeFilters)) as unknown as LorebookEntry[];
       if (activeEntries.some((entry) => Array.isArray(entry.embedding) && entry.embedding.length > 0)) {
@@ -1074,6 +1083,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
         chatEmbedding = semanticEmbeddings.defaultEmbedding;
         semanticEmbeddingsByLorebookId = semanticEmbeddings.embeddingsByLorebookId;
         semanticSimilarityBaseline = semanticEmbeddings.similarityBaseline;
+        semanticEmbeddingSpaceId = semanticEmbeddings.embeddingSpaceId;
       }
     } catch (err) {
       logger.debug(err, "[lorebooks] Semantic scan preview failed; falling back to keyword-only preview");
@@ -1090,6 +1100,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       excludedSourceAgentIds: lorebookScopeExclusions.excludedSourceAgentIds,
       chatEmbedding,
       semanticEmbeddingsByLorebookId,
+      semanticEmbeddingSpaceId,
       semanticSimilarityBaseline,
       forcedEntryIds: chat?.mode === "conversation" ? [] : (ownerSpatialProjection?.lorebookEntryIds ?? []),
       tokenBudget: typeof chatMeta.lorebookTokenBudget === "number" ? chatMeta.lorebookTokenBudget : undefined,
@@ -1178,17 +1189,18 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       : vectorizableEntries;
     if (!entries.length) return { vectorized: 0, total: allEntries.length, skipped: allEntries.length };
 
+    const embeddingBaseUrl = useLocalSidecar
+      ? ""
+      : conn!.embeddingBaseUrl
+        ? (conn!.embeddingBaseUrl as string).replace(/\/+$/, "")
+        : (conn!.baseUrl as string);
     const provider = useLocalSidecar
       ? getLocalSidecarProvider()
       : (() => {
           const resolvedConn = conn!;
-          // Use dedicated embedding base URL if configured, otherwise the connection's base URL
-          const embedBaseUrl = resolvedConn.embeddingBaseUrl
-            ? (resolvedConn.embeddingBaseUrl as string).replace(/\/+$/, "")
-            : (resolvedConn.baseUrl as string);
           return createLLMProvider(
             resolvedConn.provider as string,
-            embedBaseUrl,
+            embeddingBaseUrl,
             resolvedConn.apiKey as string,
             resolvedConn.maxContext,
             resolvedConn.openrouterProvider,
@@ -1200,21 +1212,35 @@ export async function lorebooksRoutes(app: FastifyInstance) {
           );
         })();
     const embeddingModel = useLocalSidecar ? LOCAL_SIDECAR_MODEL : body.model;
+    const embeddingProfileModel = useLocalSidecar
+      ? (sidecarModelService.getConfiguredModelRef() ?? LOCAL_SIDECAR_MODEL)
+      : embeddingModel;
+    const embeddingSpaceId = useLocalSidecar
+      ? createMemoryRecallEmbeddingSpaceId("sidecar", embeddingProfileModel, sidecarModelService.getResolvedBackend())
+      : createMemoryRecallEmbeddingSpaceId("remote", embeddingModel, conn!.provider as string, embeddingBaseUrl);
 
-    // Build text for each entry: combine name, keys, and content
-    const texts = (entries as Array<Record<string, unknown>>).map((e) => {
-      const keys = [
-        ...(Array.isArray(e.keys) ? (e.keys as string[]) : []),
-        ...(Array.isArray(e.secondaryKeys) ? (e.secondaryKeys as string[]) : []),
-      ].join(", ");
-      return `${e.name ?? ""}${keys ? ` [${keys}]` : ""}\n${e.content ?? ""}`.trim();
-    });
+    const texts = formatMemoryRecallEmbeddingTexts(
+      (entries as LorebookEntry[]).map(buildLorebookEntryEmbeddingText),
+      embeddingProfileModel,
+      "document",
+    );
     const existingEmbeddingDimension = body.onlyMissing
       ? ((allEntries as Array<Record<string, unknown>>)
           .map((entry) => entry.embedding)
           .find((embedding): embedding is unknown[] => Array.isArray(embedding) && embedding.length > 0)?.length ??
         null)
       : null;
+    const existingEmbeddingSpaceId = body.onlyMissing
+      ? ((allEntries as Array<Record<string, unknown>>)
+          .map((entry) => entry.embeddingSpaceId)
+          .find((spaceId): spaceId is string => typeof spaceId === "string" && spaceId.length > 0) ?? null)
+      : null;
+    if (existingEmbeddingSpaceId && existingEmbeddingSpaceId !== embeddingSpaceId) {
+      return reply.status(409).send({
+        error:
+          "The existing vectors use a different embedding provider or model. Use Re-vectorize all entries before switching embedding sources.",
+      });
+    }
 
     // Batch embed (most APIs support multiple texts per call)
     const BATCH_SIZE = 50;
@@ -1253,7 +1279,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       for (let j = 0; j < batchEntries.length; j++) {
         const entry = batchEntries[j] as Record<string, unknown>;
         if (embeddings[j]) {
-          await storage.updateEntryEmbedding(entry.id as string, embeddings[j]!);
+          await storage.updateEntryEmbedding(entry.id as string, embeddings[j]!, embeddingSpaceId);
           vectorized++;
         }
       }

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -1224,21 +1224,24 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       embeddingProfileModel,
       "document",
     );
-    const existingEmbeddingDimension = body.onlyMissing
-      ? ((allEntries as Array<Record<string, unknown>>)
-          .map((entry) => entry.embedding)
-          .find((embedding): embedding is unknown[] => Array.isArray(embedding) && embedding.length > 0)?.length ??
-        null)
+    const existingVectorEntries = body.onlyMissing
+      ? (allEntries as Array<Record<string, unknown>>).filter(
+          (entry) => Array.isArray(entry.embedding) && entry.embedding.length > 0,
+        )
+      : [];
+    const existingEmbeddingDimension = Array.isArray(existingVectorEntries[0]?.embedding)
+      ? existingVectorEntries[0].embedding.length
       : null;
-    const existingEmbeddingSpaceId = body.onlyMissing
-      ? ((allEntries as Array<Record<string, unknown>>)
-          .map((entry) => entry.embeddingSpaceId)
-          .find((spaceId): spaceId is string => typeof spaceId === "string" && spaceId.length > 0) ?? null)
-      : null;
-    if (existingEmbeddingSpaceId && existingEmbeddingSpaceId !== embeddingSpaceId) {
+    const hasUnknownEmbeddingSpace = existingVectorEntries.some(
+      (entry) => typeof entry.embeddingSpaceId !== "string" || !entry.embeddingSpaceId.trim(),
+    );
+    const hasDifferentEmbeddingSpace = existingVectorEntries.some(
+      (entry) => entry.embeddingSpaceId !== embeddingSpaceId,
+    );
+    if (hasUnknownEmbeddingSpace || hasDifferentEmbeddingSpace) {
       return reply.status(409).send({
         error:
-          "The existing vectors use a different embedding provider or model. Use Re-vectorize all entries before switching embedding sources.",
+          "The existing vectors use an unknown or different embedding provider, model, or input profile. Use Re-vectorize all entries before switching embedding sources.",
       });
     }
 

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -1225,7 +1225,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       "document",
     );
     const existingVectorEntries = body.onlyMissing
-      ? (allEntries as Array<Record<string, unknown>>).filter(
+      ? (vectorizableEntries as Array<Record<string, unknown>>).filter(
           (entry) => Array.isArray(entry.embedding) && entry.embedding.length > 0,
         )
       : [];

--- a/packages/server/src/services/entity-semantic-search.ts
+++ b/packages/server/src/services/entity-semantic-search.ts
@@ -83,7 +83,11 @@ const SEMANTIC_CALIBRATION_TEXTS = [
   "A city council reviews municipal zoning regulations.",
 ] as const;
 
-async function embedTexts(texts: string[], options: EntityResolveOptions): Promise<number[][]> {
+async function embedTexts(
+  texts: string[],
+  options: EntityResolveOptions,
+  inputType: "document" | "query",
+): Promise<number[][]> {
   // A throwing embedder must degrade exactly like an unavailable one — every
   // in-tree source catches internally, but a future/custom one might not.
   try {
@@ -91,6 +95,7 @@ async function embedTexts(texts: string[], options: EntityResolveOptions): Promi
       embeddingSource: options.embeddingSource,
       localEmbedder: options.localEmbedder ?? localEmbed,
       signal: options.signal,
+      inputType,
     });
   } catch (err) {
     logger.warn(err, "[entity-search] embedding call failed; degrading to substring");
@@ -123,6 +128,7 @@ export async function warmEntityEmbeddings(
   const embeddings = await embedTexts(
     missing.map((c) => c.embedText),
     options,
+    "document",
   );
   if (embeddings.length === 0) return { attempted: missing.length, embedded: 0 };
 
@@ -148,7 +154,8 @@ export async function warmEntityEmbeddings(
       embedded += 1;
     }
   }
-  if (embedded > 0) logger.debug("[entity-search] Persisted %d/%d %s embedding(s)", embedded, missing.length, descriptor.type);
+  if (embedded > 0)
+    logger.debug("[entity-search] Persisted %d/%d %s embedding(s)", embedded, missing.length, descriptor.type);
   return { attempted: missing.length, embedded };
 }
 
@@ -170,7 +177,7 @@ export async function shortlistEntities(
   // this call; it warms over subsequent fetches.
   await warmEntityEmbeddings(descriptor, pool, options);
 
-  const queryEmbeddings = await embedTexts([query, ...SEMANTIC_CALIBRATION_TEXTS], options);
+  const queryEmbeddings = await embedTexts([query, ...SEMANTIC_CALIBRATION_TEXTS], options, "query");
   const queryEmbedding = queryEmbeddings[0];
   if (!queryEmbedding || queryEmbedding.length === 0) return null; // embedder unavailable
 

--- a/packages/server/src/services/generation/agent-lorebook-triggers.ts
+++ b/packages/server/src/services/generation/agent-lorebook-triggers.ts
@@ -53,14 +53,16 @@ export function createAgentLorebookTriggerResolver(
 ): (contextMessages: AgentContext["recentMessages"]) => Promise<TriggeredEntriesByAgentId> {
   let enabledLorebooksByIdPromise: Promise<Map<string, Lorebook>> | null = null;
   const getEnabledLorebooksById = () => {
-    enabledLorebooksByIdPromise ??= options.listLorebooks().then(
-      (lorebooks) =>
-        new Map(
-          lorebooks
-            .filter((lorebook) => lorebook.enabled !== false)
-            .map((lorebook) => [lorebook.id, lorebook] as const),
-        ),
-    );
+    enabledLorebooksByIdPromise ??= options
+      .listLorebooks()
+      .then(
+        (lorebooks) =>
+          new Map(
+            lorebooks
+              .filter((lorebook) => lorebook.enabled !== false)
+              .map((lorebook) => [lorebook.id, lorebook] as const),
+          ),
+      );
     return enabledLorebooksByIdPromise;
   };
   const entriesBySourceKey = new Map<string, Promise<LorebookEntry[]>>();
@@ -135,6 +137,7 @@ export function createAgentLorebookTriggerResolver(
         let chatEmbedding: number[] | null = null;
         let semanticEmbeddingsByLorebookId: Map<string, number[] | null> | undefined;
         let semanticSimilarityBaseline = 0;
+        let semanticEmbeddingSpaceId: string | null = null;
         if (
           source.entries.some((entry) => Array.isArray(entry.embedding) && entry.embedding.length > 0) &&
           options.vectorizerAvailable
@@ -150,6 +153,7 @@ export function createAgentLorebookTriggerResolver(
             chatEmbedding = semanticEmbeddings.defaultEmbedding;
             semanticEmbeddingsByLorebookId = semanticEmbeddings.embeddingsByLorebookId;
             semanticSimilarityBaseline = semanticEmbeddings.similarityBaseline;
+            semanticEmbeddingSpaceId = semanticEmbeddings.embeddingSpaceId;
           } catch (err) {
             logger.warn(
               err,
@@ -164,6 +168,7 @@ export function createAgentLorebookTriggerResolver(
           gameState: options.gameState,
           chatEmbedding,
           semanticEmbeddingsByLorebookId,
+          semanticEmbeddingSpaceId,
           semanticSimilarityBaseline,
           activeCharacterIds: options.activeCharacterIds,
           activeCharacterTags: options.activeCharacterTags,

--- a/packages/server/src/services/generation/professor-mari-command-runtime.ts
+++ b/packages/server/src/services/generation/professor-mari-command-runtime.ts
@@ -26,7 +26,7 @@ import {
 import { bumpCharacterVersion } from "./generation-text-utils.js";
 import { createEntityEmbeddingStore } from "../entity-embedding-store.js";
 import { tieredResolveEntity, type EntityDescriptor, type EntitySearchType } from "../entity-semantic-search.js";
-import type { MemoryRecallEmbeddingSource } from "../memory-recall.js";
+import { DEFAULT_LOCAL_MEMORY_EMBEDDING_SPACE_ID, type MemoryRecallEmbeddingSource } from "../memory-recall.js";
 import {
   MAX_MARI_FETCHED_PRESET_CONTEXT_CHARS,
   normalizeAssistantPresetIdentifier,
@@ -670,7 +670,11 @@ async function resolveFetchedContent(
   args: Parameters<typeof handleProfessorMariCommand>[0],
 ): Promise<FetchResolution> {
   const type = command.fetchType as EntitySearchType;
-  const sourceId = args.embeddingSource?.spaceId ?? args.embeddingSource?.label ?? "local";
+  // Persisted entity envelopes already compare this value exactly. Remote IDs
+  // include the input-profile revision, while the local fallback is explicitly
+  // versioned, so vectors created before asymmetric formatting are re-warmed.
+  const sourceId =
+    args.embeddingSource?.spaceId ?? args.embeddingSource?.label ?? DEFAULT_LOCAL_MEMORY_EMBEDDING_SPACE_ID;
   const store = createEntityEmbeddingStore(args.db, sourceId);
   const descriptor: EntityDescriptor = {
     type,

--- a/packages/server/src/services/lorebook/embeddings.ts
+++ b/packages/server/src/services/lorebook/embeddings.ts
@@ -25,9 +25,20 @@ export interface SemanticLorebookMatch {
   similarity: number;
 }
 
-export function selectLorebookVectorQueryText(messages: Array<{ content: string }>, depth: number): string {
-  const selectedMessages = depth > 0 ? messages.slice(-depth) : messages;
-  return selectedMessages.map((message) => message.content).join("\n").trim();
+export function selectLorebookVectorQueryText(
+  messages: Array<{ content: string; role?: string }>,
+  depth: number,
+): string {
+  // Opening and assistant prose can dwarf a short, exact user query. Retrieval
+  // should follow what the user is asking about now, while still allowing a
+  // configurable history of earlier user turns.
+  const userMessages = messages.filter((message) => message.role === "user");
+  const queryMessages = userMessages.length > 0 ? userMessages : messages;
+  const selectedMessages = depth > 0 ? queryMessages.slice(-depth) : queryMessages;
+  return selectedMessages
+    .map((message) => message.content)
+    .join("\n")
+    .trim();
 }
 
 function normalizeLorebookVectorQueryDepth(value: unknown): number {
@@ -123,11 +134,24 @@ function getExistingEmbeddingDimension(entries: LorebookEntry[]): number | null 
   return null;
 }
 
-async function embedLorebookTexts(texts: string[], options: LorebookEmbeddingOptions): Promise<number[][]> {
+function getExistingEmbeddingSpaceId(entries: LorebookEntry[]): string | null {
+  for (const entry of entries) {
+    if (entry.excludeFromVectorization || !entry.embedding?.length) continue;
+    if (entry.embeddingSpaceId) return entry.embeddingSpaceId;
+  }
+  return null;
+}
+
+async function embedLorebookTexts(
+  texts: string[],
+  options: LorebookEmbeddingOptions,
+  inputType: "document" | "query",
+): Promise<number[][]> {
   return embedMemoryRecallTexts(texts, {
     localEmbedder: options.localEmbedder ?? localEmbed,
     embeddingSource: options.embeddingSource,
     signal: options.signal,
+    inputType,
   });
 }
 
@@ -138,16 +162,26 @@ export async function warmLorebookEntryEmbeddings(
 ): Promise<LorebookEmbeddingWarmupResult> {
   const batchSize = normalizePositiveInteger(options.batchSize, DEFAULT_WARMUP_BATCH_SIZE);
   const candidates = entries
-    .filter((entry) => entry.enabled && !entry.excludeFromVectorization && (!entry.embedding || entry.embedding.length === 0))
+    .filter(
+      (entry) => entry.enabled && !entry.excludeFromVectorization && (!entry.embedding || entry.embedding.length === 0),
+    )
     .slice(0, batchSize);
   if (candidates.length === 0) return { attempted: 0, embedded: 0 };
 
   const texts = candidates.map(buildLorebookEntryEmbeddingText);
-  const embeddings = await embedLorebookTexts(texts, options);
+  const embeddings = await embedLorebookTexts(texts, options, "document");
   if (embeddings.length === 0) return { attempted: candidates.length, embedded: 0 };
 
   const embeddingDimension = embeddings.find((embedding) => embedding.length > 0)?.length ?? null;
   const existingDimension = getExistingEmbeddingDimension(entries);
+  const existingSpaceId = getExistingEmbeddingSpaceId(entries);
+  const embeddingSpaceId = options.embeddingSource?.spaceId ?? null;
+  if (existingSpaceId && embeddingSpaceId && existingSpaceId !== embeddingSpaceId) {
+    logger.warn(
+      "[lorebook-embeddings] Skipping warmup because stored entries use a different embedding source. Refresh lorebook embeddings before switching provider or model.",
+    );
+    return { attempted: candidates.length, embedded: 0 };
+  }
   if (embeddingDimension && existingDimension && embeddingDimension !== existingDimension) {
     logger.warn(
       "[lorebook-embeddings] Skipping warmup because embedding dimension changed from %d to %d. Refresh lorebook embeddings before mixing embedding models.",
@@ -162,8 +196,9 @@ export async function warmLorebookEntryEmbeddings(
   for (let index = 0; index < candidates.length; index++) {
     const vector = embeddings[index];
     if (!vector || vector.length === 0) continue;
-    await storage.updateEntryEmbedding(candidates[index]!.id, vector);
+    await storage.updateEntryEmbedding(candidates[index]!.id, vector, embeddingSpaceId);
     candidates[index]!.embedding = vector;
+    candidates[index]!.embeddingSpaceId = embeddingSpaceId;
     embedded += 1;
   }
 
@@ -182,16 +217,30 @@ export async function semanticShortlistLorebookEntries(
   const queryText = query.trim();
   if (!queryText) return null;
 
-  const queryEmbeddings = await embedLorebookTexts([queryText, ...SEMANTIC_CALIBRATION_TEXTS], options);
+  const queryEmbeddings = await embedLorebookTexts([queryText, ...SEMANTIC_CALIBRATION_TEXTS], options, "query");
   const queryEmbedding = queryEmbeddings[0];
   if (!queryEmbedding || queryEmbedding.length === 0) return null;
   const similarityBaseline = lorebookSimilarityBaseline(queryEmbeddings.slice(1));
 
   let dimensionMismatchLogged = false;
+  let sourceMismatchLogged = false;
   const matches = entries
     .map((entry) => {
       const embedding = entry.embedding;
       if (!embedding || embedding.length === 0) return null;
+      if (
+        entry.embeddingSpaceId &&
+        options.embeddingSource?.spaceId &&
+        entry.embeddingSpaceId !== options.embeddingSource.spaceId
+      ) {
+        if (!sourceMismatchLogged) {
+          sourceMismatchLogged = true;
+          logger.warn(
+            "[lorebook-embeddings] Skipping one or more entries vectorized by a different provider or model. Re-vectorize the lorebook with the active embedding source.",
+          );
+        }
+        return null;
+      }
       if (embedding.length !== queryEmbedding.length) {
         if (!dimensionMismatchLogged) {
           dimensionMismatchLogged = true;
@@ -223,13 +272,14 @@ export async function buildLorebookSemanticEmbeddingsById({
 }: {
   lorebooks: Lorebook[];
   entries: LorebookEntry[];
-  scanMessages: Array<{ content: string }>;
+  scanMessages: Array<{ content: string; role?: string }>;
   embeddingSource: MemoryRecallEmbeddingOptions["embeddingSource"];
   signal?: AbortSignal;
 }): Promise<{
   defaultEmbedding: number[] | null;
   embeddingsByLorebookId?: Map<string, number[] | null>;
   similarityBaseline: number;
+  embeddingSpaceId: string | null;
 }> {
   const lorebookIdsWithVectors = new Set(
     entries
@@ -238,12 +288,16 @@ export async function buildLorebookSemanticEmbeddingsById({
       )
       .map((entry) => entry.lorebookId),
   );
-  if (lorebookIdsWithVectors.size === 0) return { defaultEmbedding: null, similarityBaseline: 0 };
+  if (lorebookIdsWithVectors.size === 0) {
+    return { defaultEmbedding: null, similarityBaseline: 0, embeddingSpaceId: embeddingSource?.spaceId ?? null };
+  }
 
   const vectorLorebooks = lorebooks.filter(
     (lorebook) => !lorebook.excludeFromVectorization && lorebookIdsWithVectors.has(lorebook.id),
   );
-  if (vectorLorebooks.length === 0) return { defaultEmbedding: null, similarityBaseline: 0 };
+  if (vectorLorebooks.length === 0) {
+    return { defaultEmbedding: null, similarityBaseline: 0, embeddingSpaceId: embeddingSource?.spaceId ?? null };
+  }
 
   const depths = Array.from(
     new Set(vectorLorebooks.map((lorebook) => normalizeLorebookVectorQueryDepth(lorebook.vectorQueryDepth))),
@@ -255,7 +309,7 @@ export async function buildLorebookSemanticEmbeddingsById({
   const populatedDepths = depths.filter((depth) => queryTextsByDepth.get(depth));
   const queryAndCalibrationEmbeddings = await embedMemoryRecallTexts(
     [...populatedDepths.map((depth) => queryTextsByDepth.get(depth)!), ...SEMANTIC_CALIBRATION_TEXTS],
-    { embeddingSource, signal },
+    { embeddingSource, signal, inputType: "query" },
   );
   for (const depth of depths) {
     const queryIndex = populatedDepths.indexOf(depth);
@@ -278,5 +332,6 @@ export async function buildLorebookSemanticEmbeddingsById({
       null,
     embeddingsByLorebookId,
     similarityBaseline,
+    embeddingSpaceId: embeddingSource?.spaceId ?? null,
   };
 }

--- a/packages/server/src/services/lorebook/embeddings.ts
+++ b/packages/server/src/services/lorebook/embeddings.ts
@@ -142,6 +142,13 @@ function getExistingEmbeddingSpaceId(entries: LorebookEntry[]): string | null {
   return null;
 }
 
+function hasIncompatibleEmbeddingSpace(entries: LorebookEntry[], activeSpaceId: string): boolean {
+  return entries.some(
+    (entry) =>
+      !entry.excludeFromVectorization && Boolean(entry.embedding?.length) && entry.embeddingSpaceId !== activeSpaceId,
+  );
+}
+
 async function embedLorebookTexts(
   texts: string[],
   options: LorebookEmbeddingOptions,
@@ -176,7 +183,11 @@ export async function warmLorebookEntryEmbeddings(
   const existingDimension = getExistingEmbeddingDimension(entries);
   const existingSpaceId = getExistingEmbeddingSpaceId(entries);
   const embeddingSpaceId = options.embeddingSource?.spaceId ?? null;
-  if (existingSpaceId && embeddingSpaceId && existingSpaceId !== embeddingSpaceId) {
+  if (
+    embeddingSpaceId &&
+    (hasIncompatibleEmbeddingSpace(entries, embeddingSpaceId) ||
+      (existingSpaceId !== null && existingSpaceId !== embeddingSpaceId))
+  ) {
     logger.warn(
       "[lorebook-embeddings] Skipping warmup because stored entries use a different embedding source. Refresh lorebook embeddings before switching provider or model.",
     );
@@ -228,11 +239,7 @@ export async function semanticShortlistLorebookEntries(
     .map((entry) => {
       const embedding = entry.embedding;
       if (!embedding || embedding.length === 0) return null;
-      if (
-        entry.embeddingSpaceId &&
-        options.embeddingSource?.spaceId &&
-        entry.embeddingSpaceId !== options.embeddingSource.spaceId
-      ) {
+      if (options.embeddingSource?.spaceId && entry.embeddingSpaceId !== options.embeddingSource.spaceId) {
         if (!sourceMismatchLogged) {
           sourceMismatchLogged = true;
           logger.warn(

--- a/packages/server/src/services/lorebook/index.ts
+++ b/packages/server/src/services/lorebook/index.ts
@@ -579,10 +579,7 @@ function getBudgetSkipReason(exceedsLorebookBudget: boolean, exceedsGlobalBudget
 function normalizeLorebookEntryLimit(value: unknown): number {
   const parsed = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(parsed)) return LIMITS.LOREBOOK_ENTRY_LIMIT_DEFAULT;
-  return Math.max(
-    LIMITS.LOREBOOK_ENTRY_LIMIT_MIN,
-    Math.min(LIMITS.LOREBOOK_ENTRY_LIMIT_MAX, Math.trunc(parsed)),
-  );
+  return Math.max(LIMITS.LOREBOOK_ENTRY_LIMIT_MIN, Math.min(LIMITS.LOREBOOK_ENTRY_LIMIT_MAX, Math.trunc(parsed)));
 }
 
 function normalizeLorebookVectorScoreThreshold(value: unknown): number {
@@ -904,7 +901,10 @@ export function resolveBudgetAndRecursivelyActivateLorebookEntriesWithDiagnostic
   const probabilityDecisions = options.probabilityDecisions ?? new Map<string, boolean>();
   const scanOptions = { ...options, probabilityDecisions };
   const canRecurseEntry = (entry: LorebookEntry) => !recursiveLorebookIds || recursiveLorebookIds.has(entry.lorebookId);
-  let frontier = mergeActivatedEntries(scanForActivatedEntries(messages, entries, scanOptions), initialActivatedEntries);
+  let frontier = mergeActivatedEntries(
+    scanForActivatedEntries(messages, entries, scanOptions),
+    initialActivatedEntries,
+  );
   const budgetSkippedEntries: LorebookBudgetSkippedEntry[] = [];
 
   for (let depth = 0; frontier.length > 0; depth++) {
@@ -1016,6 +1016,8 @@ export async function processLorebooks(
     chatEmbedding?: number[] | null;
     /** Per-lorebook pre-computed embeddings for semantic matching. */
     semanticEmbeddingsByLorebookId?: ReadonlyMap<string, number[] | null>;
+    /** Provider/model/profile identity used to create semantic query vectors. */
+    semanticEmbeddingSpaceId?: string | null;
     /** Cosine similarity threshold for semantic matching (0-1, default 0.3). */
     semanticThreshold?: number;
     /** Unrelated-text cosine floor used to calibrate clustered embedding models. */
@@ -1143,6 +1145,7 @@ export async function processLorebooks(
     semanticThreshold: options?.semanticThreshold,
     semanticSimilarityBaseline: options?.semanticSimilarityBaseline,
     semanticEmbeddingsByLorebookId: options?.semanticEmbeddingsByLorebookId,
+    semanticEmbeddingSpaceId: options?.semanticEmbeddingSpaceId,
     semanticThresholdByLorebookId: new Map(
       effectiveLorebooks.map((book) => [book.id, normalizeLorebookVectorScoreThreshold(book.vectorScoreThreshold)]),
     ),
@@ -1180,10 +1183,7 @@ export async function processLorebooks(
     }));
   const locationBudgetResult = applyCurrentLocationLoreBudget(forcedActivatedEntries, relevantLorebooksById);
   const ordinaryActivatedEntries = scanForActivatedEntries(messages, allEntries, scanOpts);
-  const initialActivatedEntries = mergeActivatedEntries(
-    ordinaryActivatedEntries,
-    locationBudgetResult.selected,
-  );
+  const initialActivatedEntries = mergeActivatedEntries(ordinaryActivatedEntries, locationBudgetResult.selected);
   const baseBudgetResult = anyRecursive
     ? resolveBudgetAndRecursivelyActivateLorebookEntriesWithDiagnostics(
         messages,

--- a/packages/server/src/services/lorebook/keyword-scanner.ts
+++ b/packages/server/src/services/lorebook/keyword-scanner.ts
@@ -13,6 +13,7 @@ import type {
   LorebookSchedule,
 } from "@marinara-engine/shared";
 import { LIMITS, testPrimaryKeys, testSecondaryKeys } from "@marinara-engine/shared";
+import { logger } from "../../lib/logger.js";
 import { calibrateLorebookSimilarity } from "./embeddings.js";
 import { vmRegexExecutor } from "./regex-timeout.js";
 
@@ -415,6 +416,8 @@ export interface ScanOptions {
   chatEmbedding?: number[] | null;
   /** Per-lorebook chat context embeddings for semantic matching. */
   semanticEmbeddingsByLorebookId?: ReadonlyMap<string, number[] | null>;
+  /** Provider/model/profile identity used to produce semantic query vectors. */
+  semanticEmbeddingSpaceId?: string | null;
   /** Cosine similarity threshold for semantic matching (0-1, default 0.3). */
   semanticThreshold?: number;
   /** Unrelated-text cosine floor used to calibrate clustered embedding models. */
@@ -458,6 +461,7 @@ export function scanForActivatedEntries(
     timingStates = new Map(),
     chatEmbedding = null,
     semanticEmbeddingsByLorebookId = new Map<string, number[] | null>(),
+    semanticEmbeddingSpaceId = null,
     semanticThreshold = 0.3,
     semanticSimilarityBaseline = 0,
     semanticThresholdByLorebookId = new Map<string, number>(),
@@ -605,13 +609,38 @@ export function scanForActivatedEntries(
       if (!entry.embedding || entry.embedding.length === 0) continue;
       const queryEmbedding = semanticEmbeddingsByLorebookId.get(entry.lorebookId) ?? chatEmbedding;
       if (!queryEmbedding || queryEmbedding.length === 0) continue;
+      if (entry.embeddingSpaceId && semanticEmbeddingSpaceId && entry.embeddingSpaceId !== semanticEmbeddingSpaceId) {
+        logger.debug(
+          "[lorebook-vectors] Rejected entry %s: stored vector space %s differs from active space %s",
+          entry.id,
+          entry.embeddingSpaceId,
+          semanticEmbeddingSpaceId,
+        );
+        continue;
+      }
+      if (entry.embedding.length !== queryEmbedding.length) {
+        logger.debug(
+          "[lorebook-vectors] Rejected entry %s: stored dimension %d differs from query dimension %d",
+          entry.id,
+          entry.embedding.length,
+          queryEmbedding.length,
+        );
+        continue;
+      }
       const timingState = timingStates.get(entry.id);
       if (!passesActivationGate(entry, timingState, filterContext, gameState, ignoreTiming)) continue;
 
       const threshold = semanticThresholdByLorebookId.get(entry.lorebookId) ?? semanticThreshold;
-      const similarity = calibrateLorebookSimilarity(
-        cosineSimilarity(queryEmbedding, entry.embedding),
+      const rawSimilarity = cosineSimilarity(queryEmbedding, entry.embedding);
+      const similarity = calibrateLorebookSimilarity(rawSimilarity, semanticSimilarityBaseline);
+      logger.debug(
+        "[lorebook-vectors] Scored entry %s: raw=%d calibrated=%d baseline=%d threshold=%d accepted=%s",
+        entry.id,
+        rawSimilarity,
+        similarity,
         semanticSimilarityBaseline,
+        threshold,
+        similarity >= threshold,
       );
       if (similarity >= threshold) {
         const entryScanText = getEntryScanText(entry);

--- a/packages/server/src/services/lorebook/keyword-scanner.ts
+++ b/packages/server/src/services/lorebook/keyword-scanner.ts
@@ -609,7 +609,7 @@ export function scanForActivatedEntries(
       if (!entry.embedding || entry.embedding.length === 0) continue;
       const queryEmbedding = semanticEmbeddingsByLorebookId.get(entry.lorebookId) ?? chatEmbedding;
       if (!queryEmbedding || queryEmbedding.length === 0) continue;
-      if (entry.embeddingSpaceId && semanticEmbeddingSpaceId && entry.embeddingSpaceId !== semanticEmbeddingSpaceId) {
+      if (semanticEmbeddingSpaceId && entry.embeddingSpaceId !== semanticEmbeddingSpaceId) {
         logger.debug(
           "[lorebook-vectors] Rejected entry %s: stored vector space %s differs from active space %s",
           entry.id,

--- a/packages/server/src/services/memory-recall-embedding.ts
+++ b/packages/server/src/services/memory-recall-embedding.ts
@@ -5,7 +5,7 @@ import { logger } from "../lib/logger.js";
 import { isLocalEmbedderAvailable } from "./local-embedder.js";
 import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "./llm/local-sidecar.js";
 import { createLLMProvider } from "./llm/provider-registry.js";
-import type { MemoryRecallEmbeddingSource } from "./memory-recall.js";
+import type { MemoryRecallEmbeddingInputType, MemoryRecallEmbeddingSource } from "./memory-recall.js";
 import { sidecarModelService } from "./sidecar/sidecar-model.service.js";
 import { createConnectionsStorage } from "./storage/connections.storage.js";
 
@@ -60,9 +60,55 @@ function nonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
-function embeddingSpaceId(kind: string, ...parts: Array<string | null | undefined>): string {
+export interface MemoryRecallEmbeddingInputProfile {
+  id: string;
+  queryPrefix: string;
+  documentPrefix: string;
+}
+
+const DEFAULT_EMBEDDING_INPUT_PROFILE: MemoryRecallEmbeddingInputProfile = {
+  id: "plain-v1",
+  queryPrefix: "",
+  documentPrefix: "",
+};
+
+/**
+ * Apply the asymmetric input prefixes required by common retrieval models.
+ * Unknown models remain untouched because adding an unsupported instruction
+ * can be more damaging than omitting one.
+ */
+export function resolveMemoryRecallEmbeddingInputProfile(model: string): MemoryRecallEmbeddingInputProfile {
+  const normalized = model.toLowerCase();
+  if (normalized.includes("snowflake-arctic-embed") && normalized.includes("v2")) {
+    return { id: "snowflake-arctic-v2", queryPrefix: "query: ", documentPrefix: "" };
+  }
+  if (/(^|[/_.-])e5([/_.-]|$)/u.test(normalized)) {
+    return { id: "e5", queryPrefix: "query: ", documentPrefix: "passage: " };
+  }
+  if (normalized.includes("nomic-embed-text")) {
+    return { id: "nomic-embed-text", queryPrefix: "search_query: ", documentPrefix: "search_document: " };
+  }
+  return DEFAULT_EMBEDDING_INPUT_PROFILE;
+}
+
+export function formatMemoryRecallEmbeddingTexts(
+  texts: string[],
+  model: string,
+  inputType: MemoryRecallEmbeddingInputType,
+): string[] {
+  const profile = resolveMemoryRecallEmbeddingInputProfile(model);
+  const prefix = inputType === "query" ? profile.queryPrefix : profile.documentPrefix;
+  return prefix ? texts.map((text) => `${prefix}${text}`) : texts;
+}
+
+export function createMemoryRecallEmbeddingSpaceId(
+  kind: string,
+  model: string,
+  ...parts: Array<string | null | undefined>
+): string {
+  const profile = resolveMemoryRecallEmbeddingInputProfile(model);
   const digest = createHash("sha256")
-    .update(JSON.stringify(parts.map((part) => part?.trim() ?? "")))
+    .update(JSON.stringify([...parts, model, profile.id].map((part) => part?.trim() ?? "")))
     .digest("hex");
   return `${kind}:${digest}`;
 }
@@ -79,7 +125,8 @@ function buildVectorizerCacheKey(options: {
     connectionId: options.connectionId ?? active?.id ?? "default",
     activeBaseUrl: options.activeBaseUrl ?? "",
     provider: active?.provider ?? "",
-    embeddingConnectionId: nonEmptyString(chatMeta.embeddingConnectionId) ?? nonEmptyString(active?.embeddingConnectionId) ?? "",
+    embeddingConnectionId:
+      nonEmptyString(chatMeta.embeddingConnectionId) ?? nonEmptyString(active?.embeddingConnectionId) ?? "",
     embeddingBaseUrl: nonEmptyString(active?.embeddingBaseUrl) ?? "",
     embeddingModel: nonEmptyString(active?.embeddingModel) ?? "",
   });
@@ -146,16 +193,21 @@ export async function resolveMemoryRecallEmbeddingSource(
 
     const provider = getLocalSidecarProvider();
     const label = "Local Model sidecar";
+    const configuredModelRef = sidecarModelService.getConfiguredModelRef() ?? LOCAL_SIDECAR_MODEL;
     return {
-      spaceId: embeddingSpaceId(
+      spaceId: createMemoryRecallEmbeddingSpaceId(
         "sidecar",
+        configuredModelRef,
         sidecarModelService.getResolvedBackend(),
-        sidecarModelService.getConfiguredModelRef(),
       ),
       label,
-      async embed(texts: string[], signal?: AbortSignal) {
+      async embed(texts: string[], signal?: AbortSignal, inputType: MemoryRecallEmbeddingInputType = "document") {
         try {
-          return await provider.embed(texts, LOCAL_SIDECAR_MODEL, signal);
+          return await provider.embed(
+            formatMemoryRecallEmbeddingTexts(texts, configuredModelRef, inputType),
+            LOCAL_SIDECAR_MODEL,
+            signal,
+          );
         } catch (err) {
           logger.warn(err, "[memory-recall] Configured embedding source %s failed", label);
           return null;
@@ -199,11 +251,20 @@ export async function resolveMemoryRecallEmbeddingSource(
   const label = `${embeddingConnection.name || embeddingConnection.provider} (${embeddingModel})`;
 
   return {
-    spaceId: embeddingSpaceId("remote", embeddingConnection.provider, embeddingBaseUrl, embeddingModel),
+    spaceId: createMemoryRecallEmbeddingSpaceId(
+      "remote",
+      embeddingModel,
+      embeddingConnection.provider,
+      embeddingBaseUrl,
+    ),
     label,
-    async embed(texts: string[], signal?: AbortSignal) {
+    async embed(texts: string[], signal?: AbortSignal, inputType: MemoryRecallEmbeddingInputType = "document") {
       try {
-        return await provider.embed(texts, embeddingModel, signal);
+        return await provider.embed(
+          formatMemoryRecallEmbeddingTexts(texts, embeddingModel, inputType),
+          embeddingModel,
+          signal,
+        );
       } catch (err) {
         logger.warn(err, "[memory-recall] Configured embedding source %s failed", label);
         return null;

--- a/packages/server/src/services/memory-recall.ts
+++ b/packages/server/src/services/memory-recall.ts
@@ -85,13 +85,17 @@ export interface MemoryRecallEmbeddingSource {
   /** Stable identity for the provider/model vector space, when known. */
   spaceId?: string;
   label: string;
-  embed(texts: string[], signal?: AbortSignal): Promise<number[][] | null>;
+  embed(texts: string[], signal?: AbortSignal, inputType?: MemoryRecallEmbeddingInputType): Promise<number[][] | null>;
 }
+
+export type MemoryRecallEmbeddingInputType = "document" | "query";
 
 export interface MemoryRecallEmbeddingOptions {
   embeddingSource?: MemoryRecallEmbeddingSource | null;
   localEmbedder?: (texts: string[], signal?: AbortSignal) => Promise<number[][] | null>;
   signal?: AbortSignal;
+  /** Whether the text is being indexed or used to search an existing index. */
+  inputType?: MemoryRecallEmbeddingInputType;
 }
 
 export interface RecallMemoriesOptions extends MemoryRecallEmbeddingOptions {
@@ -114,7 +118,11 @@ export async function embedMemoryRecallTexts(
   options: MemoryRecallEmbeddingOptions = {},
 ): Promise<number[][]> {
   if (options.embeddingSource) {
-    const configuredEmbeddings = await options.embeddingSource.embed(texts, options.signal);
+    const configuredEmbeddings = await options.embeddingSource.embed(
+      texts,
+      options.signal,
+      options.inputType ?? "document",
+    );
     if (configuredEmbeddings) {
       logger.debug("[memory-recall] Used configured embedding source %s", options.embeddingSource.label);
       return configuredEmbeddings;
@@ -128,7 +136,9 @@ export async function embedMemoryRecallTexts(
 
   if (!warnedUnavailableEmbeddingSource) {
     warnedUnavailableEmbeddingSource = true;
-    logger.warn("[memory-recall] No embedder configured; memory recall is disabled until an embedding source is available");
+    logger.warn(
+      "[memory-recall] No embedder configured; memory recall is disabled until an embedding source is available",
+    );
   }
   return [];
 }
@@ -352,7 +362,7 @@ async function chunkAndEmbedMessagesUnlocked(
 
   // Embed all chunks using local model
   const texts = embeddableChunks.map((c) => c.content);
-  const embeddings = await embedMemoryRecallTexts(texts, options);
+  const embeddings = await embedMemoryRecallTexts(texts, { ...options, inputType: "document" });
   if (
     embeddings.length !== embeddableChunks.length ||
     embeddings.some((embedding) => !Array.isArray(embedding) || embedding.length === 0)
@@ -374,7 +384,11 @@ async function chunkAndEmbedMessagesUnlocked(
     .where(and(eq(memoryChunks.chatId, chatId), isNull(memoryChunks.sourceChatId), isNotNull(memoryChunks.embedding)))
     .limit(1);
   const existingEmbedding = parseStoredEmbedding(existingEmbeddedChunk[0]?.embedding ?? null);
-  if (Array.isArray(existingEmbedding) && existingEmbedding.length > 0 && existingEmbedding.length !== embeddingDimension) {
+  if (
+    Array.isArray(existingEmbedding) &&
+    existingEmbedding.length > 0 &&
+    existingEmbedding.length !== embeddingDimension
+  ) {
     logger.warn(
       "[memory-recall] Skipping memory chunk insert for chat %s because embedding dimension changed from %d to %d. Rebuild memories before mixing embedding models.",
       chatId,
@@ -449,7 +463,7 @@ export async function recallMemories(
   if (chatIds.length === 0) return [];
 
   // Embed the query using local model
-  const queryEmbeddings = await embedMemoryRecallTexts([query], options);
+  const queryEmbeddings = await embedMemoryRecallTexts([query], { ...options, inputType: "query" });
   if (!queryEmbeddings || queryEmbeddings.length === 0) return [];
   const queryEmbedding = queryEmbeddings[0]!;
   if (queryEmbedding.length === 0) return [];

--- a/packages/server/src/services/memory-recall.ts
+++ b/packages/server/src/services/memory-recall.ts
@@ -24,6 +24,7 @@ const SIMILARITY_THRESHOLD = 0.25;
 
 /** Maximum number of recalled memories per generation. */
 const DEFAULT_TOP_K = 8;
+export const DEFAULT_LOCAL_MEMORY_EMBEDDING_SPACE_ID = "local:Xenova/all-MiniLM-L6-v2:plain-v1";
 const memoryMutationTails = new Map<string, Promise<void>>();
 
 async function serializeMemoryMutation<T>(chatId: string, task: () => Promise<T>): Promise<T> {
@@ -111,6 +112,11 @@ export interface ChunkAndEmbedMessagesOptions extends MemoryRecallEmbeddingOptio
    * active prompt window.
    */
   readBehindMessageCount?: number | null;
+}
+
+function resolveMemoryEmbeddingSpaceId(options: MemoryRecallEmbeddingOptions): string | null {
+  if (options.embeddingSource) return options.embeddingSource.spaceId?.trim() || null;
+  return DEFAULT_LOCAL_MEMORY_EMBEDDING_SPACE_ID;
 }
 
 export async function embedMemoryRecallTexts(
@@ -288,6 +294,24 @@ async function chunkAndEmbedMessagesUnlocked(
   options: ChunkAndEmbedMessagesOptions = {},
 ): Promise<void> {
   if (isLite) return;
+  const embeddingSpaceId = resolveMemoryEmbeddingSpaceId(options);
+  if (!embeddingSpaceId) {
+    logger.warn("[memory-recall] Skipping memory chunking because the active embedding source has no space ID");
+    return;
+  }
+
+  const existingEmbeddingSpaces = await db
+    .select({ embeddingSpaceId: memoryChunks.embeddingSpaceId })
+    .from(memoryChunks)
+    .where(and(eq(memoryChunks.chatId, chatId), isNull(memoryChunks.sourceChatId), isNotNull(memoryChunks.embedding)));
+  if (existingEmbeddingSpaces.some((chunk) => chunk.embeddingSpaceId !== embeddingSpaceId)) {
+    await db.delete(memoryChunks).where(and(eq(memoryChunks.chatId, chatId), isNull(memoryChunks.sourceChatId)));
+    logger.warn(
+      "[memory-recall] Rebuilding native memory chunks for chat %s because the embedding provider, model, or input profile changed",
+      chatId,
+    );
+  }
+
   const allMessages = await db
     .select({
       id: messages.id,
@@ -407,6 +431,7 @@ async function chunkAndEmbedMessagesUnlocked(
       chatId,
       content: chunk.content,
       embedding: JSON.stringify(embeddings[i]!),
+      embeddingSpaceId,
       messageCount: chunk.messageCount,
       firstMessageAt: chunk.firstMessageAt,
       lastMessageAt: chunk.lastMessageAt,
@@ -461,6 +486,11 @@ export async function recallMemories(
 ): Promise<RecalledMemory[]> {
   if (isLite) return [];
   if (chatIds.length === 0) return [];
+  const embeddingSpaceId = resolveMemoryEmbeddingSpaceId(options);
+  if (!embeddingSpaceId) {
+    logger.warn("[memory-recall] Skipping recall because the active embedding source has no space ID");
+    return [];
+  }
 
   // Embed the query using local model
   const queryEmbeddings = await embedMemoryRecallTexts([query], { ...options, inputType: "query" });
@@ -480,6 +510,7 @@ export async function recallMemories(
       chatId: memoryChunks.chatId,
       content: memoryChunks.content,
       embedding: memoryChunks.embedding,
+      embeddingSpaceId: memoryChunks.embeddingSpaceId,
       firstMessageAt: memoryChunks.firstMessageAt,
       lastMessageAt: memoryChunks.lastMessageAt,
     })
@@ -495,10 +526,20 @@ export async function recallMemories(
   if (chunks.length === 0) return [];
 
   let dimensionMismatchLogged = false;
+  let sourceMismatchLogged = false;
 
   // Score each chunk by cosine similarity
   const scored = chunks
     .map((chunk): RecalledMemory | null => {
+      if (chunk.embeddingSpaceId !== embeddingSpaceId) {
+        if (!sourceMismatchLogged) {
+          sourceMismatchLogged = true;
+          logger.warn(
+            "[memory-recall] Skipping one or more memory chunks from an unknown or different embedding provider, model, or input profile. Rebuild memories before recall.",
+          );
+        }
+        return null;
+      }
       const embedding = parseStoredEmbedding(chunk.embedding);
       if (!embedding || embedding.length !== queryEmbedding.length) {
         if (!dimensionMismatchLogged) {

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -213,6 +213,8 @@ export interface AssemblerInput {
   chatEmbedding?: number[] | null;
   /** Per-lorebook pre-computed embeddings for semantic lorebook matching. */
   semanticEmbeddingsByLorebookId?: ReadonlyMap<string, number[] | null>;
+  /** Provider/model/profile identity used to create semantic query vectors. */
+  semanticEmbeddingSpaceId?: string | null;
   /** Unrelated-text cosine floor used to calibrate clustered embedding models. */
   semanticSimilarityBaseline?: number;
   /** Per-chat ephemeral state overrides for lorebook entries (from chat metadata). */
@@ -461,6 +463,7 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
     disableLorebooks: input.disableLorebooks === true,
     chatEmbedding: input.chatEmbedding ?? null,
     semanticEmbeddingsByLorebookId: input.semanticEmbeddingsByLorebookId,
+    semanticEmbeddingSpaceId: input.semanticEmbeddingSpaceId,
     semanticSimilarityBaseline: input.semanticSimilarityBaseline,
     entryStateOverrides: input.entryStateOverrides,
     entryTimingStates: input.entryTimingStates,

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -4,11 +4,7 @@
 // ──────────────────────────────────────────────
 import type { DB } from "../../db/connection.js";
 import { logger } from "../../lib/logger.js";
-import {
-  formatRpgStatsForPrompt,
-  isExternallyImportedAgent,
-  resolveMacros,
-} from "@marinara-engine/shared";
+import { formatRpgStatsForPrompt, isExternallyImportedAgent, resolveMacros } from "@marinara-engine/shared";
 import type {
   CharacterMacroProfile,
   MarkerConfig,
@@ -69,6 +65,8 @@ export interface MarkerContext {
   chatEmbedding?: number[] | null;
   /** Per-lorebook pre-computed embeddings for semantic lorebook matching. */
   semanticEmbeddingsByLorebookId?: ReadonlyMap<string, number[] | null>;
+  /** Provider/model/profile identity used to create semantic query vectors. */
+  semanticEmbeddingSpaceId?: string | null;
   /** Unrelated-text cosine floor used to calibrate clustered embedding models. */
   semanticSimilarityBaseline?: number;
   /** Per-chat ephemeral state overrides for lorebook entries (from chat metadata). */
@@ -375,6 +373,7 @@ export async function ensureLorebookScan(ctx: MarkerContext): Promise<LorebookSc
         tokenBudget: ctx.lorebookTokenBudget,
         chatEmbedding: ctx.chatEmbedding ?? null,
         semanticEmbeddingsByLorebookId: ctx.semanticEmbeddingsByLorebookId,
+        semanticEmbeddingSpaceId: ctx.semanticEmbeddingSpaceId,
         semanticSimilarityBaseline: ctx.semanticSimilarityBaseline,
         entryStateOverrides: ctx.entryStateOverrides,
         entryTimingStates: ctx.entryTimingStates,

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -209,6 +209,7 @@ function parseEntryRow(row: Record<string, unknown>) {
     activationConditions: JSON.parse((row.activationConditions as string) || "[]"),
     schedule: row.schedule ? JSON.parse(row.schedule as string) : null,
     embedding: row.embedding ? JSON.parse(row.embedding as string) : null,
+    embeddingSpaceId: (row.embeddingSpaceId as string | null | undefined) ?? null,
   };
 }
 
@@ -1008,7 +1009,10 @@ export function createLorebooksStorage(db: DB) {
       if (changes.delayUntilRecursion !== undefined) updates.delayUntilRecursion = String(changes.delayUntilRecursion);
       if (changes.excludeFromVectorization !== undefined)
         updates.excludeFromVectorization = String(changes.excludeFromVectorization);
-      if (changes.excludeFromVectorization === true) updates.embedding = null;
+      if (changes.excludeFromVectorization === true) {
+        updates.embedding = null;
+        updates.embeddingSpaceId = null;
+      }
 
       await db
         .update(lorebookEntries)
@@ -1018,10 +1022,14 @@ export function createLorebooksStorage(db: DB) {
     },
 
     /** Update just the embedding vector for an entry. */
-    async updateEntryEmbedding(id: string, embedding: number[] | null) {
+    async updateEntryEmbedding(id: string, embedding: number[] | null, embeddingSpaceId: string | null = null) {
       await db
         .update(lorebookEntries)
-        .set({ embedding: embedding ? JSON.stringify(embedding) : null, updatedAt: now() })
+        .set({
+          embedding: embedding ? JSON.stringify(embedding) : null,
+          embeddingSpaceId: embedding ? embeddingSpaceId : null,
+          updatedAt: now(),
+        })
         .where(eq(lorebookEntries.id, id));
     },
 
@@ -1029,7 +1037,7 @@ export function createLorebooksStorage(db: DB) {
     async clearEntryEmbeddings(lorebookId: string) {
       await db
         .update(lorebookEntries)
-        .set({ embedding: null, updatedAt: now() })
+        .set({ embedding: null, embeddingSpaceId: null, updatedAt: now() })
         .where(eq(lorebookEntries.lorebookId, lorebookId));
     },
 

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -944,7 +944,10 @@ export function createLorebooksStorage(db: DB) {
       if (input.delayUntilRecursion !== undefined) updates.delayUntilRecursion = String(input.delayUntilRecursion);
       if (input.excludeFromVectorization !== undefined)
         updates.excludeFromVectorization = String(input.excludeFromVectorization);
-      if (shouldClearEmbedding) updates.embedding = null;
+      if (shouldClearEmbedding) {
+        updates.embedding = null;
+        updates.embeddingSpaceId = null;
+      }
 
       await db.update(lorebookEntries).set(updates).where(eq(lorebookEntries.id, id));
       return this.getEntry(id);

--- a/packages/shared/src/types/export.ts
+++ b/packages/shared/src/types/export.ts
@@ -26,6 +26,8 @@ export interface ExportEnvelope<T = unknown> {
 export interface ChatMemoryRecallExportChunk {
   content: string;
   embedding: number[] | null;
+  /** Stable provider/model/profile identity for the exported vector. */
+  embeddingSpaceId?: string | null;
   messageCount: number;
   firstMessageAt: string;
   lastMessageAt: string;

--- a/packages/shared/src/types/lorebook.ts
+++ b/packages/shared/src/types/lorebook.ts
@@ -232,6 +232,8 @@ export interface LorebookEntry {
   excludeFromVectorization: boolean;
   /** Pre-computed embedding vector for semantic matching (null if not vectorized) */
   embedding: number[] | null;
+  /** Stable provider/model/profile identity used to reject incompatible query vectors. */
+  embeddingSpaceId?: string | null;
 
   createdAt: string;
   updatedAt: string;

--- a/scripts/regressions/memory-recall-revectorize.regression.ts
+++ b/scripts/regressions/memory-recall-revectorize.regression.ts
@@ -41,6 +41,7 @@ try {
     { userName: "User", characterNames: {} },
     {
       embeddingSource: {
+        spaceId: "test:old-384:plain-v1",
         label: "old-384",
         async embed(texts) {
           notifyOldEmbeddingStarted();
@@ -58,6 +59,7 @@ try {
     { userName: "User", characterNames: {} },
     {
       embeddingSource: {
+        spaceId: "test:new-768:plain-v1",
         label: "new-768",
         async embed(texts) {
           newEmbeddingStarted = true;
@@ -75,6 +77,11 @@ try {
   const stored = await db.select().from(memoryChunks).where(eq(memoryChunks.chatId, "chat-memory"));
   assert.equal(stored.length, 1, "re-vectorization replaces the prior native chunk exactly once");
   assert.equal(JSON.parse(stored[0]!.embedding ?? "[]").length, 768, "only vectors from the new model remain");
+  assert.equal(
+    stored[0]!.embeddingSpaceId,
+    "test:new-768:plain-v1",
+    "rebuilt memory chunks persist the active provider/model/profile identity",
+  );
 
   const connections = createConnectionsStorage(db);
   const connectionDefaults = {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -9817,6 +9817,7 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
 
       const unknownProvenance = scanForActivatedEntries(scanMessages, [{ ...entry, embeddingSpaceId: null } as any], {
         chatEmbedding: semantic.defaultEmbedding,
+        semanticEmbeddingsByLorebookId: semantic.embeddingsByLorebookId,
         semanticEmbeddingSpaceId: "test-space",
         semanticThreshold: 0.3,
       });

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -746,9 +746,12 @@ import { isChatToolEnabledByDefault } from "../../packages/server/src/services/g
 import { scopeIndividualGroupMessagesForTarget } from "../../packages/server/src/services/generation/prompt-message-scope.js";
 import { resolveGenerationPromptPresetChoices } from "../../packages/server/src/routes/generate/prompt-preset-selection.js";
 import {
+  buildLorebookSemanticEmbeddingsById,
   calibrateLorebookSimilarity,
   lorebookSimilarityBaseline,
+  selectLorebookVectorQueryText,
 } from "../../packages/server/src/services/lorebook/embeddings.js";
+import { formatMemoryRecallEmbeddingTexts } from "../../packages/server/src/services/memory-recall-embedding.js";
 import {
   filterRelevantLorebooks,
   resolveAndBudgetActivatedLorebookEntries,
@@ -1446,10 +1449,7 @@ const cases: RegressionCase[] = [
     run() {
       const publicReference = readFileSync(new URL("../../docs/agents/built-in-agents.md", import.meta.url), "utf8");
       const publicReferenceLines = new Set(publicReference.split(/\r?\n/u));
-      const frontendArchitecture = readFileSync(
-        new URL("../../docs/development/frontend.md", import.meta.url),
-        "utf8",
-      );
+      const frontendArchitecture = readFileSync(new URL("../../docs/development/frontend.md", import.meta.url), "utf8");
       const frontendAgentCatalog = frontendArchitecture.match(
         /### First-party downloadable agents([\s\S]*?)### Agent result types/u,
       );
@@ -1465,14 +1465,17 @@ const cases: RegressionCase[] = [
 
       assert.equal(OFFICIAL_AGENT_KNOWLEDGE_ENTRIES.length, 32);
       assert.equal(new Set(OFFICIAL_AGENT_KNOWLEDGE_ENTRIES.map((entry) => entry.id)).size, 32);
-      assert.deepEqual(OFFICIAL_AGENT_KNOWLEDGE_ENTRIES.find((entry) => entry.id === "noodle"), {
-        id: "noodle",
-        name: "Noodle",
-        category: "misc",
-        modes: "Home",
-        summary:
-          "adds the optional local Noodle timeline and NoodleR creator-and-fan roleplay feed in a dedicated Home tab",
-      });
+      assert.deepEqual(
+        OFFICIAL_AGENT_KNOWLEDGE_ENTRIES.find((entry) => entry.id === "noodle"),
+        {
+          id: "noodle",
+          name: "Noodle",
+          category: "misc",
+          modes: "Home",
+          summary:
+            "adds the optional local Noodle timeline and NoodleR creator-and-fan roleplay feed in a dedicated Home tab",
+        },
+      );
       assert.ok(OFFICIAL_AGENT_KNOWLEDGE_ENTRIES.some((entry) => entry.id === "long-term-memory"));
       assert.ok(OFFICIAL_AGENT_KNOWLEDGE_ENTRIES.some((entry) => entry.id === "storyboard"));
       assert.deepEqual(
@@ -4799,10 +4802,7 @@ const cases: RegressionCase[] = [
         null,
       );
       assert.equal(
-        resolveStoryboardAnimationRefinement(
-          '{"classification":"unknown","narrationBeat":"One | Two"}',
-          motionIntent,
-        ),
+        resolveStoryboardAnimationRefinement('{"classification":"unknown","narrationBeat":"One | Two"}', motionIntent),
         null,
       );
       assert.equal(
@@ -9710,6 +9710,110 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         '{"say":"I could not create it because the name is missing.","commands":[],"stop":true}',
       );
       assert.equal(workspaceActionNeedsVerification(honestBlocker, []), null);
+    },
+  },
+  {
+    name: "lorebook vectors use retrieval intent and the latest user context",
+    async run() {
+      const scanMessages = [
+        { role: "assistant", content: "A long opening message about an unrelated ocean voyage." },
+        { role: "user", content: "Rocks stones mountain ore" },
+      ];
+      assert.equal(selectLorebookVectorQueryText(scanMessages, 10), "Rocks stones mountain ore");
+      assert.deepEqual(
+        formatMemoryRecallEmbeddingTexts(
+          ["Rocks stones mountain ore"],
+          "Casual-Autopsy/snowflake-arctic-embed-l-v2.0-gguf:Q8_0",
+          "query",
+        ),
+        ["query: Rocks stones mountain ore"],
+      );
+      assert.deepEqual(
+        formatMemoryRecallEmbeddingTexts(
+          ["Rocks stones mountain ore"],
+          "Casual-Autopsy/snowflake-arctic-embed-l-v2.0-gguf:Q8_0",
+          "document",
+        ),
+        ["Rocks stones mountain ore"],
+      );
+
+      const embeddingSource = {
+        spaceId: "test-space",
+        label: "asymmetric test embedder",
+        async embed(texts: string[], _signal?: AbortSignal, inputType?: "document" | "query") {
+          assert.equal(inputType, "query");
+          assert.equal(texts[0], "Rocks stones mountain ore");
+          return texts.map((_, index) =>
+            index === 0 ? [1, 0] : index === 1 ? [0, 1] : index === 2 ? [0, -1] : [-1, 0],
+          );
+        },
+      };
+      const entry = {
+        id: "entry-vector-exact",
+        lorebookId: "book-vector-exact",
+        name: "Mountain materials",
+        content: "Rocks stones mountain ore",
+        enabled: true,
+        constant: false,
+        selective: false,
+        keys: [],
+        secondaryKeys: [],
+        selectiveLogic: "and",
+        useRegex: false,
+        matchWholeWords: false,
+        caseSensitive: false,
+        locked: false,
+        preventRecursion: false,
+        excludeRecursion: false,
+        delayUntilRecursion: false,
+        excludeFromVectorization: false,
+        embedding: [1, 0],
+        embeddingSpaceId: "test-space",
+        order: 0,
+        group: null,
+        groupWeight: 100,
+        probability: 100,
+        sticky: null,
+        cooldown: null,
+        delay: null,
+        activationConditions: [],
+        schedule: null,
+        characterFilterMode: "any",
+        characterFilterIds: [],
+        characterTagFilterMode: "any",
+        characterTagFilters: [],
+        generationTriggerFilterMode: "any",
+        generationTriggerFilters: [],
+        additionalMatchingSources: [],
+        scanDepth: null,
+      };
+      const semantic = await buildLorebookSemanticEmbeddingsById({
+        lorebooks: [
+          {
+            id: "book-vector-exact",
+            excludeFromVectorization: false,
+            vectorQueryDepth: 10,
+          } as any,
+        ],
+        entries: [entry as any],
+        scanMessages,
+        embeddingSource,
+      });
+      const activated = scanForActivatedEntries(scanMessages, [entry as any], {
+        chatEmbedding: semantic.defaultEmbedding,
+        semanticEmbeddingsByLorebookId: semantic.embeddingsByLorebookId,
+        semanticEmbeddingSpaceId: semantic.embeddingSpaceId,
+        semanticSimilarityBaseline: semantic.similarityBaseline,
+        semanticThresholdByLorebookId: new Map([["book-vector-exact", 0.3]]),
+      });
+      assert.equal(activated[0]?.entry.id, "entry-vector-exact");
+
+      const incompatible = scanForActivatedEntries(scanMessages, [entry as any], {
+        chatEmbedding: semantic.defaultEmbedding,
+        semanticEmbeddingSpaceId: "different-space",
+        semanticThreshold: 0.3,
+      });
+      assert.equal(incompatible.length, 0);
     },
   },
   {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -9814,6 +9814,13 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         semanticThreshold: 0.3,
       });
       assert.equal(incompatible.length, 0);
+
+      const unknownProvenance = scanForActivatedEntries(scanMessages, [{ ...entry, embeddingSpaceId: null } as any], {
+        chatEmbedding: semantic.defaultEmbedding,
+        semanticEmbeddingSpaceId: "test-space",
+        semanticThreshold: 0.3,
+      });
+      assert.equal(unknownProvenance.length, 0, "legacy vectors without provenance must be re-vectorized");
     },
   },
   {


### PR DESCRIPTION
## Why

Vectorized lorebooks could call an embedding model successfully yet never activate an entry, including an exact keyword-free match. Retrieval models such as Snowflake Arctic Embed v2 require asymmetric query/document inputs; manual and automatic vectorization also used different entry text.

Closes #5104

## What changed

- classify embedding requests as query or document and apply conservative model profiles for Snowflake Arctic v2, E5, and Nomic Embed Text
- use one canonical lorebook-entry document format for manual and automatic vectorization
- build lorebook queries from user turns so long assistant openings do not drown the current request
- persist provider/model/profile vector-space provenance and reject incompatible stored vectors
- log dimensions, raw/calibrated scores, thresholds, and rejection reasons at debug level
- add an exact-match asymmetric-embedder regression

## Validation

- [ ] Manually verify a keyword-free exact match appears in Active Context and the assembled prompt with Snowflake Arctic Embed v2
- [ ] Manually verify switching embedding models asks for a full re-vectorization instead of mixing stored vectors
- [ ] Run `pnpm check`

Automated evidence run locally:
- `pnpm build:shared` passed
- `pnpm --filter @marinara-engine/server lint` passed
- the new lorebook vector regression passed inside `pnpm regression:prompt`
- the full prompt regression currently exits on an unrelated existing ElevenLabs tone-tag assertion (`[neutral]` retained instead of stripped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved lorebook semantic recall with model-specific query and document formatting.
  - Prioritized recent user messages when selecting lorebook search context.
  - Added embedding compatibility safeguards and clearer diagnostics for matching decisions.
  - Improved memory recall across supported embedding providers and model changes.

- **Bug Fixes**
  - Ensured embedding metadata stays synchronized with stored vectors.
  - Prevented incompatible or outdated embeddings from affecting lorebook and memory results.
  - Preserved embedding compatibility metadata during memory import and export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->