### PR TITLE
refactor: consolidate SSE emission ownership

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -350,7 +350,7 @@ import { registerDryRunRoute } from "./generate/dry-run-route.js";
 import { registerRawRoute } from "./generate/raw-route.js";
 import { registerRetryAgentsRoute } from "./generate/retry-agents-route.js";
 import { fingerprintChatSummary } from "../services/prompt/chat-summary-fingerprint.js";
-import { sendSseEvent, startSseKeepalive, startSseReply, trySendSseEvent } from "./generate/sse.js";
+import { isSseReplyWritable, sendSseEvent, startSseKeepalive, startSseReply } from "./generate/sse.js";
 import {
   resolveAlreadyAppliedSpatialTurn,
   resolveSpatialGenerationOrigin,
@@ -1188,17 +1188,6 @@ export async function generateRoutes(app: FastifyInstance) {
 
     let generationComplete = false;
     let clientDisconnected = false;
-    const originalSseWrite = reply.raw.write.bind(reply.raw);
-    const canWriteSse = () =>
-      !clientDisconnected && !reply.raw.destroyed && !reply.raw.writableEnded && !reply.raw.writableFinished;
-    reply.raw.write = ((chunk: any, encodingOrCallback?: any, callback?: any) => {
-      if (!canWriteSse()) return false;
-      try {
-        return originalSseWrite(chunk, encodingOrCallback, callback);
-      } catch {
-        return false;
-      }
-    }) as typeof reply.raw.write;
     const stopSseKeepalive = startSseKeepalive(reply);
 
     const onClose = () => {
@@ -1250,7 +1239,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
     // ── SSE progress helper: tells the client what phase we're in ──
     const sendProgress = (phase: string) => {
-      trySendSseEvent(reply, { type: "progress", data: { phase } });
+      sendSseEvent(reply, { type: "progress", data: { phase } });
     };
 
     try {
@@ -2298,7 +2287,7 @@ export async function generateRoutes(app: FastifyInstance) {
             finalMessages,
             abortSignal: abortController.signal,
             writeSse: (payload) => {
-              reply.raw.write(`data: ${JSON.stringify(payload)}\n\n`);
+              sendSseEvent(reply, payload as Parameters<typeof sendSseEvent>[1]);
             },
             endSse: () => {
               reply.raw.end();
@@ -3705,7 +3694,7 @@ export async function generateRoutes(app: FastifyInstance) {
           ...(requestDebug
             ? {
                 agentDebug: (event: AgentCallDebugEvent) => {
-                  trySendSseEvent(reply, { type: "agent_debug", data: event });
+                  sendSseEvent(reply, { type: "agent_debug", data: event });
                 },
               }
             : {}),
@@ -4312,7 +4301,7 @@ export async function generateRoutes(app: FastifyInstance) {
         const { sendAgentEvent: sendRawAgentEvent, sendAgentResultEvent: sendRawAgentResultEvent } =
           createAgentEventDispatcher({
             resolvedAgents: agentEventResolvedAgents,
-            sendEvent: (payload) => trySendSseEvent(reply, payload),
+            sendEvent: (payload) => sendSseEvent(reply, payload),
           });
         const sendAgentEvent = (result: AgentResult, options?: { finalized?: boolean }) => {
           const nextResult = markLorebookResultForApproval(result);
@@ -4336,7 +4325,7 @@ export async function generateRoutes(app: FastifyInstance) {
         };
         const flushDeferredParallelAgentEvents = () => {
           if (parallelAgentStartPending) {
-            trySendSseEvent(reply, { type: "agent_start", data: { phase: "parallel" } });
+            sendSseEvent(reply, { type: "agent_start", data: { phase: "parallel" } });
             parallelAgentStartPending = false;
           }
           if (deferredParallelAgentEvents.length === 0) return;
@@ -4347,7 +4336,7 @@ export async function generateRoutes(app: FastifyInstance) {
         };
 
         for (const warning of agentConnectionWarnings) {
-          trySendSseEvent(reply, { type: "agent_warning", data: warning });
+          sendSseEvent(reply, { type: "agent_warning", data: warning });
         }
 
         // Create the pipeline (exclude text rewrite agents — they run last,
@@ -4410,7 +4399,7 @@ export async function generateRoutes(app: FastifyInstance) {
           gameState,
           gameSpotifyMusicEnabled,
           agentContext,
-          emitMetadataPatch: (patch) => trySendSseEvent(reply, { type: "metadata_patch", data: patch }),
+          emitMetadataPatch: (patch) => sendSseEvent(reply, { type: "metadata_patch", data: patch }),
         });
         if (enableChatTools && toolDefs && toolDefs.length > 0 && conn.treatAsLocalEndpoint === "true") {
           const toolLines = toolDefs.map(
@@ -4501,9 +4490,7 @@ export async function generateRoutes(app: FastifyInstance) {
         const shouldRunPreGen = (hasPreGenAgents || reviewedAgentInjections.length > 0) && !input.regenerateMessageId;
         const runDirectorSecretPlotMaintenance = async (): Promise<AgentResult[]> => {
           if (!directorSecretPlotAgent) return [];
-          reply.raw.write(
-            `data: ${JSON.stringify({ type: "agent_start", data: { phase: "pre_generation", agentType: "director" } })}\n\n`,
-          );
+          sendSseEvent(reply, { type: "agent_start", data: { phase: "pre_generation", agentType: "director" } });
           const secretAgent = buildDirectorSecretPlotAgent(directorSecretPlotAgent);
           const runOnce = async (state: Record<string, unknown>): Promise<AgentResult> => {
             const secretContext: AgentContext = {
@@ -4579,9 +4566,7 @@ export async function generateRoutes(app: FastifyInstance) {
           // Build the pre-gen promise
           const preGenPromise = hasPreGenAgents
             ? (async () => {
-                reply.raw.write(
-                  `data: ${JSON.stringify({ type: "agent_start", data: { phase: "pre_generation" } })}\n\n`,
-                );
+                sendSseEvent(reply, { type: "agent_start", data: { phase: "pre_generation" } });
                 if (isDebug) {
                   const preGenAgents = pipelineAgents.filter(
                     (a) => a.phase === "pre_generation" && !EXCLUDED_FROM_PIPELINE.has(a.type),
@@ -4609,9 +4594,10 @@ export async function generateRoutes(app: FastifyInstance) {
             ? (async () => {
                 const _tKR = Date.now();
                 try {
-                  reply.raw.write(
-                    `data: ${JSON.stringify({ type: "agent_start", data: { phase: "pre_generation", agentType: "knowledge-retrieval" } })}\n\n`,
-                  );
+                  sendSseEvent(reply, {
+                    type: "agent_start",
+                    data: { phase: "pre_generation", agentType: "knowledge-retrieval" },
+                  });
                   const krConfig = {
                     id: knowledgeRetrievalAgent!.id,
                     type: knowledgeRetrievalAgent!.type,
@@ -4637,10 +4623,10 @@ export async function generateRoutes(app: FastifyInstance) {
                   // Emit agent_error so the client closes the pending state opened by
                   // agent_start above — without this the UI shows the agent as forever-
                   // running. (Mirrors the Illustrator agent's failure protocol.)
-                  // Use trySendSseEvent rather than reply.raw.write so a disconnected
+                  // Use sendSseEvent rather than reply.raw.write so a disconnected
                   // client doesn't turn this caught failure back into a rejected promise.
                   logger.warn(err, "[knowledge-retrieval] failed — continuing generation without retrieved context");
-                  trySendSseEvent(reply, {
+                  sendSseEvent(reply, {
                     type: "agent_error",
                     data: {
                       agentType: "knowledge-retrieval",
@@ -4661,9 +4647,10 @@ export async function generateRoutes(app: FastifyInstance) {
             ? (async () => {
                 const _tRouter = Date.now();
                 try {
-                  reply.raw.write(
-                    `data: ${JSON.stringify({ type: "agent_start", data: { phase: "pre_generation", agentType: "knowledge-router" } })}\n\n`,
-                  );
+                  sendSseEvent(reply, {
+                    type: "agent_start",
+                    data: { phase: "pre_generation", agentType: "knowledge-router" },
+                  });
                   const routerConfig = {
                     id: knowledgeRouterAgent!.id,
                     type: knowledgeRouterAgent!.type,
@@ -4704,10 +4691,10 @@ export async function generateRoutes(app: FastifyInstance) {
                   // Emit agent_error so the client closes the pending state opened by
                   // agent_start above — without this the UI shows the agent as forever-
                   // running. (Mirrors the Illustrator agent's failure protocol.)
-                  // Use trySendSseEvent rather than reply.raw.write so a disconnected
+                  // Use sendSseEvent rather than reply.raw.write so a disconnected
                   // client doesn't turn this caught failure back into a rejected promise.
                   logger.warn(err, "[knowledge-router] failed — continuing generation without routed context");
-                  trySendSseEvent(reply, {
+                  sendSseEvent(reply, {
                     type: "agent_error",
                     data: {
                       agentType: "knowledge-router",
@@ -4774,7 +4761,7 @@ export async function generateRoutes(app: FastifyInstance) {
             const applied = applyPromptPatchOperations(finalMessages, result.data);
             if (applied > 0) {
               logger.info("[custom-agent] Applied %d prompt patch operation(s) from %s", applied, result.agentType);
-              trySendSseEvent(reply, {
+              sendSseEvent(reply, {
                 type: "prompt_patch",
                 data: { agentType: result.agentType, applied },
               });
@@ -4873,9 +4860,7 @@ export async function generateRoutes(app: FastifyInstance) {
               (a) => a.phase === "pre_generation" && !EXCLUDED_FROM_PIPELINE.has(a.type),
             );
             if (hasContextInjectionAgents) {
-              reply.raw.write(
-                `data: ${JSON.stringify({ type: "agent_start", data: { phase: "pre_generation" } })}\n\n`,
-              );
+              sendSseEvent(reply, { type: "agent_start", data: { phase: "pre_generation" } });
               // On regens, exclude legacy Secret Plot Driver cache entries.
               contextInjections = (
                 await pipeline.preGenerate(
@@ -4947,22 +4932,20 @@ export async function generateRoutes(app: FastifyInstance) {
             appendSeparateAgentInjection(inj.agentType, inj.text);
           }
           for (const inj of contextInjections) {
-            reply.raw.write(
-              `data: ${JSON.stringify({
-                type: "agent_result",
-                data: {
-                  agentType: inj.agentType,
-                  agentName: agentNameByType.get(inj.agentType) ?? inj.agentName ?? inj.agentType,
-                  resultType: "context_injection",
-                  data: { text: inj.text },
-                  tokensUsed: 0,
-                  success: true,
-                  error: null,
-                  durationMs: 0,
-                  cached: true,
-                },
-              })}\n\n`,
-            );
+            sendSseEvent(reply, {
+              type: "agent_result",
+              data: {
+                agentType: inj.agentType,
+                agentName: agentNameByType.get(inj.agentType) ?? inj.agentName ?? inj.agentType,
+                resultType: "context_injection",
+                data: { text: inj.text },
+                tokensUsed: 0,
+                success: true,
+                error: null,
+                durationMs: 0,
+                cached: true,
+              },
+            });
           }
           clearUnusedRuntimeSectionsBeforeLtm();
         } else {
@@ -5065,7 +5048,7 @@ export async function generateRoutes(app: FastifyInstance) {
           providerThinking += chunk;
           if (showThoughts) {
             fullThinking += chunk;
-            trySendSseEvent(reply, { type: "thinking", data: chunk });
+            sendSseEvent(reply, { type: "thinking", data: chunk });
           }
         };
         const captureReasoning = chatMode === "roleplay" && showThoughts;
@@ -5084,7 +5067,7 @@ export async function generateRoutes(app: FastifyInstance) {
         const emitTokenTextChunked = async (text: string) => {
           for (let i = 0; i < text.length; i += TOKEN_CHUNK_SIZE) {
             const chunk = text.slice(i, i + TOKEN_CHUNK_SIZE);
-            trySendSseEvent(reply, { type: "token", data: chunk });
+            sendSseEvent(reply, { type: "token", data: chunk });
             tokenChunksSinceYield += 1;
             if (tokenChunksSinceYield % TOKEN_CHUNK_YIELD_EVERY === 0) {
               await yieldToEventLoop();
@@ -6021,12 +6004,10 @@ export async function generateRoutes(app: FastifyInstance) {
                 .filter((toolResult): toolResult is NonNullable<typeof toolResult> => toolResult != null);
 
               for (const tr of toolResults) {
-                reply.raw.write(
-                  `data: ${JSON.stringify({
-                    type: "tool_result",
-                    data: { name: tr.name, result: tr.result, success: tr.success },
-                  })}\n\n`,
-                );
+                sendSseEvent(reply, {
+                  type: "tool_result",
+                  data: { name: tr.name, result: tr.result, success: tr.success },
+                });
 
                 // Persist update_game_state tool calls to the game state DB
                 if (tr.name === "update_game_state" && tr.success) {
@@ -6054,7 +6035,7 @@ export async function generateRoutes(app: FastifyInstance) {
                           updates = lockedUpdates;
                           // Send game_state_patch so HUD updates live
                           logger.debug("[game_state_patch] tool update_game_state: %j", updates);
-                          reply.raw.write(`data: ${JSON.stringify({ type: "game_state_patch", data: updates })}\n\n`);
+                          sendSseEvent(reply, { type: "game_state_patch", data: updates });
                         }
                       }
                     }
@@ -6656,7 +6637,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
           if (contentReplaced) {
             if (!holdForTextRewrite) {
-              reply.raw.write(`data: ${JSON.stringify({ type: "content_replace", data: fullResponse })}\n\n`);
+              sendSseEvent(reply, { type: "content_replace", data: fullResponse });
             }
           }
 
@@ -6755,9 +6736,10 @@ export async function generateRoutes(app: FastifyInstance) {
               };
             }
             logger.warn(`[generate] Empty response from model for chat ${input.chatId} (char: ${targetCharId})`);
-            reply.raw.write(
-              `data: ${JSON.stringify({ type: "error", data: "The AI returned an empty response. Try sending your message again." })}\n\n`,
-            );
+            sendSseEvent(reply, {
+              type: "error",
+              data: "The AI returned an empty response. Try sending your message again.",
+            });
             return null;
           }
 
@@ -7138,16 +7120,14 @@ export async function generateRoutes(app: FastifyInstance) {
                 ? remainingConversationPresenceDelay(responderDelay.delayMs, conversationPresenceDelayStartedAt)
                 : 0;
               if (responderDelay && remainingDelayMs > 0) {
-                reply.raw.write(
-                  `data: ${JSON.stringify({
-                    type: "delayed",
-                    characters: [groupResponderName(charId)],
-                    characterIds: [charId],
-                    characterStatuses: { [charId]: responderDelay.status },
-                    status: responderDelay.status,
-                    delayMs: remainingDelayMs,
-                  })}\n\n`,
-                );
+                sendSseEvent(reply, {
+                  type: "delayed",
+                  characters: [groupResponderName(charId)],
+                  characterIds: [charId],
+                  characterStatuses: { [charId]: responderDelay.status },
+                  status: responderDelay.status,
+                  delayMs: remainingDelayMs,
+                });
                 await waitForConversationPresenceDelay(remainingDelayMs, abortController.signal);
                 if (abortController.signal.aborted) break;
               }
@@ -7167,15 +7147,14 @@ export async function generateRoutes(app: FastifyInstance) {
                   runningMessages.push(resolveHistoryMessageMacros([mapped])[0] ?? mapped);
                 }
               }
-              reply.raw.write(
-                `data: ${JSON.stringify({ type: "typing", characters: [groupResponderName(charId)] })}\n\n`,
-              );
+              sendSseEvent(reply, { type: "typing", characters: [groupResponderName(charId)] });
             }
 
             // Tell the client which character is responding next
-            reply.raw.write(
-              `data: ${JSON.stringify({ type: "group_turn", data: { characterId: charId, characterName: charName, index: ci } })}\n\n`,
-            );
+            sendSseEvent(reply, {
+              type: "group_turn",
+              data: { characterId: charId, characterName: charName, index: ci },
+            });
 
             // Conversation puts its short turn instruction in Output Format.
             // Keep the established Roleplay instruction placement unchanged.
@@ -7356,7 +7335,7 @@ export async function generateRoutes(app: FastifyInstance) {
           if (typeof messageId !== "string" || !messageId) return;
           const readyMessage = savedMessage ?? (await chats.getMessage(messageId));
           if (!readyMessage || readyMessage.role !== "assistant") return;
-          assistantMessageReadySent = trySendSseEvent(reply, {
+          assistantMessageReadySent = sendSseEvent(reply, {
             type: "assistant_message_ready",
             data: readyMessage,
           });
@@ -7607,7 +7586,7 @@ export async function generateRoutes(app: FastifyInstance) {
           }
           if (newText) {
             if (shouldReviewSummary) {
-              trySendSseEvent(reply, {
+              sendSseEvent(reply, {
                 type: "agent_write_proposal",
                 data: buildSummaryWriteApprovalProposal({
                   chatId: input.chatId,
@@ -7642,12 +7621,10 @@ export async function generateRoutes(app: FastifyInstance) {
                   logger.error(err, "[chat-summary] Failed to auto-hide summarized roleplay messages");
                 }
               }
-              reply.raw.write(
-                `data: ${JSON.stringify({
-                  type: "chat_summary",
-                  data: { summary: combined, entry: createdEntry, entries: summaryEntries, hiddenMessageIds },
-                })}\n\n`,
-              );
+              sendSseEvent(reply, {
+                type: "chat_summary",
+                data: { summary: combined, entry: createdEntry, entries: summaryEntries, hiddenMessageIds },
+              });
             }
           }
         };
@@ -7673,7 +7650,7 @@ export async function generateRoutes(app: FastifyInstance) {
             agentContext.memory._expressionTargetIds = [...generatedExpressionTargetIds];
           }
           if (hasPostProcessingAgents) {
-            reply.raw.write(`data: ${JSON.stringify({ type: "agent_start", data: { phase: "post_generation" } })}\n\n`);
+            sendSseEvent(reply, { type: "agent_start", data: { phase: "post_generation" } });
           }
 
           // LOG_LEVEL=debug: log post-processing agents
@@ -7859,16 +7836,14 @@ export async function generateRoutes(app: FastifyInstance) {
             // Use postResults (not retryResults) so agents skipped during retry (e.g. agentCfg not found) are included
             const stillFailed = postResults.filter((r) => !r.success);
             if (stillFailed.length > 0) {
-              reply.raw.write(
-                `data: ${JSON.stringify({
-                  type: "agents_retry_failed",
-                  data: stillFailed.map((r) => ({
-                    agentType: r.agentType,
-                    agentName: resolvedAgents.find((agent) => agent.type === r.agentType)?.name ?? r.agentType,
-                    error: r.error,
-                  })),
-                })}\n\n`,
-              );
+              sendSseEvent(reply, {
+                type: "agents_retry_failed",
+                data: stillFailed.map((r) => ({
+                  agentType: r.agentType,
+                  agentName: resolvedAgents.find((agent) => agent.type === r.agentType)?.name ?? r.agentType,
+                  error: r.error,
+                })),
+              });
             }
           }
 
@@ -8236,7 +8211,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   ...(gs.worldCustomFields !== undefined ? { worldCustomFields: newWorldCustomFields } : {}),
                 };
                 logger.debug("[game_state_patch] world-state: %j", worldStatePatch);
-                reply.raw.write(`data: ${JSON.stringify({ type: "game_state_patch", data: worldStatePatch })}\n\n`);
+                sendSseEvent(reply, { type: "game_state_patch", data: worldStatePatch });
 
                 const existingGameMap = (chatMeta.gameMap as GameMap | null) ?? null;
                 const syncedMeta =
@@ -8490,17 +8465,11 @@ export async function generateRoutes(app: FastifyInstance) {
                           undefined,
                           { baseSnapshot: trackerBaseGameStateSnapshot },
                         );
-                        try {
-                          logger.debug(
-                            "[game_state_patch] character-tracker (avatar update): %d chars",
-                            presentCharacters.length,
-                          );
-                          reply.raw.write(
-                            `data: ${JSON.stringify({ type: "game_state_patch", data: { presentCharacters } })}\n\n`,
-                          );
-                        } catch {
-                          /* stream closed */
-                        }
+                        logger.debug(
+                          "[game_state_patch] character-tracker (avatar update): %d chars",
+                          presentCharacters.length,
+                        );
+                        sendSseEvent(reply, { type: "game_state_patch", data: { presentCharacters } });
                       } catch (err) {
                         logger.warn(err, "[character-tracker] Avatar generation error");
                       }
@@ -8522,17 +8491,11 @@ export async function generateRoutes(app: FastifyInstance) {
                   `[generate] character-tracker: updateByMessage returned ${updated ? "ok" : "null (no snapshot)"}`,
                 );
                 // Merge into the game_state SSE event for the HUD
-                try {
-                  logger.debug(
-                    "[game_state_patch] character-tracker: %s",
-                    chars.map((c: any) => c.name ?? c).join(", "),
-                  );
-                  reply.raw.write(
-                    `data: ${JSON.stringify({ type: "game_state_patch", data: { presentCharacters: chars } })}\n\n`,
-                  );
-                } catch {
-                  /* stream closed */
-                }
+                logger.debug(
+                  "[game_state_patch] character-tracker: %s",
+                  chars.map((c: any) => c.name ?? c).join(", "),
+                );
+                sendSseEvent(reply, { type: "game_state_patch", data: { presentCharacters: chars } });
 
                 // Auto-populate journal: NPC encounters
                 try {
@@ -8610,9 +8573,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 }
                 if (personaPatch.changed) {
                   logger.debug("[game_state_patch] persona-stats: %j", personaPatch.patch);
-                  reply.raw.write(
-                    `data: ${JSON.stringify({ type: "game_state_patch", data: personaPatch.patch })}\n\n`,
-                  );
+                  sendSseEvent(reply, { type: "game_state_patch", data: personaPatch.patch });
                 }
 
                 // Auto-populate journal: inventory changes
@@ -8669,9 +8630,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 }
                 if (inventoryTrackerPatch.changed) {
                   logger.debug("[game_state_patch] inventory-tracker: %j", inventoryTrackerPatch.values);
-                  reply.raw.write(
-                    `data: ${JSON.stringify({ type: "game_state_patch", data: inventoryTrackerPatch.patch })}\n\n`,
-                  );
+                  sendSseEvent(reply, { type: "game_state_patch", data: inventoryTrackerPatch.patch });
                 }
               } catch (err) {
                 logger.error(err, "[generate] Failed to apply inventory tracker update");
@@ -8717,9 +8676,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   }
                   if (customTrackerPatch.changed) {
                     logger.debug("[game_state_patch] custom-tracker: %j", customTrackerPatch.values);
-                    reply.raw.write(
-                      `data: ${JSON.stringify({ type: "game_state_patch", data: customTrackerPatch.patch })}\n\n`,
-                    );
+                    sendSseEvent(reply, { type: "game_state_patch", data: customTrackerPatch.patch });
                   }
                 }
               } catch (err) {
@@ -8778,9 +8735,7 @@ export async function generateRoutes(app: FastifyInstance) {
                         .where(eq(gameStateSnapshotsTable.id, snap.id));
                     }
                     logger.debug("[game_state_patch] quests: %j", questTrackerPatch.values);
-                    reply.raw.write(
-                      `data: ${JSON.stringify({ type: "game_state_patch", data: questTrackerPatch.patch })}\n\n`,
-                    );
+                    sendSseEvent(reply, { type: "game_state_patch", data: questTrackerPatch.patch });
 
                     // Auto-populate journal: quest updates
                     for (const u of questMerge.updates) {
@@ -8957,9 +8912,10 @@ export async function generateRoutes(app: FastifyInstance) {
                         }
                       }
                       if (executedCommands.length > 0) {
-                        reply.raw.write(
-                          `data: ${JSON.stringify({ type: "haptic_command", data: { commands: executedCommands, reasoning: hData.reasoning } })}\n\n`,
-                        );
+                        sendSseEvent(reply, {
+                          type: "haptic_command",
+                          data: { commands: executedCommands, reasoning: hData.reasoning },
+                        });
                         logger.info(
                           "[haptic] Agent executed %d command(s): %s",
                           executedCommands.length,
@@ -9099,7 +9055,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     }
 
                     await chats.patchMetadata(input.chatId, { background: generated.filename });
-                    trySendSseEvent(reply, {
+                    sendSseEvent(reply, {
                       type: "agent_result",
                       data: {
                         agentType: "illustrator",
@@ -9123,7 +9079,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     );
                   } catch (backgroundError) {
                     logger.error(backgroundError, "[illustrator-background] Automatic scene background failed");
-                    trySendSseEvent(reply, {
+                    sendSseEvent(reply, {
                       type: "agent_error",
                       data: {
                         agentType: "illustrator",
@@ -9171,7 +9127,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 imgConnFull ??= await connections.getDefaultForImageGeneration();
                 if (imgConnFull) {
                   const resolvedImageConnection = imgConnFull;
-                  trySendSseEvent(reply, {
+                  sendSseEvent(reply, {
                     type: "illustration_queued",
                     data: { messageId },
                   });
@@ -9443,18 +9399,16 @@ export async function generateRoutes(app: FastifyInstance) {
                         }
 
                         // Notify client
-                        reply.raw.write(
-                          `data: ${JSON.stringify({
-                            type: "illustration",
-                            data: {
-                              messageId,
-                              imageUrl,
-                              prompt: renderedPrompt,
-                              reason: illData.reason,
-                              galleryId: (galleryEntry as any)?.id,
-                            },
-                          })}\n\n`,
-                        );
+                        sendSseEvent(reply, {
+                          type: "illustration",
+                          data: {
+                            messageId,
+                            imageUrl,
+                            prompt: renderedPrompt,
+                            reason: illData.reason,
+                            galleryId: (galleryEntry as any)?.id,
+                          },
+                        });
                       }
                       logger.info(
                         "[illustrator] Generated %d illustration(s): %s...",
@@ -9463,35 +9417,31 @@ export async function generateRoutes(app: FastifyInstance) {
                       );
                     } catch (illErr) {
                       logger.error(illErr, "[illustrator] Image generation failed");
-                      reply.raw.write(
-                        `data: ${JSON.stringify({
-                          type: "agent_error",
-                          data: {
-                            agentType: result.agentType,
-                            agentName: imagePromptAgent?.name ?? "Illustrator",
-                            retryTarget: "illustration",
-                            error: `Image generation failed: ${illErr instanceof Error ? illErr.message : String(illErr)}`,
-                          },
-                        })}\n\n`,
-                      );
+                      sendSseEvent(reply, {
+                        type: "agent_error",
+                        data: {
+                          agentType: result.agentType,
+                          agentName: imagePromptAgent?.name ?? "Illustrator",
+                          retryTarget: "illustration",
+                          error: `Image generation failed: ${illErr instanceof Error ? illErr.message : String(illErr)}`,
+                        },
+                      });
                     }
                   })();
                 } else {
                   logger.warn("[illustrator] Agent wants to generate but no image generation connection configured");
-                  reply.raw.write(
-                    `data: ${JSON.stringify({
-                      type: "agent_error",
-                      data: {
-                        agentType: result.agentType,
-                        agentName: imagePromptAgent?.name ?? "Illustrator",
-                        retryTarget: "illustration",
-                        error: `No image generation connection is set on ${
-                          imagePromptAgent?.name?.trim() ||
-                          (result.agentType === "illustrator" ? "the Illustrator agent" : "this image agent")
-                        } or under Settings → Connections → Defaults → Images. Choose one there, or assign one directly in Settings → Agents.`,
-                      },
-                    })}\n\n`,
-                  );
+                  sendSseEvent(reply, {
+                    type: "agent_error",
+                    data: {
+                      agentType: result.agentType,
+                      agentName: imagePromptAgent?.name ?? "Illustrator",
+                      retryTarget: "illustration",
+                      error: `No image generation connection is set on ${
+                        imagePromptAgent?.name?.trim() ||
+                        (result.agentType === "illustrator" ? "the Illustrator agent" : "this image agent")
+                      } or under Settings → Connections → Defaults → Images. Choose one there, or assign one directly in Settings → Agents.`,
+                    },
+                  });
                 }
               }
             }
@@ -9627,17 +9577,15 @@ export async function generateRoutes(app: FastifyInstance) {
                       });
                     }
                     textRewriteApplied = true;
-                    reply.raw.write(
-                      `data: ${JSON.stringify({
-                        type: "text_rewrite",
-                        data: {
-                          editedText: sanitizedEditedText,
-                          changes,
-                          rewriteApplied: true,
-                          ...(originalText ? { originalText, agentType: editorResult.agentType } : {}),
-                        },
-                      })}\n\n`,
-                    );
+                    sendSseEvent(reply, {
+                      type: "text_rewrite",
+                      data: {
+                        editedText: sanitizedEditedText,
+                        changes,
+                        rewriteApplied: true,
+                        ...(originalText ? { originalText, agentType: editorResult.agentType } : {}),
+                      },
+                    });
                   }
                 }
               } catch {
@@ -9647,16 +9595,14 @@ export async function generateRoutes(app: FastifyInstance) {
           }
 
           if (holdForTextRewrite && !textRewriteApplied && !abortController.signal.aborted) {
-            reply.raw.write(
-              `data: ${JSON.stringify({
-                type: "text_rewrite",
-                data: {
-                  editedText: originalResponseBeforeRewrite,
-                  changes: [],
-                  rewriteApplied: false,
-                },
-              })}\n\n`,
-            );
+            sendSseEvent(reply, {
+              type: "text_rewrite",
+              data: {
+                editedText: originalResponseBeforeRewrite,
+                changes: [],
+                rewriteApplied: false,
+              },
+            });
           }
         }
 
@@ -9679,7 +9625,7 @@ export async function generateRoutes(app: FastifyInstance) {
         // ────────────────────────────────────────
         if (collectedCommands.length > 0 && !abortController.signal.aborted) {
           const professorMariCommandCount = countProfessorMariCommands(collectedCommands);
-          trySendSseEvent(reply, {
+          sendSseEvent(reply, {
             type: "assistant_commands_start",
             data: { count: collectedCommands.length, professorMariCommandCount },
           });
@@ -9714,12 +9660,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   chatId: input.chatId,
                   chats,
                   sendUpdated: (data) => {
-                    reply.raw.write(
-                      `data: ${JSON.stringify({
-                        type: "schedule_updated",
-                        data,
-                      })}\n\n`,
-                    );
+                    sendSseEvent(reply, { type: "schedule_updated", data });
                   },
                 });
 
@@ -9731,12 +9672,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   fullResponse,
                   chats,
                   sendCrossPost: (data) => {
-                    reply.raw.write(
-                      `data: ${JSON.stringify({
-                        type: "cross_post",
-                        data,
-                      })}\n\n`,
-                    );
+                    sendSseEvent(reply, { type: "cross_post", data });
                   },
                 });
 
@@ -9766,7 +9702,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   chats,
                   connections,
                   sendEvent: (payload) => {
-                    reply.raw.write(`data: ${JSON.stringify(payload)}\n\n`);
+                    sendSseEvent(reply, payload);
                   },
                 });
 
@@ -9779,7 +9715,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   db: app.db,
                   chats,
                   sendRingingEvent: (data) => {
-                    trySendSseEvent(reply, {
+                    sendSseEvent(reply, {
                       type: "conversation_call_ringing",
                       data,
                     });
@@ -9801,7 +9737,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   chatMode,
                   agentsStore,
                   sendEvent: (event) => {
-                    trySendSseEvent(reply, event);
+                    sendSseEvent(reply, event);
                   },
                 });
 
@@ -9828,24 +9764,14 @@ export async function generateRoutes(app: FastifyInstance) {
                   allChatMessages,
                   chats,
                   sendAssistantAction: (data) => {
-                    reply.raw.write(
-                      `data: ${JSON.stringify({
-                        type: "assistant_action",
-                        data,
-                      })}\n\n`,
-                    );
+                    sendSseEvent(reply, { type: "assistant_action", data });
                   },
                 });
 
                 await handleHapticCommand({
                   command,
                   sendEvent: (data) => {
-                    reply.raw.write(
-                      `data: ${JSON.stringify({
-                        type: "haptic_command",
-                        data,
-                      })}\n\n`,
-                    );
+                    sendSseEvent(reply, { type: "haptic_command", data });
                   },
                 });
 
@@ -9855,12 +9781,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   chatId: input.chatId,
                   chars,
                   sendSceneRequested: (data) => {
-                    reply.raw.write(
-                      `data: ${JSON.stringify({
-                        type: "scene_requested",
-                        data,
-                      })}\n\n`,
-                    );
+                    sendSseEvent(reply, { type: "scene_requested", data });
                   },
                 });
 
@@ -9914,12 +9835,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   embeddingSource: memoryRecallEmbeddingSource,
                   vectorizerAvailable: memoryRecallVectorizerAvailable,
                   sendAssistantAction: (data) => {
-                    reply.raw.write(
-                      `data: ${JSON.stringify({
-                        type: "assistant_action",
-                        data,
-                      })}\n\n`,
-                    );
+                    sendSseEvent(reply, { type: "assistant_action", data });
                   },
                 });
                 if (professorMariResult.fetchSucceeded) {
@@ -9930,7 +9846,7 @@ export async function generateRoutes(app: FastifyInstance) {
               }
             }
           } finally {
-            trySendSseEvent(reply, {
+            sendSseEvent(reply, {
               type: "assistant_commands_end",
               data: {},
             });
@@ -10032,7 +9948,7 @@ export async function generateRoutes(app: FastifyInstance) {
           logger.info(
             `[generate] Posted ${collectedOocMessages.length} OOC message(s) to conversation ${chat.connectedChatId}`,
           );
-          trySendSseEvent(reply, {
+          sendSseEvent(reply, {
             type: "ooc_posted",
             data: { chatId: chat.connectedChatId, count: collectedOocMessages.length },
           });
@@ -10097,7 +10013,7 @@ export async function generateRoutes(app: FastifyInstance) {
       stopSseKeepalive();
       reply.raw.off("close", onClose);
       releaseActiveGeneration();
-      if (canWriteSse()) {
+      if (!clientDisconnected && isSseReplyWritable(reply)) {
         reply.raw.end();
       }
     }

--- a/packages/server/src/routes/generate/fallback-notification.ts
+++ b/packages/server/src/routes/generate/fallback-notification.ts
@@ -5,12 +5,12 @@ import {
   type GenerationFallbackNotice,
   type GenerationFallbackNotifier,
 } from "../../services/generation/fallback-notification.js";
-import { trySendSseEvent } from "./sse.js";
+import { sendSseEvent } from "./sse.js";
 
 export function createReplyFallbackNotifier(reply: FastifyReply): GenerationFallbackNotifier {
   return (notice: GenerationFallbackNotice) => {
     if (reply.raw.headersSent) {
-      trySendSseEvent(reply, { type: "fallback_used", data: notice });
+      sendSseEvent(reply, { type: "fallback_used", data: notice });
       return;
     }
     reply.header(GENERATION_FALLBACK_HEADER, encodeGenerationFallbackNotice(notice));

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -144,7 +144,7 @@ import {
   resolveLorebookScopeExclusions,
 } from "../../services/lorebook/game-lorebook-scope.js";
 import { isDebugAgentsEnabled } from "../../config/runtime-config.js";
-import { sendSseEvent, startSseKeepalive, startSseReply } from "./sse.js";
+import { isSseReplyWritable, sendSseEvent, startSseKeepalive, startSseReply } from "./sse.js";
 import { buildGenerationPromptPresetCandidates } from "./prompt-preset-selection.js";
 import {
   buildAgentConnectionUnavailableWarning,
@@ -3601,17 +3601,6 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
     // retry tab does not leak upstream provider requests to completion.
     const abortController = new AbortController();
     let clientDisconnected = false;
-    const originalSseWrite = reply.raw.write.bind(reply.raw);
-    const canWriteSse = () =>
-      !clientDisconnected && !reply.raw.destroyed && !reply.raw.writableEnded && !reply.raw.writableFinished;
-    reply.raw.write = ((chunk: any, encodingOrCallback?: any, callback?: any) => {
-      if (!canWriteSse()) return false;
-      try {
-        return originalSseWrite(chunk, encodingOrCallback, callback);
-      } catch {
-        return false;
-      }
-    }) as typeof reply.raw.write;
     const stopSseKeepalive = startSseKeepalive(reply);
     const onClientClose = () => {
       clientDisconnected = true;
@@ -4163,7 +4152,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
     } finally {
       stopSseKeepalive();
       reply.raw.off("close", onClientClose);
-      if (canWriteSse()) {
+      if (!clientDisconnected && isSseReplyWritable(reply)) {
         reply.raw.end();
       }
     }

--- a/packages/server/src/routes/generate/sse.ts
+++ b/packages/server/src/routes/generate/sse.ts
@@ -37,7 +37,3 @@ export function sendSseEvent(reply: FastifyReply, payload: SsePayload): boolean 
     return false;
   }
 }
-
-export function trySendSseEvent(reply: FastifyReply, payload: SsePayload): boolean {
-  return sendSseEvent(reply, payload);
-}

--- a/packages/server/src/routes/professor-mari-workspace.routes.ts
+++ b/packages/server/src/routes/professor-mari-workspace.routes.ts
@@ -4,7 +4,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { requirePrivilegedAccess } from "../middleware/privileged-gate.js";
-import { sendSseEvent, startSseKeepalive, startSseReply } from "./generate/sse.js";
+import { isSseReplyWritable, sendSseEvent, startSseKeepalive, startSseReply } from "./generate/sse.js";
 import { getProfessorMariWorkspaceService } from "../services/professor-mari/workspace-agent.service.js";
 import { getProfessorMariWorkspaceSkillsService } from "../services/professor-mari/workspace-skills.service.js";
 import { getMariDbService } from "../services/mari-db/mari-db.service.js";
@@ -244,7 +244,7 @@ export async function professorMariWorkspaceRoutes(app: FastifyInstance) {
     reply.raw.on("close", onClose);
 
     const send = (event: Parameters<typeof sendSseEvent>[1]) => {
-      if (!clientDisconnected && !reply.raw.destroyed) sendSseEvent(reply, event);
+      if (!clientDisconnected && isSseReplyWritable(reply)) sendSseEvent(reply, event);
     };
 
     try {
@@ -265,7 +265,7 @@ export async function professorMariWorkspaceRoutes(app: FastifyInstance) {
       complete = true;
       stopSseKeepalive();
       reply.raw.off("close", onClose);
-      if (!clientDisconnected && !reply.raw.destroyed && !reply.raw.writableEnded) reply.raw.end();
+      if (!clientDisconnected && isSseReplyWritable(reply)) reply.raw.end();
     }
   });
 

--- a/packages/server/src/routes/professor-mari-workspace.routes.ts
+++ b/packages/server/src/routes/professor-mari-workspace.routes.ts
@@ -4,7 +4,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { requirePrivilegedAccess } from "../middleware/privileged-gate.js";
-import { startSseKeepalive, startSseReply, trySendSseEvent } from "./generate/sse.js";
+import { sendSseEvent, startSseKeepalive, startSseReply } from "./generate/sse.js";
 import { getProfessorMariWorkspaceService } from "../services/professor-mari/workspace-agent.service.js";
 import { getProfessorMariWorkspaceSkillsService } from "../services/professor-mari/workspace-skills.service.js";
 import { getMariDbService } from "../services/mari-db/mari-db.service.js";
@@ -243,8 +243,8 @@ export async function professorMariWorkspaceRoutes(app: FastifyInstance) {
     };
     reply.raw.on("close", onClose);
 
-    const send = (event: Parameters<typeof trySendSseEvent>[1]) => {
-      if (!clientDisconnected && !reply.raw.destroyed) trySendSseEvent(reply, event);
+    const send = (event: Parameters<typeof sendSseEvent>[1]) => {
+      if (!clientDisconnected && !reply.raw.destroyed) sendSseEvent(reply, event);
     };
 
     try {

--- a/packages/server/src/services/generation/turn-game-command-runtime.ts
+++ b/packages/server/src/services/generation/turn-game-command-runtime.ts
@@ -2,6 +2,7 @@ import type { FastifyReply } from "fastify";
 import { getTurnGameEngine } from "@marinara-engine/shared";
 import type { DB } from "../../db/connection.js";
 import { logger } from "../../lib/logger.js";
+import { sendSseEvent } from "../../routes/generate/sse.js";
 import { getEnabledConversationSchedules } from "./conversation-context-utils.js";
 import { getCurrentStatus, type WeekSchedule } from "../conversation/schedule.service.js";
 import { resolveConversationTimeZone, toZonedWallClockDate } from "../conversation/timezone.js";
@@ -80,7 +81,7 @@ export async function handleTurnGameCommand(args: TurnGameCommandArgs): Promise<
       return true;
     }
 
-    args.reply.raw.write(`data: ${JSON.stringify({ type: "turn_game_state_patch", data: outcome.view })}\n\n`);
+    sendSseEvent(args.reply, { type: "turn_game_state_patch", data: outcome.view });
     logger.info(
       "[commands] %s started in chat %s with %d player(s)",
       gameType,

--- a/packages/server/src/services/turn-games/turn-game-bot-runner.service.ts
+++ b/packages/server/src/services/turn-games/turn-game-bot-runner.service.ts
@@ -20,7 +20,7 @@ import { logDebugOverride, logger } from "../../lib/logger.js";
 import { isDebugAgentsEnabled } from "../../config/runtime-config.js";
 import type { BaseLLMProvider, ChatMessage, LLMToolDefinition } from "../llm/base-provider.js";
 import { createLLMProvider } from "../llm/provider-registry.js";
-import { trySendSseEvent } from "../../routes/generate/sse.js";
+import { sendSseEvent } from "../../routes/generate/sse.js";
 import { createCharactersStorage } from "../storage/characters.storage.js";
 import { createChatsStorage } from "../storage/chats.storage.js";
 import { createGameEngineStateStorage } from "../storage/game-engine-state.storage.js";
@@ -193,7 +193,7 @@ async function drainAndVoiceAnnouncements(args: {
 
     // Whose-turn marker before the voiced dealer line, matching the loop's
     // existing group_turn marker for bot moves.
-    trySendSseEvent(reply, {
+    sendSseEvent(reply, {
       type: "group_turn",
       data: { characterId: dealerCharId, characterName: fallbackName, index: turnIndex },
     });
@@ -215,7 +215,7 @@ async function drainAndVoiceAnnouncements(args: {
         state: JSON.stringify(nextState),
         committed: true,
       });
-      trySendSseEvent(reply, { type: "message_saved", data: saved });
+      sendSseEvent(reply, { type: "message_saved", data: saved });
     } else {
       // Persistence of the dealer message failed — still advance engine state so
       // the queue doesn't grow unbounded and the game keeps moving.
@@ -245,7 +245,7 @@ async function drainAndVoiceAnnouncements(args: {
 
   // Push the redacted human-perspective board so the client clears
   // hasPendingAnnouncements and sees the drained state live.
-  trySendSseEvent(reply, { type: "turn_game_state_patch", data: engine.publicView(nextState, humanSeatId) });
+  sendSseEvent(reply, { type: "turn_game_state_patch", data: engine.publicView(nextState, humanSeatId) });
   return { state: nextState };
 }
 
@@ -335,9 +335,9 @@ export async function runTurnGameBotTurns(args: RunBotTurnsArgs): Promise<void> 
     const seatName = state.seatNames?.[seatId] ?? seatId;
 
     // Announce whose turn it is (reuses the established multi-actor marker).
-    // Non-critical marker — use the swallowing variant so a client disconnect
-    // can't throw and abort the bot-turn loop (matches the other emits below).
-    trySendSseEvent(reply, { type: "group_turn", data: { characterId: seatId, characterName: seatName, index: turn } });
+    // Non-critical marker — the canonical guarded emitter keeps a disconnect
+    // from throwing and aborting the bot-turn loop (matches the other emits below).
+    sendSseEvent(reply, { type: "group_turn", data: { characterId: seatId, characterName: seatName, index: turn } });
 
     // ── Ask the bot for a move ──
     const view = engine.describeForModel(state, seatId);
@@ -442,7 +442,7 @@ export async function runTurnGameBotTurns(args: RunBotTurnsArgs): Promise<void> 
           state: JSON.stringify(nextState),
           committed: true,
         });
-        trySendSseEvent(reply, { type: "message_saved", data: saved });
+        sendSseEvent(reply, { type: "message_saved", data: saved });
       } else {
         // Persistence of the message failed — still advance engine state so the game continues.
         await engineStorage.create({
@@ -458,7 +458,7 @@ export async function runTurnGameBotTurns(args: RunBotTurnsArgs): Promise<void> 
     }
 
     // Push the redacted human-perspective board so the client updates live.
-    trySendSseEvent(reply, { type: "turn_game_state_patch", data: engine.publicView(nextState, humanSeatId) });
+    sendSseEvent(reply, { type: "turn_game_state_patch", data: engine.publicView(nextState, humanSeatId) });
   }
 
   // Final drain: a showdown/game_over (or any other) announcement queued by the


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5138

## Why this change

Generation-family SSE data frames were emitted from several places: the canonical `sendSseEvent` helper in `packages/server/src/routes/generate/sse.ts`, an exact alias (`trySendSseEvent`), and call sites that serialized `data: ${JSON.stringify(...)}` payloads directly onto `reply.raw`, while the main `/generate` and `/retry-agents` handlers monkey-patched `reply.raw.write` per request to duplicate the closed-socket guard. Socket-lifecycle safety therefore had multiple apparent owners, native `write` identity was patched per-request, and every future event site had to remember the full framing/guard recipe or silently reintroduce unsafe writes.

## What changed

Behavior-preserving consolidation, seven files, net −98 lines:

- Route every generation-family data event through `sendSseEvent`, including the newer `delayed`, `typing`, and inventory `game_state_patch` events.
- Delete the exact `trySendSseEvent` alias and update its callers.
- Remove the route-local `reply.raw.write` interception and two obsolete character-tracker stream-closure catch layers.
- Unchanged: exact payload bytes and property order, event order, keepalive bytes/cadence/cleanup, distinct disconnect policies (main passive continuation vs impersonation/retry abort vs Professor Mari passive continuation), persistence, cancellation, and native backpressure booleans.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` exited 0 on a clean worktree at the current head `3df9f5fb8` (impeccable context, localization, workspace lint, full client+server builds).
- Focused retry regression `scripts/regressions/manual-agent-retry-resolution.regression.ts` passed (1/1).
- Disposable transport probe verified exact framing bytes, native true/false backpressure passthrough, destroyed/ended/finished rejection, thrown-write and serialization-failure containment, SSE headers, keepalive cadence/cleanup, and a delayed write after a real client disconnect; removing the guard's `try/catch` reproduced an escaping `write EPIPE` (negative efficacy), then the source was restored byte-identically.
- Live integration probe against the real server and a local stub provider: client aborted mid-stream, generation continued passively, the completed assistant message was persisted, and the server stayed healthy on post-disconnect writes.
- Not yet manually verified in a browser: streamed generation and a mid-generation tab close across roleplay and retry flows. Manually verify streaming generation and mid-generation disconnect in the browser.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable — no UI change; wire behavior is byte-identical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved reliability of real-time generation, workspace, and turn-based game updates delivered through streaming connections.
- Prevented unnecessary event writes and response completion attempts after a connection is closed or unavailable.
- Improved handling of client disconnects and completed responses during retries and ongoing streams.
- Preserved existing event payloads and generation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
