### PR TITLE
Docs: Game Mode Experiences page

### DIFF
--- a/docs/game/experiences.md
+++ b/docs/game/experiences.md
@@ -17,9 +17,9 @@ An Experience owns the surface of the game. The engine keeps running everything 
 
 ## Installing an Experience
 
-Experiences install like agents. Open **Agents > Download Agents**, find the Experience in the catalog, and install it. No restart is needed.
+Experiences install like agents. Open **Agents → Download Agents**, find the Experience in the catalog, and install it. Installing Pixelforge needs no restart — it is ready as soon as the install finishes. A package that does need a restart says so when it installs, and appears in the wizard after you restart.
 
-Each catalog entry lists the minimum engine version it needs. Pixelforge needs Marinara Engine 2.4.3 or newer. On older engines the entry does not appear.
+Each catalog entry lists the minimum engine version it needs; Pixelforge needs Marinara Engine 2.4.3 or newer. Older engines don't offer it: an engine too old to understand the package skips its catalog entry entirely, and installing a package that needs a newer engine is refused with an error naming the version it needs.
 
 ## Starting a game with an Experience
 
@@ -33,9 +33,9 @@ Every Experience still needs a GM connection — the Experience runs the surface
 
 ## Playing Pixelforge
 
-Pixelforge's setup form fits on one screen: a game name, a **Theme** (cozy village or sci-fi colony), a world seed, and the setting, tone, difficulty, and content rating you would normally set in the wizard. Pick a GM connection and click **Begin**.
+Pixelforge's setup form fits on one screen: a game name, a **Theme** (**Cozy village** or **Sci-fi colony**), a world seed, the setting, tone, difficulty, and content rating you would normally set in the wizard, and an optional **Party characters** pick — the villagers are NPCs, so bring your own characters or none. Pick a GM connection and click **Begin in Hearthvale** (the Begin button carries the current village name).
 
-You start walking immediately. Move with the arrow keys, WASD, or the on-screen D-pad. Walk up to a villager and press **Talk (E)** — what you say becomes a story turn, and the GM's narration appears in the panel below the world. Combat, when it happens, is the engine's own combat screen.
+You start walking immediately. Move with the arrow keys, WASD, or the on-screen D-pad. Walk up to a villager and press **E** — or tap the Talk button, which reads **Talk to <name> (E)** once you are close enough. Pixelforge opens the conversation by sending a greeting turn for you; everything you then type in the message box drives the story, and the GM's narration appears in the panel below the world. Combat, when it happens, is the engine's own combat screen.
 
 ### Your preferences generate the world
 
@@ -47,7 +47,7 @@ This happens in the background while you play:
 - **"The world takes shape."** means the generated world is ready. The map rebuilds in place.
 - **"World generation couldn't run — it will retry next visit."** means something temporary got in the way (the engine was busy, or the network dropped). The default world is fully playable, and generation tries again the next time you open the chat.
 
-Generation happens once per game. If the AI's plan cannot be used at all, Pixelforge keeps the default themed world — the game always works.
+Generation happens once per game. If the AI's plan cannot be used at all, Pixelforge falls back to a built-in plan for your theme — the map still rebuilds ("The world takes shape."), just with the stock cast and places. The game always works.
 
 ### Saves follow the story
 
@@ -63,11 +63,11 @@ If you uninstall an Experience's package while a campaign is using it, the chat 
 
 ## Building your own
 
