### PR TITLE
fix: preserve example dialogue without a dedicated marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Character example dialogue now falls back into the Character Info marker when a prompt preset has no dedicated Dialogue Examples marker; presets that include a disabled Dialogue Examples marker continue to omit it intentionally.
 - Roleplay speaker extraction now prints the connection's raw response when debug mode is enabled, supplies the current reply's character as the fallback for ambiguous lines, and lets harmless label formatting such as `Maukie:` or `Maukie [chuckle]` resolve to the character's assigned voice instead of Random NPC Voice (#5210).
 - Termux session logging now starts before update checks, dependency repair, and builds, so launcher-stage crashes create the same timestamped diagnostic log as server-stage crashes; it starts only after restrictive log permissions are confirmed, flushes before exit, reports logging failures, and preserves the server's own exit status (#5208).
 - Automatic card versioning now preserves imported nonnumeric version labels instead of resetting them to `1.0` on the next content edit (#5202).

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -325,6 +325,15 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
   // Build lookup maps
   const sectionMap = new Map(input.sections.map((s) => [s.id, s]));
   const groupMap = new Map(input.groups.map((g) => [g.id, g]));
+  const hasDialogueExamplesMarker = sectionOrder.some((sectionId) => {
+    const section = sectionMap.get(sectionId);
+    if (section?.isMarker !== "true" || !section.markerConfig) return false;
+    try {
+      return (JSON.parse(section.markerConfig) as MarkerConfig).type === "dialogue_examples";
+    } catch {
+      return false;
+    }
+  });
 
   // Inject choice variable values into variableValues
   // chatChoices is { variableName: value | value[] } — resolve and merge into variables so {{varName}} resolves
@@ -532,6 +541,7 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
     resolveLorebookContent: (value) => resolveMacrosWithVariableSnapshot(value, macroCtx, deferNameMacroOptions),
     onLorebookScan: addActivatedLorebookCardReferences,
     groupScenarioOverrideText: input.groupScenarioOverrideText ?? null,
+    includeExampleDialogueInCharacterMarker: !hasDialogueExamplesMarker,
     macroCtx,
   };
 

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -101,6 +101,8 @@ export interface MarkerContext {
   lorebookScanResultApplied?: boolean;
   /** When set, replaces all individual character scenario fields with this shared group scenario. */
   groupScenarioOverrideText?: string | null;
+  /** Include card example dialogue in Character Info when the preset has no dedicated marker for it. */
+  includeExampleDialogueInCharacterMarker?: boolean;
 }
 
 /** Expanded marker result. */
@@ -195,6 +197,14 @@ async function expandCharacter(config: MarkerConfig, ctx: MarkerContext): Promis
     const characterMacroContext = macroContextForCharacterProfile(ctx.macroCtx, profile);
 
     const fields = resolveCharacterMarkerFields(config.characterFields);
