### PR TITLE
fix: stop local models burning their whole budget on discarded thinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Locally hosted OpenAI-compatible models now honor Reasoning Effort set to Off, and JSON-returning Agent calls—including tool-assisted and batched runs—avoid exhausting their output budget on discarded thinking.
 - Mobile full-screen navigation now places the slightly larger Home icon first, opens Chats from the right like the resource tabs, swaps between Chats and resource tabs without replaying the entrance animation, deactivates Home while another surface is open, lets Home dismiss that surface and return to the Home page, and starts the draggable Music DJ control below Home bookmarks; the Characters tab underline now also matches its pink icon on mobile and desktop (#5248).
 - Docker update checks now recognize stable-to-Staging/UAT channel switches and show the correct `staging` image tag and host-side switch instructions instead of claiming the stable container is already current (#5249).
 - Roleplay's Agents menu now offers a Stop Agents action while parallel or post-processing work is still running, without blocking new messages or swipes (#5237).

--- a/packages/server/src/middleware/ip-allowlist.ts
+++ b/packages/server/src/middleware/ip-allowlist.ts
@@ -409,6 +409,12 @@ export function isLoopbackIp(ip: string): boolean {
   return false;
 }
 
+/** True when the IP belongs to the built-in private/non-routable ranges, independent of auth configuration. */
+export function isNonRoutableNetworkIp(ip: string): boolean {
+  const bytes = ipToBytes(ip);
+  return Boolean(bytes && DEFAULT_PRIVATE_NETWORK_CIDRS.some((cidr) => matchesCIDR(bytes, cidr)));
+}
+
 /**
  * True if the given IP belongs to a trusted private / non-routable range.
  * Defaults to RFC 1918, CGNAT, link-local, and IPv6 ULA — but the operator

--- a/packages/server/src/middleware/ip-allowlist.ts
+++ b/packages/server/src/middleware/ip-allowlist.ts
@@ -134,7 +134,7 @@ function matchesCIDR(ipBytes: number[], cidr: CIDREntry): boolean {
 }
 
 // ── Loopback CIDRs (always allowed) ──
-const LOOPBACK_CIDRS: CIDREntry[] = [parseCIDR("127.0.0.1")!, parseCIDR("::1")!];
+const LOOPBACK_CIDRS: CIDREntry[] = [parseCIDR("127.0.0.0/8")!, parseCIDR("::1")!];
 
 // ── Specific interface CIDRs used by the Tailscale / Docker bypass ──
 // Tailscale assigns Tailnet peer IPs from the CGNAT block 100.64.0.0/10.

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -728,6 +728,7 @@ export async function executeAgent(
     );
     const streamResponses = context.streaming !== false;
     const customParameters = agentCustomParameters(config);
+    const reasoningOverride = jsonAgentReasoningOverride(config);
 
     // If tools are available, use the tool call loop.
     // `await` so a rethrow from the tool loop is caught by this function's
@@ -743,6 +744,7 @@ export async function executeAgent(
         temperature,
         maxTokens,
         toolContext,
+        reasoningOverride,
         streamResponses,
         startTime,
         context,
@@ -761,8 +763,6 @@ export async function executeAgent(
       messageCount: messages.length,
       messages: debugMessages(messages),
     });
-
-    const reasoningOverride = jsonAgentReasoningOverride(config);
 
     let responseText = "";
     const result = await provider.chatComplete(messages, {
@@ -898,6 +898,7 @@ async function executeAgentWithTools(
   temperature: number | undefined,
   maxTokens: number,
   toolContext: AgentToolContext,
+  reasoningOverride: JsonReasoningOverride,
   streamResponses: boolean,
   startTime: number,
   context: AgentContext,
@@ -931,6 +932,7 @@ async function executeAgentWithTools(
       cachingAtDepth: config.cachingAtDepth,
       customParameters,
       enabledParameters: config.enabledParameters,
+      ...reasoningOverride,
       suppressModelParameters: config.suppressModelParameters,
       stream: streamResponses,
       tools: toolContext.tools,
@@ -1022,6 +1024,7 @@ async function executeAgentWithTools(
     cachingAtDepth: config.cachingAtDepth,
     customParameters,
     enabledParameters: config.enabledParameters,
+    ...reasoningOverride,
     suppressModelParameters: config.suppressModelParameters,
     stream: streamResponses,
     signal: nextCallSignal(),
@@ -1172,6 +1175,7 @@ export async function executeAgentBatch(
   const perAgentTokens = configs.map((c) => normalizeAgentMaxTokens(c.settings.maxTokens));
   const temperature = resolveAgentTemperature(configs[0]!);
   const customParameters = agentCustomParameters(configs[0]!);
+  const reasoningOverride = jsonResponseReasoningOverride(configs[0]!.enabledParameters);
   const enableCaching = configs[0]!.enableCaching;
   const anthropicExtendedCacheTtl = configs[0]!.anthropicExtendedCacheTtl;
   const cachingAtDepth = configs[0]!.cachingAtDepth;
@@ -1251,6 +1255,7 @@ export async function executeAgentBatch(
         cachingAtDepth,
         customParameters,
         enabledParameters: configs[0]!.enabledParameters,
+        ...reasoningOverride,
         suppressModelParameters: configs[0]!.suppressModelParameters,
         stream: streamResponses,
         onToken: streamResponses
@@ -2945,15 +2950,26 @@ export function resolveAgentResultType(config: Pick<AgentExecConfig, "type" | "s
  * Ask for reasoning off, unless the agent's own connection deliberately turned
  * that parameter's send-switch off (in which case the provider default stands).
  */
-function jsonAgentReasoningOverride(
-  config: Pick<AgentExecConfig, "type" | "settings" | "enabledParameters">,
-): { reasoningEffort?: "none"; enabledParameters?: Record<string, boolean> } {
-  if (!agentResponseIsJson(config)) return {};
-  if (config.enabledParameters?.reasoningEffort === false) return {};
+type JsonReasoningOverride = {
+  reasoningEffort?: "none";
+  enabledParameters?: GenerationParameterSendMap;
+};
+
+function jsonResponseReasoningOverride(
+  enabledParameters: GenerationParameterSendMap | undefined,
+): JsonReasoningOverride {
+  if (enabledParameters?.reasoningEffort === false) return {};
   return {
     reasoningEffort: "none",
-    enabledParameters: { ...(config.enabledParameters ?? {}), reasoningEffort: true },
+    enabledParameters: { ...(enabledParameters ?? {}), reasoningEffort: true },
   };
+}
+
+function jsonAgentReasoningOverride(
+  config: Pick<AgentExecConfig, "type" | "settings" | "enabledParameters">,
+): JsonReasoningOverride {
+  if (!agentResponseIsJson(config)) return {};
+  return jsonResponseReasoningOverride(config.enabledParameters);
 }
 
 function agentResponseIsJson(config: Pick<AgentExecConfig, "type" | "settings">): boolean {

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -645,9 +645,24 @@ function debugUsage(usage?: LLMUsage): Partial<AgentCallDebugEvent> {
 }
 
 function emitAgentDebug(context: AgentContext, event: AgentCallDebugEvent): void {
-  if ((event.stage === "response" || event.stage === "retry_response") && typeof event.response === "string") {
+  const debugOverrideEnabled = Boolean(context.agentDebug) || isDebugAgentsEnabled();
+  if ((event.stage === "request" || event.stage === "retry_request") && event.messages) {
+    const prompt = event.messages
+      .map((message) => `[${message.role}${message.name ? `:${message.name}` : ""}] ${message.content}`)
+      .join("\n\n");
+    const tools = event.tools?.length ? `\navailable tools: ${event.tools.join(", ")}` : "";
     logDebugOverride(
-      Boolean(context.agentDebug) || isDebugAgentsEnabled(),
+      debugOverrideEnabled,
+      "[agent-debug] %s %s request%s:\n%s%s",
+      event.agentType,
+      event.stage === "retry_request" ? "retry" : "provider",
+      event.round ? ` (round ${event.round})` : "",
+      prompt,
+      tools,
+    );
+  } else if ((event.stage === "response" || event.stage === "retry_response") && typeof event.response === "string") {
+    logDebugOverride(
+      debugOverrideEnabled,
       "[agent-debug] %s %s response (%d chars):\n%s",
       event.agentType,
       event.stage === "retry_response" ? "retry" : "raw",

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -762,6 +762,8 @@ export async function executeAgent(
       messages: debugMessages(messages),
     });
 
+    const reasoningOverride = jsonAgentReasoningOverride(config);
+
     let responseText = "";
     const result = await provider.chatComplete(messages, {
       model,
@@ -772,6 +774,7 @@ export async function executeAgent(
       cachingAtDepth: config.cachingAtDepth,
       customParameters,
       enabledParameters: config.enabledParameters,
+      ...reasoningOverride,
       suppressModelParameters: config.suppressModelParameters,
       stream: streamResponses,
       onToken: streamResponses
@@ -820,6 +823,7 @@ export async function executeAgent(
         cachingAtDepth: config.cachingAtDepth,
         customParameters,
         enabledParameters: config.enabledParameters,
+        ...reasoningOverride,
         suppressModelParameters: config.suppressModelParameters,
         stream: streamResponses,
         onToken: streamResponses
@@ -2927,6 +2931,29 @@ export function resolveAgentResultType(config: Pick<AgentExecConfig, "type" | "s
     return configured as AgentResultType;
   }
   return AGENT_RESULT_TYPE_MAP[config.type] ?? "context_injection";
+}
+
+/**
+ * Agents whose output has to parse as JSON gain nothing from a visible
+ * thinking pass — the reasoning is discarded, never injected. On local models
+ * it actively breaks them: a reasoning model can spend its entire completion
+ * budget thinking and return empty content, which fails the JSON parse and
+ * triggers a second, equally wasteful retry. Observed on Gemma-4 12B backing
+ * prose-guardian: two calls, finish_reason "length", 4096 completion tokens
+ * each, empty content both times, ~273s for a turn that should take seconds.
+ *
+ * Ask for reasoning off, unless the agent's own connection deliberately turned
+ * that parameter's send-switch off (in which case the provider default stands).
+ */
+function jsonAgentReasoningOverride(
+  config: Pick<AgentExecConfig, "type" | "settings" | "enabledParameters">,
+): { reasoningEffort?: "none"; enabledParameters?: Record<string, boolean> } {
+  if (!agentResponseIsJson(config)) return {};
+  if (config.enabledParameters?.reasoningEffort === false) return {};
+  return {
+    reasoningEffort: "none",
+    enabledParameters: { ...(config.enabledParameters ?? {}), reasoningEffort: true },
+  };
 }
 
 function agentResponseIsJson(config: Pick<AgentExecConfig, "type" | "settings">): boolean {

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -24,6 +24,7 @@ import {
   shouldSuppressUnknownModelParameters,
 } from "@marinara-engine/shared";
 import { logger } from "../../../lib/logger.js";
+import { isPrivateNetworkIp } from "../../../middleware/ip-allowlist.js";
 import { applyGlmThinkingParameters } from "./glm-request-compat.js";
 
 /**
@@ -702,6 +703,24 @@ export class OpenAIProvider extends BaseLLMProvider {
     return reasoningEffort === "none";
   }
 
+  /**
+   * True when baseUrl points at an inference server running on this machine or
+   * this LAN (llama.cpp, Ollama, vLLM, LM Studio). Such servers expose
+   * arbitrary model names that never match the OpenAI/xAI catalog patterns the
+   * reasoning gates rely on, so without this the user's explicit "reasoning
+   * off" choice is silently discarded before it reaches the request body.
+   */
+  private isLocalInferenceEndpoint(): boolean {
+    try {
+      const hostname = new URL(this.baseUrl).hostname.toLowerCase().replace(/^\[|\]$/g, "");
+      if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") return true;
+      if (hostname.endsWith(".local") || hostname.endsWith(".localhost")) return true;
+      return isPrivateNetworkIp(hostname);
+    } catch {
+      return false;
+    }
+  }
+
   private supportsOpenAIReasoningDisable(model: string): boolean {
     const normalized = model.toLowerCase().replace(/^openai\//, "");
     if (normalized.includes("-pro")) return false;
@@ -806,6 +825,20 @@ export class OpenAIProvider extends BaseLLMProvider {
     if (this.isGenericCustomProvider()) {
       if (this.hasExplicitReasoningDisable(options.reasoningEffort)) {
         body.reasoning_effort = "none";
+        // Locally hosted servers (llama.cpp, Ollama, vLLM, LM Studio) drive
+        // thinking from the chat template, and not every template reads
+        // reasoning_effort. enable_thinking=false is what actually skips the
+        // thinking pass; reasoning_format would only hide thinking the model
+        // has already spent tokens producing.
+        if (this.isLocalInferenceEndpoint()) {
+          const templateOptions =
+            body.chat_template_kwargs &&
+            typeof body.chat_template_kwargs === "object" &&
+            !Array.isArray(body.chat_template_kwargs)
+              ? (body.chat_template_kwargs as Record<string, unknown>)
+              : {};
+          body.chat_template_kwargs = { ...templateOptions, enable_thinking: false };
+        }
       } else if (this.shouldSendReasoningEffort(options.model, options.reasoningEffort)) {
         body.reasoning_effort = options.reasoningEffort;
       }

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -24,7 +24,7 @@ import {
   shouldSuppressUnknownModelParameters,
 } from "@marinara-engine/shared";
 import { logger } from "../../../lib/logger.js";
-import { isPrivateNetworkIp } from "../../../middleware/ip-allowlist.js";
+import { isNonRoutableNetworkIp } from "../../../middleware/ip-allowlist.js";
 import { applyGlmThinkingParameters } from "./glm-request-compat.js";
 
 /**
@@ -712,10 +712,12 @@ export class OpenAIProvider extends BaseLLMProvider {
    */
   private isLocalInferenceEndpoint(): boolean {
     try {
-      const hostname = new URL(this.baseUrl).hostname.toLowerCase().replace(/^\[|\]$/g, "");
+      const hostname = new URL(this.baseUrl).hostname.toLowerCase().replace(/^\[|\]$|\.$/g, "");
       if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") return true;
       if (hostname.endsWith(".local") || hostname.endsWith(".localhost")) return true;
-      return isPrivateNetworkIp(hostname);
+      if (hostname === "host.docker.internal" || hostname === "host.containers.internal") return true;
+      if (!hostname.includes(".") || hostname.endsWith(".internal")) return true;
+      return isNonRoutableNetworkIp(hostname);
     } catch {
       return false;
     }

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -24,7 +24,7 @@ import {
   shouldSuppressUnknownModelParameters,
 } from "@marinara-engine/shared";
 import { logger } from "../../../lib/logger.js";
-import { isNonRoutableNetworkIp } from "../../../middleware/ip-allowlist.js";
+import { isLoopbackIp, isNonRoutableNetworkIp } from "../../../middleware/ip-allowlist.js";
 import { applyGlmThinkingParameters } from "./glm-request-compat.js";
 
 /**
@@ -713,7 +713,7 @@ export class OpenAIProvider extends BaseLLMProvider {
   private isLocalInferenceEndpoint(): boolean {
     try {
       const hostname = new URL(this.baseUrl).hostname.toLowerCase().replace(/^\[|\]$|\.$/g, "");
-      if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") return true;
+      if (hostname === "localhost" || isLoopbackIp(hostname)) return true;
       if (hostname.endsWith(".local") || hostname.endsWith(".localhost")) return true;
       if (hostname === "host.docker.internal" || hostname === "host.containers.internal") return true;
       if (!hostname.includes(".") || hostname.endsWith(".internal")) return true;
@@ -721,6 +721,29 @@ export class OpenAIProvider extends BaseLLMProvider {
     } catch {
       return false;
     }
+  }
+
+  private enforceLocalInferenceThinkingDisable(
+    body: Record<string, unknown>,
+    options: ChatOptions,
+    suppressModelParameters: boolean,
+  ): void {
+    if (
+      suppressModelParameters ||
+      !this.isGenericCustomProvider() ||
+      !this.shouldSendParameter(options, "reasoningEffort") ||
+      !this.hasExplicitReasoningDisable(options.reasoningEffort) ||
+      !this.isLocalInferenceEndpoint()
+    ) {
+      return;
+    }
+    const templateOptions =
+      body.chat_template_kwargs &&
+      typeof body.chat_template_kwargs === "object" &&
+      !Array.isArray(body.chat_template_kwargs)
+        ? (body.chat_template_kwargs as Record<string, unknown>)
+        : {};
+    body.chat_template_kwargs = { ...templateOptions, enable_thinking: false };
   }
 
   private supportsOpenAIReasoningDisable(model: string): boolean {
@@ -827,20 +850,6 @@ export class OpenAIProvider extends BaseLLMProvider {
     if (this.isGenericCustomProvider()) {
       if (this.hasExplicitReasoningDisable(options.reasoningEffort)) {
         body.reasoning_effort = "none";
-        // Locally hosted servers (llama.cpp, Ollama, vLLM, LM Studio) drive
-        // thinking from the chat template, and not every template reads
-        // reasoning_effort. enable_thinking=false is what actually skips the
-        // thinking pass; reasoning_format would only hide thinking the model
-        // has already spent tokens producing.
-        if (this.isLocalInferenceEndpoint()) {
-          const templateOptions =
-            body.chat_template_kwargs &&
-            typeof body.chat_template_kwargs === "object" &&
-            !Array.isArray(body.chat_template_kwargs)
-              ? (body.chat_template_kwargs as Record<string, unknown>)
-              : {};
-          body.chat_template_kwargs = { ...templateOptions, enable_thinking: false };
-        }
       } else if (this.shouldSendReasoningEffort(options.model, options.reasoningEffort)) {
         body.reasoning_effort = options.reasoningEffort;
       }
@@ -1209,6 +1218,9 @@ export class OpenAIProvider extends BaseLLMProvider {
 
     this.applyOpenRouterServiceTier(body, options);
     this.applyCustomParameters(body, options);
+    // Local chat templates may ignore reasoning_effort. Apply this after custom
+    // parameters so an explicit Reasoning Effort: Off choice remains authoritative.
+    this.enforceLocalInferenceThinkingDisable(body, options, suppressModelParameters);
     this.stripUnsupportedSamplerParameters(body, options);
 
     logger.debug(
@@ -1494,6 +1506,7 @@ export class OpenAIProvider extends BaseLLMProvider {
 
     this.applyOpenRouterServiceTier(body, options);
     this.applyCustomParameters(body, options);
+    this.enforceLocalInferenceThinkingDisable(body, options, suppressModelParameters);
     this.stripUnsupportedSamplerParameters(body, options);
 
     logger.debug(

--- a/scripts/regressions/agent-runtime.regression.ts
+++ b/scripts/regressions/agent-runtime.regression.ts
@@ -219,6 +219,68 @@ const arrayJsonResult = await executeAgent(
 assert.equal(arrayJsonResult.success, false, "structured agent output must be a JSON object, not an array");
 assert.equal(arrayJsonProvider.calls, 2, "array-shaped JSON should retain the existing single retry");
 
+const toolJsonProvider = new RecordingProvider('{"weather":"rain"}');
+await executeAgent(
+  {
+    ...makeAgent("world-state", "game_state_update"),
+    enabledParameters: { temperature: true },
+  },
+  context,
+  toolJsonProvider,
+  "agent-model",
+  {
+    tools: [
+      {
+        type: "function",
+        function: { name: "lookup", description: "Look up context", parameters: { type: "object" } },
+      },
+    ],
+    executeToolCall: async () => "unused",
+  },
+);
+assert.equal(toolJsonProvider.options[0]?.reasoningEffort, "none", "JSON agents with tools should disable reasoning");
+assert.deepEqual(
+  toolJsonProvider.options[0]?.enabledParameters,
+  { temperature: true, reasoningEffort: true },
+  "the JSON reasoning override should preserve the connection's other parameter switches",
+);
+
+const batchReasoningProvider = new RecordingProvider(
+  JSON.stringify({
+    "world-state": { weather: "rain" },
+    quest: { quests: [] },
+  }),
+);
+await executeAgentBatch(
+  [makeAgent("world-state", "game_state_update"), makeAgent("quest", "quest_update")],
+  context,
+  batchReasoningProvider,
+  "agent-model",
+);
+assert.equal(
+  batchReasoningProvider.options[0]?.reasoningEffort,
+  "none",
+  "batched agent requests should disable reasoning because the combined response must be JSON",
+);
+assert.equal(batchReasoningProvider.options[0]?.enabledParameters?.reasoningEffort, true);
+
+const inheritedReasoningProvider = new RecordingProvider('{"weather":"rain"}');
+await executeAgent(
+  {
+    ...makeAgent("world-state", "game_state_update"),
+    enabledParameters: { reasoningEffort: false },
+  },
+  context,
+  inheritedReasoningProvider,
+  "agent-model",
+);
+assert.equal(
+  inheritedReasoningProvider.options[0]?.reasoningEffort,
+  undefined,
+  "the connection send-switch should still allow the provider default",
+);
+assert.equal(inheritedReasoningProvider.options[0]?.enabledParameters?.reasoningEffort, false);
+
 const mixedParameterBatchProvider = new RecordingProvider();
 await executeAgentBatch(
   [

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -503,6 +503,7 @@ try {
     stream: false,
     reasoningEffort: "none",
     enabledParameters: { reasoningEffort: true },
+    customParameters: { chat_template_kwargs: { enable_thinking: true, use_jinja: true } },
   });
   assert.ok(localReasoningRequestBody);
   assert.equal(
@@ -512,8 +513,8 @@ try {
   );
   assert.deepEqual(
     localReasoningRequestBody.chat_template_kwargs,
-    { enable_thinking: false },
-    "llama.cpp needs enable_thinking=false to actually skip the thinking pass",
+    { enable_thinking: false, use_jinja: true },
+    "llama.cpp needs enable_thinking=false to win over custom parameters while preserving sibling options",
   );
 
   // Graded levels stay gated for off-catalog models: llama.cpp accepts them but
@@ -552,6 +553,7 @@ for (const localBaseUrl of [
   "http://host.docker.internal:11434/v1",
   "http://host.containers.internal:11434/v1",
   "http://ollama:11434/v1",
+  "http://127.0.0.2:11434/v1",
 ]) {
   const localHostnameProvider = new OpenAIProvider(localBaseUrl, "test", undefined, undefined, undefined, "custom");
   assert.equal(

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -473,6 +473,123 @@ try {
   );
 }
 
+// A locally hosted OpenAI-compatible server (llama.cpp / Ollama / vLLM / LM Studio)
+// is reached through the "custom" provider kind. Disabling reasoning there has to
+// arrive as BOTH reasoning_effort and chat_template_kwargs.enable_thinking:
+// llama.cpp only skips the thinking pass for the latter, while reasoning_format
+// alone would merely hide the thinking and still pay for the tokens.
+let localReasoningRequestBody: Record<string, unknown> | null = null;
+const localReasoningServer = createServer(async (request, response) => {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  localReasoningRequestBody = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify({ choices: [{ message: { content: "ok" }, finish_reason: "stop" }] }));
+});
+await new Promise<void>((resolve) => localReasoningServer.listen(0, "127.0.0.1", resolve));
+try {
+  const address = localReasoningServer.address();
+  assert.ok(address && typeof address === "object");
+  const localProvider = new OpenAIProvider(
+    `http://127.0.0.1:${address.port}/v1`,
+    "test",
+    undefined,
+    undefined,
+    undefined,
+    "custom",
+  );
+
+  await localProvider.chatComplete([{ role: "user", content: "no thinking please" }], {
+    model: "Qwen3.8-27B-Uncensored-HauhauCS-Aggressive",
+    stream: false,
+    reasoningEffort: "none",
+    enabledParameters: { reasoningEffort: true },
+  });
+  assert.ok(localReasoningRequestBody);
+  assert.equal(
+    localReasoningRequestBody.reasoning_effort,
+    "none",
+    "local endpoints must receive an explicit reasoning disable",
+  );
+  assert.deepEqual(
+    localReasoningRequestBody.chat_template_kwargs,
+    { enable_thinking: false },
+    "llama.cpp needs enable_thinking=false to actually skip the thinking pass",
+  );
+
+  // Graded levels stay gated for off-catalog models: llama.cpp accepts them but
+  // treats every non-"none" value identically to sending nothing.
+  localReasoningRequestBody = null;
+  await localProvider.chatComplete([{ role: "user", content: "think hard" }], {
+    model: "Qwen3.8-27B-Uncensored-HauhauCS-Aggressive",
+    stream: false,
+    reasoningEffort: "high",
+    enabledParameters: { reasoningEffort: true },
+  });
+  assert.ok(localReasoningRequestBody);
+  assert.equal("reasoning_effort" in localReasoningRequestBody, false);
+  assert.equal("chat_template_kwargs" in localReasoningRequestBody, false);
+
+  // The parameter's own send-switch still wins over everything.
+  localReasoningRequestBody = null;
+  await localProvider.chatComplete([{ role: "user", content: "provider default" }], {
+    model: "Qwen3.8-27B-Uncensored-HauhauCS-Aggressive",
+    stream: false,
+    reasoningEffort: "none",
+    enabledParameters: { reasoningEffort: false },
+  });
+  assert.ok(localReasoningRequestBody);
+  assert.equal("reasoning_effort" in localReasoningRequestBody, false);
+  assert.equal("chat_template_kwargs" in localReasoningRequestBody, false);
+} finally {
+  await new Promise<void>((resolve, reject) =>
+    localReasoningServer.close((error) => (error ? reject(error) : resolve())),
+  );
+}
+
+// The enable_thinking addition is a local-endpoint carve-out. A remote custom
+// endpoint keeps the previous behaviour: reasoning_effort only, no template kwargs.
+let remoteReasoningRequestBody: Record<string, unknown> | null = null;
+const remoteReasoningServer = createServer(async (request, response) => {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  remoteReasoningRequestBody = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify({ choices: [{ message: { content: "ok" }, finish_reason: "stop" }] }));
+});
+await new Promise<void>((resolve) => remoteReasoningServer.listen(0, "127.0.0.1", resolve));
+try {
+  const address = remoteReasoningServer.address();
+  assert.ok(address && typeof address === "object");
+  const remoteProvider = new OpenAIProvider(
+    `http://127.0.0.1:${address.port}/v1`,
+    "test",
+    undefined,
+    undefined,
+    undefined,
+    "custom",
+  );
+  // Force the local check to fail while keeping the loopback transport.
+  Object.defineProperty(remoteProvider, "isLocalInferenceEndpoint", { value: () => false });
+  await remoteProvider.chatComplete([{ role: "user", content: "no thinking please" }], {
+    model: "some-remote-model",
+    stream: false,
+    reasoningEffort: "none",
+    enabledParameters: { reasoningEffort: true },
+  });
+  assert.ok(remoteReasoningRequestBody);
+  assert.equal(remoteReasoningRequestBody.reasoning_effort, "none");
+  assert.equal(
+    "chat_template_kwargs" in remoteReasoningRequestBody,
+    false,
+    "enable_thinking must stay a local-endpoint carve-out",
+  );
+} finally {
+  await new Promise<void>((resolve, reject) =>
+    remoteReasoningServer.close((error) => (error ? reject(error) : resolve())),
+  );
+}
+
 assert.deepEqual(
   resolveStoredChatOptions(
     JSON.stringify({

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -309,10 +309,9 @@ try {
 
   assert.equal(supportsAssistantReasoningPrefill("custom"), true);
   assert.equal(supportsAssistantReasoningPrefill("grok_subscription"), false);
-  assert.deepEqual(
-    buildPrefillMessages("", "Unsupported reasoning", { supportsAssistantReasoningPrefill: false }),
-    [{ role: "user", content: "Continue." }],
-  );
+  assert.deepEqual(buildPrefillMessages("", "Unsupported reasoning", { supportsAssistantReasoningPrefill: false }), [
+    { role: "user", content: "Continue." },
+  ]);
   assert.deepEqual(
     buildPrefillMessages("Visible", "Unsupported reasoning", { supportsAssistantReasoningPrefill: false }),
     [
@@ -549,6 +548,48 @@ try {
 
 // The enable_thinking addition is a local-endpoint carve-out. A remote custom
 // endpoint keeps the previous behaviour: reasoning_effort only, no template kwargs.
+for (const localBaseUrl of [
+  "http://host.docker.internal:11434/v1",
+  "http://host.containers.internal:11434/v1",
+  "http://ollama:11434/v1",
+]) {
+  const localHostnameProvider = new OpenAIProvider(localBaseUrl, "test", undefined, undefined, undefined, "custom");
+  assert.equal(
+    (
+      localHostnameProvider as unknown as {
+        isLocalInferenceEndpoint(): boolean;
+      }
+    ).isLocalInferenceEndpoint(),
+    true,
+    `${localBaseUrl} should be recognized as a local inference endpoint`,
+  );
+}
+
+const previousTrustedPrivateNetworks = process.env.TRUSTED_PRIVATE_NETWORKS;
+process.env.TRUSTED_PRIVATE_NETWORKS = "10.0.0.0/8";
+try {
+  const privateAddressProvider = new OpenAIProvider(
+    "http://192.168.50.2:11434/v1",
+    "test",
+    undefined,
+    undefined,
+    undefined,
+    "custom",
+  );
+  assert.equal(
+    (
+      privateAddressProvider as unknown as {
+        isLocalInferenceEndpoint(): boolean;
+      }
+    ).isLocalInferenceEndpoint(),
+    true,
+    "inference endpoint detection must not depend on the authentication trust-list override",
+  );
+} finally {
+  if (previousTrustedPrivateNetworks === undefined) delete process.env.TRUSTED_PRIVATE_NETWORKS;
+  else process.env.TRUSTED_PRIVATE_NETWORKS = previousTrustedPrivateNetworks;
+}
+
 let remoteReasoningRequestBody: Record<string, unknown> | null = null;
 const remoteReasoningServer = createServer(async (request, response) => {
   const chunks: Buffer[] = [];


### PR DESCRIPTION
## Linked issue

Closes #5257

## Why this change

Locally hosted reasoning models can ignore an explicit Reasoning Effort setting of Off, spend their whole completion budget on thinking that Marinara discards, and leave JSON-returning agents with empty or invalid output. The strict-JSON retry then repeats the same expensive failure.

## What changed

- Send both `reasoning_effort: "none"` and `chat_template_kwargs.enable_thinking: false` to local OpenAI-compatible endpoints when reasoning is explicitly disabled, while preserving sibling custom template parameters and keeping the template override away from remote endpoints.
- Treat loopback, private/link-local IPs, Docker host aliases, Compose service names, and local/internal hostnames as local inference endpoints without coupling provider behavior to the server authentication allowlist.
- Disable reasoning for JSON-returning agent requests across normal calls, strict-JSON retries, tool loops, final tool responses, and batched execution, unless the connection deliberately disables the reasoning send-switch.
- Log the final assembled agent request in debug mode for normal, retry, tool-assisted, and batched provider calls.
- Add focused provider-compatibility and agent-runtime regression coverage, plus an Unreleased changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated proof recorded by the maintainer without marking human verification boxes:

- `pnpm check`
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/agent-runtime.regression.ts`
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/provider-compat.regression.ts`
- CodeRabbit CLI review of the final pre-merge diff: zero findings

### Manual verification notes

- The contributor measured the original failure and corrected local-model behavior against llama.cpp/Qwen and a JSON agent running Gemma.
- Manually verify Connection Settings → Reasoning Effort → Off against a local reasoning model.
- Manually verify a JSON agent returns parseable content without exhausting its budget or invoking the strict-JSON retry.
- Manually verify remote custom endpoints retain existing behavior.
- Maintainer review approved after automated checks and CodeRabbit review.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

The user-facing fix is documented under `CHANGELOG.md` → `[Unreleased]`; no configuration or translated documentation changed.

## UI evidence (if applicable)

Not applicable; this is provider and agent-runtime behavior.

