### PR TITLE
Fix Storyboard prompt options after package updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Added newly shipped built-in prompt choices to existing Storyboard agent configurations after package updates while preserving saved overrides, custom prompts, and current selections (#5118).
 - Kept valid Gallery images visible on Windows when canonical paths differ only by drive-letter or directory casing, without weakening traversal and symlink containment checks (#5099).
 - Made vectorized lorebook recall use model-appropriate query/document formatting, prioritize recent user turns, and reject incompatible stored vector spaces with useful debug diagnostics (#5104).
 - Added a server-side pre-execution authorization gate that binds Professor Mari workspace mutations to an explicit excerpt from the active user request, while retaining Keep/Restore as a second line of defense (#5093).

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -724,6 +724,18 @@ const OBSOLETE_BUILT_IN_PROMPT_TEMPLATE_IDS: Record<string, ReadonlySet<string>>
   illustrator: new Set(["illustration", "sketch"]),
 };
 
+const ADDITIONAL_BUILT_IN_PROMPT_TEMPLATE_COLLECTION_KEYS: Record<string, readonly string[]> = {
+  storyboard: [
+    "illustrationTemplates",
+    "videoTemplates",
+    "animationRefinementTemplates",
+    "roleplayEpisodeTemplates",
+    "roleplayStyleTemplates",
+    "roleplayAnimationTemplates",
+    "roleplayOutputTemplates",
+  ],
+};
+
 const RETIRED_BUILT_IN_AGENT_TOOLS: Record<string, ReadonlySet<string>> = {
   expression: new Set(["set_expression"]),
 };
@@ -733,6 +745,30 @@ export function normalizeBuiltInAgentEnabledTools(agentType: string, value: unkn
   const enabledTools = value.filter((tool): tool is string => typeof tool === "string");
   const retiredTools = RETIRED_BUILT_IN_AGENT_TOOLS[agentType];
   return retiredTools ? enabledTools.filter((tool) => !retiredTools.has(tool)) : enabledTools;
+}
+
+function mergeBuiltInPromptTemplateCollection(
+  defaultValue: unknown,
+  savedValue: unknown,
+  obsoleteIds: ReadonlySet<string> = new Set(),
+): AgentPromptTemplateOption[] {
+  const defaultOptions = normalizeAgentPromptTemplateOptions(defaultValue);
+  const savedOptions = normalizeAgentPromptTemplateOptions(savedValue);
+  const savedOptionsById = new Map(
+    savedOptions.filter((entry) => !obsoleteIds.has(entry.id)).map((entry) => [entry.id, entry]),
+  );
+  const usedIds = new Set<string>();
+  const mergedDefaultOptions = defaultOptions.map((defaultOption) => {
+    usedIds.add(defaultOption.id);
+    const savedOption = savedOptionsById.get(defaultOption.id);
+    return savedOption ? { ...defaultOption, ...savedOption } : defaultOption;
+  });
+  const customOptions = savedOptions.filter((entry) => {
+    if (obsoleteIds.has(entry.id) || usedIds.has(entry.id)) return false;
+    usedIds.add(entry.id);
+    return true;
+  });
+  return [...mergedDefaultOptions, ...customOptions];
 }
 
 export function mergeBuiltInAgentSettings(agentType: string, settings: unknown): Record<string, unknown> {
@@ -749,29 +785,23 @@ export function mergeBuiltInAgentSettings(agentType: string, settings: unknown):
     ...normalizedSettings,
   };
 
-  const defaultPromptTemplates = normalizeAgentPromptTemplateOptions(defaults.promptTemplates);
-  const savedPromptTemplates = normalizeAgentPromptTemplateOptions(normalizedSettings.promptTemplates);
-  const obsoleteIds = OBSOLETE_BUILT_IN_PROMPT_TEMPLATE_IDS[agentType] ?? new Set<string>();
-  const savedPromptTemplatesById = new Map(
-    savedPromptTemplates.filter((entry) => !obsoleteIds.has(entry.id)).map((entry) => [entry.id, entry]),
-  );
-  const usedIds = new Set<string>();
-  const mergedDefaultPromptTemplates = defaultPromptTemplates.map((defaultOption) => {
-    usedIds.add(defaultOption.id);
-    const savedOption = savedPromptTemplatesById.get(defaultOption.id);
-    return savedOption ? { ...defaultOption, ...savedOption } : defaultOption;
-  });
-  const customPromptTemplates = savedPromptTemplates.filter((entry) => {
-    if (obsoleteIds.has(entry.id) || usedIds.has(entry.id)) return false;
-    usedIds.add(entry.id);
-    return true;
-  });
-  const promptTemplates = [...mergedDefaultPromptTemplates, ...customPromptTemplates];
-
-  if (promptTemplates.length) {
-    merged.promptTemplates = promptTemplates;
-  } else {
-    delete merged.promptTemplates;
+  const promptTemplateCollectionKeys = [
+    "promptTemplates",
+    ...(ADDITIONAL_BUILT_IN_PROMPT_TEMPLATE_COLLECTION_KEYS[agentType] ?? []),
+  ];
+  for (const key of promptTemplateCollectionKeys) {
+    const obsoleteIds =
+      key === "promptTemplates" ? (OBSOLETE_BUILT_IN_PROMPT_TEMPLATE_IDS[agentType] ?? new Set<string>()) : undefined;
+    const promptTemplates = mergeBuiltInPromptTemplateCollection(
+      defaults[key],
+      normalizedSettings[key],
+      obsoleteIds,
+    );
+    if (promptTemplates.length) {
+      merged[key] = promptTemplates;
+    } else {
+      delete merged[key];
+    }
   }
 
   return merged;

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -19,6 +19,7 @@ import {
   createDefaultImageStyleProfileSettings,
   characterTrackerCustomFieldDefaultsToRecord,
   getDefaultBuiltInAgentSettings,
+  mergeBuiltInAgentSettings,
   generateChatSummaryEntryTitle,
   isAgentAvailableInChatMode,
   isPatternSafe,
@@ -922,6 +923,76 @@ const keywordOptions = {
 };
 
 const cases: RegressionCase[] = [
+  {
+    name: "Storyboard package updates merge new built-in prompts without replacing saved choices",
+    run() {
+      const collectionKeys = [
+        "illustrationTemplates",
+        "videoTemplates",
+        "animationRefinementTemplates",
+        "roleplayEpisodeTemplates",
+        "roleplayStyleTemplates",
+        "roleplayAnimationTemplates",
+        "roleplayOutputTemplates",
+      ] as const;
+      const storyboardDefinition = {
+        id: "storyboard",
+        name: "Storyboard",
+        description: "Storyboard regression fixture.",
+        phase: "post_processing" as const,
+        enabledByDefault: false,
+        category: "misc" as const,
+        defaultTools: [],
+        defaultPromptTemplate: "Plan a storyboard.",
+        defaultSettings: Object.fromEntries(
+          collectionKeys.map((key) => [
+            key,
+            [
+              { id: `${key.toLowerCase()}-existing`, name: "Existing built-in", promptTemplate: `DEFAULT ${key}` },
+              { id: `${key.toLowerCase()}-new`, name: "New built-in", promptTemplate: `NEW ${key}` },
+            ],
+          ]),
+        ),
+      };
+      replaceBuiltInAgentDefinitions([...regressionAgentDefinitions, storyboardDefinition]);
+
+      try {
+        const savedSettings = Object.fromEntries(
+          collectionKeys.map((key) => [
+            key,
+            [
+              { id: `${key.toLowerCase()}-existing`, name: "Saved override", promptTemplate: `SAVED ${key}` },
+              { id: `${key.toLowerCase()}-custom`, name: "Custom prompt", promptTemplate: `CUSTOM ${key}` },
+            ],
+          ]),
+        );
+        const merged = mergeBuiltInAgentSettings("storyboard", {
+          ...savedSettings,
+          roleplayAnimationTemplateId: "roleplayanimationtemplates-custom",
+        });
+
+        for (const key of collectionKeys) {
+          const templates = merged[key] as Array<{ id: string; promptTemplate: string }>;
+          assert.deepEqual(
+            templates.map((template) => [template.id, template.promptTemplate]),
+            [
+              [`${key.toLowerCase()}-existing`, `SAVED ${key}`],
+              [`${key.toLowerCase()}-new`, `NEW ${key}`],
+              [`${key.toLowerCase()}-custom`, `CUSTOM ${key}`],
+            ],
+            `${key} must add new built-ins while preserving saved overrides and custom prompts`,
+          );
+        }
+        assert.equal(
+          merged.roleplayAnimationTemplateId,
+          "roleplayanimationtemplates-custom",
+          "merging package defaults must preserve the selected prompt id",
+        );
+      } finally {
+        replaceBuiltInAgentDefinitions(regressionAgentDefinitions);
+      }
+    },
+  },
   {
     name: "explicitly selected persona lorebooks remain usable outside their owner persona",
     run() {


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5118

## Why this change

- Storyboard 1.1.3 ships new MiniMax H3 prompt choices, but existing installations retain their previously saved Storyboard prompt arrays and therefore cannot see the newly added package defaults.
- The shared settings merge already reconciles the generic `promptTemplates` collection. Storyboard's specialized prompt collections bypassed that reconciliation and were replaced wholesale by saved settings.

## What changed

- Reused the built-in prompt-template merge behavior for all seven Storyboard-specific collections.
- Preserved saved same-ID overrides, custom prompts, ordering, and selected prompt IDs while adding newly introduced package defaults.
- Added a regression covering illustration, video, image-aware refinement, Roleplay episode, style, animation, and output prompt collections.
- Added an Unreleased changelog entry.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` completed successfully, including localization, TypeScript, ESLint, server build, and production client build.
- The new prompt regression passes for every Storyboard-specific prompt collection and verifies new defaults, saved overrides, custom prompts, and selected IDs.
- The full `pnpm regression:prompt` command remains red on current `staging` because the unrelated existing `ElevenLabs TTS input does not prepend sprite tone tags` case expects the tone tag to be absent; the new Storyboard case passes in that run.
- Manual browser verification of an upgraded Storyboard 1.1.3 installation remains for the human contributor.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing documentation changes are needed; the fix restores the existing package-update contract. `CHANGELOG.md` is updated.

## UI evidence (if applicable)

No UI code changed. The reporter's before-state shows Storyboard 1.1.3 with only `Simple Storyboard Motion` available in the Animation addon selector.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Existing Storyboard agent configurations now receive newly shipped built-in prompt choices after package updates.
  * Saved overrides, custom prompts, and current selections are preserved during updates.

* **Bug Fixes**
  * Improved merging of built-in prompts across supported template collections.
  * Removed obsolete entries while retaining valid custom configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->