### PR TITLE
Add semantic retrieval to Roleplay Chat Summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Added
 
 - Chat Settings now shows the current chat ID with a one-click copy action, making exact chats easy to reference in Professor Mari and other tools (#5235).
-- Automatic summaries can now keep recent summaries in context while semantically retrieving relevant older summaries for long-running chats (#5240).
+- Conversation and Roleplay automatic summaries can now keep recent summaries in context while semantically retrieving relevant older summaries for long-running chats (#5240).
 
 ### Fixed
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -11646,6 +11646,77 @@ test("Conversation Chat Settings can attach and retain custom agents", async ({ 
   }
 });
 
+test("Roleplay Chat Summaries persists semantic retrieval without overflowing its mobile panel", async ({
+  page,
+  request,
+}, testInfo) => {
+  const chatResponse = await request.post("/api/chats", {
+    data: { name: "Roleplay Semantic Summary Smoke", mode: "roleplay", characterIds: [] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+  const metadataResponse = await request.patch(`/api/chats/${chat.id}/metadata`, {
+    data: { automaticSummaryEnabled: true },
+  });
+  expect(metadataResponse.ok()).toBeTruthy();
+
+  const readSemanticSetting = async () => {
+    const response = await request.get(`/api/chats/${chat.id}`);
+    const current = (await response.json()) as { metadata?: unknown };
+    const metadata =
+      typeof current.metadata === "string"
+        ? (JSON.parse(current.metadata) as Record<string, unknown>)
+        : ((current.metadata ?? {}) as Record<string, unknown>);
+    return metadata.semanticSummaryRetrievalEnabled;
+  };
+  const openSummary = async () => {
+    if (testInfo.project.name.includes("mobile")) {
+      await page.getByRole("button", { name: "More options", exact: true }).click();
+    }
+    const summaryButton = page.getByRole("button", { name: "Chat Summary", exact: true }).filter({ visible: true });
+    await expect(summaryButton).toHaveCount(1);
+    await summaryButton.click();
+    const panel = page.locator("[data-chat-floating-panel]").filter({ hasText: "Automatic Summaries" });
+    await expect(panel).toBeVisible();
+    return panel;
+  };
+
+  try {
+    await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
+    await page.goto("/");
+
+    let panel = await openSummary();
+    const semanticSwitch = panel.getByRole("checkbox", { name: "Semantic retrieval", exact: true });
+    await expect(semanticSwitch).not.toBeChecked();
+    await semanticSwitch.click();
+    await expect.poll(readSemanticSetting).toBe(true);
+    await expect(semanticSwitch).toBeChecked();
+
+    const [panelBounds, panelOverflow] = await Promise.all([
+      panel.boundingBox(),
+      panel.evaluate((element) => ({ clientWidth: element.clientWidth, scrollWidth: element.scrollWidth })),
+    ]);
+    const viewport = page.viewportSize();
+    expect(panelBounds).not.toBeNull();
+    expect(viewport).not.toBeNull();
+    expect(panelBounds!.x).toBeGreaterThanOrEqual(0);
+    expect(panelBounds!.x + panelBounds!.width).toBeLessThanOrEqual(viewport!.width + 1);
+    expect(panelOverflow.scrollWidth).toBeLessThanOrEqual(panelOverflow.clientWidth + 1);
+
+    await page.reload();
+    panel = await openSummary();
+    await expect(panel.getByRole("checkbox", { name: "Semantic retrieval", exact: true })).toBeChecked();
+    await page.evaluate(async () => {
+      const module = await import("/src/stores/ui.store.ts");
+      module.useUIStore.getState().setTheme("light");
+    });
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    await expect(panel.getByRole("checkbox", { name: "Semantic retrieval", exact: true })).toBeVisible();
+  } finally {
+    await request.delete(`/api/chats/${chat.id}`);
+  }
+});
+
 test("Chat Settings exposes the chat ID and persists semantic summary retrieval", async ({
   context,
   page,

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -759,6 +759,7 @@ function SummaryButton({
   summaryConnectionId,
   summaryMaxTokens,
   automaticSummaryEnabled,
+  semanticSummaryRetrievalEnabled,
   activeAgentIds,
   summaryRunInterval,
   hideSummarisedMessages,
@@ -777,6 +778,7 @@ function SummaryButton({
   summaryConnectionId?: string | null;
   summaryMaxTokens?: number;
   automaticSummaryEnabled: boolean;
+  semanticSummaryRetrievalEnabled: boolean;
   activeAgentIds: string[];
   summaryRunInterval?: number;
   hideSummarisedMessages?: boolean;
@@ -906,6 +908,7 @@ function SummaryButton({
             summaryConnectionId={summaryConnectionId}
             summaryMaxTokens={summaryMaxTokens}
             automaticSummaryEnabled={automaticSummaryEnabled}
+            semanticSummaryRetrievalEnabled={semanticSummaryRetrievalEnabled}
             activeAgentIds={activeAgentIds}
             summaryRunInterval={summaryRunInterval}
             hideSummarisedMessages={hideSummarisedMessages}
@@ -1636,6 +1639,7 @@ export function ChatRoleplaySurface({
   const automaticSummaryEnabled =
     chatMeta.automaticSummaryEnabled === true ||
     (chatMeta.enableAgents === true && summaryActiveAgentIds.includes("chat-summary"));
+  const semanticSummaryRetrievalEnabled = chatMeta.semanticSummaryRetrievalEnabled === true;
   const summaryRunInterval =
     typeof chatMeta.summaryRunInterval === "number" && Number.isFinite(chatMeta.summaryRunInterval)
       ? chatMeta.summaryRunInterval
@@ -1867,6 +1871,7 @@ export function ChatRoleplaySurface({
                       }
                       summaryMaxTokens={summaryMaxTokens}
                       automaticSummaryEnabled={automaticSummaryEnabled}
+                      semanticSummaryRetrievalEnabled={semanticSummaryRetrievalEnabled}
                       activeAgentIds={summaryActiveAgentIds}
                       summaryRunInterval={summaryRunInterval}
                       hideSummarisedMessages={hideSummarisedMessages}
@@ -1995,6 +2000,7 @@ export function ChatRoleplaySurface({
                           }
                           summaryMaxTokens={summaryMaxTokens}
                           automaticSummaryEnabled={automaticSummaryEnabled}
+                          semanticSummaryRetrievalEnabled={semanticSummaryRetrievalEnabled}
                           activeAgentIds={summaryActiveAgentIds}
                           summaryRunInterval={summaryRunInterval}
                           hideSummarisedMessages={hideSummarisedMessages}
@@ -2078,6 +2084,7 @@ export function ChatRoleplaySurface({
                         }
                         summaryMaxTokens={summaryMaxTokens}
                         automaticSummaryEnabled={automaticSummaryEnabled}
+                        semanticSummaryRetrievalEnabled={semanticSummaryRetrievalEnabled}
                         activeAgentIds={summaryActiveAgentIds}
                         summaryRunInterval={summaryRunInterval}
                         hideSummarisedMessages={hideSummarisedMessages}

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -96,6 +96,7 @@ interface SummaryPopoverProps {
   summaryConnectionId?: string | null;
   summaryMaxTokens?: number;
   automaticSummaryEnabled?: boolean;
+  semanticSummaryRetrievalEnabled?: boolean;
   activeAgentIds?: string[];
   summaryRunInterval?: number;
   /** Per-chat persisted "Hide summarised messages" preference (metadata-backed). Undefined/false means off (opt-in default). */
@@ -334,6 +335,7 @@ export function SummaryPopover({
   summaryConnectionId = null,
   summaryMaxTokens,
   automaticSummaryEnabled = false,
+  semanticSummaryRetrievalEnabled = false,
   activeAgentIds = [],
   summaryRunInterval,
   hideSummarisedMessages,
@@ -1482,6 +1484,21 @@ export function SummaryPopover({
                       <span>{localizeUi("ui.chat.summarypopover.userMessages")}</span>
                     </span>
                   </label>
+
+                  {import.meta.env.VITE_MARINARA_LITE !== "true" && (
+                    <div className="border-t border-[var(--border)]/70 pt-1">
+                      <SummarySettingsToggle
+                        label={localizeUi("ui.chat.summarypopover.semanticRetrieval")}
+                        checked={semanticSummaryRetrievalEnabled}
+                        onChange={(checked) =>
+                          updateMeta.mutate({ id: chatId, semanticSummaryRetrievalEnabled: checked })
+                        }
+                      />
+                      <p className="px-1.5 pb-1 text-[0.625rem] leading-snug text-[var(--muted-foreground)]">
+                        {localizeUi("ui.chat.summarypopover.semanticRetrievalDescription")}
+                      </p>
+                    </div>
+                  )}
 
                   {backfillState.status === "running" && backfillState.chatId === chatId && (
                     <div className="space-y-1.5">

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -4003,6 +4003,8 @@
   "ui.chat.summarypopover.promptInstructionsForSummaryGeneration": "Prompt instructions for summary generation...",
   "ui.chat.summarypopover.range": "Range",
   "ui.chat.summarypopover.recentMessageTail": "Recent message tail",
+  "ui.chat.summarypopover.semanticRetrieval": "Semantic retrieval",
+  "ui.chat.summarypopover.semanticRetrievalDescription": "Keeps manual and recent summaries in context, then recalls relevant older automatic summaries when needed.",
   "ui.chat.summarypopover.showInactive": "Show Inactive",
   "ui.chat.summarypopover.stop": "Stop",
   "ui.chat.summarypopover.summaryConnection": "Summary Connection",

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -279,7 +279,7 @@ import {
   resolvePromptCharacterIdsForTarget,
   resolveRegenerationGameStateFallbackMessageIds,
   resolveRegenerationGameStateAnchor,
-  resolveRoleplayChatSummary,
+  resolveRoleplayChatSummaryForPrompt,
   resolveUserRegenerationPersistentAttachments,
   resolveVisibleGameStateAnchor,
   resolveKnowledgeSourceLorebookIds,
@@ -1818,8 +1818,16 @@ export async function generateRoutes(app: FastifyInstance) {
         const agentPromptTemplateSelections = normalizeAgentPromptTemplateSelectionMap(chatMeta.agentPromptTemplateIds);
         const hasPerChatAgentList = chatActiveAgentIds.length > 0;
         const perChatAgentSet = new Set(chatActiveAgentIds);
-        const activeChatSummary = resolveRoleplayChatSummary(chatMode, chatMeta, {
+        const activeChatSummary = await resolveRoleplayChatSummaryForPrompt({
+          chatMode,
+          chatMetadata: chatMeta,
+          messages: currentInputMessages(),
           excludeMessageIds: input.regenerateMessageId ? [input.regenerateMessageId] : undefined,
+          vectorizerAvailable: memoryRecallVectorizerAvailable,
+          embeddingOptions: {
+            embeddingSource: memoryRecallEmbeddingSource,
+            signal: abortController.signal,
+          },
         });
         const runtimeSectionEligibleAgentTypes = buildRuntimeAgentSectionEligibleTypes({
           enableAgents: chatEnableAgents,

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -27,6 +27,10 @@ import { processLorebooks } from "../../services/lorebook/index.js";
 import { resolveLorebookScopeExclusions } from "../../services/lorebook/game-lorebook-scope.js";
 import { injectAtDepth } from "../../services/lorebook/prompt-injector.js";
 import { createLLMProvider } from "../../services/llm/provider-registry.js";
+import {
+  isMemoryRecallVectorizerAvailable,
+  resolveMemoryRecallEmbeddingSource,
+} from "../../services/memory-recall-embedding.js";
 import { withConnectionAdmissionProvider } from "../../services/generation/connection-admission.js";
 import { getLocalSidecarProvider } from "../../services/llm/local-sidecar.js";
 import {
@@ -88,7 +92,7 @@ import {
   resolveGroupGenerationMode,
   resolveRegenerationGameStateAnchor,
   resolveProviderTopK,
-  resolveRoleplayChatSummary,
+  resolveRoleplayChatSummaryForPrompt,
   normalizeServiceTier,
   resolveVisibleGameStateAnchor,
   resolveBaseUrl,
@@ -586,7 +590,6 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     // Pull existing messages, apply the same conversation-start + context limit filtering
     const allChatMessages = await chats.listMessages(chatId);
     const chatMode = (chat.mode as string) ?? "roleplay";
-    const activeChatSummary = resolveRoleplayChatSummary(chatMode, chatMeta);
     const dryRunActiveAgentIds = Array.isArray(chatMeta.activeAgentIds) ? (chatMeta.activeAgentIds as string[]) : [];
     const dryRunChatEnableAgents = shouldEnableAgentsForGeneration({
       chatEnableAgents: chatMeta.enableAgents === true,
@@ -749,6 +752,37 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     if (audienceCharacterIds.length > 0) {
       mappedMessages = filterPromptMessagesForCharacterAudience(mappedMessages, audienceCharacterIds);
     }
+
+    let summaryEmbeddingSource: Awaited<ReturnType<typeof resolveMemoryRecallEmbeddingSource>> | null = null;
+    let summaryVectorizerAvailable = false;
+    if (chatMode === "roleplay" && chatMeta.semanticSummaryRetrievalEnabled === true) {
+      try {
+        summaryEmbeddingSource = await resolveMemoryRecallEmbeddingSource(app.db, {
+          chatMetadata: chatMeta,
+          connectionId: connId,
+          activeConnection: conn,
+          activeBaseUrl: baseUrl,
+        });
+        summaryVectorizerAvailable =
+          summaryEmbeddingSource !== null ||
+          (await isMemoryRecallVectorizerAvailable(app.db, {
+            chatMetadata: chatMeta,
+            connectionId: connId,
+            activeConnection: conn,
+            activeBaseUrl: baseUrl,
+          }));
+      } catch (error) {
+        logger.warn(error, "[dryRun] Roleplay summary embedding setup failed; keeping all summaries in context");
+      }
+    }
+    const activeChatSummary = await resolveRoleplayChatSummaryForPrompt({
+      chatMode,
+      chatMetadata: chatMeta,
+      messages: mappedMessages,
+      excludeMessageIds: regenerateMessageId ? [regenerateMessageId] : undefined,
+      vectorizerAvailable: summaryVectorizerAvailable,
+      embeddingOptions: { embeddingSource: summaryEmbeddingSource },
+    });
 
     // Persona resolution (same strategy as generation; read-only)
     let personaId: string | null = null;

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -3,10 +3,8 @@ import {
   GENERATION_PARAMETER_SEND_KEYS,
   SUMMARY_TAIL_MESSAGES,
   applyTrackerFieldLocksToGameStatePatch,
-  compileChatSummaryEntries,
   generationParametersSchema,
   normalizeInventoryTrackerRows,
-  normalizeChatSummaryEntries,
   normalizeTextForMatch,
   normalizeSummaryTailMessages,
   normalizeWorldCustomFields,
@@ -41,6 +39,10 @@ export {
   createLocalSidecarGenerationConnection,
   type LocalSidecarGenerationConnection,
 } from "../../services/generation/local-sidecar-generation-connection.js";
+export {
+  resolveRoleplayChatSummary,
+  resolveRoleplayChatSummaryForPrompt,
+} from "../../services/generation/roleplay-summary-retrieval.js";
 export {
   appendReadableAttachmentsToContent,
   buildReadableAttachmentBlocks,
@@ -787,27 +789,6 @@ export function selectRollingSummaryMessages<T extends { id: string; extra?: unk
     .slice(lastBoundaryIndex + 1)
     .filter((message) => !isMessageHiddenFromAI(message)).length;
   return visible.slice(-Math.max(size, sinceBoundary));
-}
-
-export function resolveRoleplayChatSummary(
-  chatMode: string,
-  chatMetadata: Record<string, unknown>,
-  options: { excludeMessageIds?: readonly string[] } = {},
-): string | null {
-  if (!isRoleplaySummaryMode(chatMode)) return null;
-  const summary = ((chatMetadata.summary as string) ?? "").trim() || null;
-  const excludedMessageIds = new Set((options.excludeMessageIds ?? []).filter(Boolean));
-  if (excludedMessageIds.size === 0) return summary;
-
-  const entries = normalizeChatSummaryEntries(chatMetadata.summaryEntries);
-  // Legacy summaries have no per-message provenance, so they cannot be
-  // safely retained while regenerating a historical message.
-  if (entries.length === 0) return null;
-  const retainedEntries = entries.filter((entry) => {
-    const coveredMessageIds = [...(entry.messageIds ?? []), ...(entry.hiddenMessageIds ?? [])];
-    return !coveredMessageIds.some((messageId) => excludedMessageIds.has(messageId));
-  });
-  return retainedEntries.length === entries.length ? summary : compileChatSummaryEntries(retainedEntries);
 }
 
 function escapeRegex(value: string): string {

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -82,7 +82,10 @@ import {
   applyTrackerLorebookContextPolicy,
   getTrackerAgentTypes,
 } from "../../services/generation/tracker-agent-context.js";
-import { resolveMemoryRecallEmbeddingSource } from "../../services/memory-recall-embedding.js";
+import {
+  isMemoryRecallVectorizerAvailable,
+  resolveMemoryRecallEmbeddingSource,
+} from "../../services/memory-recall-embedding.js";
 import {
   loadImageGenerationUserSettings,
   resolveIllustratorImageSize,
@@ -131,7 +134,7 @@ import {
   preserveTrackerCharacterUiFields,
   resolveActiveCharacterIds,
   resolveBaseUrl,
-  resolveRoleplayChatSummary,
+  resolveRoleplayChatSummaryForPrompt,
   resolveVisibleGameStateAnchor,
 } from "./generate-route-utils.js";
 import {
@@ -877,12 +880,29 @@ async function buildRetryAgentContext(args: {
     ];
   });
   let recalledAgentVectorMemories: string[] = [];
+  let embeddingSource: Awaited<ReturnType<typeof resolveMemoryRecallEmbeddingSource>> | null = null;
+  let summaryVectorizerAvailable = false;
+  if (customAgentVectorAccessEnabled || chatMeta.semanticSummaryRetrievalEnabled === true) {
+    try {
+      const connectionId = typeof chat.connectionId === "string" ? chat.connectionId : null;
+      embeddingSource = await resolveMemoryRecallEmbeddingSource(db, {
+        chatMetadata: chatMeta,
+        connectionId,
+      });
+      if (chatMeta.semanticSummaryRetrievalEnabled === true) {
+        summaryVectorizerAvailable =
+          embeddingSource !== null ||
+          (await isMemoryRecallVectorizerAvailable(db, {
+            chatMetadata: chatMeta,
+            connectionId,
+          }));
+      }
+    } catch (err) {
+      logger.warn(err, "[retry-agents] Failed to resolve vector context");
+    }
+  }
   if (customAgentVectorAccessEnabled) {
     try {
-      const embeddingSource = await resolveMemoryRecallEmbeddingSource(db, {
-        chatMetadata: chatMeta,
-        connectionId: typeof chat.connectionId === "string" ? chat.connectionId : null,
-      });
       const latestUserMessage = [...resolvedAgentSlice]
         .reverse()
         .find((message: any) => message.role === "user" && message.content?.trim());
@@ -901,6 +921,13 @@ async function buildRetryAgentContext(args: {
       logger.warn(err, "[retry-agents] Failed to resolve custom-agent vector context");
     }
   }
+  const activeChatSummary = await resolveRoleplayChatSummaryForPrompt({
+    chatMode,
+    chatMetadata: chatMeta,
+    messages: resolvedAgentSlice,
+    vectorizerAvailable: summaryVectorizerAvailable,
+    embeddingOptions: { embeddingSource },
+  });
   const agentContext: AgentContext = {
     chatId,
     chatMode,
@@ -950,7 +977,7 @@ async function buildRetryAgentContext(args: {
           }
         : null,
     writableLorebookIds: null,
-    chatSummary: resolveRoleplayChatSummary(chatMode, chatMeta),
+    chatSummary: activeChatSummary,
     authorNotes:
       typeof chatMeta.authorNotes === "string" && chatMeta.authorNotes.trim()
         ? resolveMacros(chatMeta.authorNotes, promptMacroContext, { trimResult: false }).trim()

--- a/packages/server/src/services/generation/roleplay-summary-retrieval.ts
+++ b/packages/server/src/services/generation/roleplay-summary-retrieval.ts
@@ -1,0 +1,132 @@
+import { compileChatSummaryEntries, normalizeChatSummaryEntries, type ChatSummaryEntry } from "@marinara-engine/shared";
+
+import { logger } from "../../lib/logger.js";
+import { calibrateLorebookSimilarity, cosineSimilarity, lorebookSimilarityBaseline } from "../lorebook/embeddings.js";
+import { embedMemoryRecallTexts, type MemoryRecallEmbeddingOptions } from "../memory-recall.js";
+
+const SEMANTIC_SUMMARY_RECENT_ENTRY_COUNT = 2;
+const SEMANTIC_SUMMARY_TOP_K = 3;
+const SEMANTIC_SUMMARY_MIN_SIMILARITY = 0.15;
+const SEMANTIC_SUMMARY_CALIBRATION_TEXTS = [
+  "A recipe explains how to bake a loaf of bread.",
+  "A spacecraft studies distant galaxies and nebulae.",
+  "A city council reviews municipal zoning regulations.",
+] as const;
+
+type RoleplaySummaryQueryMessage = {
+  role?: string | null;
+  content?: unknown;
+};
+
+function filterExcludedSummaryEntries(entries: ChatSummaryEntry[], excludeMessageIds: readonly string[]) {
+  const excludedMessageIds = new Set(excludeMessageIds.filter(Boolean));
+  if (excludedMessageIds.size === 0) return entries;
+  return entries.filter((entry) => {
+    const coveredMessageIds = [...(entry.messageIds ?? []), ...(entry.hiddenMessageIds ?? [])];
+    return !coveredMessageIds.some((messageId) => excludedMessageIds.has(messageId));
+  });
+}
+
+function buildRoleplaySummaryRetrievalQuery(messages: readonly RoleplaySummaryQueryMessage[]): string {
+  return messages
+    .filter((message) => message.role === "user" || message.role === "assistant")
+    .slice(-4)
+    .map((message) => (typeof message.content === "string" ? message.content.trim() : ""))
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function resolveRoleplayChatSummary(
+  chatMode: string,
+  chatMetadata: Record<string, unknown>,
+  options: { excludeMessageIds?: readonly string[] } = {},
+): string | null {
+  if (chatMode !== "roleplay") return null;
+  const summary = ((chatMetadata.summary as string) ?? "").trim() || null;
+  const excludedMessageIds = options.excludeMessageIds ?? [];
+  if (excludedMessageIds.length === 0) return summary;
+
+  const entries = normalizeChatSummaryEntries(chatMetadata.summaryEntries);
+  // Legacy summaries have no per-message provenance, so they cannot be
+  // safely retained while regenerating a historical message.
+  if (entries.length === 0) return null;
+  const retainedEntries = filterExcludedSummaryEntries(entries, excludedMessageIds);
+  return retainedEntries.length === entries.length ? summary : compileChatSummaryEntries(retainedEntries);
+}
+
+/** Keep manual and recent Roleplay summaries active while recalling only relevant older automatic entries. */
+export async function resolveRoleplayChatSummaryForPrompt(args: {
+  chatMode: string;
+  chatMetadata: Record<string, unknown>;
+  messages: readonly RoleplaySummaryQueryMessage[];
+  excludeMessageIds?: readonly string[];
+  vectorizerAvailable: boolean;
+  embeddingOptions?: MemoryRecallEmbeddingOptions;
+}): Promise<string | null> {
+  const fallbackSummary = resolveRoleplayChatSummary(args.chatMode, args.chatMetadata, {
+    excludeMessageIds: args.excludeMessageIds,
+  });
+  if (!fallbackSummary || args.chatMetadata.semanticSummaryRetrievalEnabled !== true || !args.vectorizerAvailable) {
+    return fallbackSummary;
+  }
+
+  const query = buildRoleplaySummaryRetrievalQuery(args.messages);
+  if (!query) return fallbackSummary;
+
+  const entries = filterExcludedSummaryEntries(
+    normalizeChatSummaryEntries(args.chatMetadata.summaryEntries),
+    args.excludeMessageIds ?? [],
+  );
+  const automatedEntries = entries.filter((entry) => entry.enabled && entry.origin === "automated");
+  if (automatedEntries.length <= SEMANTIC_SUMMARY_RECENT_ENTRY_COUNT) return fallbackSummary;
+
+  const newestAutomatedIds = new Set(
+    [...automatedEntries]
+      .sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt))
+      .slice(-SEMANTIC_SUMMARY_RECENT_ENTRY_COUNT)
+      .map((entry) => entry.id),
+  );
+  const olderEntries = automatedEntries.filter((entry) => !newestAutomatedIds.has(entry.id));
+
+  try {
+    const [queryEmbeddings, summaryEmbeddings] = await Promise.all([
+      embedMemoryRecallTexts([query, ...SEMANTIC_SUMMARY_CALIBRATION_TEXTS], {
+        ...(args.embeddingOptions ?? {}),
+        inputType: "query",
+      }),
+      embedMemoryRecallTexts(
+        olderEntries.map((entry) => entry.content),
+        { ...(args.embeddingOptions ?? {}), inputType: "document" },
+      ),
+    ]);
+    const queryEmbedding = queryEmbeddings[0];
+    if (!queryEmbedding?.length || summaryEmbeddings.length !== olderEntries.length) return fallbackSummary;
+
+    const baseline = lorebookSimilarityBaseline(queryEmbeddings.slice(1));
+    const relevantOlderIds = new Set(
+      olderEntries
+        .map((entry, index) => {
+          const embedding = summaryEmbeddings[index];
+          if (!embedding || embedding.length !== queryEmbedding.length) return null;
+          return {
+            id: entry.id,
+            similarity: calibrateLorebookSimilarity(cosineSimilarity(queryEmbedding, embedding), baseline),
+          };
+        })
+        .filter((match): match is { id: string; similarity: number } => match !== null)
+        .filter((match) => match.similarity >= SEMANTIC_SUMMARY_MIN_SIMILARITY)
+        .sort((left, right) => right.similarity - left.similarity)
+        .slice(0, SEMANTIC_SUMMARY_TOP_K)
+        .map((match) => match.id),
+    );
+
+    return compileChatSummaryEntries(
+      entries.filter(
+        (entry) => entry.origin !== "automated" || newestAutomatedIds.has(entry.id) || relevantOlderIds.has(entry.id),
+      ),
+    );
+  } catch (error) {
+    logger.warn(error, "[roleplay-summary] Semantic retrieval failed; keeping all summaries in context");
+    return fallbackSummary;
+  }
+}

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -264,6 +264,8 @@ export interface ChatMetadata {
   summaryRunInterval?: number;
   /** Whether the Chat Summary popover should automatically generate rolling Roleplay summaries. */
   automaticSummaryEnabled?: boolean;
+  /** Keep recent automatic summaries in context while retrieving relevant older Conversation weeks or Roleplay entries. */
+  semanticSummaryRetrievalEnabled?: boolean;
   /** Last assistant message ID processed by the automatic Roleplay summary updater. */
   lastAutomaticSummaryMessageId?: string | null;
   /** Chat-scoped manual summary prompt templates. Missing or empty uses the built-in default. */
@@ -674,8 +676,6 @@ export interface ChatMetadata {
   daySummaries?: Record<string, DaySummaryEntry>;
   /** Per-week consolidated conversation summaries (key: Monday "DD.MM.YYYY"). */
   weekSummaries?: Record<string, WeekSummaryEntry>;
-  /** Keep recent conversation summaries in-context and retrieve only relevant older weeks with embeddings. */
-  semanticSummaryRetrievalEnabled?: boolean;
   /**
    * Hour of day (0-11, local time) at which a conversation "day" rolls over for
    * summarization. Messages sent before this hour are filed under the previous

--- a/scripts/regressions/regeneration-context.regression.ts
+++ b/scripts/regressions/regeneration-context.regression.ts
@@ -5,7 +5,10 @@ import { join } from "node:path";
 
 import { createFileNativeDB } from "../../packages/server/src/db/file-backed-store.js";
 import { memoryChunks } from "../../packages/server/src/db/schema/index.js";
-import { resolveRoleplayChatSummary } from "../../packages/server/src/routes/generate/generate-route-utils.js";
+import {
+  resolveRoleplayChatSummary,
+  resolveRoleplayChatSummaryForPrompt,
+} from "../../packages/server/src/routes/generate/generate-route-utils.js";
 import { injectMemoryRecallContext } from "../../packages/server/src/services/generation/memory-recall-context.js";
 import {
   chunkAndEmbedMessages,
@@ -76,6 +79,94 @@ assert.equal(
   ),
   null,
   "regeneration must omit a legacy summary that cannot prove it excludes the discarded response",
+);
+
+const semanticSummaryEntries = [
+  {
+    id: "manual-anchor",
+    origin: "manual",
+    content: "Mari wrote down the permanent relationship anchor.",
+    enabled: true,
+    createdAt: "2026-07-01T08:00:00.000Z",
+    updatedAt: "2026-07-01T08:00:00.000Z",
+  },
+  {
+    id: "relevant-old-summary",
+    origin: "automated",
+    content: "The dragon pact was sealed beneath the red moon.",
+    enabled: true,
+    createdAt: "2026-07-02T08:00:00.000Z",
+    updatedAt: "2026-07-02T08:00:00.000Z",
+  },
+  {
+    id: "irrelevant-old-summary",
+    origin: "automated",
+    content: "They spent a quiet afternoon baking bread.",
+    enabled: true,
+    createdAt: "2026-07-03T08:00:00.000Z",
+    updatedAt: "2026-07-03T08:00:00.000Z",
+  },
+  {
+    id: "recent-summary-one",
+    origin: "automated",
+    content: "They reached the mountain pass.",
+    enabled: true,
+    createdAt: "2026-07-04T08:00:00.000Z",
+    updatedAt: "2026-07-04T08:00:00.000Z",
+  },
+  {
+    id: "recent-summary-two",
+    origin: "automated",
+    content: "A storm forced them into the same shelter.",
+    enabled: true,
+    createdAt: "2026-07-05T08:00:00.000Z",
+    updatedAt: "2026-07-05T08:00:00.000Z",
+  },
+];
+const semanticSummaryMetadata = {
+  summary: semanticSummaryEntries.map((entry) => entry.content).join("\n\n"),
+  summaryEntries: semanticSummaryEntries,
+  semanticSummaryRetrievalEnabled: true,
+};
+const semanticSummaryEmbeddingSource: MemoryRecallEmbeddingSource = {
+  label: "roleplay summary regression",
+  embed: async (texts, _signal, inputType) =>
+    texts.map((text) => {
+      if (inputType === "query") {
+        if (text.includes("dragon pact")) return [1, 0];
+        if (text.includes("recipe")) return [0, 1];
+        if (text.includes("spacecraft")) return [-1, 0];
+        return [0, -1];
+      }
+      return text.includes("dragon pact") ? [1, 0] : [0, 1];
+    }),
+};
+const selectedSemanticSummary = await resolveRoleplayChatSummaryForPrompt({
+  chatMode: "roleplay",
+  chatMetadata: semanticSummaryMetadata,
+  messages: [{ role: "user", content: "What did the dragon pact require?" }],
+  vectorizerAvailable: true,
+  embeddingOptions: { embeddingSource: semanticSummaryEmbeddingSource },
+});
+assert.equal(
+  selectedSemanticSummary,
+  [
+    semanticSummaryEntries[0]!.content,
+    semanticSummaryEntries[1]!.content,
+    semanticSummaryEntries[3]!.content,
+    semanticSummaryEntries[4]!.content,
+  ].join("\n\n"),
+  "semantic Roleplay summaries must retain manual and recent entries while retrieving only relevant older automatic entries",
+);
+assert.equal(
+  await resolveRoleplayChatSummaryForPrompt({
+    chatMode: "roleplay",
+    chatMetadata: semanticSummaryMetadata,
+    messages: [{ role: "user", content: "What did the dragon pact require?" }],
+    vectorizerAvailable: false,
+  }),
+  semanticSummaryMetadata.summary,
+  "Roleplay summary retrieval must keep the complete summary when embeddings are unavailable",
 );
 
 const storageDir = mkdtempSync(join(tmpdir(), "marinara-regeneration-context-"));


### PR DESCRIPTION
## Linked issue

Closes #5240

## Why this change

- The first #5240 implementation exposed semantic summary retrieval only in Conversation mode, while the request is specifically motivated by long-running Roleplay chats.
- Roleplay users need the same bounded-context behavior inside the Chat Summaries workflow they already use, without losing manually curated or recent narrative context.

## What changed

- Added a compact **Semantic retrieval** switch to Roleplay’s existing Automatic Summaries card; the setting persists per chat and remains usable in the mobile popover.
- Kept every enabled manual/legacy summary and the two newest enabled automatic summaries in context, then semantically selected up to three relevant older automatic summaries using the existing calibrated embedding path.
- Kept the full summary as a safe fallback when semantic retrieval is off, unavailable, empty, or fails.
- Applied the selected summary consistently to normal Roleplay generation, dry-run prompt assembly, and retried Agent context.
- Updated the shared metadata description, English UI catalog, and Unreleased changelog entry.
- Added deterministic retrieval coverage and desktop/mobile Playwright coverage for persistence, viewport overflow, reload, and light-theme rendering.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran `pnpm check`.
- Ran `pnpm regression:prompt`.
- Ran the focused `scripts/regressions/regeneration-context.regression.ts` regression.
- Ran the Roleplay semantic-summary Playwright flow against desktop Chromium and a Pixel 7 viewport.
- Verified the switch persists after reload, the mobile panel has no horizontal overflow, and the control remains legible in dark and light themes.
- Verified unavailable embeddings retain the complete summary instead of dropping context.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

`CHANGELOG.md` is updated. No version-bearing files or user guides changed.

## UI evidence (if applicable)

- Captured and inspected local desktop and Pixel 7 screenshots in both dark and light themes; evidence files are intentionally not committed under the project’s PR-evidence policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional semantic retrieval setting for chat summaries, available in supported chats.
  - When enabled, summaries can surface older, relevant conversation details while preserving manual and recent summaries.
  - The setting is saved per chat and remains enabled after reopening or reloading.
  - Added localized descriptions and responsive settings-panel behavior.

- **Bug Fixes**
  - Improved summary retrieval during generation, retries, and regeneration, with reliable fallback behavior when semantic retrieval is unavailable.
  - Clarified that automatic summaries apply to both Conversation and Roleplay chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->