+    if (
+      ctx.includeExampleDialogueInCharacterMarker === true &&
+      config.characterFields === undefined &&
+      !fields.includes("mes_example") &&
+      !fields.includes("example_dialogue")
+    ) {
+      fields.push("mes_example");
+    }
 
     const charParts: string[] = [];
     for (const field of fields) {

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -196,14 +196,14 @@ async function expandCharacter(config: MarkerConfig, ctx: MarkerContext): Promis
     const profile = characterMacroProfileFromData(data);
     const characterMacroContext = macroContextForCharacterProfile(ctx.macroCtx, profile);
 
-    const fields = resolveCharacterMarkerFields(config.characterFields);
+    let fields = resolveCharacterMarkerFields(config.characterFields);
     if (
       ctx.includeExampleDialogueInCharacterMarker === true &&
       config.characterFields === undefined &&
       !fields.includes("mes_example") &&
       !fields.includes("example_dialogue")
     ) {
-      fields.push("mes_example");
+      fields = orderCharacterMarkerFields([...fields, "mes_example"]);
     }
 
     const charParts: string[] = [];

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -8317,7 +8317,7 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
     },
   },
   {
-    name: "character markers omit removed or disabled Example Dialogue sections",
+    name: "character markers own Example Dialogue only when no dedicated marker exists",
     async run() {
       const characterRow = {
         id: "char-example-fallback",
@@ -8402,13 +8402,16 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         });
 
       for (const wrapFormat of ["xml", "markdown", "none"] as const) {
-        for (const dialogueMarker of ["absent", "disabled"] as const) {
-          const result = await assemble(wrapFormat, dialogueMarker);
-          const promptText = result.messages.map((message) => message.content).join("\n");
-          assert.equal(promptText.includes("CHARACTER_EXAMPLE_DIALOGUE"), false);
-          assert.equal(promptText.includes("mes_example"), false);
-          assert.equal(promptText.includes("dialogue_examples"), false);
-        }
+        const absentMarkerResult = await assemble(wrapFormat, "absent");
+        const absentMarkerPromptText = absentMarkerResult.messages.map((message) => message.content).join("\n");
+        assert.equal(absentMarkerPromptText.match(/CHARACTER_EXAMPLE_DIALOGUE/g)?.length, 1);
+        if (wrapFormat === "xml") assert.match(absentMarkerPromptText, /<mes_example>/);
+
+        const disabledMarkerResult = await assemble(wrapFormat, "disabled");
+        const disabledMarkerPromptText = disabledMarkerResult.messages.map((message) => message.content).join("\n");
+        assert.equal(disabledMarkerPromptText.includes("CHARACTER_EXAMPLE_DIALOGUE"), false);
+        assert.equal(disabledMarkerPromptText.includes("mes_example"), false);
+        assert.equal(disabledMarkerPromptText.includes("dialogue_examples"), false);
       }
 
       const explicitCharacterField = await assemble("xml", "absent", ["mes_example"]);

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -8405,6 +8405,11 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         const absentMarkerResult = await assemble(wrapFormat, "absent");
         const absentMarkerPromptText = absentMarkerResult.messages.map((message) => message.content).join("\n");
         assert.equal(absentMarkerPromptText.match(/CHARACTER_EXAMPLE_DIALOGUE/g)?.length, 1);
+        assert.ok(
+          absentMarkerPromptText.indexOf("CHARACTER_EXAMPLE_DIALOGUE") <
+            absentMarkerPromptText.indexOf("CHARACTER_SYSTEM_PROMPT"),
+          "fallback Example Dialogue should retain canonical character field order",
+        );
         if (wrapFormat === "xml") assert.match(absentMarkerPromptText, /<mes_example>/);
 
         const disabledMarkerResult = await assemble(wrapFormat, "disabled");


### PR DESCRIPTION
## Linked issue

Closes #5213

## Why this change

Character-card Example Dialogue silently disappeared from model prompts whenever a preset kept Character Info but omitted the dedicated Dialogue Examples marker.

## What changed

- Fall back to the card's Example Dialogue inside the default Character Info marker when no Dialogue Examples marker exists.
- Keep enabled Dialogue Examples markers authoritative so content is injected exactly once.
- Treat a present but disabled Dialogue Examples marker as an explicit opt-out.
- Add regression coverage across XML, Markdown, and unwrapped prompt formats.
- Add an Unreleased changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Not manually exercised in the browser; this is server-side prompt assembly.
- Automated prompt regression covered missing, enabled, and disabled marker states in XML, Markdown, and unwrapped formats.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

## Automated evidence

- `pnpm regression:prompt` passed.
- `pnpm check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Character prompts now include example dialogue automatically when no dedicated Dialogue Examples marker is configured.
  * Example dialogue is included only once when both character and dedicated dialogue sections are available.
  * Disabled Dialogue Examples markers continue to suppress example dialogue as expected.
* **Tests**
  * Added regression coverage for prompt configurations with missing, enabled, and disabled dialogue markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->