### PR TITLE
Fix Professor Mari chat chrome and close controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Professor Mari's mobile message labels, action icons, context details, and suggestion guidance now follow the configured Chat Chrome Text Color, while her desktop close controls use the same full-size treatment as editor exits (#5273).
 - APK-managed Android setup no longer opens a separate localhost browser that asks the user to paste Marinara's private local-access secret, and its self-authenticating WebView/session routes no longer fail CSRF when Android reports an opaque `Origin: null`; `null` remains rejected for every other unsafe API route. The generated credential stays automatic inside the app, and releases now publish a stable one-click APK download asset alongside the versioned file (#5222; docs follow-up: #5223).
 - Game Mode no longer replaces a matching Character-library portrait when recovering a missing scene background or retrying a failed portrait load (#4746).
 - Character-created Conversation reactions can now be removed directly by clicking their chip on desktop or long-pressing it on mobile, without discarding the user's own matching reaction (#5216).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -13000,19 +13000,6 @@ test("Professor Mari follows an open conversation across chats and mobile naviga
     const professorWindow = page.locator('[data-component="HomeProfessorMariChat.Window"]');
     await expect(professorWindow).toBeVisible();
 
-    if (!testInfo.project.name.includes("mobile")) {
-      const closeProfessorMari = professorWindow.getByRole("button", { name: "Close Professor Mari chat" });
-      await expect(closeProfessorMari).toHaveClass(/mari-editor-action/u);
-      const [buttonBox, iconBox] = await Promise.all([
-        closeProfessorMari.boundingBox(),
-        closeProfessorMari.locator("svg").boundingBox(),
-      ]);
-      expect(buttonBox?.width).toBeGreaterThanOrEqual(36);
-      expect(buttonBox?.height).toBeGreaterThanOrEqual(36);
-      expect(iconBox?.width).toBeGreaterThanOrEqual(18);
-      expect(iconBox?.height).toBeGreaterThanOrEqual(18);
-    }
-
     if (testInfo.project.name.includes("mobile")) {
       await page.locator('[data-tour="sidebar-toggle"]').click();
       const reopenProfessorMari = page.getByRole("button", { name: "Open Professor Mari chat" });
@@ -13032,7 +13019,17 @@ test("Professor Mari follows an open conversation across chats and mobile naviga
       await page.getByRole("button", { name: "Close Professor Mari chat" }).last().click();
       await expect(page.getByRole("button", { name: "Open Professor Mari chat" })).toBeVisible();
     } else {
-      await expect(page.getByRole("button", { name: "Dismiss Professor Mari floating chat" })).toBeVisible();
+      const dismissProfessorMari = page.getByRole("button", { name: "Dismiss Professor Mari floating chat" });
+      await expect(dismissProfessorMari).toBeVisible();
+      await expect(dismissProfessorMari).toHaveClass(/mari-editor-action/u);
+      const [buttonBox, iconBox] = await Promise.all([
+        dismissProfessorMari.boundingBox(),
+        dismissProfessorMari.locator("svg").boundingBox(),
+      ]);
+      expect(buttonBox?.width).toBeGreaterThanOrEqual(36);
+      expect(buttonBox?.height).toBeGreaterThanOrEqual(36);
+      expect(iconBox?.width).toBeGreaterThanOrEqual(18);
+      expect(iconBox?.height).toBeGreaterThanOrEqual(18);
       await expect(page.getByPlaceholder("Ask Professor Mari")).toBeVisible();
     }
 
@@ -13171,10 +13168,7 @@ test("Professor Mari shows the latest context budget when token usage is enabled
       useUIStore.getState().setChatChromeTextColor("#14b8a6");
       useUIStore.getState().setShowTokenUsage(true);
     });
-    await page
-      .locator('[data-component="HomeProfessorMariChat.MariPanel"]')
-      .getByRole("button", { name: "Ask Professor Mari" })
-      .click();
+    await page.getByRole("tab", { name: "Professor", exact: true }).click();
 
     const window = page.locator('[data-component="HomeProfessorMariChat.Window"]');
     const budget = window.locator('[data-component="HomeProfessorMariChat.ContextBudget"]');

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -13045,26 +13045,33 @@ test("Professor Mari suggestions stay visible after chat history loads", async (
   const chatResponse = await page.request.get("/api/chats/internal/professor-mari");
   expect(chatResponse.ok()).toBeTruthy();
   const chat = (await chatResponse.json()) as { id: string };
-  const userMessageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
-    data: {
-      role: "user",
-      content: `Professor Mari chrome color request ${Date.now()}`,
-    },
-  });
-  expect(userMessageResponse.ok()).toBeTruthy();
-  const userMessage = (await userMessageResponse.json()) as { id: string };
   const messageContent = `Professor Mari suggestion stability ${Date.now()}`;
-  const messageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
-    data: {
-      role: "assistant",
-      characterId: "__professor_mari__",
-      content: messageContent,
-    },
-  });
-  expect(messageResponse.ok()).toBeTruthy();
-  const message = (await messageResponse.json()) as { id: string };
+  const createdMessageIds: string[] = [];
 
   try {
+    const userMessageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
+      data: {
+        role: "user",
+        content: `Professor Mari chrome color request ${Date.now()}`,
+      },
+    });
+    const userMessage = (await userMessageResponse.json().catch(() => null)) as { id?: unknown } | null;
+    if (typeof userMessage?.id === "string") createdMessageIds.push(userMessage.id);
+    expect(userMessageResponse.ok()).toBeTruthy();
+    expect(userMessage?.id).toEqual(expect.any(String));
+
+    const messageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
+      data: {
+        role: "assistant",
+        characterId: "__professor_mari__",
+        content: messageContent,
+      },
+    });
+    const message = (await messageResponse.json().catch(() => null)) as { id?: unknown } | null;
+    if (typeof message?.id === "string") createdMessageIds.push(message.id);
+    expect(messageResponse.ok()).toBeTruthy();
+    expect(message?.id).toEqual(expect.any(String));
+
     await page.goto("/");
     await page.evaluate(async () => {
       const [{ useAgentStore }, { useUIStore }] = await Promise.all([
@@ -13084,7 +13091,11 @@ test("Professor Mari suggestions stay visible after chat history loads", async (
     const suggestions = window.getByRole("group", { name: "Suggested replies" });
     await expect(suggestions).toBeVisible();
     await expect(suggestions.getByRole("button", { name: "Create a character" })).toBeVisible();
+    const configuredChromeTextColor = await page.evaluate(() =>
+      document.documentElement.style.getPropertyValue("--marinara-chat-chrome-text").trim(),
+    );
     const chromeMutedColor = await readCssVariableColor(page, "--marinara-chat-chrome-panel-muted");
+    expect(configuredChromeTextColor).toBe("#14b8a6");
     await expect(window.getByText("You", { exact: true }).last()).toHaveCSS("color", chromeMutedColor);
     await expect(window.getByRole("button", { name: "Edit Message" }).last()).toHaveCSS("color", chromeMutedColor);
     await expect(window.getByText("Suggestions only. Pick one, or type your own.", { exact: true })).toHaveCSS(
@@ -13093,7 +13104,7 @@ test("Professor Mari suggestions stay visible after chat history loads", async (
     );
   } finally {
     await Promise.all(
-      [userMessage.id, message.id].map((id) => bestEffortDelete(page.request, `/api/chats/${chat.id}/messages/${id}`)),
+      createdMessageIds.map((id) => bestEffortDelete(page.request, `/api/chats/${chat.id}/messages/${id}`)),
     );
   }
 });
@@ -13172,8 +13183,12 @@ test("Professor Mari shows the latest context budget when token usage is enabled
 
     const window = page.locator('[data-component="HomeProfessorMariChat.Window"]');
     const budget = window.locator('[data-component="HomeProfessorMariChat.ContextBudget"]');
+    const configuredChromeTextColor = await page.evaluate(() =>
+      document.documentElement.style.getPropertyValue("--marinara-chat-chrome-text").trim(),
+    );
     const chromeMutedColor = await readCssVariableColor(page, "--marinara-chat-chrome-panel-muted");
     const chromeTextColor = await readCssVariableColor(page, "--marinara-chat-chrome-panel-text");
+    expect(configuredChromeTextColor).toBe("#14b8a6");
     await expect(budget).toContainText("Context");
     await expect(budget).toContainText("12.3k / 128k tokens");
     await expect(budget.getByText("Context", { exact: true })).toHaveCSS("color", chromeMutedColor);

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -12997,7 +12997,21 @@ test("Professor Mari follows an open conversation across chats and mobile naviga
   try {
     await page.goto("/");
     await page.getByRole("button", { name: "Ask Professor Mari", exact: true }).click();
-    await expect(page.locator('[data-component="HomeProfessorMariChat.Window"]')).toBeVisible();
+    const professorWindow = page.locator('[data-component="HomeProfessorMariChat.Window"]');
+    await expect(professorWindow).toBeVisible();
+
+    if (!testInfo.project.name.includes("mobile")) {
+      const closeProfessorMari = professorWindow.getByRole("button", { name: "Close Professor Mari chat" });
+      await expect(closeProfessorMari).toHaveClass(/mari-editor-action/u);
+      const [buttonBox, iconBox] = await Promise.all([
+        closeProfessorMari.boundingBox(),
+        closeProfessorMari.locator("svg").boundingBox(),
+      ]);
+      expect(buttonBox?.width).toBeGreaterThanOrEqual(36);
+      expect(buttonBox?.height).toBeGreaterThanOrEqual(36);
+      expect(iconBox?.width).toBeGreaterThanOrEqual(18);
+      expect(iconBox?.height).toBeGreaterThanOrEqual(18);
+    }
 
     if (testInfo.project.name.includes("mobile")) {
       await page.locator('[data-tour="sidebar-toggle"]').click();
@@ -13034,6 +13048,14 @@ test("Professor Mari suggestions stay visible after chat history loads", async (
   const chatResponse = await page.request.get("/api/chats/internal/professor-mari");
   expect(chatResponse.ok()).toBeTruthy();
   const chat = (await chatResponse.json()) as { id: string };
+  const userMessageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
+    data: {
+      role: "user",
+      content: `Professor Mari chrome color request ${Date.now()}`,
+    },
+  });
+  expect(userMessageResponse.ok()).toBeTruthy();
+  const userMessage = (await userMessageResponse.json()) as { id: string };
   const messageContent = `Professor Mari suggestion stability ${Date.now()}`;
   const messageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
     data: {
@@ -13055,6 +13077,7 @@ test("Professor Mari suggestions stay visible after chat history loads", async (
       useAgentStore.getState().clearMariChips();
       useAgentStore.getState().clearMariPlan();
       useUIStore.getState().setProfessorMariSuggestionsEnabled(true);
+      useUIStore.getState().setChatChromeTextColor("#14b8a6");
     });
 
     await page.getByRole("tab", { name: "Professor", exact: true }).click();
@@ -13064,8 +13087,17 @@ test("Professor Mari suggestions stay visible after chat history loads", async (
     const suggestions = window.getByRole("group", { name: "Suggested replies" });
     await expect(suggestions).toBeVisible();
     await expect(suggestions.getByRole("button", { name: "Create a character" })).toBeVisible();
+    const chromeMutedColor = await readCssVariableColor(page, "--marinara-chat-chrome-panel-muted");
+    await expect(window.getByText("You", { exact: true }).last()).toHaveCSS("color", chromeMutedColor);
+    await expect(window.getByRole("button", { name: "Edit Message" }).last()).toHaveCSS("color", chromeMutedColor);
+    await expect(window.getByText("Suggestions only. Pick one, or type your own.", { exact: true })).toHaveCSS(
+      "color",
+      chromeMutedColor,
+    );
   } finally {
-    await bestEffortDelete(page.request, `/api/chats/${chat.id}/messages/${message.id}`);
+    await Promise.all(
+      [userMessage.id, message.id].map((id) => bestEffortDelete(page.request, `/api/chats/${chat.id}/messages/${id}`)),
+    );
   }
 });
 
@@ -13129,8 +13161,14 @@ test("Professor Mari shows the latest context budget when token usage is enabled
     await page.goto("/");
     await page.evaluate(async () => {
       const { useUIStore } = (await import("/src/stores/ui.store.ts")) as {
-        useUIStore: { getState: () => { setShowTokenUsage: (value: boolean) => void } };
+        useUIStore: {
+          getState: () => {
+            setChatChromeTextColor: (value: string) => void;
+            setShowTokenUsage: (value: boolean) => void;
+          };
+        };
       };
+      useUIStore.getState().setChatChromeTextColor("#14b8a6");
       useUIStore.getState().setShowTokenUsage(true);
     });
     await page
@@ -13140,8 +13178,12 @@ test("Professor Mari shows the latest context budget when token usage is enabled
 
     const window = page.locator('[data-component="HomeProfessorMariChat.Window"]');
     const budget = window.locator('[data-component="HomeProfessorMariChat.ContextBudget"]');
+    const chromeMutedColor = await readCssVariableColor(page, "--marinara-chat-chrome-panel-muted");
+    const chromeTextColor = await readCssVariableColor(page, "--marinara-chat-chrome-panel-text");
     await expect(budget).toContainText("Context");
     await expect(budget).toContainText("12.3k / 128k tokens");
+    await expect(budget.getByText("Context", { exact: true })).toHaveCSS("color", chromeMutedColor);
+    await expect(budget.getByText("12.3k / 128k tokens", { exact: true })).toHaveCSS("color", chromeTextColor);
     await expect(budget.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "12345");
     await expect(budget.getByRole("progressbar")).toHaveAttribute("aria-valuemax", "128000");
   } finally {

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -1554,7 +1554,7 @@ function WorkspaceTimelineList({
 const MARI_MESSAGE_ACTIONS_CLASS =
   "mt-1 flex gap-1.5 opacity-100 transition-opacity [@media(pointer:fine)]:opacity-0 [@media(pointer:fine)]:group-focus-within:opacity-100 [@media(pointer:fine)]:group-hover:opacity-100";
 const MARI_MESSAGE_ACTION_BUTTON_CLASS =
-  "rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--primary)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--primary)] focus-visible:text-[var(--primary)]";
+  "rounded p-1 text-[var(--marinara-chat-chrome-panel-muted)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--primary)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--primary)] focus-visible:text-[var(--primary)]";
 
 const CompactMariMessage = memo(function CompactMariMessage({
   message,
@@ -1584,7 +1584,7 @@ const CompactMariMessage = memo(function CompactMariMessage({
       <TranscriptRow
         className="group border-y border-[var(--border)]/60 py-2.5"
         marker={
-          <span className="pt-0.5 text-[0.6875rem] font-semibold text-[var(--muted-foreground)]">
+          <span className="pt-0.5 text-[0.6875rem] font-semibold text-[var(--marinara-chat-chrome-panel-muted)]">
             {localizeUi("ui.chat.compactmarimessage.you")}
           </span>
         }
@@ -1761,11 +1761,11 @@ function ProfessorMariContextBudgetIndicator({ budget }: { budget: ProfessorMari
   return (
     <div
       data-component="HomeProfessorMariChat.ContextBudget"
-      className="mb-2 space-y-1 px-0.5 text-[0.6875rem] text-[var(--muted-foreground)]"
+      className="mb-2 space-y-1 px-0.5 text-[0.6875rem] text-[var(--marinara-chat-chrome-panel-muted)]"
     >
       <div className="flex items-center justify-between gap-3">
         <span>{localizeUi("ui.chat.homeprofessormarichat.contextBudget")}</span>
-        <span className="tabular-nums text-[var(--foreground)]/70">
+        <span className="tabular-nums text-[var(--marinara-chat-chrome-panel-text)]">
           {localizeUi("ui.chat.homeprofessormarichat.contextBudgetValue", { used, maximum })}
         </span>
       </div>
@@ -5172,7 +5172,7 @@ export function HomeProfessorMariChat({
           onRemove={(index) => setAttachments((current) => current.filter((_, itemIndex) => itemIndex !== index))}
         />
         {chipRowHint && (
-          <p className="mb-1 flex items-center gap-1.5 px-0.5 text-xs text-[var(--muted-foreground)]">
+          <p className="mb-1 flex items-center gap-1.5 px-0.5 text-xs text-[var(--marinara-chat-chrome-panel-muted)]">
             <Sparkles size="0.75rem" className="shrink-0 text-[var(--primary)]" />
             <span>{chipRowHint}</span>
           </p>
@@ -5394,11 +5394,11 @@ export function HomeProfessorMariChat({
             data-professor-mari-floating-action
             type="button"
             onClick={onFloatingDismiss}
-            className="mari-chrome-control mari-chrome-control--small mari-accent-animated inline-flex h-7 w-7 items-center justify-center rounded-md p-0"
+            className="mari-editor-action mari-accent-animated inline-flex shrink-0"
             aria-label={t("home.professorMari.dismiss")}
             title={t("home.professorMari.dismiss")}
           >
-            <X size="0.85rem" />
+            <X size="1.125rem" />
           </button>
         </div>
         {renderFloatingChatBody()}
@@ -5848,11 +5848,11 @@ export function HomeProfessorMariChat({
                               <button
                                 type="button"
                                 onClick={closeChatWindow}
-                                className="mari-chrome-control mari-chrome-control--small mari-accent-animated inline-flex h-8 w-8 items-center justify-center rounded-md p-0"
+                                className="mari-editor-action mari-accent-animated inline-flex shrink-0"
                                 aria-label={t("home.professorMari.close")}
                                 title={t("home.professorMari.close")}
                               >
-                                <X size="0.9rem" />
+                                <X size="1.125rem" />
                               </button>
                             )}
                           </div>
@@ -5929,7 +5929,7 @@ export function HomeProfessorMariChat({
                             }
                           />
                           {chipRowHint && (
-                            <p className="mb-1 flex items-center gap-1.5 px-0.5 text-[0.6875rem] text-[var(--muted-foreground)]">
+                            <p className="mb-1 flex items-center gap-1.5 px-0.5 text-[0.6875rem] text-[var(--marinara-chat-chrome-panel-muted)]">
                               <Sparkles size="0.6875rem" className="shrink-0 text-[var(--primary)]" />
                               <span>{chipRowHint}</span>
                             </p>


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5273

## Why this change

- Professor Mari's ordinary mobile chat chrome bypassed the dedicated Chat Chrome Text Color tokens, so user labels, inactive message actions, context copy, and suggestion guidance retained the default theme colors.
- Her desktop close controls used a smaller local treatment than the established editor-exit controls, making the action unnecessarily hard to see and target.

## What changed

- Routed the affected Professor Mari labels and inactive icons through the existing chat-chrome text tokens while preserving Accent Color for hover/focus emphasis and progress fill.
- Reused the existing full-size editor action style for both desktop Professor Mari close variants.
- Extended the existing Professor Mari browser coverage and added the user-facing changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passed locally (localization, formatting, lint, TypeScript, and production builds).
- Focused Playwright coverage passed on desktop Chromium and Pixel 7 mobile Chromium: 6 tests passed.
- The focused tests verify the configured Chat Chrome Text Color on `You`, inactive message actions, context labels/values, and suggestion guidance, plus the desktop floating close button's editor-action class and minimum 36 px button / 18 px icon dimensions.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Automated viewport evidence is covered by the focused desktop/mobile Playwright run above. The in-app browser was unavailable for a separate screenshot attachment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Professor Mari chat readability on mobile by applying configured text colors to message labels, actions, context details, and suggestion guidance.
  - Updated floating and embedded chat close controls with more consistent editor-aligned styling and sizing.
- **Tests**
  - Expanded coverage for chat colors, dismissal controls, message handling, suggestions, and context-budget indicators across key chat flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->