### PR TITLE
Fix macro modal rendering and layering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Macro reference guidance now renders the literal `{{macro}}` example, and expanded macro editors and guides stay above Author's Notes, summary, and other floating panels at narrow viewports (#5266, #5267, #5270).
 - The compact music player now stays hidden until Music DJ is installed, and its General Settings switch remains unavailable with a clear explanation until the agent is ready; installing Music DJ unlocks both immediately (#5262).
 - Professor Mari's open chat now follows the user again when they move into another chat or editor, with the interactive floating window on desktop and the quick-return avatar on mobile navigation surfaces (#5263).
 - The mobile Chats topbar icon now stays in the configured accent color after taps and double taps while its active underline keeps the cyan-orange-pink gradient (#5264).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1122,8 +1122,6 @@ test("settings profiles enforce chat modes and preserve branch identity", async 
 });
 
 test("Author's Notes keeps its expand and full macro guide inside the field", async ({ page, request }, testInfo) => {
-  test.skip(!testInfo.project.name.includes("desktop"), "Author's Notes field chrome is covered on desktop.");
-
   const chatResponse = await request.post("/api/chats", {
     data: {
       name: "Author Notes Macro Field Smoke",
@@ -1137,10 +1135,15 @@ test("Author's Notes keeps its expand and full macro guide inside the field", as
 
   try {
     await page.goto("/");
+    if (testInfo.project.name.includes("mobile")) {
+      await page.getByRole("button", { name: "More options", exact: true }).click();
+    }
     await page.getByRole("button", { name: "Author's Notes", exact: true }).filter({ visible: true }).click();
 
     const heading = page.locator("h3").filter({ hasText: "Author's Notes" });
     await expect(heading).toBeVisible();
+    const floatingPanel = heading.locator("xpath=ancestor::div[contains(@class, 'fixed')][1]");
+    const floatingPanelZIndex = await floatingPanel.evaluate((element) => Number(getComputedStyle(element).zIndex));
     const panel = heading.locator("..");
     const field = panel.locator(".mari-author-notes-field");
     await expect(field.getByRole("textbox", { name: "Author's Notes", exact: true })).toBeVisible();
@@ -1151,6 +1154,10 @@ test("Author's Notes keeps its expand and full macro guide inside the field", as
     await field.getByRole("button", { name: "Macro reference", exact: true }).click();
     const macroReference = page.locator('[data-component="MacroReference"]');
     await expect(macroReference).toBeVisible();
+    await expect(macroReference.locator("section").first()).toContainText("Use {{macro}} anywhere in prompt fields.");
+    expect(await macroReference.evaluate((element) => Number(getComputedStyle(element).zIndex))).toBeGreaterThan(
+      floatingPanelZIndex,
+    );
     await expect(macroReference.getByText("{{charPostHistory}}", { exact: true })).toBeVisible();
     await expect(macroReference.getByText("{{agent::TYPE}}", { exact: true })).toBeVisible();
     await expect(macroReference.getByText(/Conditional block with/)).toBeVisible();
@@ -1160,6 +1167,9 @@ test("Author's Notes keeps its expand and full macro guide inside the field", as
     await field.getByRole("button", { name: "Expand editor", exact: true }).click();
     const expandedEditor = page.locator('[data-component="ExpandedMacroEditor"]');
     await expect(expandedEditor).toBeVisible();
+    expect(await expandedEditor.evaluate((element) => Number(getComputedStyle(element).zIndex))).toBeGreaterThan(
+      floatingPanelZIndex,
+    );
     const savedNotes = '{{#if char == "Albedo"}}Keep {{user}} curious.{{else}}Keep the scene curious.{{/if}}';
     await expandedEditor.locator("textarea").fill(savedNotes);
     await expandedEditor.getByRole("button", { name: "Close expanded editor", exact: true }).click();
@@ -1175,6 +1185,66 @@ test("Author's Notes keeps its expand and full macro guide inside the field", as
         return metadata.authorNotes;
       })
       .toBe(savedNotes);
+  } finally {
+    await request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
+  }
+});
+
+test("summary macro editor stays above its floating panel", async ({ page, request }, testInfo) => {
+  const chatResponse = await request.post("/api/chats", {
+    data: { name: "Summary Macro Modal Layering Smoke", mode: "roleplay", characterIds: [] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+  const timestamp = new Date().toISOString();
+  const metadataResponse = await request.patch(`/api/chats/${chat.id}/metadata`, {
+    data: {
+      summaryEntries: [
+        {
+          id: "summary-macro-layering-entry",
+          kind: "rolling",
+          origin: "manual",
+          title: "Layered summary",
+          content: "A summary that should remain editable.",
+          enabled: true,
+          sourceMode: "last",
+          tokenEstimate: 7,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+    },
+  });
+  expect(metadataResponse.ok()).toBeTruthy();
+  await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
+
+  try {
+    await page.goto("/");
+    if (testInfo.project.name.includes("mobile")) {
+      await page.getByRole("button", { name: "More options", exact: true }).click();
+    }
+    await page
+      .getByRole("button", { name: "Chat Summary (1 active summary)", exact: true })
+      .filter({ visible: true })
+      .click();
+
+    const summaryPanel = page.locator("[data-chat-floating-panel]").filter({ hasText: "Chat Summary" });
+    await expect(summaryPanel).toBeVisible();
+    await summaryPanel.getByRole("button", { name: "Edit summary entry", exact: true }).click();
+    const summaryField = summaryPanel.getByRole("textbox", {
+      name: "Write or paste a summary of this chat...",
+      exact: true,
+    });
+    await expect(summaryField).toBeVisible();
+    await summaryField.locator("..").getByRole("button", { name: "Expand editor", exact: true }).click();
+
+    const expandedEditor = page.locator('[data-component="ExpandedMacroEditor"]');
+    await expect(expandedEditor).toBeVisible();
+    expect(await expandedEditor.evaluate((element) => Number(getComputedStyle(element).zIndex))).toBeGreaterThan(
+      await summaryPanel.evaluate((element) => Number(getComputedStyle(element).zIndex)),
+    );
+    await expandedEditor.getByRole("button", { name: "Close expanded editor", exact: true }).click();
+    await expect(summaryPanel).toBeVisible();
   } finally {
     await request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
   }

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1223,10 +1223,10 @@ test("summary macro editor stays above its floating panel", async ({ page, reque
     if (testInfo.project.name.includes("mobile")) {
       await page.getByRole("button", { name: "More options", exact: true }).click();
     }
-    await page
+    const summaryButton = page
       .getByRole("button", { name: "Chat Summary (1 active summary)", exact: true })
-      .filter({ visible: true })
-      .click();
+      .filter({ visible: true });
+    await summaryButton.click();
 
     const summaryPanel = page.locator("[data-chat-floating-panel]").filter({ hasText: "Chat Summary" });
     await expect(summaryPanel).toBeVisible();
@@ -1243,6 +1243,9 @@ test("summary macro editor stays above its floating panel", async ({ page, reque
     expect(await expandedEditor.evaluate((element) => Number(getComputedStyle(element).zIndex))).toBeGreaterThan(
       await summaryPanel.evaluate((element) => Number(getComputedStyle(element).zIndex)),
     );
+    await summaryButton.evaluate((button: HTMLButtonElement) => button.click());
+    await expect(expandedEditor).toBeVisible();
+    await expandedEditor.locator("textarea").fill("The expanded summary remains usable.");
     await expandedEditor.getByRole("button", { name: "Close expanded editor", exact: true }).click();
     await expect(summaryPanel).toBeVisible();
   } finally {

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -568,7 +568,10 @@ function ActiveContextLinksButton({
 
   useEffect(() => {
     if (!open) return;
-    const handleDismiss = () => setOpen(false);
+    const handleDismiss = () => {
+      if (document.querySelector("[data-macro-modal]")) return;
+      setOpen(false);
+    };
     window.addEventListener(CHAT_FLOATING_UI_DISMISS_EVENT, handleDismiss);
     return () => window.removeEventListener(CHAT_FLOATING_UI_DISMISS_EVENT, handleDismiss);
   }, [open]);
@@ -877,6 +880,7 @@ function SummaryButton({
         ref={buttonRef}
         data-chat-toolbar-panel-action="summary"
         onClick={() => {
+          if (open && document.querySelector("[data-macro-modal]")) return;
           setAnchor(readSummaryAnchor());
           setOpen(!open);
         }}

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -427,6 +427,7 @@ export function SummaryPopover({
     if (!panel) return false;
     const path = typeof event.composedPath === "function" ? event.composedPath() : [];
     if (path.includes(panel)) return true;
+    if (event.target instanceof Element && event.target.closest("[data-macro-modal]")) return true;
     return event.target instanceof Node && panel.contains(event.target);
   }, []);
 
@@ -1110,6 +1111,7 @@ export function SummaryPopover({
   }, [commitCombinePromptDraft]);
 
   const handleClose = useCallback(async () => {
+    if (document.querySelector("[data-macro-modal]")) return;
     if (await commitCombinePromptDraft()) onClose();
   }, [commitCombinePromptDraft, onClose]);
 

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -130,7 +130,7 @@ function ExpandedMacroEditor({
         data-component="ExpandedMacroEditor"
         data-macro-modal="true"
         className={cn(
-          "fixed inset-0 z-[140] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4",
+          "fixed inset-0 z-[10050] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4",
           EDITOR_MODAL_SURFACE_VARIABLES,
         )}
       >
@@ -204,7 +204,7 @@ function MacrosReferenceModal({ open, onClose }: MacrosReferenceModalProps) {
         data-component="MacroReference"
         data-macro-modal="true"
         className={cn(
-          "fixed inset-0 z-[145] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4",
+          "fixed inset-0 z-[10050] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4",
           EDITOR_MODAL_SURFACE_VARIABLES,
         )}
       >
@@ -233,9 +233,9 @@ function MacrosReferenceModal({ open, onClose }: MacrosReferenceModalProps) {
               <p>
                 <Trans
                   i18nKey="ui.ui.macrosreferencemodal.macroUsageGuidance"
-                  values={{ example: "{{macro}}" }}
+                  values={{ macroExample: "{{macro}}" }}
                   components={{
-                    macro: <code className="text-[var(--foreground)]" />,
+                    macroCode: <code className="text-[var(--foreground)]" />,
                     or: <code className="text-[var(--foreground)]" />,
                     and: <code className="text-[var(--foreground)]" />,
                   }}

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -8670,7 +8670,7 @@
   "ui.ui.macrosreferencemodal.conditionalBlock": "Conditional block",
   "ui.ui.macrosreferencemodal.macroReference": "Macro reference",
   "ui.ui.macrosreferencemodal.macrosAreReplacedWithLiveChatCharacterAndPreset": "Macros are replaced with live chat, character, and preset values during generation.",
-  "ui.ui.macrosreferencemodal.macroUsageGuidance": "Use <macro>{{example}}</macro> anywhere in prompt fields. Conditional blocks can combine checks with <or>||</or> (OR) and <and>&&</and> (AND).",
+  "ui.ui.macrosreferencemodal.macroUsageGuidance": "Use <macroCode>{{macroExample}}</macroCode> anywhere in prompt fields. Conditional blocks can combine checks with <or>||</or> (OR) and <and>&&</and> (AND).",
   "ui.ui.macrosreferencemodal.orAnd": "(OR) and",
   "ui.ui.macrotextarea.editMarkdownSource": "Edit Markdown source",
   "ui.ui.macrotextarea.expandEditor": "Expand editor",

--- a/packages/client/src/localization/locales/ko.json
+++ b/packages/client/src/localization/locales/ko.json
@@ -7255,7 +7255,7 @@
   "ui.ui.macrosreferencemodal.conditionalBlock": "조건부 블록",
   "ui.ui.macrosreferencemodal.macroReference": "매크로 참조",
   "ui.ui.macrosreferencemodal.macrosAreReplacedWithLiveChatCharacterAndPreset": "매크로는 생성 중에 실시간 채팅, 캐릭터 및 프리셋 값으로 대체됩니다.",
-  "ui.ui.macrosreferencemodal.macroUsageGuidance": "프롬프트 필드 어디에서나 <macro>{{example}}</macro>을(를) 사용하세요. 조건 블록은 <or>||</or>(OR) 및 <and>&&</and>(AND)로 검사를 조합할 수 있습니다.",
+  "ui.ui.macrosreferencemodal.macroUsageGuidance": "프롬프트 필드 어디에서나 <macroCode>{{macroExample}}</macroCode>을(를) 사용하세요. 조건 블록은 <or>||</or>(OR) 및 <and>&&</and>(AND)로 검사를 조합할 수 있습니다.",
   "ui.ui.macrosreferencemodal.orAnd": "(OR) 및",
   "ui.ui.macrotextarea.editMarkdownSource": "Markdown 소스 편집",
   "ui.ui.macrotextarea.expandEditor": "편집기 펼치기",

--- a/packages/client/src/localization/locales/zh-Hans.json
+++ b/packages/client/src/localization/locales/zh-Hans.json
@@ -8456,7 +8456,7 @@
   "ui.ui.macrosreferencemodal.conditionalBlock": "条件块",
   "ui.ui.macrosreferencemodal.macroReference": "宏参考",
   "ui.ui.macrosreferencemodal.macrosAreReplacedWithLiveChatCharacterAndPreset": "生成时，宏会替换为当前聊天、角色和预设的值。",
-  "ui.ui.macrosreferencemodal.macroUsageGuidance": "可在提示词字段的任意位置使用 <macro>{{example}}</macro>。条件块可用 <or>||</or>（或）和 <and>&&</and>（且）组合检查。",
+  "ui.ui.macrosreferencemodal.macroUsageGuidance": "可在提示词字段的任意位置使用 <macroCode>{{macroExample}}</macroCode>。条件块可用 <or>||</or>（或）和 <and>&&</and>（且）组合检查。",
   "ui.ui.macrosreferencemodal.orAnd": "（或）以及",
   "ui.ui.macrotextarea.editMarkdownSource": "编辑 Markdown 源码",
   "ui.ui.macrotextarea.expandEditor": "展开编辑器",


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issues

Closes #5266
Closes #5267
Closes #5270

## Why this change

- The macro example value recursively collided with the `<macro>` component key, so react-i18next rendered `[object Object]` instead of `{{macro}}`.
- Both body-portaled macro dialogs used z-indexes below the mobile Author's Notes panel, the summary panel, and other floating chat panels, making the dialogs inaccessible and allowing parent panels to dismiss them.

## What changed

- Renamed the internal translated component tag and interpolation key while preserving the existing English, Korean, and Simplified Chinese text.
- Raised both shared macro-dialog backdrops above the existing floating-panel stack.
- Extended Author's Notes coverage to mobile and added a focused summary-editor layering regression.
- Added the user-facing changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passed locally (localization, formatting, lint, TypeScript, and production builds).
- Focused Playwright coverage passed on desktop Chromium and Pixel 7 mobile Chromium: 4 tests passed.
- The focused tests verify literal `{{macro}}` guidance, dialog z-order above Author's Notes and summary panels, and preservation of the parent panel after the expanded editor closes.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Automated viewport evidence is covered by the focused desktop/mobile Playwright run above. The in-app browser was unavailable for a separate screenshot attachment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macro references and expanded editors appearing behind floating panels, especially at narrow viewport widths.
  * Improved layering for macro-related dialogs and summary editors.

* **Localization**
  * Updated macro usage guidance placeholders across English, Korean, and Simplified Chinese translations.

* **Tests**
  * Expanded end-to-end coverage for mobile layouts, macro references, floating panels, and summary editing workflows.

* **Documentation**
  * Added release notes for the v2.4.3 rendering and layering fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->