### PR TITLE
Fix mobile navigation and Docker channel switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Mobile full-screen navigation now places the slightly larger Home icon first, opens Chats from the right like the resource tabs, swaps between Chats and resource tabs without replaying the entrance animation, deactivates Home while another surface is open, lets Home dismiss that surface and return to the Home page, and starts the draggable Music DJ control below Home bookmarks; the Characters tab underline now also matches its pink icon on mobile and desktop (#5248).
+- Docker update checks now recognize stable-to-Staging/UAT channel switches and show the correct `staging` image tag and host-side switch instructions instead of claiming the stable container is already current (#5249).
 - Roleplay's Agents menu now offers a Stop Agents action while parallel or post-processing work is still running, without blocking new messages or swipes (#5237).
 - ComfyUI Video Generation workflows now support the same Base64 reference-image placeholders as image workflows, including `%reference_image%` and `%reference_image_01%` through `%reference_image_04%` (#5238).
 - Automatic backups, manual backups, and profile exports no longer fail at an artificial 8,192-entry ZIP ceiling; archive size and path-safety protections remain enforced (#5239).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -16261,35 +16261,211 @@ test("mobile topbar remains reachable while sidebars switch", async ({ page }, t
   test.skip(!testInfo.project.name.includes("mobile"), "Mobile shell smoke only runs in the mobile project.");
 
   const errors = collectUnexpectedErrors(page);
+  await page.route("**/api/capability-packages/installed", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
   await page.goto("/");
 
-  await page.locator('[data-tour="sidebar-toggle"]').click();
+  const topbar = page.locator('[data-component="TopBar"]');
+  const homeButton = topbar.getByTitle("Home");
+  const chatsButton = topbar.locator('[data-tour="sidebar-toggle"]');
+  const homeBounds = await homeButton.boundingBox();
+  const chatsBounds = await chatsButton.boundingBox();
+  expect(homeBounds).not.toBeNull();
+  expect(chatsBounds).not.toBeNull();
+  const mobileActionOrder = [
+    "home",
+    "chats",
+    "characters",
+    "personas",
+    "lorebooks",
+    "presets",
+    "connections",
+    "agents",
+    "settings",
+  ];
+  const mobileActionOffsets = await Promise.all(
+    mobileActionOrder.map(async (key) =>
+      Math.round((await topbar.locator(`[data-topbar-hover-key="${key}"]`).boundingBox())?.x ?? -1),
+    ),
+  );
+  expect(mobileActionOffsets.every((offset) => offset >= 0)).toBe(true);
+  expect(new Set(mobileActionOffsets).size).toBe(mobileActionOrder.length);
+  expect(mobileActionOffsets).toEqual([...mobileActionOffsets].sort((left, right) => left - right));
+  const homeIconBounds = await homeButton.locator("svg").boundingBox();
+  const chatsIconBounds = await chatsButton.locator("svg").boundingBox();
+  expect(homeIconBounds).not.toBeNull();
+  expect(chatsIconBounds).not.toBeNull();
+  expect(homeIconBounds!.width).toBeGreaterThan(chatsIconBounds!.width);
+
+  const musicDjButton = page.getByRole("button", { name: "Open Music DJ download prompt" });
+  await expect(musicDjButton).toBeVisible();
+  const bookmarksBounds = await page.getByRole("navigation", { name: "Home bookmarks" }).boundingBox();
+  const initialMusicDjBounds = await musicDjButton.boundingBox();
+  expect(bookmarksBounds).not.toBeNull();
+  expect(initialMusicDjBounds).not.toBeNull();
+  const musicDjOverlapsBookmarks =
+    initialMusicDjBounds!.x < bookmarksBounds!.x + bookmarksBounds!.width &&
+    initialMusicDjBounds!.x + initialMusicDjBounds!.width > bookmarksBounds!.x &&
+    initialMusicDjBounds!.y < bookmarksBounds!.y + bookmarksBounds!.height &&
+    initialMusicDjBounds!.y + initialMusicDjBounds!.height > bookmarksBounds!.y;
+  expect(musicDjOverlapsBookmarks).toBe(false);
+  const initialMusicDjPosition = await page.evaluate(async () => {
+    const { useUIStore } = await import("/src/stores/ui.store.ts");
+    return useUIStore.getState().spotifyMobileWidgetPosition;
+  });
+  await musicDjButton.dispatchEvent("pointerdown", {
+    pointerId: 1,
+    pointerType: "touch",
+    clientX: initialMusicDjBounds!.x + 24,
+    clientY: initialMusicDjBounds!.y + 24,
+  });
+  await musicDjButton.dispatchEvent("pointermove", {
+    pointerId: 1,
+    pointerType: "touch",
+    clientX: initialMusicDjBounds!.x + 88,
+    clientY: initialMusicDjBounds!.y + 88,
+  });
+  await musicDjButton.dispatchEvent("pointerup", {
+    pointerId: 1,
+    pointerType: "touch",
+    clientX: initialMusicDjBounds!.x + 88,
+    clientY: initialMusicDjBounds!.y + 88,
+  });
+  await expect
+    .poll(() =>
+      page.evaluate(async () => {
+        const { useUIStore } = await import("/src/stores/ui.store.ts");
+        return useUIStore.getState().spotifyMobileWidgetPosition.x;
+      }),
+    )
+    .toBeGreaterThan(initialMusicDjPosition.x + 32);
+
+  await chatsButton.click();
   await expect(page.locator('[data-component="TopBar"]')).toBeVisible();
   await expect(page.locator('[data-component="ChatSidebar"]')).toBeVisible();
+  await expect(homeButton).toHaveAttribute("aria-pressed", "false");
+  await expect(chatsButton).toHaveAttribute("aria-pressed", "true");
   const mobileChatSidebar = page.locator('[data-component="ChatSidebarPanel"]');
+  await expect.poll(async () => (await mobileChatSidebar.boundingBox())?.x ?? Number.POSITIVE_INFINITY).toBeLessThan(1);
+  await mobileChatSidebar.evaluate((element) => element.setAttribute("data-e2e-mobile-shell", "preserved"));
+
+  await page.locator('[data-tour="panel-characters"]').click();
+  const swappedRightPanel = page.locator('[data-component="RightPanelMobile"]');
+  await expect(swappedRightPanel).toBeVisible();
+  await expect(swappedRightPanel).toHaveAttribute("data-e2e-mobile-shell", "preserved");
+  await expect(homeButton).toHaveAttribute("aria-pressed", "false");
+  const charactersUnderline = topbar.locator('[data-component="CharactersTopbarUnderline"]');
+  await expect(charactersUnderline).toBeVisible();
+  await expect
+    .poll(() =>
+      charactersUnderline.evaluate((element) =>
+        getComputedStyle(element).getPropertyValue("--mari-panel-gradient-start").trim(),
+      ),
+    )
+    .toBe("#f472b6");
+
+  await chatsButton.click();
+  await expect(mobileChatSidebar).toBeVisible();
+  await expect(mobileChatSidebar).toHaveAttribute("data-e2e-mobile-shell", "preserved");
   const openMobileSidebarX = (await mobileChatSidebar.boundingBox())?.x ?? 0;
-  await page.locator('[data-tour="sidebar-toggle"]').click();
-  await expect(mobileChatSidebar).toHaveClass(/mari-shell-panel-exit-left/);
+  await homeButton.click();
   expect((await mobileChatSidebar.boundingBox())?.width ?? 0).toBeGreaterThan(
     (await page.evaluate(() => innerWidth)) * 0.9,
   );
   await expect
     .poll(async () => (await mobileChatSidebar.boundingBox())?.x ?? Number.POSITIVE_INFINITY)
-    .toBeLessThan(openMobileSidebarX - 8);
-  await expect(mobileChatSidebar).toHaveAttribute("aria-hidden", "true");
+    .toBeGreaterThan(openMobileSidebarX + 8);
+  await expect(mobileChatSidebar).toHaveCount(0);
+  await expect(homeButton).toHaveAttribute("aria-pressed", "true");
 
-  await page.locator('[data-tour="sidebar-toggle"]').click();
-  await expect(page.locator('[data-component="ChatSidebar"]')).toBeVisible();
-
-  await page.locator('[data-tour="panel-characters"]').click();
-  await expect(page.locator('[data-component="TopBar"]')).toBeVisible();
-  await expect(page.locator('[data-component="RightPanelMobile"]')).toBeVisible();
-
-  await page.locator('[data-tour="panel-settings"]').click();
-  await expect(page.locator('[data-component="TopBar"]')).toBeVisible();
-  await expect(page.locator('[data-component="RightPanelMobile"]')).toBeVisible();
+  for (const panel of ["characters", "personas", "lorebooks", "presets", "connections", "agents", "settings"]) {
+    await page.locator(`[data-tour="panel-${panel}"]`).click();
+    await expect(page.locator('[data-component="TopBar"]')).toBeVisible();
+    await expect(page.locator('[data-component="RightPanelMobile"]')).toBeVisible();
+    await expect(homeButton).toHaveAttribute("aria-pressed", "false");
+    await homeButton.click();
+    await expect(page.locator('[data-component="RightPanelMobile"]')).toHaveCount(0);
+    await expect(homeButton).toHaveAttribute("aria-pressed", "true");
+  }
 
   expect(errors).toEqual([]);
+});
+
+test("Characters topbar underline uses the Characters pink", async ({ page }) => {
+  await page.goto("/");
+  await page.locator('[data-tour="panel-characters"]').click();
+
+  const underline = page.locator('[data-component="CharactersTopbarUnderline"]');
+  await expect(underline).toBeVisible();
+  await expect
+    .poll(() =>
+      underline.evaluate((element) =>
+        getComputedStyle(element).getPropertyValue("--mari-panel-gradient-start").trim(),
+      ),
+    )
+    .toBe("#f472b6");
+});
+
+test("mobile Docker update checks offer the selected staging image", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("mobile"), "Mobile Docker channel regression.");
+
+  await page.route("**/api/updates/check?channel=staging", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        currentVersion: APP_VERSION,
+        currentCommit: "stable123456",
+        currentBuild: `${APP_VERSION}+stable123456`,
+        channel: "staging",
+        channelLabel: "Staging/UAT",
+        currentBranch: `v${APP_VERSION}`,
+        channels: [
+          { id: "stable", label: "Latest Stable", branch: "main", targetRef: "origin/main", warning: null },
+          {
+            id: "staging",
+            label: "Staging/UAT",
+            branch: "staging",
+            targetRef: "origin/staging",
+            warning: "Staging builds are pre-release tester builds. Back up your app data before applying them.",
+          },
+        ],
+        targetRef: "origin/staging",
+        targetCommit: null,
+        latestVersion: APP_VERSION,
+        updateAvailable: true,
+        channelSwitch: true,
+        versionUpdate: false,
+        commitsBehind: 0,
+        releaseUrl: `https://github.com/Pasta-Devs/Marinara-Engine/releases/tag/v${APP_VERSION}`,
+        releaseNotes: "",
+        publishedAt: "",
+        dockerImage: "ghcr.io/pasta-devs/marinara-engine",
+        dockerImageTag: "ghcr.io/pasta-devs/marinara-engine:staging",
+        dockerLiteImageTag: null,
+        installType: "docker",
+        serverPlatform: "linux",
+        clientPlatform: "android",
+        applyAvailable: false,
+        updatesApplyEnabled: false,
+        applyUnavailableReason: "container-install",
+        manualUpdateCommand: "docker compose pull && docker compose up -d",
+        manualUpdateHint:
+          "Set the Compose image to ghcr.io/pasta-devs/marinara-engine:staging, then pull it and restart the container. Use a separate data volume for staging.",
+      }),
+    }),
+  );
+
+  await page.goto("/");
+  await page.locator('[data-tour="panel-settings"]').click();
+  await page.getByRole("tab", { name: "Advanced" }).click();
+  await page.getByLabel("Release Channel").selectOption("staging");
+  await page.getByRole("button", { name: "Check for Updates" }).click();
+
+  await expect(page.getByText("Switch to Staging/UAT", { exact: true })).toBeVisible();
+  await expect(page.getByText("ghcr.io/pasta-devs/marinara-engine:staging", { exact: true })).toBeVisible();
+  await expect(page.getByText(/Set the Compose image to .*:staging, then pull it and restart the container\./)).toBeVisible();
+  await expect(page.getByText(/latest Staging\/UAT target/)).toHaveCount(0);
 });
 
 test("coarse-pointer iPad widths use full-screen side panels", async ({ page }, testInfo) => {

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -16292,6 +16292,12 @@ test("mobile topbar remains reachable while sidebars switch", async ({ page }, t
   expect(mobileActionOffsets.every((offset) => offset >= 0)).toBe(true);
   expect(new Set(mobileActionOffsets).size).toBe(mobileActionOrder.length);
   expect(mobileActionOffsets).toEqual([...mobileActionOffsets].sort((left, right) => left - right));
+  const mobileDomActionOrder = await topbar.locator("[data-topbar-hover-key]").evaluateAll((elements) =>
+    elements
+      .map((element) => (element as HTMLElement).dataset.topbarHoverKey)
+      .filter((key): key is string => Boolean(key)),
+  );
+  expect(mobileDomActionOrder.slice(0, mobileActionOrder.length)).toEqual(mobileActionOrder);
   const homeIconBounds = await homeButton.locator("svg").boundingBox();
   const chatsIconBounds = await chatsButton.locator("svg").boundingBox();
   expect(homeIconBounds).not.toBeNull();
@@ -16482,6 +16488,11 @@ test("coarse-pointer iPad widths use full-screen side panels", async ({ page }, 
   const panelBounds = await mobilePanel.boundingBox();
   expect(panelBounds).not.toBeNull();
   expect(panelBounds!.width).toBeGreaterThanOrEqual(1023);
+  const homeButton = page.locator('[data-component="TopBar"]').getByTitle("Home");
+  await expect(homeButton).toHaveAttribute("aria-pressed", "false");
+  await homeButton.click();
+  await expect(mobilePanel).toHaveCount(0);
+  await expect(homeButton).toHaveAttribute("aria-pressed", "true");
 });
 
 test("mobile Game keeps CYOA usable above four HUD widgets", async ({ page, request }, testInfo) => {

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -435,6 +435,7 @@ export function AppShell() {
   }, []);
 
   const shellOverlayMode = isMobile;
+  const mobileNavigationPanel = shellOverlayMode ? (sidebarOpen ? "chats" : rightPanelOpen ? "right" : null) : null;
   const [rightPanelEverOpened, setRightPanelEverOpened] = useState(rightPanelOpen);
   useEffect(() => {
     if (rightPanelOpen) setRightPanelEverOpened(true);
@@ -1246,51 +1247,46 @@ export function AppShell() {
         </>
       )}
 
-      {/* Overlay sidebar backdrop */}
-      {sidebarOpen && shellOverlayMode && (
+      {/* Mobile navigation backdrop */}
+      {mobileNavigationPanel && (
         <div
           className={cn("fixed inset-x-0 bottom-0 z-[45] bg-black/50 backdrop-blur-sm", MOBILE_SHELL_PANEL_TOP_CLASS)}
-          onClick={() => setSidebarOpen(false)}
+          onClick={() => {
+            setSidebarOpen(false);
+            closeRightPanel();
+          }}
         />
       )}
 
       {/* Left sidebar - Chat list */}
-      <aside
-        data-tour="sidebar"
-        data-component="ChatSidebarSlot"
-        aria-label={localizeUi("ui.layout.appshell.chatList")}
-        aria-hidden={!sidebarOpen}
-        inert={!sidebarOpen}
-        className={cn(
-          "mari-shell-panel-slot flex-shrink-0 overflow-hidden",
-          !shellOverlayMode && "md:relative",
-          sidebarDragWidth != null && "!transition-none",
-          !sidebarOpen && "pointer-events-none",
-          shellOverlayMode &&
-            cn(
-              "fixed bottom-0 left-0 z-50 max-h-none pb-[max(env(safe-area-inset-bottom),0.5rem)] shadow-2xl",
-              MOBILE_SHELL_PANEL_TOP_CLASS,
-            ),
-        )}
-        style={{
-          width: shellOverlayMode ? "100vw" : sidebarOpen ? liveSidebarWidth : 0,
-        }}
-      >
-        <div
-          data-component="ChatSidebarPanel"
+      {!shellOverlayMode && (
+        <aside
+          data-tour="sidebar"
+          data-component="ChatSidebarSlot"
+          aria-label={localizeUi("ui.layout.appshell.chatList")}
           aria-hidden={!sidebarOpen}
           inert={!sidebarOpen}
           className={cn(
-            "mari-sidebar mari-shell-panel-motion absolute inset-y-0 left-0 overflow-hidden bg-[var(--background)]/95",
-            shellOverlayMode && "backdrop-blur-xl",
-            sidebarOpen ? "mari-shell-panel-enter-left" : "mari-shell-panel-exit-left pointer-events-none",
-            !shellOverlayMode && "mari-shell-panel-edge mari-shell-panel-edge--right",
+            "mari-shell-panel-slot relative flex-shrink-0 overflow-hidden",
+            sidebarDragWidth != null && "!transition-none",
+            !sidebarOpen && "pointer-events-none",
           )}
-          style={{ width: shellOverlayMode ? "100vw" : liveSidebarWidth }}
+          style={{ width: sidebarOpen ? liveSidebarWidth : 0 }}
         >
-          <ChatSidebar />
-        </div>
-      </aside>
+          <div
+            data-component="ChatSidebarPanel"
+            aria-hidden={!sidebarOpen}
+            inert={!sidebarOpen}
+            className={cn(
+              "mari-sidebar mari-shell-panel-motion mari-shell-panel-edge mari-shell-panel-edge--right absolute inset-y-0 left-0 overflow-hidden bg-[var(--background)]/95",
+              sidebarOpen ? "mari-shell-panel-enter-left" : "mari-shell-panel-exit-left pointer-events-none",
+            )}
+            style={{ width: liveSidebarWidth }}
+          >
+            <ChatSidebar />
+          </div>
+        </aside>
+      )}
       {!shellOverlayMode && sidebarOpen && (
         <div
           role="separator"
@@ -1427,37 +1423,41 @@ export function AppShell() {
         </AnimatePresence>
       )}
 
-      {/* Overlay right panel backdrop */}
-      {rightPanelOpen && shellOverlayMode && (
-        <div
-          className={cn("fixed inset-x-0 bottom-0 z-[45] bg-black/50 backdrop-blur-sm", MOBILE_SHELL_PANEL_TOP_CLASS)}
-          onClick={() => closeRightPanel()}
-        />
-      )}
-
       {shellOverlayMode && <ChatResourceMobileDropDock />}
 
-      {/* Right panel - Context / Settings */}
+      {/* Mobile navigation swaps content in one shell; desktop keeps independent sidebars. */}
       {shellOverlayMode ? (
         <AnimatePresence mode="wait">
-          {rightPanelOpen && (
+          {mobileNavigationPanel && (
             <motion.aside
-              key="mobile"
+              key="mobile-navigation"
               initial={{ x: "100%" }}
               animate={{ x: 0 }}
               exit={{ x: "100%" }}
               transition={{ type: "spring", damping: 28, stiffness: 350 }}
-              data-component="RightPanelMobile"
-              aria-label={localizeUi("ui.layout.appshell.settingsAndToolsPanel")}
+              data-tour={mobileNavigationPanel === "chats" ? "sidebar" : undefined}
+              data-component={mobileNavigationPanel === "chats" ? "ChatSidebarPanel" : "RightPanelMobile"}
+              aria-label={localizeUi(
+                mobileNavigationPanel === "chats"
+                  ? "ui.layout.appshell.chatList"
+                  : "ui.layout.appshell.settingsAndToolsPanel",
+              )}
               className={cn(
-                "mari-right-panel !fixed bottom-0 right-0 z-50 !w-full overflow-hidden bg-[var(--background)]/80 pb-[max(env(safe-area-inset-bottom),0.5rem)] shadow-2xl backdrop-blur-xl",
+                "!fixed right-0 bottom-0 z-50 !w-full overflow-hidden pb-[max(env(safe-area-inset-bottom),0.5rem)] shadow-2xl backdrop-blur-xl",
                 MOBILE_SHELL_PANEL_TOP_CLASS,
+                mobileNavigationPanel === "chats"
+                  ? "mari-sidebar bg-[var(--background)]/95"
+                  : "mari-right-panel bg-[var(--background)]/80",
               )}
               style={{ "--mari-right-panel-width": "100vw" } as CSSProperties}
             >
-              <Suspense fallback={<SidePanelFallback />}>
-                <RightPanel />
-              </Suspense>
+              {mobileNavigationPanel === "chats" ? (
+                <ChatSidebar />
+              ) : (
+                <Suspense fallback={<SidePanelFallback />}>
+                  <RightPanel />
+                </Suspense>
+              )}
             </motion.aside>
           )}
         </AnimatePresence>

--- a/packages/client/src/components/layout/TopBar.tsx
+++ b/packages/client/src/components/layout/TopBar.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
-import { useUIStore } from "../../stores/ui.store";
+import { MOBILE_SHELL_MEDIA_QUERY, useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { cn } from "../../lib/utils";
 import { SpotifyMiniPlayer } from "../spotify/SpotifyMiniPlayer";
@@ -85,7 +85,7 @@ const TOPBAR_ACCENT_ICON_CLASS = "mari-topbar-accent-icon mari-accent-animated";
 const CHAT_TOPBAR_GRADIENT_ID = "mari-topbar-chats-gradient";
 
 function isMobileTopbarNavigation() {
-  return typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches;
+  return typeof window !== "undefined" && window.matchMedia(MOBILE_SHELL_MEDIA_QUERY).matches;
 }
 
 export function TopBar() {
@@ -119,6 +119,7 @@ export function TopBar() {
   const [spotifyDesktopViewport, setSpotifyDesktopViewport] = useState(false);
   const [spotifyUseFloatingFallback, setSpotifyUseFloatingFallback] = useState(false);
   const [hoveredTopbarKey, setHoveredTopbarKey] = useState<string | null>(null);
+  const [mobileTopbarNavigation, setMobileTopbarNavigation] = useState(isMobileTopbarNavigation);
   const { data: installedCapabilities = [], isLoading: installedCapabilitiesLoading } =
     useInstalledCapabilityPackages();
   const musicDjInstalled = installedCapabilities.some(
@@ -145,7 +146,7 @@ export function TopBar() {
       Boolean(personaDetailId) ||
       (characterLibraryOpen && cardLibraryKind === "personas"),
   };
-  const isMobileOverlayActive = isMobileTopbarNavigation() && (sidebarOpen || rightPanelOpen);
+  const isMobileOverlayActive = mobileTopbarNavigation && (sidebarOpen || rightPanelOpen);
   const isHomeActive =
     !activeChatId &&
     !isMobileOverlayActive &&
@@ -202,6 +203,14 @@ export function TopBar() {
   };
 
   const clearTopbarHover = useCallback(() => setHoveredTopbarKey(null), []);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(MOBILE_SHELL_MEDIA_QUERY);
+    const syncMobileNavigation = () => setMobileTopbarNavigation(mediaQuery.matches);
+    syncMobileNavigation();
+    mediaQuery.addEventListener("change", syncMobileNavigation);
+    return () => mediaQuery.removeEventListener("change", syncMobileNavigation);
+  }, []);
 
   useEffect(() => {
     const header = headerRef.current;
@@ -263,6 +272,64 @@ export function TopBar() {
     };
   }, [clearTopbarHover]);
 
+  const chatsButton = (
+    <button
+      key="chats"
+      onClick={handleSidebarClick}
+      aria-pressed={sidebarOpen}
+      data-tour="sidebar-toggle"
+      data-topbar-hover-key="chats"
+      className={cn(
+        TOPBAR_BUTTON_CLASS,
+        sidebarOpen
+          ? cn(TOPBAR_ACTIVE_BUTTON_CLASS, "mari-topbar-chat-gradient-icon")
+          : cn(
+              "mari-topbar-chat-gradient-hover text-[var(--muted-foreground)]",
+              isTopbarHovered("chats") && cn(TOPBAR_FORCE_HOVER_CLASS, "mari-topbar-chat-gradient-icon"),
+            ),
+      )}
+      title={localize("Chats")}
+    >
+      <MessageSquareText size={15} className={TOPBAR_ACCENT_ICON_CLASS}>
+        <defs>
+          <linearGradient id={CHAT_TOPBAR_GRADIENT_ID} x1="2" x2="18" y1="3" y2="18" gradientUnits="userSpaceOnUse">
+            <stop offset="0%" stopColor="var(--mari-logo-cyan)" />
+            <stop offset="48%" stopColor="var(--mari-logo-orange)" />
+            <stop offset="100%" stopColor="var(--mari-logo-pink)" />
+          </linearGradient>
+        </defs>
+      </MessageSquareText>
+      {sidebarOpen && (
+        <span className="mari-topbar-chat-gradient-underline absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full" />
+      )}
+    </button>
+  );
+
+  const homeButton = (
+    <button
+      key="home"
+      onClick={handleHomeClick}
+      aria-pressed={isHomeActive}
+      data-topbar-hover-key="home"
+      className={cn(
+        TOPBAR_BUTTON_CLASS,
+        isHomeActive
+          ? TOPBAR_ACTIVE_BUTTON_CLASS
+          : cn(
+              "text-[var(--muted-foreground)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]",
+              isTopbarHovered("home") &&
+                cn(TOPBAR_FORCE_HOVER_CLASS, "text-[var(--marinara-chat-chrome-button-text-hover)]"),
+            ),
+      )}
+      title={localize("Home")}
+    >
+      <Home size={15} className={TOPBAR_ACCENT_ICON_CLASS} />
+      {isHomeActive && (
+        <span className="mari-topbar-active-underline absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full" />
+      )}
+    </button>
+  );
+
   return (
     <header
       ref={headerRef}
@@ -280,64 +347,7 @@ export function TopBar() {
           ref={leftControlsRef}
           className="mari-topbar-left-controls mari-rgb-icon-scope flex shrink-0 items-center gap-2"
         >
-          <button
-            onClick={handleSidebarClick}
-            aria-pressed={sidebarOpen}
-            data-tour="sidebar-toggle"
-            data-topbar-hover-key="chats"
-            className={cn(
-              TOPBAR_BUTTON_CLASS,
-              sidebarOpen
-                ? cn(TOPBAR_ACTIVE_BUTTON_CLASS, "mari-topbar-chat-gradient-icon")
-                : cn(
-                    "mari-topbar-chat-gradient-hover text-[var(--muted-foreground)]",
-                    isTopbarHovered("chats") && cn(TOPBAR_FORCE_HOVER_CLASS, "mari-topbar-chat-gradient-icon"),
-                  ),
-            )}
-            title={localize("Chats")}
-          >
-            <MessageSquareText size={15} className={TOPBAR_ACCENT_ICON_CLASS}>
-              <defs>
-                <linearGradient
-                  id={CHAT_TOPBAR_GRADIENT_ID}
-                  x1="2"
-                  x2="18"
-                  y1="3"
-                  y2="18"
-                  gradientUnits="userSpaceOnUse"
-                >
-                  <stop offset="0%" stopColor="var(--mari-logo-cyan)" />
-                  <stop offset="48%" stopColor="var(--mari-logo-orange)" />
-                  <stop offset="100%" stopColor="var(--mari-logo-pink)" />
-                </linearGradient>
-              </defs>
-            </MessageSquareText>
-            {sidebarOpen && (
-              <span className="mari-topbar-chat-gradient-underline absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full" />
-            )}
-          </button>
-
-          <button
-            onClick={handleHomeClick}
-            aria-pressed={isHomeActive}
-            data-topbar-hover-key="home"
-            className={cn(
-              TOPBAR_BUTTON_CLASS,
-              isHomeActive
-                ? TOPBAR_ACTIVE_BUTTON_CLASS
-                : cn(
-                    "text-[var(--muted-foreground)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]",
-                    isTopbarHovered("home") &&
-                      cn(TOPBAR_FORCE_HOVER_CLASS, "text-[var(--marinara-chat-chrome-button-text-hover)]"),
-                  ),
-            )}
-            title={localize("Home")}
-          >
-            <Home size={15} className={TOPBAR_ACCENT_ICON_CLASS} />
-            {isHomeActive && (
-              <span className="mari-topbar-active-underline absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full" />
-            )}
-          </button>
+          {mobileTopbarNavigation ? [homeButton, chatsButton] : [chatsButton, homeButton]}
         </div>
         {showMusicDjUnavailablePlayer ? (
           <MusicDjUnavailablePlayer floating={spotifyUseFloatingFallback} />

--- a/packages/client/src/components/layout/TopBar.tsx
+++ b/packages/client/src/components/layout/TopBar.tsx
@@ -92,7 +92,9 @@ export function TopBar() {
   const localize = useLocalizedUiText();
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
   const toggleSidebar = useUIStore((s) => s.toggleSidebar);
+  const setSidebarOpen = useUIStore((s) => s.setSidebarOpen);
   const toggleRightPanel = useUIStore((s) => s.toggleRightPanel);
+  const closeRightPanel = useUIStore((s) => s.closeRightPanel);
   const rightPanel = useUIStore((s) => s.rightPanel);
   const rightPanelOpen = useUIStore((s) => s.rightPanelOpen);
   const activeChatId = useChatStore((s) => s.activeChatId);
@@ -143,8 +145,10 @@ export function TopBar() {
       Boolean(personaDetailId) ||
       (characterLibraryOpen && cardLibraryKind === "personas"),
   };
+  const isMobileOverlayActive = isMobileTopbarNavigation() && (sidebarOpen || rightPanelOpen);
   const isHomeActive =
     !activeChatId &&
+    !isMobileOverlayActive &&
     !characterDetailId &&
     !lorebookDetailId &&
     !presetDetailId &&
@@ -176,6 +180,15 @@ export function TopBar() {
     },
     [prepareMobileTopbarNavigation, toggleRightPanel],
   );
+
+  const handleHomeClick = useCallback(() => {
+    window.dispatchEvent(new Event("marinara:home-professor-mari-close"));
+    setActiveChatId(null);
+    closeAllDetails();
+    if (!isMobileTopbarNavigation()) return;
+    setSidebarOpen(false);
+    closeRightPanel();
+  }, [closeAllDetails, closeRightPanel, setActiveChatId, setSidebarOpen]);
 
   const handleTopbarPointerOver = (event: ReactPointerEvent<HTMLElement>) => {
     if (event.pointerType !== "mouse") return;
@@ -269,6 +282,7 @@ export function TopBar() {
         >
           <button
             onClick={handleSidebarClick}
+            aria-pressed={sidebarOpen}
             data-tour="sidebar-toggle"
             data-topbar-hover-key="chats"
             className={cn(
@@ -304,11 +318,8 @@ export function TopBar() {
           </button>
 
           <button
-            onClick={() => {
-              window.dispatchEvent(new Event("marinara:home-professor-mari-close"));
-              setActiveChatId(null);
-              closeAllDetails();
-            }}
+            onClick={handleHomeClick}
+            aria-pressed={isHomeActive}
             data-topbar-hover-key="home"
             className={cn(
               TOPBAR_BUTTON_CLASS,
@@ -348,6 +359,7 @@ export function TopBar() {
       >
         <button
           onClick={() => handleRightPanelClick("characters")}
+          aria-pressed={isCharactersPanelActive}
           data-tour="panel-characters"
           data-topbar-hover-key="characters"
           className={cn(
@@ -364,7 +376,10 @@ export function TopBar() {
         >
           <Users size={15} className={TOPBAR_ACCENT_ICON_CLASS} />
           {isCharactersPanelActive && (
-            <span className="mari-topbar-active-underline absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full" />
+            <span
+              data-component="CharactersTopbarUnderline"
+              className="mari-panel-gradient-surface mari-panel-gradient--characters absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full"
+            />
           )}
         </button>
 
@@ -375,6 +390,7 @@ export function TopBar() {
             <button
               key={panel}
               onClick={() => handleRightPanelClick(panel)}
+              aria-pressed={isActive}
               data-tour={`panel-${panel}`}
               data-topbar-hover-key={panel}
               className={cn(

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -7706,7 +7706,7 @@ function AdvancedSettings() {
     releaseTag?: string;
     dockerImage?: string;
     dockerImageTag?: string;
-    dockerLiteImageTag?: string;
+    dockerLiteImageTag?: string | null;
     installType: "git" | "docker" | "standalone";
     serverPlatform?: "windows" | "macos" | "linux" | "android-termux" | "unknown";
     clientPlatform?: "ios" | "android" | "desktop" | "unknown";
@@ -7935,15 +7935,19 @@ function AdvancedSettings() {
             <div className="flex flex-col gap-2 rounded-lg bg-[var(--secondary)] p-2.5 ring-1 ring-[var(--border)]">
               <div className="flex items-center justify-between">
                 <span className="text-xs font-medium">
-                  {updateCheck.data.versionUpdate
-                    ? localizeUi("ui.panels.advancedsettings.vValue1Available", {
-                        value1: updateCheck.data.latestVersion,
+                  {updateCheck.data.channelSwitch
+                    ? localizeUi("ui.panels.advancedsettings.switchToValue1", {
+                        value1: updateCheck.data.channelLabel,
                       })
-                    : localizeUi("ui.panels.advancedsettings.value1CommitValue2BehindValue3", {
-                        value1: commitsBehind,
-                        value2: commitsBehind !== 1 ? localizeUi("ui.noodle.stageprofileview.s") : "",
-                        value3: updateCheck.data.targetRef ?? localizeUi("ui.panels.advancedsettings.originMain"),
-                      })}
+                    : updateCheck.data.versionUpdate
+                      ? localizeUi("ui.panels.advancedsettings.vValue1Available", {
+                          value1: updateCheck.data.latestVersion,
+                        })
+                      : localizeUi("ui.panels.advancedsettings.value1CommitValue2BehindValue3", {
+                          value1: commitsBehind,
+                          value2: commitsBehind !== 1 ? localizeUi("ui.noodle.stageprofileview.s") : "",
+                          value3: updateCheck.data.targetRef ?? localizeUi("ui.panels.advancedsettings.originMain"),
+                        })}
                 </span>
                 {updateCheck.data.versionUpdate && (
                   <a

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -94,6 +94,7 @@ export interface FloatingWidgetPosition {
   x: number;
   y: number;
 }
+export const DEFAULT_MOBILE_MUSIC_WIDGET_POSITION = { x: 16, y: 144 } as const;
 export interface SummaryPopoverSettings {
   sourceMode: SummaryPopoverSourceMode;
   contextSize: number | null;
@@ -1505,7 +1506,7 @@ export const useUIStore = create<UIState>()(
       conversationCallVoiceVolume: 100,
       conversationCallVoiceMuted: false,
       spotifyMobileWidgetCollapsed: true,
-      spotifyMobileWidgetPosition: { x: 16, y: 96 },
+      spotifyMobileWidgetPosition: { ...DEFAULT_MOBILE_MUSIC_WIDGET_POSITION },
       intuitiveSwipeNavigation: false,
       intuitiveSwipeRerollLatest: false,
       editLastMessageOnArrowUp: true,
@@ -2304,8 +2305,12 @@ export const useUIStore = create<UIState>()(
       setSpotifyMobileWidgetPosition: (position) =>
         set({
           spotifyMobileWidgetPosition: {
-            x: Number.isFinite(position.x) ? Math.max(8, Math.round(position.x)) : 16,
-            y: Number.isFinite(position.y) ? Math.max(8, Math.round(position.y)) : 96,
+            x: Number.isFinite(position.x)
+              ? Math.max(8, Math.round(position.x))
+              : DEFAULT_MOBILE_MUSIC_WIDGET_POSITION.x,
+            y: Number.isFinite(position.y)
+              ? Math.max(8, Math.round(position.y))
+              : DEFAULT_MOBILE_MUSIC_WIDGET_POSITION.y,
           },
         }),
       setIntuitiveSwipeNavigation: (v) => set({ intuitiveSwipeNavigation: v }),
@@ -2514,12 +2519,9 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      // v93 -> v94: add the Inventory tracker-panel section. The bump matters:
-      // `migrate` re-normalizes `trackerPanelSectionOrder`, and it only runs when
-      // the persisted version changes. Without it an existing user's saved order
-      // never gains "inventory" and the section stays invisible until they
-      // reorder the panel by hand.
-      version: 94,
+      // v94 -> v95: move only the untouched mobile music-player default below Home bookmarks.
+      // The version bump ensures existing stores run the exact-coordinate migration below.
+      version: 95,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2711,7 +2713,7 @@ export const useUIStore = create<UIState>()(
         if (version <= 19) {
           if (persisted.spotifyMobileWidgetCollapsed === undefined) persisted.spotifyMobileWidgetCollapsed = true;
           if (persisted.spotifyMobileWidgetPosition === undefined) {
-            persisted.spotifyMobileWidgetPosition = { x: 16, y: 96 };
+            persisted.spotifyMobileWidgetPosition = { ...DEFAULT_MOBILE_MUSIC_WIDGET_POSITION };
           }
         }
         // v20 -> v21: remember Game setup free-text fields and learned preference chips.
@@ -3083,6 +3085,15 @@ export const useUIStore = create<UIState>()(
         // v90 -> v91: make the Home navigation assistant an explicit, default-on preference.
         if (version <= 90 && persisted.professorMariNavigationEnabled === undefined) {
           persisted.professorMariNavigationEnabled = true;
+        }
+        // v94 -> v95: existing custom positions stay untouched; the exact legacy
+        // default is the only reliable indication that the widget was never moved.
+        if (
+          version <= 94 &&
+          persisted.spotifyMobileWidgetPosition?.x === 16 &&
+          persisted.spotifyMobileWidgetPosition?.y === 96
+        ) {
+          persisted.spotifyMobileWidgetPosition = { ...DEFAULT_MOBILE_MUSIC_WIDGET_POSITION };
         }
         // v84 -> v85: keep the historical blank-line behavior for /continue by default.
         if (version <= 84 && persisted.continueAddsNewline === undefined) {

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -5771,6 +5771,7 @@ strong {
   }
 
   .mari-topbar-action {
+    order: 10;
     flex: 1 1 0;
     min-width: 0;
     width: auto !important;
@@ -5780,6 +5781,47 @@ strong {
   .mari-topbar-action > svg {
     width: clamp(13px, 3.9vw, 17px);
     height: clamp(13px, 3.9vw, 17px);
+  }
+
+  .mari-topbar-action[data-topbar-hover-key="home"] {
+    order: 1;
+  }
+
+  .mari-topbar-action[data-topbar-hover-key="chats"] {
+    order: 2;
+  }
+
+  .mari-topbar-action[data-topbar-hover-key="characters"] {
+    order: 3;
+  }
+
+  .mari-topbar-action[data-topbar-hover-key="personas"] {
+    order: 4;
+  }
+
+  .mari-topbar-action[data-topbar-hover-key="lorebooks"] {
+    order: 5;
+  }
+
+  .mari-topbar-action[data-topbar-hover-key="presets"] {
+    order: 6;
+  }
+
+  .mari-topbar-action[data-topbar-hover-key="connections"] {
+    order: 7;
+  }
+
+  .mari-topbar-action[data-topbar-hover-key="agents"] {
+    order: 8;
+  }
+
+  .mari-topbar-action[data-topbar-hover-key="settings"] {
+    order: 9;
+  }
+
+  .mari-topbar-action[data-topbar-hover-key="home"] > svg {
+    width: clamp(15px, 4.4vw, 18px);
+    height: clamp(15px, 4.4vw, 18px);
   }
 
   .mari-settings-tab-button {
@@ -5911,6 +5953,11 @@ strong {
   .mari-topbar-action > svg {
     width: clamp(12px, 3.8vw, 15px);
     height: clamp(12px, 3.8vw, 15px);
+  }
+
+  .mari-topbar-action[data-topbar-hover-key="home"] > svg {
+    width: clamp(14px, 4.4vw, 17px);
+    height: clamp(14px, 4.4vw, 17px);
   }
 
   .retro-badge {

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -5783,12 +5783,8 @@ strong {
     height: clamp(13px, 3.9vw, 17px);
   }
 
-  .mari-topbar-action[data-topbar-hover-key="home"] {
+  .mari-topbar-left-controls .mari-topbar-action {
     order: 1;
-  }
-
-  .mari-topbar-action[data-topbar-hover-key="chats"] {
-    order: 2;
   }
 
   .mari-topbar-action[data-topbar-hover-key="characters"] {

--- a/packages/server/src/routes/updates.routes.ts
+++ b/packages/server/src/routes/updates.routes.ts
@@ -19,7 +19,11 @@ import { getBuildBranch, getBuildCommit, getBuildLabel } from "../config/build-i
 import { getFileStorageDir } from "../config/runtime-config.js";
 import { requirePrivilegedAccess } from "../middleware/privileged-gate.js";
 import { isLoopbackIp } from "../middleware/ip-allowlist.js";
-import { isGitUpdateApplyAllowed } from "../services/updates/update-apply-policy.js";
+import {
+  isGitUpdateApplyAllowed,
+  isUpdateChannelSwitch,
+  resolveDockerChannelImageTags,
+} from "../services/updates/update-apply-policy.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -221,7 +225,10 @@ function getManualUpdateCommand(installType: InstallType, platform: ServerPlatfo
 
 function getManualUpdateHint(installType: InstallType, platform: ServerPlatform, channel = UPDATE_CHANNELS.stable) {
   if (installType === "docker") {
-    return "Pull the published container image and restart the container. Versioned tags are published from vX.Y.Z release tags.";
+    if (channel.id === "staging") {
+      return `Set the Compose image to ${DOCKER_IMAGE}:staging, then pull it and restart the container. Use a separate data volume for staging.`;
+    }
+    return `Set the Compose image to the stable tag shown below (or ${DOCKER_IMAGE}:latest), then pull it and restart the container.`;
   }
   if (installType === "git" && channel.id === "staging") {
     return "Staging is a tester branch. Make a profile backup first, then apply from the browser or run the command below from the repo checkout.";
@@ -766,14 +773,12 @@ function serializeUpdateChannels() {
   }));
 }
 
-function buildReleasePayload(release: NonNullable<typeof cachedRelease>) {
+function buildReleasePayload(release: NonNullable<typeof cachedRelease>, channel = UPDATE_CHANNELS.stable) {
   const releaseTag = `v${release.latestVersion}`;
   return {
     ...release,
     releaseTag,
-    dockerImage: DOCKER_IMAGE,
-    dockerImageTag: `${DOCKER_IMAGE}:${release.latestVersion}`,
-    dockerLiteImageTag: `${DOCKER_IMAGE}:${release.latestVersion}-lite`,
+    ...resolveDockerChannelImageTags(DOCKER_IMAGE, release.latestVersion, channel.id),
   };
 }
 
@@ -843,7 +848,7 @@ export async function updatesRoutes(app: FastifyInstance) {
       (req.query as { channel?: unknown } | undefined)?.channel,
       currentBranch,
     );
-    const channelSwitch = gitInstall && currentChannel.id !== channel.id;
+    const channelSwitch = isUpdateChannelSwitch(installType, currentChannel.id, channel.id);
     const applyAvailability = getApplyAvailability(
       installType,
       serverPlatform,
@@ -888,6 +893,7 @@ export async function updatesRoutes(app: FastifyInstance) {
           currentBranch,
           channels: serializeUpdateChannels(),
           updateAvailable: channelSwitch || (commitsBehind != null && commitsBehind > 0),
+          channelSwitch,
           commitsBehind: commitsBehind ?? 0,
           installType,
           serverPlatform,
@@ -906,9 +912,10 @@ export async function updatesRoutes(app: FastifyInstance) {
       channelLabel: channel.label,
       currentBranch,
       channels: serializeUpdateChannels(),
-      ...buildReleasePayload(release),
+      ...buildReleasePayload(release, channel),
       updateAvailable:
         channelSwitch || (channel.id === "stable" && versionUpdate) || (commitsBehind != null && commitsBehind > 0),
+      channelSwitch,
       versionUpdate: channel.id === "stable" ? versionUpdate : false,
       commitsBehind: commitsBehind ?? 0,
       installType,

--- a/packages/server/src/services/updates/update-apply-policy.ts
+++ b/packages/server/src/services/updates/update-apply-policy.ts
@@ -9,3 +9,30 @@ export function isGitUpdateApplyAllowed(options: {
 }): boolean {
   return options.updatesApplyEnabled || options.localChannelSwitchRequested;
 }
+
+export type UpdateInstallType = "git" | "docker" | "standalone";
+export type UpdateChannelId = "stable" | "staging";
+
+export function isUpdateChannelSwitch(
+  installType: UpdateInstallType,
+  currentChannel: UpdateChannelId,
+  selectedChannel: UpdateChannelId,
+): boolean {
+  return installType !== "standalone" && currentChannel !== selectedChannel;
+}
+
+export function resolveDockerChannelImageTags(image: string, latestVersion: string, channel: UpdateChannelId) {
+  if (channel === "staging") {
+    return {
+      dockerImage: image,
+      dockerImageTag: `${image}:staging`,
+      dockerLiteImageTag: null,
+    };
+  }
+
+  return {
+    dockerImage: image,
+    dockerImageTag: `${image}:${latestVersion}`,
+    dockerLiteImageTag: `${image}:${latestVersion}-lite`,
+  };
+}

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -133,7 +133,11 @@ import {
   isBundledGameAssetFolderPath,
   isBundledGameAssetPath,
 } from "../../packages/server/src/services/game/native-game-assets.js";
-import { isGitUpdateApplyAllowed } from "../../packages/server/src/services/updates/update-apply-policy.js";
+import {
+  isGitUpdateApplyAllowed,
+  isUpdateChannelSwitch,
+  resolveDockerChannelImageTags,
+} from "../../packages/server/src/services/updates/update-apply-policy.js";
 import { parseNoodleAvatarCrop } from "../../packages/server/src/services/storage/noodle.storage.js";
 import { sanitizeExampleDialoguePromptLeaf } from "../../packages/server/src/services/prompt/prompt-escaping.js";
 import {
@@ -1027,6 +1031,20 @@ assert.match(
   /gitInstall \? await getCurrentBranch\(root\)\.catch\(\(\) => null\) : getBuildBranch\(\)/u,
 );
 assert.match(updatesRouteSource, /const currentChannel = await getUpdateChannelForCheckout\(root, currentBranch\)/u);
+assert.equal(isUpdateChannelSwitch("docker", "stable", "staging"), true);
+assert.equal(isUpdateChannelSwitch("docker", "staging", "staging"), false);
+assert.equal(isUpdateChannelSwitch("git", "stable", "staging"), true);
+assert.equal(isUpdateChannelSwitch("standalone", "stable", "staging"), false);
+assert.deepEqual(resolveDockerChannelImageTags("ghcr.io/pasta-devs/marinara-engine", "2.4.3", "stable"), {
+  dockerImage: "ghcr.io/pasta-devs/marinara-engine",
+  dockerImageTag: "ghcr.io/pasta-devs/marinara-engine:2.4.3",
+  dockerLiteImageTag: "ghcr.io/pasta-devs/marinara-engine:2.4.3-lite",
+});
+assert.deepEqual(resolveDockerChannelImageTags("ghcr.io/pasta-devs/marinara-engine", "2.4.3", "staging"), {
+  dockerImage: "ghcr.io/pasta-devs/marinara-engine",
+  dockerImageTag: "ghcr.io/pasta-devs/marinara-engine:staging",
+  dockerLiteImageTag: null,
+});
 for (const dockerfile of ["Dockerfile", "Dockerfile.lite"]) {
   const dockerSource = readFileSync(join(REPOSITORY_ROOT, dockerfile), "utf8");
   assert.match(dockerSource, /^ARG BUILD_BRANCH$/mu, `${dockerfile} must accept the source ref as build metadata`);


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #5248
Closes #5249

## Why this change

- Mobile full-screen tabs left Home selected and Home could not dismiss the active tab.
- Chats appeared on the wrong side and replayed a slide animation when switching between it and another mobile tab.
- The requested mobile topbar order and larger Home icon were not represented correctly.
- The default Music DJ control overlapped Home bookmarks.
- The Characters active underline did not match the tab icon pink.
- Docker users on stable were incorrectly told they were already current on Staging/UAT.

## What changed

- Gives mobile topbar actions the explicit order Home, Chats, Characters, Personas, Lorebooks, Presets, Connections, Agents, Settings, with a slightly larger Home icon.
- Uses one right-side mobile navigation shell for Chats and resource tabs, so opening/closing animates but tab-to-tab swaps replace content in place.
- Makes Home inactive while a mobile tab is open and lets Home close Chats or any resource tab.
- Moves the untouched Music DJ mobile default below bookmarks while preserving custom dragged positions.
- Uses the Characters pink gradient for its active underline on desktop and mobile.
- Treats Docker stable/staging changes as channel switches and returns the selected channel image tag and host instructions.
- Adds focused server and Playwright regressions plus Unreleased changelog entries.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated local proof completed:

- `pnpm check`
- `pnpm build:shared && node ./scripts/run-regressions.mjs --filter scripts/regressions/open-issues.regression.ts`
- Mobile Playwright coverage for exact icon order, larger Home icon, Music DJ placement/dragging, Home dismissal, shared-shell tab swapping, and Docker staging selection
- Desktop and mobile Playwright coverage for the Characters pink underline

Manual contributor checkboxes remain intentionally unchecked.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

`CHANGELOG.md` is updated under `[Unreleased]`; no version-bearing files or translated user documentation changed.

## UI evidence (if applicable)

Focused Playwright assertions cover both mobile breakpoints and desktop underline styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved mobile navigation with a unified panel experience, clearer active states, and smoother transitions.
  - Added more consistent mobile top-bar action ordering and improved Home and Characters styling.
  - Repositioned the mobile Music DJ widget for better visibility and usability.

- **Bug Fixes**
  - Corrected Docker update handling when switching between Stable and Staging channels.
  - Improved staging image selection and update guidance, including clearer manual instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->