### PR TITLE
Stream prepared backups directly to Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Safari backup downloads now stream the prepared ZIP directly through the browser instead of buffering the entire archive in page memory; a short-lived one-time download capability preserves remote and Docker admin protection without exposing the reusable admin secret (#5259).
 - Embedding connections now accept either an OpenAI-compatible API base URL or the provider's full `/embeddings` endpoint, so documented NanoGPT and OpenRouter URLs no longer become a nonexistent doubled path (#5252).
 - Windows, macOS, and Linux launchers now recognize an already-running healthy Marinara server before updating or rebuilding, then reopen that instance instead of attempting a second storage writer; genuinely conflicting or unresponsive processes remain blocked to protect user data (#5256).
 - Locally hosted OpenAI-compatible models now honor Reasoning Effort set to Off, and JSON-returning Agent calls—including tool-assisted and batched runs—avoid exhausting their output budget on discarded thinking.

--- a/docs/data/backup-and-restore.md
+++ b/docs/data/backup-and-restore.md
@@ -28,10 +28,8 @@ From a phone, tablet, or any other device, backup and restore need the **Admin A
 3. Find the **Backup & Export** section.
 4. Click **Download Backup**.
 5. The button shows **Creating backup…** while it works.
-6. On desktop Chrome or Edge, a **Save As** dialog opens so you pick where the file goes. Choose a folder and save.
-7. You should see **Backup saved!** or **Backup downloaded!** when it finishes.
-
-On some browsers the **Save As** dialog is not available. In that case the file goes to your normal Downloads folder instead.
+6. When the archive is ready, Marinara streams it straight to your browser without holding the whole file in page memory.
+7. Your browser either opens its normal **Save As** dialog or puts the file in your Downloads folder, depending on your download settings.
 
 This step matters most on Android and iOS. On those devices the app's own data folder is usually not reachable. That makes **Download Backup** the only easy way to get a copy off the device. Save it somewhere safe and private, like your own cloud storage.
 

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -1593,23 +1593,6 @@ const EXPUNGE_SCOPE_OPTIONS: Array<{ id: ExpungeScope; label: string; descriptio
   },
 ];
 
-async function readSettingsResponseError(res: Response, fallback: string) {
-  const contentType = res.headers.get("content-type") ?? "";
-
-  try {
-    if (contentType.includes("application/json")) {
-      const payload = (await res.json()) as { error?: unknown; message?: unknown };
-      const message = typeof payload.message === "string" ? payload.message : payload.error;
-      return typeof message === "string" && message.trim() ? message : fallback;
-    }
-
-    const text = (await res.text()).trim();
-    return text ? text.slice(0, 500) : fallback;
-  } catch {
-    return fallback;
-  }
-}
-
 function formatStorageBytes(bytes: number): string {
   const safeBytes = Math.max(0, Number.isFinite(bytes) ? bytes : 0);
   if (safeBytes < 1_000) {

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -7482,20 +7482,20 @@ function AdvancedSettings() {
   const [creatingBackup, setCreatingBackup] = useState(false);
 
   /**
-   * Download a full backup to a user-chosen location.
-   *
-   * Uses the File System Access API (`showSaveFilePicker`) when available so
-   * the browser opens a native "Save As" dialog — this is important on Android
-   * and iOS, where the server-side `data/backups/` folder isn't reachable
-   * without root. Falls back to an anchor-triggered download (which routes
-   * through the browser's default Downloads handling).
+   * Prepare a full backup, then hand its finished stream directly to the browser.
+   * Keeping the archive out of a page-held Blob lets Safari and memory-limited
+   * mobile browsers save large backups through their normal download handling.
    */
   const handleCreateBackup = async () => {
     setCreatingBackup(true);
     try {
       const started = await api.post<{ jobId: string; status: "preparing" }>("/backup/download/start");
       const deadline = Date.now() + 60 * 60 * 1_000;
-      let status: { status: "preparing" | "ready" | "failed"; error?: string } = { status: started.status };
+      let status: {
+        status: "preparing" | "ready" | "failed";
+        error?: string;
+        downloadUrl?: string;
+      } = { status: started.status };
       while (status.status === "preparing") {
         if (Date.now() >= deadline) {
           throw new Error(localizeUi("ui.panels.advancedsettings.backupPreparationTimedOut"));
@@ -7506,65 +7506,12 @@ function AdvancedSettings() {
       if (status.status === "failed") {
         throw new Error(status.error || localizeUi("ui.panels.advancedsettings.failedToCreateBackup"));
       }
-
-      const res = await api.raw(`/backup/download/file/${encodeURIComponent(started.jobId)}`);
-      if (!res.ok) {
-        throw new Error(
-          await readSettingsResponseError(res, localizeUi("ui.panels.advancedsettings.failedToCreateBackup")),
-        );
+      if (!status.downloadUrl) {
+        throw new Error(localizeUi("ui.panels.advancedsettings.failedToCreateBackup"));
       }
 
-      // Pull the filename from Content-Disposition if provided
-      const disposition = res.headers.get("content-disposition") ?? "";
-      const filenameMatch = disposition.match(/filename="?([^"]+)"?/i);
-      const timestamp = new Date().toISOString().replace(/[:.]/g, "-").replace("T", "_").slice(0, 19);
-      const suggestedName = filenameMatch?.[1] ?? `marinara-backup-${timestamp}.zip`;
-
-      const blob = await res.blob();
-
-      // Preferred path: native "Save As" dialog (Chromium desktop, some Android)
-      const w = window as typeof window & {
-        showSaveFilePicker?: (options: {
-          suggestedName?: string;
-          types?: Array<{ description?: string; accept: Record<string, string[]> }>;
-        }) => Promise<{
-          createWritable: () => Promise<{ write: (data: Blob) => Promise<void>; close: () => Promise<void> }>;
-        }>;
-      };
-      if (typeof w.showSaveFilePicker === "function") {
-        try {
-          const handle = await w.showSaveFilePicker({
-            suggestedName,
-            types: [
-              {
-                description: "Marinara backup archive",
-                accept: { "application/zip": [".zip"] },
-              },
-            ],
-          });
-          const writable = await handle.createWritable();
-          await writable.write(blob);
-          await writable.close();
-          toast.success(localizeUi("ui.panels.advancedsettings.backupSaved"));
-          qc.invalidateQueries({ queryKey: ["backups"] });
-          return;
-        } catch (err) {
-          // User cancelled the native picker — treat as a silent no-op
-          if (err instanceof DOMException && err.name === "AbortError") return;
-          // Any other failure falls through to the anchor fallback
-        }
-      }
-
-      // Fallback: anchor download. On Android Chrome this routes through the
-      // system Downloads handler (which typically prompts the user or drops
-      // the file in the Downloads folder, both of which are user-accessible).
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = suggestedName;
-      a.click();
-      URL.revokeObjectURL(url);
-      toast.success(localizeUi("ui.panels.advancedsettings.backupDownloaded"));
+      window.location.assign(status.downloadUrl);
+      toast.success(localizeUi("ui.panels.advancedsettings.backupDownloadStarted"));
       qc.invalidateQueries({ queryKey: ["backups"] });
     } catch (err) {
       toast.error(err instanceof Error ? err.message : localizeUi("ui.panels.advancedsettings.failedToCreateBackup"));

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -7066,6 +7066,7 @@
   "ui.panels.advancedsettings.automaticBackupWillBeCreatedShortly": "The first automatic backup will be created shortly.",
   "ui.panels.advancedsettings.backupDeleted": "Backup deleted",
   "ui.panels.advancedsettings.backupDownloaded": "Backup downloaded!",
+  "ui.panels.advancedsettings.backupDownloadStarted": "Backup ready. Download started.",
   "ui.panels.advancedsettings.backupPreparationTimedOut": "Backup preparation timed out after one hour.",
   "ui.panels.advancedsettings.backupSaved": "Backup saved!",
   "ui.panels.advancedsettings.branch": "Branch:",

--- a/packages/server/src/middleware/privileged-gate.ts
+++ b/packages/server/src/middleware/privileged-gate.ts
@@ -16,7 +16,12 @@ export function isAdminAuthorized(request: FastifyRequest): boolean {
 export function requirePrivilegedAccess(
   request: FastifyRequest,
   reply: FastifyReply,
-  options: { loopbackOnly?: boolean; trustedNetwork?: boolean; feature?: string } = {},
+  options: {
+    loopbackOnly?: boolean;
+    trustedNetwork?: boolean;
+    feature?: string;
+    oneTimeCapabilityAuthorized?: boolean;
+  } = {},
 ): boolean {
   if (!isRequestHostTrusted(request)) {
     reply.status(421).send({
@@ -49,6 +54,10 @@ export function requirePrivilegedAccess(
   if (options.trustedNetwork && (isInIpAllowlist(request.ip) || isTrustedInterfaceRequest(request))) {
     return true;
   }
+
+  // A route-scoped, single-use capability may replace the reusable admin secret,
+  // but never the trusted-host or normal-authentication checks above.
+  if (options.oneTimeCapabilityAuthorized) return true;
 
   if (!getAdminSecret()) {
     reply.status(403).send({

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -3512,7 +3512,7 @@ export async function backupRoutes(app: FastifyInstance) {
 
   app.get<{ Params: { jobId: string }; Querystring: { token?: string } }>(
     "/download/file/:jobId",
-    { config: { rateLimit: BACKUP_RATE_LIMIT } },
+    { exposeHeadRoute: false, config: { rateLimit: BACKUP_RATE_LIMIT } },
     async (req, reply) => {
       const jobId = req.params.jobId;
       const job = backupDownloadJobs.get(jobId);

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -10,7 +10,7 @@ import type { FileHandle } from "fs/promises";
 import { tmpdir } from "os";
 import { pipeline } from "stream/promises";
 import { StringDecoder } from "string_decoder";
-import { createHash, randomUUID } from "crypto";
+import { createHash, randomBytes, randomUUID } from "crypto";
 import { inflateRawSync } from "zlib";
 import AdmZip from "adm-zip";
 import { FILE_BACKED_TABLES } from "../db/file-backed-store.js";
@@ -35,7 +35,7 @@ import { normalizeTimestampOverrides } from "../services/import/import-timestamp
 import { flushDB, type DB } from "../db/connection.js";
 import { requirePrivilegedAccess } from "../middleware/privileged-gate.js";
 import { BACKUP_RATE_LIMIT } from "../middleware/rate-limit.js";
-import { assertInsideDir } from "../utils/security.js";
+import { assertInsideDir, safeCompareString } from "../utils/security.js";
 import { logger } from "../lib/logger.js";
 import { crc32Buffer, finishCrc32, updateCrc32State } from "../utils/crc32.js";
 import { ENCRYPTED_WEBHOOK_PREFIX, encryptCustomToolWebhookUrl } from "../utils/custom-tool-webhook.js";
@@ -165,6 +165,14 @@ type AutomaticBackupSettings = {
   lastError: string | null;
   lastOmittedEntries: string[];
 };
+
+export function buildPreparedBackupDownloadUrl(jobId: string, token: string): string {
+  return `/api/backup/download/file/${encodeURIComponent(jobId)}?token=${encodeURIComponent(token)}`;
+}
+
+export function isPreparedBackupDownloadTokenValid(expected: string, provided: unknown): boolean {
+  return typeof provided === "string" && provided.length > 0 && safeCompareString(provided, expected);
+}
 
 export function limitAutomaticBackupOmissionHistory(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
@@ -3208,6 +3216,7 @@ export async function backupRoutes(app: FastifyInstance) {
     size?: number;
     omittedCount?: number;
     error?: string;
+    downloadToken: string;
   };
   const backupDownloadJobs = new Map<string, BackupDownloadJob>();
   let activeBackupDownloadJobId: string | null = null;
@@ -3452,6 +3461,7 @@ export async function backupRoutes(app: FastifyInstance) {
       tempDir,
       archivePath,
       createdAt: Date.now(),
+      downloadToken: randomBytes(32).toString("base64url"),
     };
     backupDownloadJobs.set(jobId, job);
 
@@ -3488,19 +3498,28 @@ export async function backupRoutes(app: FastifyInstance) {
       return reply.send({
         status: job.status,
         filename: `${job.backupName}.zip`,
-        ...(job.status === "ready" ? { size: job.size, omittedCount: job.omittedCount ?? 0 } : {}),
+        ...(job.status === "ready"
+          ? {
+              size: job.size,
+              omittedCount: job.omittedCount ?? 0,
+              downloadUrl: buildPreparedBackupDownloadUrl(req.params.jobId, job.downloadToken),
+            }
+          : {}),
         ...(job.status === "failed" ? { error: job.error ?? "Backup download failed" } : {}),
       });
     },
   );
 
-  app.get<{ Params: { jobId: string } }>(
+  app.get<{ Params: { jobId: string }; Querystring: { token?: string } }>(
     "/download/file/:jobId",
     { config: { rateLimit: BACKUP_RATE_LIMIT } },
     async (req, reply) => {
-      if (!requirePrivilegedAccess(req, reply, { feature: "Backup download" })) return;
       const jobId = req.params.jobId;
       const job = backupDownloadJobs.get(jobId);
+      const oneTimeCapabilityAuthorized = job
+        ? isPreparedBackupDownloadTokenValid(job.downloadToken, req.query.token)
+        : false;
+      if (!requirePrivilegedAccess(req, reply, { feature: "Backup download", oneTimeCapabilityAuthorized })) return;
       if (!job) return reply.status(404).send({ error: "Backup download job not found or expired" });
       if (job.status === "failed") return reply.status(500).send({ error: job.error ?? "Backup download failed" });
       if (job.status !== "ready" || job.size === undefined) {

--- a/scripts/regressions/backup-download-handoff.regression.ts
+++ b/scripts/regressions/backup-download-handoff.regression.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildPreparedBackupDownloadUrl,
+  isPreparedBackupDownloadTokenValid,
+} from "../../packages/server/src/routes/backup.routes.js";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const jobId = "job/id";
+const token = "token+value";
+
+assert.equal(buildPreparedBackupDownloadUrl(jobId, token), "/api/backup/download/file/job%2Fid?token=token%2Bvalue");
+assert.equal(isPreparedBackupDownloadTokenValid(token, token), true);
+assert.equal(isPreparedBackupDownloadTokenValid(token, "wrong-token"), false);
+assert.equal(isPreparedBackupDownloadTokenValid(token, undefined), false);
+
+const settingsPanelSource = readFileSync(
+  join(repositoryRoot, "packages/client/src/components/panels/SettingsPanel.tsx"),
+  "utf8",
+);
+const handlerStart = settingsPanelSource.indexOf("const handleCreateBackup = async () =>");
+const handlerEnd = settingsPanelSource.indexOf("const { data: backups }", handlerStart);
+assert.ok(handlerStart >= 0 && handlerEnd > handlerStart);
+const handlerSource = settingsPanelSource.slice(handlerStart, handlerEnd);
+assert.match(handlerSource, /window\.location\.assign\(status\.downloadUrl\)/u);
+assert.doesNotMatch(handlerSource, /\.blob\(\)|createObjectURL|showSaveFilePicker/u);
+
+console.log("Backup download handoff regression passed.");

--- a/scripts/regressions/backup-download-handoff.regression.ts
+++ b/scripts/regressions/backup-download-handoff.regression.ts
@@ -20,6 +20,12 @@ const settingsPanelSource = readFileSync(
   join(repositoryRoot, "packages/client/src/components/panels/SettingsPanel.tsx"),
   "utf8",
 );
+const backupRoutesSource = readFileSync(join(repositoryRoot, "packages/server/src/routes/backup.routes.ts"), "utf8");
+assert.match(
+  backupRoutesSource,
+  /"\/download\/file\/:jobId",\s*\{ exposeHeadRoute: false,/u,
+  "HEAD requests must not consume the one-time prepared backup job",
+);
 const handlerStart = settingsPanelSource.indexOf("const handleCreateBackup = async () =>");
 const handlerEnd = settingsPanelSource.indexOf("const { data: backups }", handlerStart);
 assert.ok(handlerStart >= 0 && handlerEnd > handlerStart);

--- a/scripts/regressions/docker-proxy-auth.regression.ts
+++ b/scripts/regressions/docker-proxy-auth.regression.ts
@@ -18,11 +18,15 @@ const ENV_KEYS = [
   "BASIC_AUTH_USER",
   "BYPASS_AUTH_DOCKER",
   "BYPASS_AUTH_TAILSCALE",
+  "CORS_ORIGINS",
+  "CSRF_TRUSTED_ORIGINS",
+  "HOST",
   "IP_ALLOWLIST",
   "IP_ALLOWLIST_ENABLED",
   "MARINARA_DOCKER",
   "MARINARA_REQUIRE_ADMIN_SECRET_ON_LOOPBACK",
   "REQUIRE_AUTH_FOR_DOCKER_PROXY",
+  "TRUSTED_HOSTS",
 ] as const;
 
 const originalEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
@@ -288,6 +292,50 @@ try {
     "the privileged gate must require normal auth before accepting the admin secret",
   );
   assert.equal(privilegedRejectedReply.statusCode(), 403);
+
+  const capabilityWithoutBasicAuthReply = replyRecorder();
+  assert.equal(
+    requirePrivilegedAccess(
+      request({
+        "x-forwarded-for": "198.51.100.10",
+      }),
+      capabilityWithoutBasicAuthReply.reply,
+      { oneTimeCapabilityAuthorized: true, feature: "Security regression" },
+    ),
+    false,
+    "a one-time capability must not bypass normal Basic Auth",
+  );
+  assert.equal(capabilityWithoutBasicAuthReply.statusCode(), 403);
+
+  const capabilityWithUntrustedHostReply = replyRecorder();
+  assert.equal(
+    requirePrivilegedAccess(
+      request({
+        authorization: basicHeader(),
+        host: "attacker.example",
+        "x-forwarded-for": "198.51.100.10",
+      }),
+      capabilityWithUntrustedHostReply.reply,
+      { oneTimeCapabilityAuthorized: true, feature: "Security regression" },
+    ),
+    false,
+    "a one-time capability must not bypass trusted-host validation",
+  );
+  assert.equal(capabilityWithUntrustedHostReply.statusCode(), 421);
+
+  const capabilityAllowedReply = replyRecorder();
+  assert.equal(
+    requirePrivilegedAccess(
+      request({
+        authorization: basicHeader(),
+        "x-forwarded-for": "198.51.100.10",
+      }),
+      capabilityAllowedReply.reply,
+      { oneTimeCapabilityAuthorized: true, feature: "Security regression" },
+    ),
+    true,
+    "a verified one-time capability may replace the reusable admin secret after normal auth",
+  );
 
   const privilegedAllowedReply = replyRecorder();
   assert.equal(

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -9276,13 +9276,17 @@ assert.equal(({} as { tags?: string[] }).tags, undefined, "Background metadata m
   );
   assert.match(backupRoutesSource, /app\.post\("\/download\/start"/u);
   assert.match(backupRoutesSource, /app\.get<\{ Params: \{ jobId: string \} \}>\(\s*"\/download\/status\/:jobId"/u);
-  assert.match(backupRoutesSource, /app\.get<\{ Params: \{ jobId: string \} \}>\(\s*"\/download\/file\/:jobId"/u);
+  assert.match(
+    backupRoutesSource,
+    /app\.get<\{ Params: \{ jobId: string \}; Querystring: \{ token\?: string \} \}>\(\s*"\/download\/file\/:jobId"/u,
+  );
   assert.match(
     backupRoutesSource,
     /if \(job\?\.status === "preparing"\) return;/u,
     "backup cleanup cannot remove a temporary directory while its archive is still being written",
   );
   assert.match(settingsPanelSource, /\/backup\/download\/status\/\$\{encodeURIComponent\(started\.jobId\)\}/u);
+  assert.match(settingsPanelSource, /window\.location\.assign\(status\.downloadUrl\)/u);
 
   const retryAgentsRouteSource = readFileSync(
     join(REPOSITORY_ROOT, "packages/server/src/routes/generate/retry-agents-route.ts"),


### PR DESCRIPTION
## Why

Safari still buffered the entire prepared backup ZIP into page memory before handing it to the browser. Large backups could therefore fail after a long preparation even though the asynchronous job introduced for v2.4.3 had completed successfully.

## What changed

- return a short-lived, job-scoped download URL only after privileged status polling confirms the archive is ready
- stream the ZIP through the browser's native download handling instead of creating a page-held Blob
- allow that one-time capability to replace only the reusable admin secret; trusted-host and normal authentication checks still apply
- add focused handoff and trust-boundary regressions
- update the backup documentation and changelog

Closes #5259

## Validation

- [ ] Manually verify a large backup download in Safari
- [ ] Manually verify remote/Docker download with Basic Auth and an admin secret
- [ ] Run `pnpm check`
- [ ] Run `pnpm localization:check`
- [ ] Run the focused backup/auth regression scripts

AI-generated PR: validation boxes intentionally remain unchecked for maintainer verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Backup archives now download directly through the browser after preparation, including improved Safari support.
  - Secure, short-lived one-time download links are provided.
  - A confirmation message appears when the download starts.

- **Bug Fixes**
  - Removed unnecessary file-saving prompts and fallback behavior.

- **Documentation**
  - Updated backup and restore instructions to explain browser-dependent download behavior.

- **Security**
  - Authentication and trusted-host protections remain enforced for backup downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->