### PR TITLE
fix: preserve turn-game state across conversation branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Conversation branches now retain active turn-game state at copied message and swipe anchors instead of resetting or losing the game after branching (#5131).
 - Professor Mari now wires up the preset variables she creates: her authoring guidance and worked example make her drop a variable's `{{variableName}}` macro into a prompt section, so a choice block she adds actually changes the assembled prompt instead of leaving the user a picker that does nothing (#5080).
 - Preserved omitted Inventory Tracker groups, kept equipped items out of carried inventory after lock merging and name normalization, clamped oversized quantities, and migrated existing Tracker Panel layouts to show the new section (#5125).
 - Kept launcher update snapshots small by excluding downloaded model caches and sidecar runtimes, while continuing to preserve user content and recovery backups (#5124).

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -3880,20 +3880,20 @@ export async function chatsRoutes(app: FastifyInstance) {
     // them to the new branch's message IDs. Copying all snapshots (not just the latest)
     // ensures that branching a branch at an earlier point finds the correct tracker state
     // for that specific message, not just the latest snapshot in the source chat.
-    const spatialStore = createSpatialContextStorage();
-    const spatialBootstrap = await spatialStore.getBootstrap(req.params.id);
-    if (spatialBootstrap) {
-      await spatialStore.replaceBootstrap({
-        chatId: newChat.id,
-        currentLocationId: spatialBootstrap.currentLocationId,
-        definitionRevision: spatialBootstrap.definitionRevision,
-        source: "branch_copy",
-        transitionCommandId: null,
-        transitionPayloadHash: null,
-      });
-    }
-
     try {
+      const spatialStore = createSpatialContextStorage();
+      const spatialBootstrap = await spatialStore.getBootstrap(req.params.id);
+      if (spatialBootstrap) {
+        await spatialStore.replaceBootstrap({
+          chatId: newChat.id,
+          currentLocationId: spatialBootstrap.currentLocationId,
+          definitionRevision: spatialBootstrap.definitionRevision,
+          source: "branch_copy",
+          transitionCommandId: null,
+          transitionPayloadHash: null,
+        });
+      }
+
       const { createGameStateStorage } = await import("../services/storage/game-state.storage.js");
       const gameStateStore = createGameStateStorage(app.db);
       const gameEngineStore =

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -3897,7 +3897,7 @@ export async function chatsRoutes(app: FastifyInstance) {
       const { createGameStateStorage } = await import("../services/storage/game-state.storage.js");
       const gameStateStore = createGameStateStorage(app.db);
       const gameEngineStore =
-        sourceChat.mode === "game"
+        sourceChat.mode === "game" || sourceChat.mode === "conversation"
           ? (await import("../services/storage/game-engine-state.storage.js")).createGameEngineStateStorage(app.db)
           : null;
 

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -3944,7 +3944,7 @@ export async function chatsRoutes(app: FastifyInstance) {
             overrides,
           );
         } catch (err) {
-          logger.warn(err, "Failed to copy tracker snapshot while branching chat");
+          logger.error(err, "Failed to copy tracker snapshot while branching chat");
           throw err;
         }
       };
@@ -4024,6 +4024,16 @@ export async function chatsRoutes(app: FastifyInstance) {
         await storage.remove(newChat.id);
       } catch (cleanupErr) {
         logger.error(cleanupErr, "Failed to remove incomplete chat branch after state copy failed");
+      }
+      if (!sourceChat.groupId) {
+        try {
+          const remainingGroupChats = await storage.listByGroup(groupId);
+          if (remainingGroupChats.every((chat) => chat.id === sourceChat.id)) {
+            await storage.update(sourceChat.id, { groupId: null });
+          }
+        } catch (restoreErr) {
+          logger.error(restoreErr, "Failed to restore source chat grouping after branch copy failed");
+        }
       }
       throw err;
     }

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -3893,7 +3893,7 @@ export async function chatsRoutes(app: FastifyInstance) {
       });
     }
 
-    if (sourceToBranchedMessageId.size > 0) {
+    try {
       const { createGameStateStorage } = await import("../services/storage/game-state.storage.js");
       const gameStateStore = createGameStateStorage(app.db);
       const gameEngineStore =
@@ -3954,60 +3954,58 @@ export async function chatsRoutes(app: FastifyInstance) {
         targetSwipeIndex: number,
       ) => {
         if (!gameEngineStore) return;
-        try {
-          await gameEngineStore.create({
-            chatId: newChat.id,
-            messageId: targetMessageId,
-            swipeIndex: targetSwipeIndex,
-            gameType: snapshot.gameType,
-            schemaVersion: snapshot.schemaVersion,
-            state: snapshot.state,
-            committed: (snapshot.committed as any) === 1,
-          });
-        } catch (err) {
-          logger.warn(err, "Failed to copy turn-game engine snapshot while branching chat");
-        }
+        await gameEngineStore.create({
+          chatId: newChat.id,
+          messageId: targetMessageId,
+          swipeIndex: targetSwipeIndex,
+          gameType: snapshot.gameType,
+          schemaVersion: snapshot.schemaVersion,
+          state: snapshot.state,
+          committed: (snapshot.committed as any) === 1,
+        });
       };
 
-      for (const srcMsg of copiedSourceMessages) {
-        const branchedMsgId = sourceToBranchedMessageId.get(srcMsg.id);
-        if (!branchedMsgId) continue;
-        const swipeIndexes = sourceToCopiedSwipeIndexes.get(srcMsg.id) ?? [srcMsg.activeSwipeIndex ?? 0];
-        for (const swipeIndex of swipeIndexes) {
-          const spatialSnapshot = await spatialStore.getByAnchor(req.params.id, srcMsg.id, swipeIndex);
-          if (spatialSnapshot) {
-            await spatialStore.create({
-              chatId: newChat.id,
-              messageId: branchedMsgId,
-              swipeIndex,
-              currentLocationId: spatialSnapshot.currentLocationId,
-              definitionRevision: spatialSnapshot.definitionRevision,
-              source: "branch_copy",
-              transitionCommandId: null,
-              transitionPayloadHash: null,
-            });
-          }
-          const snapshot = await gameStateStore.getByMessage(srcMsg.id, swipeIndex);
-          if (snapshot) {
-            await copySnapshot(snapshot, branchedMsgId, swipeIndex);
-          }
-          if (gameEngineStore) {
-            // One anchor can hold a row per gameType writer (a turn-game AND an
-            // Experience, #5102) — branching must copy every one, not limit(1).
-            for (const engineSnapshot of await gameEngineStore.listByChatAndMessage(
-              req.params.id,
-              srcMsg.id,
-              swipeIndex,
-            )) {
-              await copyEngineSnapshot(engineSnapshot, branchedMsgId, swipeIndex);
+      if (sourceToBranchedMessageId.size > 0) {
+        for (const srcMsg of copiedSourceMessages) {
+          const branchedMsgId = sourceToBranchedMessageId.get(srcMsg.id);
+          if (!branchedMsgId) continue;
+          const swipeIndexes = sourceToCopiedSwipeIndexes.get(srcMsg.id) ?? [srcMsg.activeSwipeIndex ?? 0];
+          for (const swipeIndex of swipeIndexes) {
+            const spatialSnapshot = await spatialStore.getByAnchor(req.params.id, srcMsg.id, swipeIndex);
+            if (spatialSnapshot) {
+              await spatialStore.create({
+                chatId: newChat.id,
+                messageId: branchedMsgId,
+                swipeIndex,
+                currentLocationId: spatialSnapshot.currentLocationId,
+                definitionRevision: spatialSnapshot.definitionRevision,
+                source: "branch_copy",
+                transitionCommandId: null,
+                transitionPayloadHash: null,
+              });
+            }
+            const snapshot = await gameStateStore.getByMessage(srcMsg.id, swipeIndex);
+            if (snapshot) {
+              await copySnapshot(snapshot, branchedMsgId, swipeIndex);
+            }
+            if (gameEngineStore) {
+              // One anchor can hold a row per gameType writer (a turn-game AND an
+              // Experience, #5102) — branching must copy every one, not limit(1).
+              for (const engineSnapshot of await gameEngineStore.listByChatAndMessage(
+                req.params.id,
+                srcMsg.id,
+                swipeIndex,
+              )) {
+                await copyEngineSnapshot(engineSnapshot, branchedMsgId, swipeIndex);
+              }
             }
           }
         }
       }
 
       // Also copy the bootstrap snapshot (messageId: "") if one exists.
-      // This is created when tracker state is set manually before any generation,
-      // and is not tied to any specific message.
+      // This is created when state is set manually before any generation and
+      // must be handled even when the source chat contains no messages.
       const bootstrap = await gameStateStore.getByChatAndMessage(req.params.id, "", 0);
       if (bootstrap) {
         await copySnapshot(bootstrap, "", 0);
@@ -4017,6 +4015,13 @@ export async function chatsRoutes(app: FastifyInstance) {
           await copyEngineSnapshot(engineBootstrap, "", 0);
         }
       }
+    } catch (err) {
+      try {
+        await storage.remove(newChat.id);
+      } catch (cleanupErr) {
+        logger.error(cleanupErr, "Failed to remove incomplete chat branch after state copy failed");
+      }
+      throw err;
     }
 
     // Return the fully-updated chat (including copied metadata)

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -3945,7 +3945,7 @@ export async function chatsRoutes(app: FastifyInstance) {
           );
         } catch (err) {
           logger.warn(err, "Failed to copy tracker snapshot while branching chat");
-          // Ignore individual snapshot copy failures; branching should still succeed.
+          throw err;
         }
       };
       const copyEngineSnapshot = async (
@@ -3991,11 +3991,13 @@ export async function chatsRoutes(app: FastifyInstance) {
             if (gameEngineStore) {
               // One anchor can hold a row per gameType writer (a turn-game AND an
               // Experience, #5102) — branching must copy every one, not limit(1).
-              for (const engineSnapshot of await gameEngineStore.listByChatAndMessage(
+              const engineSnapshots = await gameEngineStore.listByChatAndMessage(
                 req.params.id,
                 srcMsg.id,
                 swipeIndex,
-              )) {
+              );
+              // Reads are newest-first; replay oldest-first so the source-effective row wins dedupe.
+              for (const engineSnapshot of engineSnapshots.reverse()) {
                 await copyEngineSnapshot(engineSnapshot, branchedMsgId, swipeIndex);
               }
             }
@@ -4011,7 +4013,9 @@ export async function chatsRoutes(app: FastifyInstance) {
         await copySnapshot(bootstrap, "", 0);
       }
       if (gameEngineStore) {
-        for (const engineBootstrap of await gameEngineStore.listByChatAndMessage(req.params.id, "", 0)) {
+        const engineBootstraps = await gameEngineStore.listByChatAndMessage(req.params.id, "", 0);
+        // Preserve the same effective row when a legacy anchor contains history.
+        for (const engineBootstrap of engineBootstraps.reverse()) {
           await copyEngineSnapshot(engineBootstrap, "", 0);
         }
       }

--- a/scripts/regressions/chat-branch-lineage.regression.ts
+++ b/scripts/regressions/chat-branch-lineage.regression.ts
@@ -18,9 +18,14 @@ try {
     "../../packages/server/src/services/capability-packages/capability-persistence.service.js"
   );
   const { getDB } = await import("../../packages/server/src/db/connection.js");
+  const { createGameEngineStateStorage } = await import(
+    "../../packages/server/src/services/storage/game-engine-state.storage.js"
+  );
 
   app = await buildApp();
   await app.ready();
+  const db = await getDB();
+  const engineStore = createGameEngineStateStorage(db);
 
   const create = async (name: string, mode: "conversation" | "roleplay" = "roleplay") => {
     const response = await app!.inject({
@@ -45,6 +50,15 @@ try {
   const first = await addMessage(root.id, "before fork");
   const middle = await addMessage(root.id, "fork here");
   await addMessage(root.id, "after fork");
+  await engineStore.create({
+    chatId: root.id,
+    messageId: middle.id,
+    swipeIndex: 0,
+    gameType: "roleplay-negative-control",
+    schemaVersion: 1,
+    state: JSON.stringify({ turn: 1 }),
+    committed: true,
+  });
 
   const branchResponse = await app.inject({
     method: "POST",
@@ -67,6 +81,11 @@ try {
   );
   assert.equal(typeof branch.metadata.branchMessageId, "string");
   assert.equal(branchMessages.at(-1).id, branch.metadata.branchMessageId);
+  assert.deepEqual(
+    await engineStore.listByChatAndMessage(branch.id, branchMessages.at(-1).id, 0),
+    [],
+    "Roleplay branches must not copy game-engine rows",
+  );
 
   const childResponse = await app.inject({ method: "POST", url: `/api/chats/${branch.id}/branch`, payload: {} });
   assert.equal(childResponse.statusCode, 200);
@@ -86,7 +105,7 @@ try {
   assert.equal(emptyBranch.metadata.branchParentMessageId, null);
   assert.equal(emptyBranch.metadata.branchMessageId, null);
 
-  const persistence = createCapabilityPersistenceHost(await getDB());
+  const persistence = createCapabilityPersistenceHost(db);
   const listed = await persistence.listChats();
   assert.equal((await persistence.getChat(root.id))?.branch, null);
   const listedBranch = listed.find((chat) => chat.id === branch.id);
@@ -99,13 +118,39 @@ try {
   assert.deepEqual((await persistence.getChat(branch.id))?.branch, listedBranch?.branch);
 
   const conversation = await create("Conversation scene origin", "conversation");
-  await addMessage(conversation.id, "Convert this conversation into a scene");
+  const conversationMessage = await addMessage(conversation.id, "Convert this conversation into a scene");
+  const conversationState = JSON.stringify({ position: "after-e4", turn: "black" });
+  await engineStore.create({
+    chatId: conversation.id,
+    messageId: conversationMessage.id,
+    swipeIndex: 0,
+    gameType: "chess",
+    schemaVersion: 1,
+    state: conversationState,
+    committed: true,
+  });
   const conversationBranchResponse = await app.inject({
     method: "POST",
     url: `/api/chats/${conversation.id}/branch`,
     payload: {},
   });
   assert.equal(conversationBranchResponse.statusCode, 200);
+  const conversationBranch = conversationBranchResponse.json();
+  const conversationBranchMessagesResponse = await app.inject({
+    method: "GET",
+    url: `/api/chats/${conversationBranch.id}/messages`,
+  });
+  assert.equal(conversationBranchMessagesResponse.statusCode, 200);
+  const conversationBranchMessages = conversationBranchMessagesResponse.json();
+  const copiedConversationState = await engineStore.listByChatAndMessage(
+    conversationBranch.id,
+    conversationBranchMessages.at(-1).id,
+    0,
+  );
+  assert.equal(copiedConversationState.length, 1, "Conversation branches must retain turn-game state");
+  assert.equal(copiedConversationState[0].gameType, "chess");
+  assert.equal(copiedConversationState[0].state, conversationState);
+  assert.equal(copiedConversationState[0].committed, 1);
   const groupedConversation = (await app.inject({ method: "GET", url: `/api/chats/${conversation.id}` })).json();
   assert.equal(typeof groupedConversation.groupId, "string");
 

--- a/scripts/regressions/chat-branch-lineage.regression.ts
+++ b/scripts/regressions/chat-branch-lineage.regression.ts
@@ -128,8 +128,19 @@ try {
   const conversationSwipe = conversationSwipeResponse.json();
   assert.equal(conversationSwipe.index, 1);
   const conversationState = JSON.stringify({ position: "after-e4", turn: "black" });
+  const olderConversationState = JSON.stringify({ position: "opening", turn: "white" });
   const alternateConversationState = JSON.stringify({ position: "after-d4", turn: "black" });
   const conversationBootstrapState = JSON.stringify({ phase: "waiting-for-players" });
+  const olderConversationStateId = await engineStore.create({
+    chatId: conversation.id,
+    messageId: "legacy-chess-history",
+    swipeIndex: 0,
+    gameType: "chess",
+    schemaVersion: 1,
+    state: olderConversationState,
+    committed: true,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 2));
   await engineStore.create({
     chatId: conversation.id,
     messageId: conversationMessage.id,
@@ -139,6 +150,11 @@ try {
     state: conversationState,
     committed: true,
   });
+  await engineStore.reanchor(olderConversationStateId, conversationMessage.id, 0);
+  assert.equal(
+    (await engineStore.getByChatAndMessage(conversation.id, conversationMessage.id, 0))?.state,
+    conversationState,
+  );
   await engineStore.create({
     chatId: conversation.id,
     messageId: conversationMessage.id,

--- a/scripts/regressions/chat-branch-lineage.regression.ts
+++ b/scripts/regressions/chat-branch-lineage.regression.ts
@@ -119,7 +119,17 @@ try {
 
   const conversation = await create("Conversation scene origin", "conversation");
   const conversationMessage = await addMessage(conversation.id, "Convert this conversation into a scene");
+  const conversationSwipeResponse = await app.inject({
+    method: "POST",
+    url: `/api/chats/${conversation.id}/messages/${conversationMessage.id}/swipes`,
+    payload: { content: "Play the alternate continuation", silent: true },
+  });
+  assert.equal(conversationSwipeResponse.statusCode, 200);
+  const conversationSwipe = conversationSwipeResponse.json();
+  assert.equal(conversationSwipe.index, 1);
   const conversationState = JSON.stringify({ position: "after-e4", turn: "black" });
+  const alternateConversationState = JSON.stringify({ position: "after-d4", turn: "black" });
+  const conversationBootstrapState = JSON.stringify({ phase: "waiting-for-players" });
   await engineStore.create({
     chatId: conversation.id,
     messageId: conversationMessage.id,
@@ -127,6 +137,24 @@ try {
     gameType: "chess",
     schemaVersion: 1,
     state: conversationState,
+    committed: true,
+  });
+  await engineStore.create({
+    chatId: conversation.id,
+    messageId: conversationMessage.id,
+    swipeIndex: conversationSwipe.index,
+    gameType: "chess",
+    schemaVersion: 1,
+    state: alternateConversationState,
+    committed: true,
+  });
+  await engineStore.create({
+    chatId: conversation.id,
+    messageId: "",
+    swipeIndex: 0,
+    gameType: "uno",
+    schemaVersion: 1,
+    state: conversationBootstrapState,
     committed: true,
   });
   const conversationBranchResponse = await app.inject({
@@ -151,6 +179,19 @@ try {
   assert.equal(copiedConversationState[0].gameType, "chess");
   assert.equal(copiedConversationState[0].state, conversationState);
   assert.equal(copiedConversationState[0].committed, 1);
+  const copiedAlternateConversationState = await engineStore.listByChatAndMessage(
+    conversationBranch.id,
+    conversationBranchMessages.at(-1).id,
+    conversationSwipe.index,
+  );
+  assert.equal(copiedAlternateConversationState.length, 1);
+  assert.equal(copiedAlternateConversationState[0].messageId, conversationBranchMessages.at(-1).id);
+  assert.equal(copiedAlternateConversationState[0].swipeIndex, 1);
+  assert.equal(copiedAlternateConversationState[0].state, alternateConversationState);
+  const copiedConversationBootstrap = await engineStore.listByChatAndMessage(conversationBranch.id, "", 0);
+  assert.equal(copiedConversationBootstrap.length, 1, "Conversation branches must retain bootstrap turn-game state");
+  assert.equal(copiedConversationBootstrap[0].gameType, "uno");
+  assert.equal(copiedConversationBootstrap[0].state, conversationBootstrapState);
   const groupedConversation = (await app.inject({ method: "GET", url: `/api/chats/${conversation.id}` })).json();
   assert.equal(typeof groupedConversation.groupId, "string");
 


### PR DESCRIPTION
## Why

Conversation-mode turn games such as UNO and Chess persist their live state in the game-engine store. Branching copied that state only when the chat mode was Game, so a branch from Conversation silently lost or reset the active game.

Closes #5131.

## What changed

- Open the game-engine state store while branching Conversation chats as well as Game chats.
- Reuse the existing per-message/per-swipe copy and rekeying path so every copied turn-game snapshot points at the new branch.
- Extend the branch-lineage regression with a Conversation turn-game case and a Roleplay negative control.
- Add the user-facing fix to the Unreleased changelog.

## Validation evidence

- pnpm check — passed.
- Focused chat-branch-lineage regression — failed before the route fix with zero copied engine rows, then passed after it.
- pnpm regression — 123/123 passed.
- git diff --check — passed.

## Manual verification

- [ ] Start a Conversation chat with an active turn game, branch it, and verify play resumes from the copied state.
- [ ] Branch a Roleplay chat and verify no unrelated game-engine state is copied.

## Review checklist

- [ ] Confirm the Conversation-only extension does not broaden game-engine copying to Roleplay.
- [ ] Confirm copied state remains keyed to the branch's new message IDs and swipe indexes.

## Notes

No client UI, localization, release metadata, or user-facing documentation changed. The server route is covered end-to-end through Fastify injection in the regression suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation branches now preserve active turn-based game state when created from copied messages, swipe anchors, or initial setup points.
  * Branches retain the correct game type, saved state, message association, swipe position, and committed status instead of resetting or losing progress.
  * Game-state handling is now consistent across game and conversation chats, including chess and UNO sessions.
  * Branch creation now stops cleanly if required game-state data cannot be copied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->