### PR TITLE
Remove unused Mari chat assignments

### DIFF
--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -3496,11 +3496,9 @@ export function HomeProfessorMariChat({
   // #5073: attaching chat history needs a Mari workspace chat to attach TO; create one if the user
   // hasn't sent a message yet, then open the picker (the picker itself is gated on a live chatId).
   const handleOpenHistoryPicker = useCallback(async () => {
-    let id = activeChatIdRef.current;
-    if (!id) {
+    if (!activeChatIdRef.current) {
       try {
-        const chat = await ensureProfessorMariChat(effectiveConnectionId);
-        id = chat.id;
+        await ensureProfessorMariChat(effectiveConnectionId);
       } catch {
         toast.error(localizeUi("ui.chat.homeprofessormarichat.attachChatHistoryNeedsChat"));
         return;
@@ -3512,11 +3510,9 @@ export function HomeProfessorMariChat({
   // The Context Viewer is gated on a live chatId too (attachModals), so ensure one before opening —
   // otherwise the menu item would be a silent no-op when the user hasn't sent a message yet.
   const handleOpenContextViewer = useCallback(async () => {
-    let id = activeChatIdRef.current;
-    if (!id) {
+    if (!activeChatIdRef.current) {
       try {
-        const chat = await ensureProfessorMariChat(effectiveConnectionId);
-        id = chat.id;
+        await ensureProfessorMariChat(effectiveConnectionId);
       } catch {
         toast.error(localizeUi("ui.chat.homeprofessormarichat.attachChatHistoryNeedsChat"));
         return;


### PR DESCRIPTION
## Why

GitHub code quality surfaced two unresolved no-op assignments while reviewing the v2.4.3 staging-to-main promotion. Main correctly refuses the release promotion until those annotations are resolved.

## What changed

- Check the active Professor Mari chat ref directly in both modal callbacks.
- Await chat creation for its side effect without storing an unused result.
- Preserve the existing success and error behavior.

Relates to #5228 and unblocks #5230.

## Test plan

- [ ] Run pnpm check.
- [ ] Confirm required PR checks pass.
- [ ] Confirm CodeRabbit has no unresolved actionable feedback.
- [ ] Confirm #5230 refreshes to the new staging head after merge.