### PR TITLE
Fix stale macOS storage writer leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Stale file-storage writer leases on macOS now survive VPN and virtual-interface changes: new leases use the stable platform identity instead of hashing the currently visible network adapters, and existing v1 leases from the same Mac are reclaimed after their PID exits instead of blocking startup (#5194).
 - Custom lorebook-writing agents now support a configurable Read Behind depth, keep each delayed run attached to the assistant reply it processed, and avoid duplicate work when the newest reply is swiped. Lorebook Keeper's mobile Backfill controls now stack inside their settings card instead of overflowing it (#5191).
 - The staging update-channel warning now follows the active theme accent color instead of always rendering in amber (#5184).
 - Character avatar uploads now reject path-like character IDs before constructing their storage filename, keeping uploaded files confined to the avatar directory even when a malformed route parameter is supplied (#5181).

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -20,6 +20,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { chmod, copyFile, open, rename, unlink, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { dirname, join, resolve, sep } from "node:path";
 import { hostname, networkInterfaces } from "node:os";
@@ -92,7 +93,7 @@ type TableSnapshotManifest = {
 };
 
 type StorageWriterLeaseRecord = {
-  version: 1;
+  version: 1 | 2;
   pid: number;
   hostId: string | null;
   hostname: string;
@@ -1042,7 +1043,7 @@ function writerLeaseOwnerPath(path: string) {
 }
 
 const CURRENT_HOSTNAME = hostname();
-const CURRENT_HOST_ID = (() => {
+const CURRENT_LEGACY_HOST_ID = (() => {
   const machineId = ["/etc/machine-id", "/var/lib/dbus/machine-id"].flatMap((path) => {
     try {
       return [readFileSync(path, "utf8").trim()];
@@ -1060,6 +1061,72 @@ const CURRENT_HOST_ID = (() => {
     .update([CURRENT_HOSTNAME, machineId ?? "", ...macs].join("\n"))
     .digest("hex");
 })();
+
+function readStableMachineId() {
+  if (process.platform === "darwin") {
+    try {
+      const output = execFileSync("/usr/sbin/ioreg", ["-rd1", "-c", "IOPlatformExpertDevice"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 1_000,
+        maxBuffer: 64 * 1024,
+      });
+      return output.match(/"IOPlatformUUID"\s*=\s*"([^"]+)"/)?.[1] ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  if (process.platform === "win32") {
+    try {
+      const executable = process.env.SystemRoot ? join(process.env.SystemRoot, "System32", "reg.exe") : "reg.exe";
+      const output = execFileSync(
+        executable,
+        ["query", "HKLM\\SOFTWARE\\Microsoft\\Cryptography", "/v", "MachineGuid"],
+        {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: 1_000,
+          maxBuffer: 64 * 1024,
+        },
+      );
+      return output.match(/MachineGuid\s+REG_SZ\s+([^\r\n]+)/i)?.[1]?.trim() ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  return (
+    ["/etc/machine-id", "/var/lib/dbus/machine-id"].flatMap((path) => {
+      try {
+        return [readFileSync(path, "utf8").trim()];
+      } catch {
+        return [];
+      }
+    })[0] ?? null
+  );
+}
+
+const CURRENT_HOST_ID = (() => {
+  const machineId = readStableMachineId();
+  if (!machineId) return null;
+  return createHash("sha256")
+    .update(`marinara-writer-lease-v2\n${process.platform}\n${machineId.toLowerCase()}`)
+    .digest("hex");
+})();
+
+function writerLeaseBelongsToCurrentHost(record: StorageWriterLeaseRecord) {
+  if (record.version === 2) {
+    return Boolean(CURRENT_HOST_ID && record.hostId === CURRENT_HOST_ID);
+  }
+  if (CURRENT_LEGACY_HOST_ID && record.hostId === CURRENT_LEGACY_HOST_ID) return true;
+
+  // Version 1 used every visible MAC address in its fingerprint. On macOS,
+  // VPN and virtual interfaces can change that list between launches. The
+  // hostname fallback is intentionally limited to legacy macOS leases; v2
+  // leases always require the stable platform UUID above.
+  return process.platform === "darwin" && record.hostname === CURRENT_HOSTNAME;
+}
 
 class WriterLeasePendingError extends Error {}
 
@@ -1085,7 +1152,7 @@ function parseWriterLease(path: string): { raw: string; record: StorageWriterLea
   try {
     const record = JSON.parse(raw) as StorageWriterLeaseRecord;
     if (
-      record.version !== 1 ||
+      (record.version !== 1 && record.version !== 2) ||
       !Number.isSafeInteger(record.pid) ||
       record.pid <= 0 ||
       (record.hostId !== null && typeof record.hostId !== "string") ||
@@ -1432,7 +1499,7 @@ class FileTableStore {
         mkdirSync(path, { mode: PRIVATE_DIRECTORY_MODE });
         created = true;
         const record: StorageWriterLeaseRecord = {
-          version: 1,
+          version: 2,
           pid: process.pid,
           hostId: CURRENT_HOST_ID,
           hostname: CURRENT_HOSTNAME,
@@ -1468,9 +1535,7 @@ class FileTableStore {
         }
         throw err;
       }
-      const sameHost =
-        Boolean(CURRENT_HOST_ID && existing.record.hostId === CURRENT_HOST_ID) ||
-        isTermuxPrivateHomeStorage(this.rootDir);
+      const sameHost = writerLeaseBelongsToCurrentHost(existing.record) || isTermuxPrivateHomeStorage(this.rootDir);
       if (!sameHost || !pidDefinitelyExited(existing.record.pid)) {
         throw new StorageWriterLeaseError(
           `Another Marinara Engine process (PID ${existing.record.pid}, host ${existing.record.hostname}) may be using ${this.rootDir}. ` +

--- a/scripts/regressions/storage-writer-lock.regression.ts
+++ b/scripts/regressions/storage-writer-lock.regression.ts
@@ -123,6 +123,20 @@ try {
           JSON.stringify({
             ...leaseTemplate,
             version: 1,
+            pid: process.pid,
+            hostId: "legacy-fingerprint-before-network-change",
+            token: "legacy-macos-live-token",
+          }),
+        );
+        await assert.rejects(createFileNativeDB(), StorageWriterLeaseError);
+        rmSync(leasePath(dir), { recursive: true });
+
+        mkdirSync(leasePath(dir));
+        writeFileSync(
+          ownerPath(dir),
+          JSON.stringify({
+            ...leaseTemplate,
+            version: 1,
             pid: await exitedPid(),
             hostId: "legacy-fingerprint-before-network-change",
             token: "legacy-macos-stale-token",

--- a/scripts/regressions/storage-writer-lock.regression.ts
+++ b/scripts/regressions/storage-writer-lock.regression.ts
@@ -14,7 +14,7 @@ import { appSettings, lorebookEntries, lorebooks } from "../../packages/server/s
 import { getMariDbService } from "../../packages/server/src/services/mari-db/mari-db.service.js";
 
 type LeaseRecord = {
-  version: 1;
+  version: 1 | 2;
   pid: number;
   hostId: string | null;
   hostname: string;
@@ -61,6 +61,7 @@ try {
     const dir = useTempStorage("writer-lock");
     const db = await createFileNativeDB();
     const leaseTemplate = readJson<LeaseRecord>(ownerPath(dir));
+    assert.equal(leaseTemplate.version, 2, "new leases use the stable host-identity format");
     await assert.rejects(
       createFileNativeDB(),
       (error: unknown) =>
@@ -107,6 +108,45 @@ try {
       const afterCrash = await createFileNativeDB();
       assert.notEqual(readJson<LeaseRecord>(ownerPath(dir)).token, "stale-owner-token");
       await afterCrash._fileStore.close();
+    }
+
+    if (process.platform !== "win32") {
+      // Legacy macOS leases fingerprinted every visible network interface.
+      // A changed VPN/virtual-interface set must not strand a dead same-host
+      // lease, while v2 leases still require the stable machine identity.
+      const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+      try {
+        Object.defineProperty(process, "platform", { ...platformDescriptor, value: "darwin" });
+        mkdirSync(leasePath(dir));
+        writeFileSync(
+          ownerPath(dir),
+          JSON.stringify({
+            ...leaseTemplate,
+            version: 1,
+            pid: await exitedPid(),
+            hostId: "legacy-fingerprint-before-network-change",
+            token: "legacy-macos-stale-token",
+          }),
+        );
+        const afterNetworkChange = await createFileNativeDB();
+        assert.notEqual(readJson<LeaseRecord>(ownerPath(dir)).token, "legacy-macos-stale-token");
+        await afterNetworkChange._fileStore.close();
+
+        mkdirSync(leasePath(dir));
+        writeFileSync(
+          ownerPath(dir),
+          JSON.stringify({
+            ...leaseTemplate,
+            pid: await exitedPid(),
+            hostId: "stable-id-from-another-machine",
+            token: "foreign-v2-token",
+          }),
+        );
+        await assert.rejects(createFileNativeDB(), StorageWriterLeaseError);
+        rmSync(leasePath(dir), { recursive: true });
+      } finally {
+        Object.defineProperty(process, "platform", platformDescriptor);
+      }
     }
 
     // Windows cannot faithfully simulate Android's POSIX permission semantics;


### PR DESCRIPTION
## Linked issue

Closes #5194

## Why this change

- A stale macOS storage lease could survive its owner process and permanently block startup after VPN, privacy, or virtual interfaces changed the network-adapter list used by the v1 host fingerprint.

## What changed

- Write v2 leases using a stable, hashed platform machine identity on macOS, Windows, and machine-id platforms.
- Reclaim dead legacy v1 macOS leases by hostname only for that compatibility path; v2 leases still require the stable identity.
- Extend the storage writer-lock regression with legacy recovery and foreign-v2 negative controls.
- Document the user-facing fix in the changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran `pnpm build:shared && node ./scripts/run-regressions.mjs --filter scripts/regressions/storage-writer-lock.regression.ts`; the targeted regression passed.
- Started `pnpm dev:server` against the reported stale v1 lease. The server reclaimed PID 75050's lease, rewrote it as v2, and returned `status: ok` from `/api/health`.
- A separate automatic-backup attempt reported `ENOSPC` because the host disk was nearly full; no user data was removed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable; this is a server bootstrap/storage-lock fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file-storage writer lease stability on macOS when network interfaces change.
  - Added safer recovery of abandoned leases from exited processes.
  - Preserved compatibility with existing legacy leases while preventing reclaim of active or unrelated leases.

- **Documentation**
  - Added a changelog entry describing the storage lease improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->