### PR TITLE
test(e2e): repair Storyboard cleanup contract

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -12402,7 +12402,7 @@ test("Illustrator owns the merged scene-video and Storyboard subsections while a
     await durationInput.blur();
     await expect(durationInput).toHaveValue("9");
     await durationControl.getByRole("button", { name: "Use agent default" }).click();
-    await expect(durationInput).toHaveValue("6");
+    await expect(durationInput).toHaveValue("5");
     await expect(durationControl.getByText("Using agent default", { exact: true })).toBeVisible();
     await expect(gameIllustratorCard.getByText("Attach Card Appearance", { exact: true })).toHaveCount(1);
     await expect(gameIllustratorCard.getByText("Send Avatar References", { exact: true })).toHaveCount(1);
@@ -12415,7 +12415,10 @@ test("Illustrator owns the merged scene-video and Storyboard subsections while a
     await expect(gameSceneVideosSubsection.locator("[data-agent-settings-subsection-header] > svg")).toHaveCount(0);
     expect(errors).toEqual([]);
   } finally {
-    await Promise.all([chat.id, gameChat.id].map((chatId) => request.delete(`/api/chats/${chatId}`)));
+    await Promise.all([
+      bestEffortDelete(request, `/api/chats/${chat.id}`),
+      bestEffortDelete(request, `/api/chats/${gameChat.id}?force=true`),
+    ]);
   }
 });
 


### PR DESCRIPTION
## Linked issue

Closes #5254

## Why this change

The desktop Storyboard Chat Settings E2E row encoded the obsolete animation-duration default and could leave its protected Game chat fixture behind after teardown.

## What changed

- Expect **Use agent default** to restore the shared duration default of `5`.
- Delete the Roleplay and Game fixtures concurrently with the existing non-throwing helper.
- Add explicit `force=true` confirmation only to the protected Game fixture deletion.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`
- [x] Exact desktop Chromium Storyboard E2E row passes on the final rebased commit

### Manual verification notes

- Ran Playwright project `desktop-chromium` with the exact title filter `Illustrator owns the merged scene-video and Storyboard subsections while agent removal stays away from collapse` on commit `0aef8e5c5d4b68d293d2daf890975608f2a12ce6`: `1 passed (43.8s)`.
- Used isolated client/server ports `60794`–`60797` and isolated Playwright storage.
- Confirmed no owned Node processes or listeners remained, removed generated Playwright output, and confirmed a clean worktree.
- Ran final-head `pnpm check` after normalizing the local checkout to LF line endings: formatting, lint, TypeScript checks, and production builds all passed.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable; this changes only an existing E2E assertion and teardown.
