### PR TITLE
Adopt Ponytail minimalism guidance for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,15 @@ This file is a thin maintainer note for contributors using Codex. Canonical work
 - Follow `.github/agents/chai-workflow.md` as the repo's additive AI-agent workflow overlay for proof discipline, bugfix lanes, feature sizing, issue filing, PR gates, and risky-work claim boundaries.
 - The overlay does not replace this file, `CONTRIBUTING.md`, package instructions, or maintainer requests. Repo rules and the user's latest request still win.
 
+## Ponytail Implementation Discipline
+
+- Apply [Ponytail](https://github.com/DietrichGebert/ponytail) as an additive minimalism overlay after understanding the task and tracing the affected flow. It never overrides repository rules, validation requirements, or the maintainer's latest request.
+- Before adding code, stop at the first option that works: skip unnecessary work, reuse an existing helper or pattern, use the standard library, use a native platform capability, use an already-installed dependency, choose a clear inline solution, then write the minimum new code.
+- Prefer shared root-cause fixes after checking every caller, deletion over addition, boring over clever, and the fewest files. Avoid speculative abstractions, dependencies, and boilerplate.
+- Never trade away trust-boundary validation, data-loss prevention, security, accessibility, real-hardware calibration, or explicitly requested behavior.
+- Non-trivial logic must leave behind the smallest runnable regression proof. Trivial one-line and instruction-only changes do not need a dedicated test.
+- Mark a deliberate shortcut with a `ponytail:` comment that names its known ceiling and the upgrade path.
+
 ## Preferred Workflow
 
 - Start with `pnpm install`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Changed
 
+- Coding-agent contributors now follow a Ponytail-inspired minimalism ladder that favors reuse, platform capabilities, and the smallest correct implementation without weakening safety or validation requirements (#5186).
 - Project validation now checks the maintained TypeScript and TSX source tree with Prettier before linting and building, so formatting drift is rejected by the same `pnpm check` command used in pull-request CI (#5181).
 - The Inventory Tracker panel now flows its entries as wrapping pills across the full panel width, with the quantity shown as `×N` only when it is above one. The previous layout split the panel into three fixed columns and reserved a quantity cell on every row, so at the widest setting each column was around 95 px and item names truncated — while a group holding two rows sat mostly empty. The panel also establishes its own container context, so it now lays out identically in the docked sidebar and the HUD popover instead of differing between them (#5125).
 


### PR DESCRIPTION
## Linked issue

Closes #5186

## Why this change

- Coding agents need a shared default that prefers the smallest correct implementation without weakening Marinara's proof and safety rules.
- Ponytail's repository-portable guidance supplies that discipline without requiring plugin hooks or vendored skills.

## What changed

- Added a concise Ponytail implementation discipline to the root AGENTS.md.
- Kept repository rules, validation, security, accessibility, data-loss handling, and explicit maintainer requests authoritative.
- Added an Unreleased contributor-workflow changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated evidence: `pnpm check` passed locally, including localization, Prettier, ESLint, TypeScript, server build, client production build, and PWA generation.
- Reviewed the root agent guide to confirm Ponytail is additive and every existing Marinara workflow requirement remains intact.
- Browser verification is not applicable because this changes contributor instructions only.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not applicable; contributor-instruction change only.
