### PR TITLE
Fix embedding endpoints and repeat launcher starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Embedding connections now accept either an OpenAI-compatible API base URL or the provider's full `/embeddings` endpoint, so documented NanoGPT and OpenRouter URLs no longer become a nonexistent doubled path (#5252).
+- Windows, macOS, and Linux launchers now recognize an already-running healthy Marinara server before updating or rebuilding, then reopen that instance instead of attempting a second storage writer; genuinely conflicting or unresponsive processes remain blocked to protect user data (#5256).
 - Locally hosted OpenAI-compatible models now honor Reasoning Effort set to Off, and JSON-returning Agent calls—including tool-assisted and batched runs—avoid exhausting their output budget on discarded thinking.
 - Mobile full-screen navigation now places the slightly larger Home icon first, opens Chats from the right like the resource tabs, swaps between Chats and resource tabs without replaying the entrance animation, deactivates Home while another surface is open, lets Home dismiss that surface and return to the Home page, and starts the draggable Music DJ control below Home bookmarks; the Characters tab underline now also matches its pink icon on mobile and desktop (#5248).
 - Docker update checks now recognize stable-to-Staging/UAT channel switches and show the correct `staging` image tag and host-side switch instructions instead of claiming the stable container is already current (#5249).

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "regression:professor-mari-shell-sandbox": "pnpm build:shared && node ./scripts/run-regressions.mjs --filter scripts/regressions/professor-mari/shell-sandbox.regression.ts",
     "regression:runtime-integrity": "pnpm build:shared && node ./scripts/run-regressions.mjs --filter scripts/regressions/runtime-integrity.regression.ts",
     "regression:static-cache": "node ./scripts/run-regressions.mjs --filter scripts/regressions/static-cache-headers.regression.ts",
-    "regression:launcher-update": "node ./scripts/regressions/pnpm-runner.regression.mjs && node ./scripts/regressions/launcher/env.regression.mjs && node ./scripts/regressions/launcher/update.regression.mjs && node ./scripts/regressions/dev-launcher-process.regression.mjs && node ./scripts/regressions/launcher/format-guard.regression.mjs && node ./scripts/check-windows-installer-layout.mjs",
+    "regression:launcher-update": "node ./scripts/regressions/pnpm-runner.regression.mjs && node ./scripts/regressions/launcher/env.regression.mjs && node ./scripts/regressions/launcher/existing-server.regression.mjs && node ./scripts/regressions/launcher/update.regression.mjs && node ./scripts/regressions/dev-launcher-process.regression.mjs && node ./scripts/regressions/launcher/format-guard.regression.mjs && node ./scripts/check-windows-installer-layout.mjs",
     "regression:android-local-auth:run": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/android-local-auth.regression.ts",
     "regression:android-local-auth": "pnpm build:shared && pnpm regression:android-local-auth:run",
     "smoke:ui": "pnpm regression:ui",

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -4393,7 +4393,7 @@
   "ui.connections.connectioneditor.openaiOrAnyCompatibleAudioSpeechEndpoint": "OpenAI or any compatible /v1/audio/speech endpoint.",
   "ui.connections.connectioneditor.openrouterAiModels": "openrouter.ai/models",
   "ui.connections.connectioneditor.optional": "Optional",
-  "ui.connections.connectioneditor.optionalASeparateBaseUrlForYourEmbeddingBackend": "Optional. A separate base URL for your embedding backend. Useful when running two instances of llama.cpp on different ports — one for chat, one for embeddings. Leave empty to use the connection's main URL.",
+  "ui.connections.connectioneditor.optionalASeparateBaseUrlForYourEmbeddingBackend": "Optional. Enter either the embedding API base URL, such as https://host/v1, or its full /embeddings endpoint. Leave empty to use this connection's main URL.",
   "ui.connections.connectioneditor.optionalConfigureTheEmbeddingSourceUsedForLorebookSemantic": "Optional. Configure the embedding source used for lorebook semantic search and memory recall.",
   "ui.connections.connectioneditor.optionalTypeAGrokCliModelIdOrLeave": "Optional: type a Grok CLI model ID, or leave blank for CLI default",
   "ui.connections.connectioneditor.optionalWhenRoleplayChatsUseThisConnectionMarinaraAssembles": "Optional. When roleplay chats use this connection, Marinara assembles this prompt preset instead of the chat's selected prompt preset. Conversation and game mode keep their built-in prompt flows.",

--- a/packages/client/src/localization/locales/ko.json
+++ b/packages/client/src/localization/locales/ko.json
@@ -3629,7 +3629,7 @@
   "ui.connections.connectioneditor.onlyUseUrlsFromProvidersYouTrustAMalicious": "신뢰하는 제공자의 URL만 사용하세요. 악성 엔드포인트가 메시지와 API 키를 가로챌 수 있습니다.",
   "ui.connections.connectioneditor.onOpenrouterThisCurrentlyTargetsClaudeModelsByAdding": "현재 OpenRouter에서는 최상위 cache_control을 추가하여 Claude 모델에 적용합니다. 캐시 읽기는 일반 프롬프트 토큰보다 훨씬 저렴하지만 첫 캐시 쓰기는 비용이 더 듭니다.",
   "ui.connections.connectioneditor.optional": "선택 사항",
-  "ui.connections.connectioneditor.optionalASeparateBaseUrlForYourEmbeddingBackend": "선택 사항입니다. 임베딩 백엔드에 사용할 별도의 기본 URL입니다. llama.cpp 인스턴스 두 개를 서로 다른 포트에서 실행하여 하나는 채팅, 하나는 임베딩에 사용할 때 유용합니다. 이 연결의 기본 URL을 사용하려면 비워 두세요.",
+  "ui.connections.connectioneditor.optionalASeparateBaseUrlForYourEmbeddingBackend": "선택 사항입니다. 임베딩 API 기본 URL(예: https://host/v1) 또는 전체 /embeddings 엔드포인트를 입력하세요. 비워 두면 이 연결의 기본 URL을 사용합니다.",
   "ui.connections.connectioneditor.optionalConfigureTheEmbeddingSourceUsedForLorebookSemantic": "선택 사항입니다. 로어북 시맨틱 검색과 기억 회상에 사용할 임베딩 소스를 구성하세요.",
   "ui.connections.connectioneditor.optionalTypeAGrokCliModelIdOrLeave": "선택 사항: Grok CLI 모델 ID를 입력하거나 CLI 기본값을 사용하려면 비워 두세요",
   "ui.connections.connectioneditor.optionalWhenRoleplayChatsUseThisConnectionMarinaraAssembles": "선택 사항입니다. 롤플레이 채팅에서 이 연결을 사용하면 Marinara는 채팅에서 선택한 프롬프트 프리셋 대신 이 프롬프트 프리셋을 구성합니다. 대화(콘보)와 게임 모드는 내장 프롬프트 흐름을 그대로 유지합니다.",

--- a/packages/client/src/localization/locales/zh-Hans.json
+++ b/packages/client/src/localization/locales/zh-Hans.json
@@ -4258,7 +4258,7 @@
   "ui.connections.connectioneditor.onOpenrouterThisCurrentlyTargetsClaudeModelsByAdding": "在 OpenRouter 上，目前会通过添加顶层 cache_control 作用于 Claude 模型。读取缓存远比普通提示词 token 便宜，但首次写入缓存费用更高。",
   "ui.connections.connectioneditor.openrouterAiModels": "openrouter.ai/models",
   "ui.connections.connectioneditor.optional": "可选",
-  "ui.connections.connectioneditor.optionalASeparateBaseUrlForYourEmbeddingBackend": "可选。嵌入后端的独立基础 URL。适合在不同端口运行两个 llama.cpp 实例：一个用于聊天，一个用于嵌入。留空则使用此连接的主 URL。",
+  "ui.connections.connectioneditor.optionalASeparateBaseUrlForYourEmbeddingBackend": "可选。输入嵌入 API 基础 URL（例如 https://host/v1）或完整的 /embeddings 端点。留空则使用此连接的主 URL。",
   "ui.connections.connectioneditor.optionalConfigureTheEmbeddingSourceUsedForLorebookSemantic": "可选。配置世界书语义搜索和记忆检索所用的嵌入来源。",
   "ui.connections.connectioneditor.optionalTypeAGrokCliModelIdOrLeave": "可选：输入 Grok CLI 模型 ID，或留空使用 CLI 默认值",
   "ui.connections.connectioneditor.optionalWhenRoleplayChatsUseThisConnectionMarinaraAssembles": "可选。当角色扮演聊天使用此连接时，Marinara 会组装此提示词预设，而不是聊天所选的提示词预设。对话和游戏模式仍使用各自内置的提示词流程。",

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -102,6 +102,14 @@ export function llmHttpErrorFromResponse(message: string, response: Response): L
   });
 }
 