-An Experience is a capability package that contributes a `game-surface` — the same packaging system agents use, with a client entrypoint that renders the game. Pixelforge is open source and is the reference implementation: its package source, build scripts, and the World Brief specification behind its world generation live in the [Marinara-Agents repository](https://github.com/Pasta-Devs/Marinara-Agents/tree/main/packages/pixelforge).
+An Experience is a capability package that contributes a `game-surface` — the same packaging system agents use, with a client entrypoint that renders the game. Pixelforge is open source and is the reference implementation: its package source, build scripts, and the World Brief specification behind its world generation live in the `packages/pixelforge` folder of the [Marinara-Agents repository](https://github.com/Pasta-Devs/Marinara-Agents).
 
-## Related pages
+## Related guides
 
-- [Game Mode: Getting Started](getting-started.md) — the standard setup wizard and Game Mode basics
-- [Agents Overview](../agents/agents-overview.md) — installing packages from **Download Agents**
-- [Sessions and Saves](sessions-and-saves.md) — checkpoints, branching, and the story timeline
-- [Combat](combat.md) — the engine combat every Experience shares
+- [Game Mode: Getting Started](getting-started.md)
+- [Agents: AI Helpers for Your Chats](../agents/agents-overview.md)
+- [Game Mode: Sessions and Saves](sessions-and-saves.md)
+- [Game Mode: Combat](combat.md)

--- a/docs/game/experiences.md
+++ b/docs/game/experiences.md
@@ -1,0 +1,73 @@
+# Game Mode: Experiences
+
+An **Experience** is a downloadable package that takes over how a game looks and plays. Instead of the standard setup wizard and narration layout, the Experience brings its own — a rendered world, its own controls, its own setup form. The AI Game Master still runs the story underneath it.
+
+The first Experience is **Pixelforge**, a walkable pixel-art RPG where your setup preferences generate the world. This page uses it as the running example.
+
+## What an Experience changes, and what it does not
+
+An Experience owns the surface of the game. The engine keeps running everything underneath. This split is what makes Experiences safe to try: your story, saves, and settings work the same way in every game.
+
+| The Experience owns | The engine keeps |
+|---|---|
+| The setup form you fill in | The GM connection and every AI call |
+| The play area (for Pixelforge, a rendered pixel world) | The story itself — turns, swipes, branches, checkpoints |
+| Its own controls and on-screen buttons | Combat |
+| How your actions become story turns | World Maps, agents, Chat Settings |
+
+## Installing an Experience
+
+Experiences install like agents. Open **Agents > Download Agents**, find the Experience in the catalog, and install it. No restart is needed.
+
+Each catalog entry lists the minimum engine version it needs. Pixelforge needs Marinara Engine 2.4.3 or newer. On older engines the entry does not appear.
+
+## Starting a game with an Experience
+
+1. Create a **Game Mode** chat as usual. The setup wizard opens.
+2. On the first step, find the **Experiences** block and click **Show**. It lists every installed Experience.
+3. Turn the Experience on. The wizard is replaced by that Experience's own setup form.
+
+Turning the Experience off returns you to the standard wizard. Nothing else about the chat changes.
+
+Every Experience still needs a GM connection — the Experience runs the surface, but the AI Game Master runs the story. Pixelforge asks for one in its own setup form and only lists text-capable connections.
+
+## Playing Pixelforge
+
+Pixelforge's setup form fits on one screen: a game name, a **Theme** (cozy village or sci-fi colony), a world seed, and the setting, tone, difficulty, and content rating you would normally set in the wizard. Pick a GM connection and click **Begin**.
+
+You start walking immediately. Move with the arrow keys, WASD, or the on-screen D-pad. Walk up to a villager and press **Talk (E)** — what you say becomes a story turn, and the GM's narration appears in the panel below the world. Combat, when it happens, is the engine's own combat screen.
+
+### Your preferences generate the world
+
+Since Pixelforge 0.4.0, the setting text and preferences you enter decide what the world contains. Shortly after the game starts, Pixelforge makes one structured GM call that plans the settlement: who lives there, which households they belong to, which buildings and landmarks exist. A deterministic builder then lays out the map from that plan — the AI decides what exists, the algorithm decides where every tile goes.
+
+This happens in the background while you play:
+
+- **"Generating your world — keep exploring meanwhile…"** appears when the game starts. You are walking in a default themed world in the meantime.
+- **"The world takes shape."** means the generated world is ready. The map rebuilds in place.
+- **"World generation couldn't run — it will retry next visit."** means something temporary got in the way (the engine was busy, or the network dropped). The default world is fully playable, and generation tries again the next time you open the chat.
+
+Generation happens once per game. If the AI's plan cannot be used at all, Pixelforge keeps the default themed world — the game always works.
+
+### Saves follow the story
+
+The world's state — where you are, the in-game clock, what has been introduced — is saved with the story timeline. If you swipe a GM response, branch the chat, or load a checkpoint, the world rewinds with the story, and a toast says so. You never manage world saves yourself.
+
+## If things look plain
+
+Pixelforge ships authored pixel art, and falls back to simpler procedural art whenever that art cannot load (for example, on a network hiccup). The game keeps working either way, and it retries loading the authored art on its own.
+
+## Uninstalling mid-campaign
+
+If you uninstall an Experience's package while a campaign is using it, the chat is not lost. The next time you open it, the standard Game Mode layout is back and the story continues without the Experience's surface. Reinstall the package to get the surface back.
+
+## Building your own
+
+An Experience is a capability package that contributes a `game-surface` — the same packaging system agents use, with a client entrypoint that renders the game. Pixelforge is open source and is the reference implementation: its package source, build scripts, and the World Brief specification behind its world generation live in the [Marinara-Agents repository](https://github.com/Pasta-Devs/Marinara-Agents/tree/main/packages/pixelforge).
+
+## Related pages
+
+- [Game Mode: Getting Started](getting-started.md) — the standard setup wizard and Game Mode basics
+- [Agents Overview](../agents/agents-overview.md) — installing packages from **Download Agents**
+- [Sessions and Saves](sessions-and-saves.md) — checkpoints, branching, and the story timeline
+- [Combat](combat.md) — the engine combat every Experience shares

--- a/docs/game/getting-started.md
+++ b/docs/game/getting-started.md
@@ -111,6 +111,7 @@ For the full parameter reference, see [Generation Parameters](../prompts/generat
 
 This guide gets you into a game. Each deeper topic has its own guide:
 
+- [Game Mode: Experiences](experiences.md) covers downloadable Experiences such as Pixelforge, which replace the standard wizard and play area with their own.
 - [Game Mode: Combat](combat.md) covers encounters, the action menu, damage math, and quick-time events.
 - [Game Mode: Party and NPCs](party-and-npcs.md) covers the party bar, character sheets, and the Adventure Journal.
 - [Game Mode: Sessions and Saves](sessions-and-saves.md) covers ending and starting sessions and the session history.

--- a/docs/game/getting-started.md
+++ b/docs/game/getting-started.md
@@ -142,6 +142,7 @@ Some models stay upbeat no matter the tone. You have two options. Add a clear in
 
 ## Related guides
 
+- [Game Mode: Experiences](experiences.md)
 - [Game Mode: Combat](combat.md)
 - [Game Mode: Party and NPCs](party-and-npcs.md)
 - [Game Mode: Sessions and Saves](sessions-and-saves.md)


### PR DESCRIPTION
## Linked issue

Closes #5140

## Why this change

Experiences shipped across 2.4.3-staging and the first one (Pixelforge 0.4.0) is live in the Marinara-Agents catalog, but no user-facing documentation exists. Both Marinara-Agents releases deferred "an Engine-side Experiences docs page" as the post-release follow-up; this is that page.

## What changed

- New `docs/game/experiences.md` (auto-indexed by the docs viewer's filesystem walk): what an Experience owns vs what the engine keeps, installing from **Agents > Download Agents**, the Experiences block in the New Game wizard, playing Pixelforge — including 0.4.0's background world generation and the exact meaning of its three toasts — timeline-anchored world saves, the Tier-0 art fallback, uninstall-mid-campaign behavior (built-in chrome returns, story continues), and a short builders' pointer to the Pixelforge reference implementation.
- One cross-link added to `docs/game/getting-started.md` under Related guides.

Claims were written against the current staging code (`NewGameExperienceChooser.tsx`, `GameSurface.tsx` `experienceOwnsGame` fallback) and the shipped Pixelforge 0.4.0 client, not from memory.

## Manual verification

- Manually verify in browser: the new page appears in the in-app docs viewer under Game Mode and renders correctly.
- Manually verify the getting-started Related guides link navigates to the new page.

## Documentation impact

A `[docs-i18n]` follow-up issue will be opened for the language packs (this adds one EN doc + modifies getting-started.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)