### PR TITLE
Fix Game portrait recovery replacing library avatars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Game Mode no longer replaces a matching Character-library portrait when recovering a missing scene background or retrying a failed portrait load (#4746).
 - Character-created Conversation reactions can now be removed directly by clicking their chip on desktop or long-pressing it on mobile, without discarding the user's own matching reaction (#5216).
 - Character example dialogue now falls back into the Character Info marker when a prompt preset has no dedicated Dialogue Examples marker; presets that include a disabled Dialogue Examples marker continue to omit it intentionally.
 - Preserved Long-Term Memory recall in Roleplay chats when a custom preset's agent marker cannot be matched, using a logged fallback injection instead of silently dropping the selected memories.

--- a/packages/client/src/components/game/game-asset-generation-payload.ts
+++ b/packages/client/src/components/game/game-asset-generation-payload.ts
@@ -34,6 +34,16 @@ export function normalizeSceneAssetNameForGeneration(value: string): string {
   return value.trim().toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ");
 }
 
+function isChatOwnedNpcAvatar(avatarUrl: string | undefined, chatId: string): boolean {
+  if (!avatarUrl) return false;
+  try {
+    const pathname = new URL(avatarUrl, "http://marinara.local").pathname;
+    return pathname.startsWith(`/api/avatars/npc/${encodeURIComponent(chatId)}/`);
+  } catch {
+    return false;
+  }
+}
+
 export function getMissingBackgroundTag(
   backgroundTag: string | undefined | null,
   manifest: AssetManifestMap,
@@ -78,7 +88,8 @@ export function buildMissingSceneAssetGenerationPayload({
   const forceNpcAvatarNameSet = new Set<string>();
   if (savedGeneratedBackgroundMissing) {
     for (const npc of npcAssetCandidates) {
-      if (npcAvatarLookup.has(normalizeSceneAssetNameForGeneration(npc.name))) {
+      const avatarUrl = npcAvatarLookup.get(normalizeSceneAssetNameForGeneration(npc.name));
+      if (isChatOwnedNpcAvatar(avatarUrl, activeChatId)) {
         forceNpcAvatarNameSet.add(npc.name);
       }
     }
@@ -87,7 +98,9 @@ export function buildMissingSceneAssetGenerationPayload({
     [...(failedNpcAvatarNames ?? [])].map(normalizeSceneAssetNameForGeneration).filter(Boolean),
   );
   for (const npc of npcAssetCandidates) {
-    if (failedNpcAvatarNameSet.has(normalizeSceneAssetNameForGeneration(npc.name))) {
+    const normalizedName = normalizeSceneAssetNameForGeneration(npc.name);
+    const avatarUrl = npcAvatarLookup.get(normalizedName);
+    if (failedNpcAvatarNameSet.has(normalizedName) && isChatOwnedNpcAvatar(avatarUrl, activeChatId)) {
       forceNpcAvatarNameSet.add(npc.name);
     }
   }

--- a/scripts/regressions/game-portrait-recovery.regression.ts
+++ b/scripts/regressions/game-portrait-recovery.regression.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { buildMissingSceneAssetGenerationPayload } from "../../packages/client/src/components/game/game-asset-generation-payload.js";
+
+const chatId = "game-chat";
+const npc = {
+  name: "Il Dottore",
+  description: "A familiar character with an existing portrait.",
+};
+const libraryAvatar = "/api/avatars/file/dottore.png";
+const generatedAvatar = `/api/avatars/npc/${chatId}/il-dottore.png?v=1`;
+const baseInput = {
+  gameImageGenerationEnabled: true,
+  activeChatId: chatId,
+  currentBackground: "backgrounds:forest",
+  savedSceneBackground: "backgrounds:forest",
+  assetMap: { "backgrounds:forest": { path: "/forest.png" } },
+  sceneAssetNpcs: [npc],
+  npcsNeedingAvatars: [],
+};
+
+assert.equal(
+  buildMissingSceneAssetGenerationPayload({
+    ...baseInput,
+    npcAvatarLookup: new Map([["il dottore", libraryAvatar]]),
+    failedNpcAvatarNames: [npc.name],
+  }),
+  null,
+  "a library-avatar load error must not replace the character portrait",
+);
+
+const libraryBackgroundRecovery = buildMissingSceneAssetGenerationPayload({
+  ...baseInput,
+  currentBackground: null,
+  savedSceneBackground: "backgrounds:generated:missing-scene",
+  assetMap: {},
+  npcAvatarLookup: new Map([["il dottore", libraryAvatar]]),
+});
+assert.equal(libraryBackgroundRecovery?.backgroundTag, "backgrounds:generated:missing-scene");
+assert.equal(
+  libraryBackgroundRecovery?.npcsNeedingAvatars,
+  undefined,
+  "recovering a missing background must not regenerate a library portrait",
+);
+assert.equal(libraryBackgroundRecovery?.forceNpcAvatarNames, undefined);
+
+for (const recovery of [
+  {
+    label: "load error",
+    input: { failedNpcAvatarNames: [npc.name] },
+  },
+  {
+    label: "missing background",
+    input: {
+      currentBackground: null,
+      savedSceneBackground: "backgrounds:generated:missing-scene",
+      assetMap: {},
+    },
+  },
+]) {
+  const result = buildMissingSceneAssetGenerationPayload({
+    ...baseInput,
+    ...recovery.input,
+    npcAvatarLookup: new Map([["il dottore", generatedAvatar]]),
+  });
+  assert.deepEqual(result?.npcsNeedingAvatars, [{ ...npc, gender: null, pronouns: null }], `${recovery.label} payload`);
+  assert.deepEqual(result?.forceNpcAvatarNames, [npc.name], `${recovery.label} force list`);
+}
+
+console.log("Game portrait recovery regression passed.");


### PR DESCRIPTION
## Linked issue

Closes #4746

## Why this change

Game Mode's automatic asset recovery treated every existing portrait as a game-owned generated NPC file. When a saved scene background was missing or an avatar emitted a load error, the client sent the character name in `forceNpcAvatarNames`. The server then intentionally bypassed both its existing-avatar check and its Character-library lookup, generating and persisting a replacement for a matching Character portrait.

## What changed

- Restrict automatic forced portrait recovery to files owned by the current game under `/api/avatars/npc/<chatId>/...`.
- Keep matching Character-library avatars authoritative during missing-background and portrait-load recovery.
- Preserve explicit manual **Generate portrait** behavior.
- Add a focused regression for both recovery triggers and both avatar ownership classes.
- Add the user-facing fix under `CHANGELOG.md` `[Unreleased]`.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Automated evidence

- `node scripts/run-regressions.mjs --filter scripts/regressions/game-portrait-recovery.regression.ts`
- `pnpm localization:check`
- `pnpm check`

### Manual verification notes

- Manual browser verification remains requested for a Game Mode chat where a Character-library portrait encounters an image load error.
- Checklist boxes remain intentionally unchecked for human verification.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing documentation or release metadata changed. `CHANGELOG.md` is updated under `[Unreleased]`.

## UI evidence (if applicable)

No visual UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented Game Mode from overwriting matching Character Library portraits when restoring missing scene backgrounds or retrying failed portrait loads.
  - Ensured NPC portrait recovery only uses avatars belonging to the active chat.
  - Improved recovery for generated NPC avatars while preserving existing library portraits.

- **Tests**
  - Added regression coverage for portrait recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->