+/** Accept either an OpenAI-compatible API base URL or its full embeddings endpoint. */
+export function resolveEmbeddingEndpointUrl(baseUrl: string): string {
+  const endpoint = new URL(baseUrl.trim());
+  const pathname = endpoint.pathname.replace(/\/+$/u, "");
+  endpoint.pathname = /\/embeddings$/iu.test(pathname) ? pathname : `${pathname}/embeddings`;
+  return endpoint.toString();
+}
+
 /**
  * True when an error is a provider rate-limit / transient-overload the caller should pause and
  * retry rather than surface: HTTP 429 (rate limited) or 529 (Anthropic "overloaded").
@@ -802,7 +810,7 @@ export abstract class BaseLLMProvider {
       "Content-Type": "application/json",
       Authorization: `Bearer ${this.apiKey}`,
     };
-    const res = await llmFetch(`${this.baseUrl}/embeddings`, {
+    const res = await llmFetch(resolveEmbeddingEndpointUrl(this.baseUrl), {
       method: "POST",
       headers,
       body: JSON.stringify({ input: texts, model }),

--- a/scripts/check-port-available.mjs
+++ b/scripts/check-port-available.mjs
@@ -3,11 +3,39 @@ import { createServer } from "node:net";
 const rawPort = process.env.PORT ?? "7860";
 const port = Number.parseInt(rawPort, 10);
 const host = process.env.HOST ?? "0.0.0.0";
+const protocol = process.env.SSL_CERT && process.env.SSL_KEY ? "https" : "http";
+const browserHost = host === "" || host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
+const urlHost = browserHost.includes(":") && !browserHost.startsWith("[") ? `[${browserHost}]` : browserHost;
+const browserUrl = `${protocol}://${urlHost}:${rawPort}`;
+
+async function findRunningMarinara() {
+  try {
+    const response = await fetch(`${browserUrl}/api/health`, {
+      signal: AbortSignal.timeout(1_500),
+    });
+    if (!response.ok) return null;
+    const health = await response.json();
+    if (
+      !health ||
+      typeof health !== "object" ||
+      health.status !== "ok" ||
+      typeof health.version !== "string" ||
+      typeof health.build !== "string"
+    ) {
+      return null;
+    }
+    return health;
+  } catch {
+    return null;
+  }
+}
 
 function printPortBusyMessage() {
   console.error("");
   console.error(`  [ERROR] Port ${rawPort} is already in use.`);
-  console.error("  Marinara Engine did not start, and the browser was not opened to avoid showing another local service.");
+  console.error(
+    "  Marinara Engine did not start, and the browser was not opened to avoid showing another local service.",
+  );
   console.error("  Close the app using that port or start Marinara on another port:");
   console.error("");
   console.error("    macOS/Linux:       PORT=7869 bash ./start.sh");
@@ -21,6 +49,12 @@ if (!Number.isFinite(port) || port <= 0 || port > 65_535) {
   console.error(`  [ERROR] PORT must be a number from 1 to 65535. Received: ${rawPort}`);
   console.error("");
   process.exit(1);
+}
+
+const runningMarinara = await findRunningMarinara();
+if (runningMarinara) {
+  console.log(`  [OK] Marinara Engine ${runningMarinara.build} is already running at ${browserUrl}`);
+  process.exit(2);
 }
 
 const server = createServer();

--- a/scripts/regressions/launcher/existing-server.regression.mjs
+++ b/scripts/regressions/launcher/existing-server.regression.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const checkerPath = join(repositoryRoot, "scripts/check-port-available.mjs");
+
+function listen(server) {
+  return new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+}
+
+function close(server) {
+  return new Promise((resolveClose, reject) => server.close((error) => (error ? reject(error) : resolveClose())));
+}
+
+function runChecker(port) {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(process.execPath, [checkerPath], {
+      cwd: repositoryRoot,
+      env: { ...process.env, HOST: "127.0.0.1", PORT: String(port), SSL_CERT: "", SSL_KEY: "" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8").on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.setEncoding("utf8").on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("close", (status) => resolveRun({ status, stdout, stderr }));
+  });
+}
+
+const healthyServer = createServer((request, response) => {
+  if (request.url === "/api/health") {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ status: "ok", version: "2.4.4", build: "v2.4.4 regression" }));
+    return;
+  }
+  response.writeHead(404).end();
+});
+await listen(healthyServer);
+const healthyAddress = healthyServer.address();
+assert.ok(healthyAddress && typeof healthyAddress === "object");
+const healthyResult = await runChecker(healthyAddress.port);
+assert.equal(healthyResult.status, 2, healthyResult.stderr);
+assert.match(healthyResult.stdout, /Marinara Engine v2\.4\.4 regression is already running/u);
+await close(healthyServer);
+
+const unrelatedServer = createServer((_request, response) => {
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify({ status: "ok" }));
+});
+await listen(unrelatedServer);
+const unrelatedAddress = unrelatedServer.address();
+assert.ok(unrelatedAddress && typeof unrelatedAddress === "object");
+const unrelatedResult = await runChecker(unrelatedAddress.port);
+assert.equal(unrelatedResult.status, 1);
+assert.match(unrelatedResult.stderr, /Port \d+ is already in use/u);
+await close(unrelatedServer);
+
+const freeResult = await runChecker(unrelatedAddress.port);
+assert.equal(freeResult.status, 0, freeResult.stderr);
+
+for (const launcherPath of ["start.bat", "start.sh"]) {
+  const source = readFileSync(join(repositoryRoot, launcherPath), "utf8");
+  const firstPortCheck = source.indexOf("check_launch_port");
+  const updateCheck = source.indexOf("Checking for updates");
+  assert.ok(
+    firstPortCheck >= 0 && firstPortCheck < updateCheck,
+    `${launcherPath} must reuse the server before updates`,
+  );
+  assert.match(source, /Reopening the running Marinara Engine instance/u);
+}
+
+console.log("Existing-server launcher regressions passed.");

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -44,6 +44,7 @@ import {
 } from "../../packages/server/src/services/llm/connection-fallback-provider.js";
 import {
   BaseLLMProvider,
+  resolveEmbeddingEndpointUrl,
   type ChatMessage,
   type ChatOptions,
   type LLMUsage,
@@ -149,6 +150,15 @@ const gatewaySseBody = [
 assert.equal(resolveNovelAiStyleReferenceSecondaryStrength(1), 0);
 assert.equal(resolveNovelAiStyleReferenceSecondaryStrength(0.75), 0.25);
 assert.equal(resolveNovelAiStyleReferenceSecondaryStrength(0), 1);
+assert.equal(resolveEmbeddingEndpointUrl("https://openrouter.ai/api/v1"), "https://openrouter.ai/api/v1/embeddings");
+assert.equal(
+  resolveEmbeddingEndpointUrl("https://nano-gpt.com/api/v1/embeddings"),
+  "https://nano-gpt.com/api/v1/embeddings",
+);
+assert.equal(
+  resolveEmbeddingEndpointUrl("https://example.com/v1/embeddings/?source=memory"),
+  "https://example.com/v1/embeddings?source=memory",
+);
 const gatewayServer = createServer((_request, response) => {
   response.writeHead(200, { "content-type": "text/event-stream" });
   response.end(gatewaySseBody);

--- a/start.bat
+++ b/start.bat
@@ -51,6 +51,35 @@ if !NODE_MAJOR! LSS 24 (
     exit /b 1
 )
 
+:: Resolve the browser URL before update/install work so repeat shortcut launches
+:: can reopen a healthy server immediately.
+set NODE_ENV=production
+if not defined PORT set PORT=7860
+if not defined HOST set HOST=0.0.0.0
+if not defined SIDECAR_RUNTIME_INSTALL_ENABLED set SIDECAR_RUNTIME_INSTALL_ENABLED=true
+
+set PROTOCOL=http
+if defined SSL_CERT if defined SSL_KEY set PROTOCOL=https
+set "BROWSER_HOST=%HOST%"
+if "%BROWSER_HOST%"=="" set "BROWSER_HOST=127.0.0.1"
+if "%BROWSER_HOST%"=="0.0.0.0" set "BROWSER_HOST=127.0.0.1"
+if "%BROWSER_HOST%"=="::" set "BROWSER_HOST=127.0.0.1"
+
+set "AUTO_OPEN_BROWSER_ENABLED=1"
+if defined AUTO_OPEN_BROWSER (
+    if /I "%AUTO_OPEN_BROWSER%"=="0" set "AUTO_OPEN_BROWSER_ENABLED="
+    if /I "%AUTO_OPEN_BROWSER%"=="false" set "AUTO_OPEN_BROWSER_ENABLED="
+    if /I "%AUTO_OPEN_BROWSER%"=="no" set "AUTO_OPEN_BROWSER_ENABLED="
+    if /I "%AUTO_OPEN_BROWSER%"=="off" set "AUTO_OPEN_BROWSER_ENABLED="
+)
+
+call :check_launch_port
+if errorlevel 2 goto :existing_server
+if errorlevel 1 (
+    pause
+    exit /b 1
+)
+
 :: Resolve the exact repo-pinned pnpm before any install path uses it.
 call :resolve_pnpm_runner
 if errorlevel 1 (
@@ -59,6 +88,10 @@ if errorlevel 1 (
 )
 
 goto :after_restore_helper
+
+:check_launch_port
+node scripts\check-port-available.mjs
+exit /b !errorlevel!
 
 :restore_stashed_changes
 if not "!STASHED!"=="1" goto :eof
@@ -333,32 +366,25 @@ if "!BUILD_REQUIRED!"=="1" (
 
 :: Database migrations are handled automatically at server startup by runMigrations()
 
-:: Set defaults only if not already set
-set NODE_ENV=production
-if not defined PORT set PORT=7860
-if not defined HOST set HOST=0.0.0.0
-if not defined SIDECAR_RUNTIME_INSTALL_ENABLED set SIDECAR_RUNTIME_INSTALL_ENABLED=true
-
-set PROTOCOL=http
-if defined SSL_CERT if defined SSL_KEY set PROTOCOL=https
-set "BROWSER_HOST=%HOST%"
-if "%BROWSER_HOST%"=="" set "BROWSER_HOST=127.0.0.1"
-if "%BROWSER_HOST%"=="0.0.0.0" set "BROWSER_HOST=127.0.0.1"
-if "%BROWSER_HOST%"=="::" set "BROWSER_HOST=127.0.0.1"
-
-set "AUTO_OPEN_BROWSER_ENABLED=1"
-if defined AUTO_OPEN_BROWSER (
-    if /I "%AUTO_OPEN_BROWSER%"=="0" set "AUTO_OPEN_BROWSER_ENABLED="
-    if /I "%AUTO_OPEN_BROWSER%"=="false" set "AUTO_OPEN_BROWSER_ENABLED="
-    if /I "%AUTO_OPEN_BROWSER%"=="no" set "AUTO_OPEN_BROWSER_ENABLED="
-    if /I "%AUTO_OPEN_BROWSER%"=="off" set "AUTO_OPEN_BROWSER_ENABLED="
-)
-
-node scripts\check-port-available.mjs
+call :check_launch_port
+if errorlevel 2 goto :existing_server
 if errorlevel 1 (
     pause
-    goto :eof
+    exit /b 1
 )
+
+goto :start_server
+
+:existing_server
+if defined AUTO_OPEN_BROWSER_ENABLED (
+    echo  [OK] Reopening the running Marinara Engine instance...
+    start "" "%PROTOCOL%://%BROWSER_HOST%:%PORT%" || explorer "%PROTOCOL%://%BROWSER_HOST%:%PORT%"
+) else (
+    echo  [OK] Marinara Engine is already running. Auto-open is disabled ^(AUTO_OPEN_BROWSER=%AUTO_OPEN_BROWSER%^)
+)
+exit /b 0
+
+:start_server
 
 echo.
 echo  ==========================================

--- a/start.sh
+++ b/start.sh
@@ -68,6 +68,47 @@ case "$AUTO_UPDATE_ENABLED_NORMALIZED" in
   *) AUTO_UPDATE_DISABLED=0 ;;
 esac
 
+# Resolve the browser URL before update/install work so repeat launcher runs
+# can reopen a healthy server immediately.
+export NODE_ENV=production
+export PORT=${PORT:-7860}
+export HOST=${HOST:-0.0.0.0}
+
+if [ -n "$SSL_CERT" ] && [ -n "$SSL_KEY" ]; then
+  PROTOCOL=https
+else
+  PROTOCOL=http
+fi
+
+BROWSER_HOST="$HOST"
+case "$BROWSER_HOST" in
+  ""|"0.0.0.0"|"::") BROWSER_HOST="127.0.0.1" ;;
+esac
+
+AUTO_OPEN_BROWSER_VALUE="${AUTO_OPEN_BROWSER:-true}"
+AUTO_OPEN_BROWSER_NORMALIZED=$(printf '%s' "$AUTO_OPEN_BROWSER_VALUE" | tr '[:upper:]' '[:lower:]')
+case "$AUTO_OPEN_BROWSER_NORMALIZED" in
+  0|false|no|off) AUTO_OPEN_BROWSER_ENABLED=0 ;;
+  *) AUTO_OPEN_BROWSER_ENABLED=1 ;;
+esac
+
+check_launch_port() {
+  local port_check_status=0
+  node scripts/check-port-available.mjs || port_check_status=$?
+  if [ "$port_check_status" = "2" ]; then
+    if [ "$AUTO_OPEN_BROWSER_ENABLED" = "1" ]; then
+      echo "  [OK] Reopening the running Marinara Engine instance..."
+      (open "${PROTOCOL}://${BROWSER_HOST}:$PORT" 2>/dev/null || xdg-open "${PROTOCOL}://${BROWSER_HOST}:$PORT" 2>/dev/null) &
+    else
+      echo "  [OK] Marinara Engine is already running. Auto-open is disabled (AUTO_OPEN_BROWSER=${AUTO_OPEN_BROWSER_VALUE})"
+    fi
+    exit 0
+  fi
+  return "$port_check_status"
+}
+
+check_launch_port || exit 1
+
 # ── Check pnpm ──
 PNPM_VERSION=""
 PNPM_DESCRIPTOR=""
@@ -380,31 +421,7 @@ fi
 
 # ── Start ──
 
-export NODE_ENV=production
-export PORT=${PORT:-7860}
-export HOST=${HOST:-0.0.0.0}
-
-if [ -n "$SSL_CERT" ] && [ -n "$SSL_KEY" ]; then
-  PROTOCOL=https
-else
-  PROTOCOL=http
-fi
-
-BROWSER_HOST="$HOST"
-case "$BROWSER_HOST" in
-  ""|"0.0.0.0"|"::") BROWSER_HOST="127.0.0.1" ;;
-esac
-
-AUTO_OPEN_BROWSER_VALUE="${AUTO_OPEN_BROWSER:-true}"
-AUTO_OPEN_BROWSER_NORMALIZED=$(printf '%s' "$AUTO_OPEN_BROWSER_VALUE" | tr '[:upper:]' '[:lower:]')
-case "$AUTO_OPEN_BROWSER_NORMALIZED" in
-  0|false|no|off) AUTO_OPEN_BROWSER_ENABLED=0 ;;
-  *) AUTO_OPEN_BROWSER_ENABLED=1 ;;
-esac
-
-if ! node scripts/check-port-available.mjs; then
-  exit 1
-fi
+check_launch_port || exit 1
 
 echo ""
 echo "  ══════════════════════════════════════════"


### PR DESCRIPTION
## Linked issue

Closes #5252
Closes #5256

## Why this change

- NanoGPT and OpenRouter document complete `/embeddings` URLs, but the Engine always appended another `/embeddings`, producing a 404.
- Launching an installed copy while its server was already running performed update and build work before checking the port, then could attempt a second writer instead of reopening the existing app.

## What changed

- Accept either an embedding API base URL or a complete `/embeddings` endpoint and clarify the connection helper text.
- Probe the configured port before launcher update/install work and reopen a healthy Marinara instance on repeat launches.
- Keep unknown and unresponsive port occupants blocked, preserving the existing single-writer data guard.
- Add focused provider and launcher regressions plus Unreleased changelog entries.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated regression verifies API base URLs, complete `/embeddings` URLs, a healthy Marinara port occupant, an unrelated port occupant, and a newly freed port.
- Manually verify a second Windows shortcut launch reopens the already-running app.
- Manually verify an unrelated service on the configured port remains blocked and is not opened.
- Manually verify NanoGPT and OpenRouter memory vectorization with each provider's documented full embedding endpoint.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Copy-only clarification in the existing Embedding Endpoint URL field; no layout change.
