### PR TITLE
feat(agents): run Beholder as five narrow passes for per-lane extractors

### DIFF
--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -44,6 +44,7 @@ import { getAssetManifest } from "../game/asset-manifest.service.js";
 import {
   BEHOLDER_PASS_LANES,
   formatBeholderRequestContext,
+  isBeholderLaneResponse,
   mergeBeholderLaneDeltas,
   parseBeholderLanePrompts,
   resolveBeholderStateResponse,
@@ -1007,8 +1008,8 @@ async function executeBeholderLanePasses(args: {
     // parseError marker instead of throwing, and treating that as a usable
     // lane would let five broken replies look like a clean no-change turn.
     const laneData = parseAgentResponse(config, outcome.value.laneText).data;
-    if (shouldFailInvalidJsonResult(config, laneData)) {
-      logger.warn("[agent] %s pass %s returned unparseable output; skipping lane", config.type, lane);
+    if (shouldFailInvalidJsonResult(config, laneData) || !isBeholderLaneResponse(laneData)) {
+      logger.warn("[agent] %s pass %s did not answer in the extraction contract; skipping lane", config.type, lane);
       continue;
     }
     laneResponses.push(laneData);

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -937,9 +937,19 @@ async function executeBeholderLanePasses(args: {
 
   logger.info(`[agent] ${config.type} (${config.name}) — ${model} — ${BEHOLDER_PASS_LANES.length} passes`);
 
-  const settled = await Promise.allSettled(
-    BEHOLDER_PASS_LANES.map(async (lane) => {
+  // Bounded dispatch, not Promise.all: each lane's timeout budget starts when
+  // agentCallSignal builds it, so launching all five at once would let a lane
+  // queued behind a rate limit burn its budget before the provider starts work.
+  const settled = await settleAgentJobsWithConcurrencyLimit(
+    [...BEHOLDER_PASS_LANES],
+    AGENT_BATCH_FALLBACK_MAX_CONCURRENT,
+    async (lane) => {
       const messages = buildStandardAgentMessages(config, lanePrompts[lane], context);
+      logger.debug(`[agent] ═══ ${config.type} [${lane}] PROMPT ═══`);
+      for (const msg of messages) {
+        logger.debug(`[agent] [${msg.role}] ${msg.content}`);
+      }
+      logger.debug(`[agent] ═══ END ${lane} PROMPT — temperature=${temperature} maxTokens=${maxTokens} ═══\n`);
       emitAgentDebug(context, {
         stage: "request",
         ...agentDebugBase(config, model, temperature, maxTokens),
@@ -979,29 +989,33 @@ async function executeBeholderLanePasses(args: {
         ...responseDebugFields(laneText),
       });
       return { laneText, tokens: result.usage?.totalTokens ?? 0 };
-    }),
+    },
   );
 
   const laneResponses: unknown[] = [];
   let totalTokens = 0;
   for (const [index, outcome] of settled.entries()) {
-    if (outcome.status === "fulfilled") {
-      // Reuse the shared JSON extraction so a fenced or chatty lane reply is
-      // handled exactly like a single-call response.
-      laneResponses.push(parseAgentResponse(config, outcome.value.laneText).data);
-      totalTokens += outcome.value.tokens;
-    } else {
-      logger.warn(
-        "[agent] %s pass %s failed: %s",
-        config.type,
-        BEHOLDER_PASS_LANES[index],
-        extractErrorMessage(outcome.reason),
-      );
+    const lane = BEHOLDER_PASS_LANES[index];
+    if (outcome.status !== "fulfilled") {
+      logger.warn("[agent] %s pass %s failed: %s", config.type, lane, extractErrorMessage(outcome.reason));
+      continue;
     }
+    totalTokens += outcome.value.tokens;
+    // Reuse the shared JSON extraction so a fenced or chatty lane reply is
+    // handled exactly like a single-call response. Unparseable output is
+    // reported rather than counted: parseAgentResponse hands back a
+    // parseError marker instead of throwing, and treating that as a usable
+    // lane would let five broken replies look like a clean no-change turn.
+    const laneData = parseAgentResponse(config, outcome.value.laneText).data;
+    if (shouldFailInvalidJsonResult(config, laneData)) {
+      logger.warn("[agent] %s pass %s returned unparseable output; skipping lane", config.type, lane);
+      continue;
+    }
+    laneResponses.push(laneData);
   }
 
   if (laneResponses.length === 0) {
-    return makeError(config, "Every Beholder extraction pass failed", startTime);
+    return makeError(config, "Every Beholder extraction pass failed or returned unusable output", startTime);
   }
 
   const merged = mergeBeholderLaneDeltas(laneResponses);

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -41,7 +41,14 @@ import { sanitizePromptLeaf } from "../prompt/prompt-escaping.js";
 import { settleAgentJobsWithConcurrencyLimit } from "./agent-concurrency.js";
 import { normalizeCyoaChoiceOutput } from "./cyoa-choice-normalization.js";
 import { getAssetManifest } from "../game/asset-manifest.service.js";
-import { formatBeholderRequestContext, resolveBeholderStateResponse } from "./beholder-state.js";
+import {
+  BEHOLDER_PASS_LANES,
+  formatBeholderRequestContext,
+  mergeBeholderLaneDeltas,
+  parseBeholderLanePrompts,
+  resolveBeholderStateResponse,
+  type BeholderPassLane,
+} from "./beholder-state.js";
 
 const MAX_AGENT_CONTEXT_MESSAGES = 200;
 const EXPRESSION_AGENT_RECENT_CONTEXT_MESSAGES = 2;
@@ -749,6 +756,25 @@ export async function executeAgent(
       );
     }
 
+    // A per-pass Beholder template asks one narrow question per call, which is
+    // what a locally hosted per-lane extractor was trained on. Single-prompt
+    // templates parse to null and keep the one-call path below.
+    const lanePrompts = config.type === "beholder" ? parseBeholderLanePrompts(template) : null;
+    if (lanePrompts) {
+      return await executeBeholderLanePasses({
+        config,
+        context,
+        provider,
+        model,
+        lanePrompts,
+        temperature,
+        maxTokens,
+        streamResponses,
+        customParameters,
+        startTime,
+      });
+    }
+
     // Call LLM (streaming to avoid proxy timeouts, no tools)
     logger.info(`[agent] ${config.type} (${config.name}) — ${model}`);
     for (const msg of messages) {
@@ -880,6 +906,119 @@ export async function executeAgent(
     });
     return makeError(config, extractErrorMessage(err), startTime);
   }
+}
+
+/**
+ * Run one Beholder extraction as five narrow passes and union the results.
+ *
+ * A locally hosted Beholder model is trained per lane: it answers about worn
+ * items, wounds, held items, species, or bare/missing flags one at a time, so
+ * asking for the whole state in a single call is off-distribution for it. Each
+ * lane gets the same user message with its own system prompt; the lanes own
+ * disjoint slot fields, so their deltas union cleanly into the single
+ * `{changed, delta}` payload the rest of the pipeline already understands.
+ *
+ * A lane that fails or returns nothing is skipped rather than failing the turn —
+ * losing one lane is better than discarding the four that succeeded.
+ */
+async function executeBeholderLanePasses(args: {
+  config: AgentExecConfig;
+  context: AgentContext;
+  provider: BaseLLMProvider;
+  model: string;
+  lanePrompts: Record<BeholderPassLane, string>;
+  temperature: number | undefined;
+  maxTokens: number;
+  streamResponses: boolean;
+  customParameters: Record<string, unknown> | undefined;
+  startTime: number;
+}): Promise<AgentResult> {
+  const { config, context, provider, model, lanePrompts, temperature, maxTokens, streamResponses, startTime } = args;
+
+  logger.info(`[agent] ${config.type} (${config.name}) — ${model} — ${BEHOLDER_PASS_LANES.length} passes`);
+
+  const settled = await Promise.allSettled(
+    BEHOLDER_PASS_LANES.map(async (lane) => {
+      const messages = buildStandardAgentMessages(config, lanePrompts[lane], context);
+      emitAgentDebug(context, {
+        stage: "request",
+        ...agentDebugBase(config, model, temperature, maxTokens),
+        messageCount: messages.length,
+        messages: debugMessages(messages),
+      });
+
+      let laneText = "";
+      const result = await provider.chatComplete(messages, {
+        model,
+        temperature,
+        maxTokens,
+        enableCaching: config.enableCaching,
+        anthropicExtendedCacheTtl: config.anthropicExtendedCacheTtl,
+        cachingAtDepth: config.cachingAtDepth,
+        customParameters: args.customParameters,
+        enabledParameters: config.enabledParameters,
+        suppressModelParameters: config.suppressModelParameters,
+        stream: streamResponses,
+        onToken: streamResponses
+          ? (chunk) => {
+              laneText += chunk;
+            }
+          : undefined,
+        signal: agentCallSignal(context.signal),
+      });
+      if (!laneText && result.content) laneText = result.content;
+      laneText = laneText.trim();
+      logger.debug(`[agent] ${config.type} [${lane}] raw response: ${laneText.slice(0, 500)}`);
+      emitAgentDebug(context, {
+        stage: "response",
+        ...agentDebugBase(config, model, temperature, maxTokens),
+        messageCount: messages.length,
+        durationMs: Date.now() - startTime,
+        finishReason: result.finishReason,
+        ...debugUsage(result.usage),
+        ...responseDebugFields(laneText),
+      });
+      return { laneText, tokens: result.usage?.totalTokens ?? 0 };
+    }),
+  );
+
+  const laneResponses: unknown[] = [];
+  let totalTokens = 0;
+  for (const [index, outcome] of settled.entries()) {
+    if (outcome.status === "fulfilled") {
+      // Reuse the shared JSON extraction so a fenced or chatty lane reply is
+      // handled exactly like a single-call response.
+      laneResponses.push(parseAgentResponse(config, outcome.value.laneText).data);
+      totalTokens += outcome.value.tokens;
+    } else {
+      logger.warn(
+        "[agent] %s pass %s failed: %s",
+        config.type,
+        BEHOLDER_PASS_LANES[index],
+        extractErrorMessage(outcome.reason),
+      );
+    }
+  }
+
+  if (laneResponses.length === 0) {
+    return makeError(config, "Every Beholder extraction pass failed", startTime);
+  }
+
+  const merged = mergeBeholderLaneDeltas(laneResponses);
+  logger.info(
+    `[agent] ${config.type} done (${laneResponses.length}/${BEHOLDER_PASS_LANES.length} passes, changed=${merged.changed}, ${Date.now() - startTime}ms)`,
+  );
+  const structured = resolveStructuredAgentResult(config, context, merged);
+  return {
+    agentId: config.id,
+    agentType: config.type,
+    type: resolveAgentResultType(config),
+    data: structured.data,
+    tokensUsed: totalTokens,
+    durationMs: Date.now() - startTime,
+    success: structured.valid,
+    error: structured.error ?? null,
+  };
 }
 
 /**

--- a/packages/server/src/services/agents/beholder-state.ts
+++ b/packages/server/src/services/agents/beholder-state.ts
@@ -248,6 +248,103 @@ function mergeWounds(current: BeholderWound[] | undefined, updates: BeholderWoun
   return merged.filter((_, index) => !dropped.has(index));
 }
 
+/**
+ * The lanes a per-pass Beholder extractor answers one at a time. The local
+ * Beholder model is trained per-lane, so it is prompted once per entry here and
+ * the five narrow deltas are unioned back into a single delta.
+ */
+export const BEHOLDER_PASS_LANES = ["worn", "wounds", "holding", "species", "flags"] as const;
+
+export type BeholderPassLane = (typeof BEHOLDER_PASS_LANES)[number];
+
+const LANE_HEADING = /^[ \t]*\[(worn|wounds|holding|species|flags)\][ \t]*$/gmu;
+
+/**
+ * Split a multi-pass prompt template into its per-lane system prompts. The
+ * template marks each section with a `[lane]` heading on its own line. Returns
+ * null unless every lane is present with a non-empty body, so a normal
+ * single-prompt template falls through to the one-call path untouched.
+ */
+export function parseBeholderLanePrompts(template: unknown): Record<BeholderPassLane, string> | null {
+  if (typeof template !== "string" || !template.includes("[")) return null;
+
+  const headings: Array<{ lane: BeholderPassLane; start: number; end: number }> = [];
+  LANE_HEADING.lastIndex = 0;
+  for (let match = LANE_HEADING.exec(template); match; match = LANE_HEADING.exec(template)) {
+    headings.push({
+      lane: match[1] as BeholderPassLane,
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+  }
+  if (headings.length !== BEHOLDER_PASS_LANES.length) return null;
+
+  const prompts: Partial<Record<BeholderPassLane, string>> = {};
+  for (const [index, heading] of headings.entries()) {
+    const body = template.slice(heading.end, headings[index + 1]?.start ?? template.length).trim();
+    if (!body || prompts[heading.lane]) return null;
+    prompts[heading.lane] = body;
+  }
+  return BEHOLDER_PASS_LANES.every((lane) => prompts[lane]) ? (prompts as Record<BeholderPassLane, string>) : null;
+}
+
+function mergeLaneSlot(target: Record<string, unknown>, incoming: Record<string, unknown>): void {
+  for (const [field, value] of Object.entries(incoming)) {
+    if (field === "worn_remove" && Array.isArray(target.worn_remove) && Array.isArray(value)) {
+      target.worn_remove = [...target.worn_remove, ...value];
+      continue;
+    }
+    target[field] = value;
+  }
+}
+
+/**
+ * Union the per-lane deltas into one delta payload. Each lane owns a disjoint
+ * set of slot fields (worn, wounds, holding, species, bare/missing), so the
+ * union is field-level and conflict-free; `changed` is true when any lane
+ * reported a change.
+ */
+export function mergeBeholderLaneDeltas(responses: readonly unknown[]): {
+  changed: boolean;
+  delta: Record<string, unknown>;
+} {
+  const delta: Record<string, unknown> = {};
+  let changed = false;
+
+  for (const response of responses) {
+    const parsed = parseMaybeJson(response);
+    if (!isRecord(parsed) || parsed.changed !== true || !isRecord(parsed.delta)) continue;
+
+    for (const [charName, rawCharacter] of Object.entries(parsed.delta)) {
+      if (!isRecord(rawCharacter)) continue;
+      const character = (isRecord(delta[charName]) ? delta[charName] : {}) as Record<string, unknown>;
+
+      if (typeof rawCharacter.species === "string" && rawCharacter.species.trim()) {
+        character.species = rawCharacter.species;
+        changed = true;
+      }
+
+      if (isRecord(rawCharacter.body)) {
+        const body = (isRecord(character.body) ? character.body : {}) as Record<string, unknown>;
+        for (const [slotName, rawSlot] of Object.entries(rawCharacter.body)) {
+          if (!isRecord(rawSlot)) continue;
+          const slot = (isRecord(body[slotName]) ? body[slotName] : {}) as Record<string, unknown>;
+          mergeLaneSlot(slot, rawSlot);
+          body[slotName] = slot;
+          // The species lane emits empty exotic-slot stubs ({"tail": {}}) as an
+          // anatomy hint; those carry no state and must not count as a change.
+          if (Object.keys(rawSlot).length > 0) changed = true;
+        }
+        character.body = body;
+      }
+
+      delta[charName] = character;
+    }
+  }
+
+  return { changed, delta };
+}
+
 function mergeSlotDelta(
   current: BeholderSlotState | undefined,
   rawDelta: unknown,
@@ -283,6 +380,24 @@ function mergeSlotDelta(
         next.worn = mergeWornItems(next.worn, wornUpdates);
         used = true;
       }
+    }
+  }
+
+  // `worn_remove` names the garments coming off a slot. The single-prompt path
+  // never emits it (it clears a slot with `worn: []`), but the per-lane worn
+  // pass uses it for partial takeoff, so subtract by the same identity.
+  if (Array.isArray(rawDelta.worn_remove) && next.worn?.length) {
+    const removals = new Set(
+      rawDelta.worn_remove
+        .filter((entry): entry is string => typeof entry === "string")
+        .map((entry) => entry.trim().toLocaleLowerCase("en-US"))
+        .filter((entry) => entry.length > 0),
+    );
+    if (removals.size > 0) {
+      const kept = next.worn.filter((item) => !removals.has(wornItemIdentity(item)));
+      if (kept.length > 0) next.worn = kept;
+      else delete next.worn;
+      used = true;
     }
   }
 

--- a/packages/server/src/services/agents/beholder-state.ts
+++ b/packages/server/src/services/agents/beholder-state.ts
@@ -288,6 +288,20 @@ export function parseBeholderLanePrompts(template: unknown): Record<BeholderPass
   return BEHOLDER_PASS_LANES.every((lane) => prompts[lane]) ? (prompts as Record<BeholderPassLane, string>) : null;
 }
 
+/**
+ * True when a lane answered in the extraction contract: either `{changed:
+ * false}` or `{changed: true, delta: {...}}`. Anything else — an empty object,
+ * a bare array, a chat reply that happened to be valid JSON — is not a usable
+ * answer, and accepting it would let a lane that said nothing count towards the
+ * all-lanes-failed guard.
+ */
+export function isBeholderLaneResponse(value: unknown): boolean {
+  const parsed = parseMaybeJson(value);
+  if (!isRecord(parsed)) return false;
+  if (parsed.changed === false) return true;
+  return parsed.changed === true && isRecord(parsed.delta);
+}
+
 function mergeLaneSlot(target: Record<string, unknown>, incoming: Record<string, unknown>): void {
   for (const [field, value] of Object.entries(incoming)) {
     if (field === "worn_remove" && Array.isArray(target.worn_remove) && Array.isArray(value)) {

--- a/packages/server/src/services/agents/beholder-state.ts
+++ b/packages/server/src/services/agents/beholder-state.ts
@@ -386,7 +386,7 @@ function mergeSlotDelta(
   // `worn_remove` names the garments coming off a slot. The single-prompt path
   // never emits it (it clears a slot with `worn: []`), but the per-lane worn
   // pass uses it for partial takeoff, so subtract by the same identity.
-  if (Array.isArray(rawDelta.worn_remove) && next.worn?.length) {
+  if (Array.isArray(rawDelta.worn_remove)) {
     const removals = new Set(
       rawDelta.worn_remove
         .filter((entry): entry is string => typeof entry === "string")
@@ -394,9 +394,14 @@ function mergeSlotDelta(
         .filter((entry) => entry.length > 0),
     );
     if (removals.size > 0) {
-      const kept = next.worn.filter((item) => !removals.has(wornItemIdentity(item)));
-      if (kept.length > 0) next.worn = kept;
-      else delete next.worn;
+      // A removal that matches nothing still counts as a handled instruction:
+      // the slot is already in the requested state, and treating it as unused
+      // would make a lone "took the coat off" turn look like an empty delta.
+      if (next.worn?.length) {
+        const kept = next.worn.filter((item) => !removals.has(wornItemIdentity(item)));
+        if (kept.length > 0) next.worn = kept;
+        else delete next.worn;
+      }
       used = true;
     }
   }

--- a/scripts/regressions/beholder-lane-passes.regression.ts
+++ b/scripts/regressions/beholder-lane-passes.regression.ts
@@ -47,6 +47,11 @@ assert.equal(
   null,
   "A lane with an empty body must not be treated as a usable pass",
 );
+assert.equal(
+  parseBeholderLanePrompts(template.replace("[species]", "[worn]")),
+  null,
+  "A template repeating one heading while dropping another must not parse",
+);
 
 // Every lane reporting no change must produce a no-op, not a spurious update.
 const quiet = mergeBeholderLaneDeltas([{ changed: false }, { changed: false }, '{"changed": false}']);
@@ -78,6 +83,17 @@ assert.equal(self.body.left_foot.bare, true);
 // A lane that only carries empty exotic-slot stubs must not count as a change.
 const stubsOnly = mergeBeholderLaneDeltas([{ changed: true, delta: { self: { body: { tail: {} } } } }]);
 assert.equal(stubsOnly.changed, false, "Empty anatomy stubs alone are not a state change");
+
+// Two lane responses naming removals on the same slot concatenate rather than overwrite.
+const removals = mergeBeholderLaneDeltas([
+  { changed: true, delta: { self: { body: { chest: { worn_remove: ["coat"] } } } } },
+  { changed: true, delta: { self: { body: { chest: { worn_remove: ["shirt"] } } } } },
+]);
+assert.deepEqual(
+  (removals.delta.self as { body: Record<string, { worn_remove?: string[] }> }).body.chest.worn_remove,
+  ["coat", "shirt"],
+  "worn_remove arrays concatenate across lane responses instead of replacing",
+);
 
 // End to end: the unioned delta resolves against prior state through the normal path.
 const prior = {
@@ -117,3 +133,13 @@ assert.deepEqual(
   ["shirt"],
   "worn_remove drops the named garment by identity and keeps the others",
 );
+
+// A removal naming a garment that is not on the slot is still a handled turn,
+// not an "unusable delta" error — the slot already matches what was asked.
+const alreadyOff = resolveBeholderStateResponse(
+  { changed: true, delta: { Rissha: { body: { left_foot: { worn_remove: ["boot"] } } } } },
+  dressed,
+  "Rissha",
+);
+assert.equal(alreadyOff.valid, true, "A no-op removal must not invalidate the turn");
+assert.equal(alreadyOff.error, undefined);

--- a/scripts/regressions/beholder-lane-passes.regression.ts
+++ b/scripts/regressions/beholder-lane-passes.regression.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   BEHOLDER_PASS_LANES,
+  isBeholderLaneResponse,
   mergeBeholderLaneDeltas,
   parseBeholderLanePrompts,
   resolveBeholderStateResponse,
@@ -52,6 +53,17 @@ assert.equal(
   null,
   "A template repeating one heading while dropping another must not parse",
 );
+
+// Only a lane answering in the extraction contract counts as an answer: a lane
+// that returns valid JSON of the wrong shape must not stand in for a real reply.
+assert.equal(isBeholderLaneResponse({ changed: false }), true);
+assert.equal(isBeholderLaneResponse({ changed: true, delta: { self: {} } }), true);
+assert.equal(isBeholderLaneResponse('{"changed": false}'), true);
+assert.equal(isBeholderLaneResponse({}), false, "An empty object is not an answer");
+assert.equal(isBeholderLaneResponse({ changed: true }), false, "changed:true without a delta is not an answer");
+assert.equal(isBeholderLaneResponse([]), false);
+assert.equal(isBeholderLaneResponse("not json"), false);
+assert.equal(isBeholderLaneResponse(null), false);
 
 // Every lane reporting no change must produce a no-op, not a spurious update.
 const quiet = mergeBeholderLaneDeltas([{ changed: false }, { changed: false }, '{"changed": false}']);

--- a/scripts/regressions/beholder-lane-passes.regression.ts
+++ b/scripts/regressions/beholder-lane-passes.regression.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import {
+  BEHOLDER_PASS_LANES,
+  mergeBeholderLaneDeltas,
+  parseBeholderLanePrompts,
+  resolveBeholderStateResponse,
+} from "../../packages/server/src/services/agents/beholder-state.js";
+
+// A single-prompt template must not be mistaken for a multi-pass one.
+assert.equal(parseBeholderLanePrompts("You track characters' physical state. Return JSON."), null);
+assert.equal(parseBeholderLanePrompts(""), null);
+assert.equal(parseBeholderLanePrompts(undefined), null);
+assert.equal(
+  parseBeholderLanePrompts("[worn]\nonly one lane\n[wounds]\nsecond lane"),
+  null,
+  "A template missing lanes must fall back to the single-call path",
+);
+
+const template = [
+  "[worn]",
+  "Extract ONLY worn items.",
+  "",
+  "[wounds]",
+  "Extract ONLY wounds.",
+  "",
+  "[holding]",
+  "Extract ONLY held items.",
+  "",
+  "[species]",
+  "Extract ONLY species.",
+  "",
+  "[flags]",
+  "Extract ONLY bare and missing flags.",
+].join("\n");
+
+const lanes = parseBeholderLanePrompts(template);
+assert.ok(lanes, "A template carrying every lane heading must parse");
+assert.deepEqual(Object.keys(lanes).sort(), [...BEHOLDER_PASS_LANES].sort());
+assert.equal(lanes.worn, "Extract ONLY worn items.");
+assert.equal(lanes.flags, "Extract ONLY bare and missing flags.");
+assert.ok(
+  parseBeholderLanePrompts(template.replaceAll("[worn]", "  [worn]  ")),
+  "A lane heading tolerates surrounding whitespace on its own line",
+);
+assert.equal(
+  parseBeholderLanePrompts(template.replace("Extract ONLY species.", "")),
+  null,
+  "A lane with an empty body must not be treated as a usable pass",
+);
+
+// Every lane reporting no change must produce a no-op, not a spurious update.
+const quiet = mergeBeholderLaneDeltas([{ changed: false }, { changed: false }, '{"changed": false}']);
+assert.equal(quiet.changed, false);
+assert.deepEqual(quiet.delta, {});
+
+// The five narrow deltas union into one payload, including across separate slots.
+const merged = mergeBeholderLaneDeltas([
+  {
+    changed: true,
+    delta: { self: { body: { chest: { worn: [{ item: "gown", color: "white", damage: "pristine" }] } } } },
+  },
+  {
+    changed: true,
+    delta: { self: { body: { chest: { wounds: [{ text: "gash", severity: "serious", bleeding: true }] } } } },
+  },
+  { changed: true, delta: { self: { body: { right_hand: { holding: { item: "lantern" } } } } } },
+  { changed: true, delta: { self: { species: "angel", body: { tail: {} } } } },
+  { changed: true, delta: { self: { body: { left_foot: { bare: true } } } } },
+]);
+assert.equal(merged.changed, true);
+const self = merged.delta.self as { species?: string; body: Record<string, Record<string, unknown>> };
+assert.equal(self.species, "angel");
+assert.ok(Array.isArray(self.body.chest.worn), "The worn lane contributes worn items");
+assert.ok(Array.isArray(self.body.chest.wounds), "The wounds lane contributes wounds to the SAME slot");
+assert.deepEqual(self.body.right_hand.holding, { item: "lantern" });
+assert.equal(self.body.left_foot.bare, true);
+
+// A lane that only carries empty exotic-slot stubs must not count as a change.
+const stubsOnly = mergeBeholderLaneDeltas([{ changed: true, delta: { self: { body: { tail: {} } } } }]);
+assert.equal(stubsOnly.changed, false, "Empty anatomy stubs alone are not a state change");
+
+// End to end: the unioned delta resolves against prior state through the normal path.
+const prior = {
+  characters: [{ name: "Rissha", body: { chest: { worn: [{ item: "gown", color: "white", damage: "pristine" }] } } }],
+};
+const resolved = resolveBeholderStateResponse(merged, prior, "Rissha");
+assert.equal(resolved.valid, true);
+const rissha = resolved.state.characters.find((entry) => entry.name === "Rissha");
+assert.equal(rissha?.species, "angel", "`self` maps back onto the persona");
+assert.equal(rissha?.body.right_hand?.holding?.item, "lantern");
+assert.equal(rissha?.body.chest?.wounds?.length, 1);
+
+// worn_remove takes a named garment off the slot it occupied, leaving the rest.
+const dressed = {
+  characters: [
+    {
+      name: "Rissha",
+      body: {
+        chest: {
+          worn: [
+            { item: "coat", color: "black", damage: "pristine" },
+            { item: "shirt", color: "white", damage: "pristine" },
+          ],
+        },
+      },
+    },
+  ],
+};
+const undressed = resolveBeholderStateResponse(
+  { changed: true, delta: { Rissha: { body: { chest: { worn_remove: ["Coat"] } } } } },
+  dressed,
+  "Rissha",
+);
+assert.equal(undressed.valid, true);
+assert.deepEqual(
+  undressed.state.characters.find((entry) => entry.name === "Rissha")?.body.chest?.worn?.map((item) => item.item),
+  ["shirt"],
+  "worn_remove drops the named garment by identity and keeps the others",
+);


### PR DESCRIPTION
## Linked issue

Follow-up to #5204 (the delta protocol) — extends it so a locally hosted per-lane Beholder extractor can be used as well as a SOTA model. Stacked on #5241; review that first (this branch contains its commits).

## Why this change

Beholder currently issues one call asking for the whole physical state, which is right for a SOTA model. A **locally hosted Beholder model is trained per lane** — it answers about worn items, wounds, held items, species, or bare/missing flags one at a time. Handing it a single whole-state prompt is off-distribution for it, and it returns partial or malformed JSON.

This adds a second, opt-in execution shape so both kinds of model work behind the same agent, chosen by which prompt template the user picks.

## What changed

- `parseBeholderLanePrompts()` splits a prompt template that marks each lane with a `[worn]`, `[wounds]`, `[holding]`, `[species]`, or `[flags]` heading on its own line. **It returns `null` unless all five lanes are present with non-empty bodies**, so any ordinary single-prompt template falls through to the existing one-call path untouched.
- `executeBeholderLanePasses()` runs one call per lane with the same user message, then `mergeBeholderLaneDeltas()` unions the five narrow deltas into one `{changed, delta}` payload. The lanes own disjoint slot fields, so the union is field-level and conflict-free. The merged delta then goes through the **existing** `resolveBeholderStateResponse` path — nothing downstream changes.
- A lane that fails is logged and skipped rather than failing the turn; only an all-lane failure errors.
- `worn_remove` is now honoured in `mergeSlotDelta`: the worn lane emits it for partial takeoff (the single-prompt path only ever clears a slot with `worn: []`). Named garments are subtracted by the same identity `mergeWornItems` uses.
- The species lane's empty exotic-slot stubs (`{"tail": {}}`) are anatomy hints, not state, so they no longer mark a turn as changed.

No schema, storage, API, or client change. No new settings: the switch is the existing per-agent prompt-template selector, so a package can offer "single prompt" and "five passes" as two options.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Rather than tick boxes I did not earn: **I have not exercised this against a live model in the app.** `pnpm install` fails in my environment at the `onnxruntime-node` postinstall, so I could not run the full `pnpm check` or launch the app. A maintainer should confirm a real end-to-end turn before merge.

What I did verify locally, working around the broken install:

- **Typecheck is clean.** Ran `tsc -b ../shared && tsc --noEmit` for `packages/server` against this branch's own `packages/shared`: **0 errors**.
- **Prettier is clean** on both changed source files.
- **Added `scripts/regressions/beholder-lane-passes.regression.ts`** and ran it (exit 0). It covers: a single-prompt template and a partial template both parsing to `null` (i.e. the existing path is preserved); a full five-lane template parsing into its five prompts; whitespace-tolerant headings; an empty lane body rejected; all-lanes-quiet producing a no-op; the five deltas unioning across the same and different slots; empty anatomy stubs not counting as a change; the unioned delta resolving against prior state with `self` mapped back to the persona; and `worn_remove` dropping a named garment while keeping the others.
- The existing `beholder-wound-merge.regression.ts` from #5241 still passes.

Note that `pull-request-checks.yml` does not run the regression suite (only `regression:launcher-update` and `regression:android-local-auth`), so neither regression file executes in CI as things stand.

### Sequencing note

A package that offers a five-pass template must require an Engine version containing this change — otherwise the whole multi-lane template is sent as one system prompt. Happy to follow up in `Marinara-Agents` once this lands and the minimum version is known.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Beholder state extraction across equipment, wounds, inventory, species, and flags.
  * Multiple state sections can now be processed concurrently and combined into one result.
  * Selective removal of individual worn items is supported without clearing other equipment.
* **Bug Fixes**
  * Partial processing failures no longer discard successful state updates; errors occur only when all sections fail.
  * Empty, duplicate, invalid, or unchanged state sections are handled more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->