### PR TITLE
Fix renamed Roleplay branch display names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Renamed Roleplay branches now use their branch names in the Chats sidebar, sidebar search, alphabetical sorting, and capability-package chat records instead of falling back to their parent chat names (#5268).
 - Macro reference guidance now renders the literal `{{macro}}` example, and expanded macro editors and guides stay above Author's Notes, summary, and other floating panels at narrow viewports (#5266, #5267, #5270).
 - The compact music player now stays hidden until Music DJ is installed, and its General Settings switch remains unavailable with a clear explanation until the agent is ready; installing Music DJ unlocks both immediately (#5262).
 - Professor Mari's open chat now follows the user again when they move into another chat or editor, with the interactive floating window on desktop and the quick-return avatar on mobile navigation surfaces (#5263).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -3236,7 +3236,10 @@ test("Character and persona sheets persist an explicit reference choice and fall
 
     await page.goto("/");
     await page.locator('[data-tour="panel-characters"]').click();
-    await page.getByText(characterName, { exact: true }).first().click({ position: { x: 2, y: 2 } });
+    await page
+      .getByText(characterName, { exact: true })
+      .first()
+      .click({ position: { x: 2, y: 2 } });
     const editor = page.locator(".mari-editor-shell");
     await expect(editor).toBeVisible();
     await editor
@@ -3269,7 +3272,11 @@ test("Character and persona sheets persist an explicit reference choice and fall
       .getByRole("navigation", { name: "Editor sections" })
       .getByRole("button", { name: "Gallery", exact: true })
       .click();
-    await expect(editor.getByText("Use the Select button above to enter batch editing mode and apply an action to multiple entries at once.")).toBeVisible();
+    await expect(
+      editor.getByText(
+        "Use the Select button above to enter batch editing mode and apply an action to multiple entries at once.",
+      ),
+    ).toBeVisible();
     await editor.getByRole("button", { name: "Select All", exact: true }).click();
     await expect(editor.getByText("1 selected", { exact: true })).toBeVisible();
     await expect(editor.getByRole("button", { name: "Toggle image selection" })).toHaveAttribute(
@@ -3291,7 +3298,10 @@ test("Character and persona sheets persist an explicit reference choice and fall
       .evaluate((button: HTMLButtonElement) => button.click());
     await expect(editor).toHaveCount(0);
     await page.locator('[data-tour="panel-personas"]').click();
-    await page.getByText(personaName, { exact: true }).first().click({ position: { x: 2, y: 2 } });
+    await page
+      .getByText(personaName, { exact: true })
+      .first()
+      .click({ position: { x: 2, y: 2 } });
     const personaEditor = page.locator(".mari-editor-shell");
     await expect(personaEditor).toBeVisible();
     await expect(personaEditor.getByRole("heading", { name: "Character Sheet", exact: true })).toHaveCount(0);
@@ -4453,7 +4463,10 @@ test("empty focused chat composers keep keyboard swipe navigation", async ({ pag
   }
 });
 
-test("mobile transcript swipes navigate Conversation and Roleplay alternatives", async ({ page, request }, testInfo) => {
+test("mobile transcript swipes navigate Conversation and Roleplay alternatives", async ({
+  page,
+  request,
+}, testInfo) => {
   test.skip(!testInfo.project.name.includes("mobile"), "Touch swipe navigation is covered on mobile.");
 
   const fixtures: Array<{ chatId: string; messageId: string; first: string; second: string }> = [];
@@ -6235,13 +6248,13 @@ test("Gallery Illustrate offers active custom image agents", async ({ page, requ
     await expect(menu.getByRole("menuitem", { name: "Illustrator", exact: true })).toBeVisible();
     await expect(menu.getByRole("menuitem", { name: activeAgentName, exact: true })).toBeVisible();
     await expect(menu.getByRole("menuitem", { name: inactiveAgentName, exact: true })).toHaveCount(0);
-    await drawer
-      .getByRole("searchbox", { name: "Search gallery images", exact: true })
-      .dispatchEvent("pointerdown");
+    await drawer.getByRole("searchbox", { name: "Search gallery images", exact: true }).dispatchEvent("pointerdown");
     await expect(menu).toHaveCount(0);
   } finally {
     if (chatId) await request.delete(`/api/chats/${chatId}`).catch(() => undefined);
-    await Promise.all(createdAgentIds.map((agentId) => request.delete(`/api/agents/${agentId}`).catch(() => undefined)));
+    await Promise.all(
+      createdAgentIds.map((agentId) => request.delete(`/api/agents/${agentId}`).catch(() => undefined)),
+    );
   }
 });
 
@@ -7447,13 +7460,8 @@ test("Game combat sheet helpers preserve ability types, card matches, and zero H
   await page.goto("/");
   const result = await page.evaluate(async () => {
     const module = (await import("/src/components/game/GameSurface.tsx")) as unknown as {
-      combatSkillsFromSheet(value: unknown):
-        | Array<{ name: string; type: string; description?: string }>
-        | undefined;
-      findGameCombatCard(
-        cards: Array<{ name?: string }>,
-        targetName: string,
-      ): { name?: string } | undefined;
+      combatSkillsFromSheet(value: unknown): Array<{ name: string; type: string; description?: string }> | undefined;
+      findGameCombatCard(cards: Array<{ name?: string }>, targetName: string): { name?: string } | undefined;
       generatedPartyMemberToCombatant(
         member: Record<string, unknown>,
         index: number,
@@ -7492,11 +7500,7 @@ test("Game combat sheet helpers preserve ability types, card matches, and zero H
         [],
         1,
       ),
-      enemy: module.generatedEnemyToCombatant(
-        { name: "Slime", hp: 0, maxHp: 9, attacks: [], statuses: [] },
-        0,
-        1,
-      ),
+      enemy: module.generatedEnemyToCombatant({ name: "Slime", hp: 0, maxHp: 9, attacks: [], statuses: [] }, 0, 1),
       invalidPartyHp: module.generatedPartyMemberToCombatant(
         { name: "Mika", hp: false, maxHp: 12, attacks: [], statuses: [] },
         0,
@@ -13519,7 +13523,9 @@ test("Lorebook vectorization saves pending eligibility settings first", async ({
       const entries = (await response.json()) as Array<Record<string, unknown>>;
       await route.fulfill({
         response,
-        json: entries.map((candidate) => (candidate.id === entry.id ? { ...candidate, embedding: [0.1, 0.2] } : candidate)),
+        json: entries.map((candidate) =>
+          candidate.id === entry.id ? { ...candidate, embedding: [0.1, 0.2] } : candidate,
+        ),
       });
     });
 
@@ -13527,8 +13533,8 @@ test("Lorebook vectorization saves pending eligibility settings first", async ({
       vectorizeRequestCount += 1;
       const savedResponse = await request.get(`/api/lorebooks/${lorebook.id}`);
       expect(savedResponse.ok()).toBeTruthy();
-      excludedAtVectorization = ((await savedResponse.json()) as { excludeFromVectorization?: boolean })
-        .excludeFromVectorization ?? null;
+      excludedAtVectorization =
+        ((await savedResponse.json()) as { excludeFromVectorization?: boolean }).excludeFromVectorization ?? null;
       reportStoredVector = true;
       await route.fulfill({
         status: 200,
@@ -14847,9 +14853,7 @@ test("home browser hub scales cleanly and opens FAQ as a bookmark window", async
     const [widgetBounds, shortcutBounds] = await Promise.all([widget.boundingBox(), lastShortcut.boundingBox()]);
     expect(widgetBounds).not.toBeNull();
     expect(shortcutBounds).not.toBeNull();
-    expect(shortcutBounds!.y + shortcutBounds!.height).toBeLessThanOrEqual(
-      widgetBounds!.y + widgetBounds!.height + 1,
-    );
+    expect(shortcutBounds!.y + shortcutBounds!.height).toBeLessThanOrEqual(widgetBounds!.y + widgetBounds!.height + 1);
   }
 
   if (mobile) {
@@ -15201,10 +15205,10 @@ test("Professor Mari navigation can be repositioned within Home on desktop", asy
     module.useUIStore.getState().setProfessorMariNavigationEnabled(true);
   });
   await expect(sprite).toBeVisible({ timeout: 1_000 });
-  await expect(page.getByText("Hey, having trouble finding something? Looking for a Chats tab? Let me help!", { exact: true })).toBeVisible();
-  await expect
-    .poll(() => page.evaluate(() => localStorage.getItem("marinara:home:professor-position:v1")))
-    .toBeNull();
+  await expect(
+    page.getByText("Hey, having trouble finding something? Looking for a Chats tab? Let me help!", { exact: true }),
+  ).toBeVisible();
+  await expect.poll(() => page.evaluate(() => localStorage.getItem("marinara:home:professor-position:v1"))).toBeNull();
   const resetPosition = await sprite.boundingBox();
   expect(resetPosition).not.toBeNull();
   expect(resetPosition!.x).toBeLessThan(contentBounds!.x + contentBounds!.width / 2);
@@ -15624,6 +15628,39 @@ test("chat mode tabs and new-chat actions stay reachable", async ({ page }) => {
     expect(errors).toEqual([]);
   } finally {
     await Promise.allSettled(characterlessChats.map((chat) => page.request.delete(`/api/chats/${chat.id}?force=true`)));
+  }
+});
+
+test("renamed Roleplay branches use their display name in the Chats sidebar and search", async ({ page, request }) => {
+  const rawName = `Branch parent fallback ${Date.now()}`;
+  const displayName = `NPC_First Kiss ${Date.now()}`;
+  const chatResponse = await request.post("/api/chats", {
+    data: { name: rawName, mode: "roleplay", characterIds: [] },
+  });
+  expect(chatResponse.ok(), await chatResponse.text()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+
+  try {
+    const metadataResponse = await request.patch(`/api/chats/${chat.id}/metadata`, {
+      data: { branchName: displayName, branchParentChatId: "branch-display-parent" },
+    });
+    expect(metadataResponse.ok(), await metadataResponse.text()).toBeTruthy();
+
+    await page.goto("/");
+    await page.locator('[data-tour="sidebar-toggle"]').click();
+    const sidebar = page.locator('[data-component="ChatSidebar"]');
+    await expect(sidebar).toBeVisible();
+    await sidebar.locator('[data-tour="chat-mode-roleplay"]').click();
+
+    const chatRow = sidebar.locator(`[data-chat-id="${chat.id}"]`);
+    await expect(chatRow).toContainText(displayName);
+    await expect(chatRow).not.toContainText(rawName);
+
+    const search = sidebar.getByPlaceholder("Search roleplays");
+    await search.fill("First Kiss");
+    await expect(chatRow).toBeVisible();
+  } finally {
+    await request.delete(`/api/chats/${chat.id}?force=true`).catch(() => undefined);
   }
 });
 
@@ -16528,11 +16565,13 @@ test("mobile topbar remains reachable while sidebars switch", async ({ page }, t
   expect(mobileActionOffsets.every((offset) => offset >= 0)).toBe(true);
   expect(new Set(mobileActionOffsets).size).toBe(mobileActionOrder.length);
   expect(mobileActionOffsets).toEqual([...mobileActionOffsets].sort((left, right) => left - right));
-  const mobileDomActionOrder = await topbar.locator("[data-topbar-hover-key]").evaluateAll((elements) =>
-    elements
-      .map((element) => (element as HTMLElement).dataset.topbarHoverKey)
-      .filter((key): key is string => Boolean(key)),
-  );
+  const mobileDomActionOrder = await topbar
+    .locator("[data-topbar-hover-key]")
+    .evaluateAll((elements) =>
+      elements
+        .map((element) => (element as HTMLElement).dataset.topbarHoverKey)
+        .filter((key): key is string => Boolean(key)),
+    );
   expect(mobileDomActionOrder.slice(0, mobileActionOrder.length)).toEqual(mobileActionOrder);
   const homeIconBounds = await homeButton.locator("svg").boundingBox();
   const chatsIconBounds = await chatsButton.locator("svg").boundingBox();
@@ -16666,9 +16705,7 @@ test("Characters topbar underline uses the Characters pink", async ({ page }) =>
   await expect(underline).toBeVisible();
   await expect
     .poll(() =>
-      underline.evaluate((element) =>
-        getComputedStyle(element).getPropertyValue("--mari-panel-gradient-start").trim(),
-      ),
+      underline.evaluate((element) => getComputedStyle(element).getPropertyValue("--mari-panel-gradient-start").trim()),
     )
     .toBe("#f472b6");
 });
@@ -16730,7 +16767,9 @@ test("mobile Docker update checks offer the selected staging image", async ({ pa
 
   await expect(page.getByText("Switch to Staging/UAT", { exact: true })).toBeVisible();
   await expect(page.getByText("ghcr.io/pasta-devs/marinara-engine:staging", { exact: true })).toBeVisible();
-  await expect(page.getByText(/Set the Compose image to .*:staging, then pull it and restart the container\./)).toBeVisible();
+  await expect(
+    page.getByText(/Set the Compose image to .*:staging, then pull it and restart the container\./),
+  ).toBeVisible();
   await expect(page.getByText(/latest Staging\/UAT target/)).toHaveCount(0);
 });
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -15712,7 +15712,8 @@ test("renamed Roleplay branches use their display name in the Chats sidebar and 
     await search.fill("First Kiss");
     await expect(chatRow).toBeVisible();
   } finally {
-    await request.delete(`/api/chats/${chat.id}?force=true`).catch(() => undefined);
+    const cleanupResponse = await request.delete(`/api/chats/${chat.id}?force=true`);
+    expect(cleanupResponse.ok(), await cleanupResponse.text()).toBeTruthy();
   }
 });
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -3236,10 +3236,7 @@ test("Character and persona sheets persist an explicit reference choice and fall
 
     await page.goto("/");
     await page.locator('[data-tour="panel-characters"]').click();
-    await page
-      .getByText(characterName, { exact: true })
-      .first()
-      .click({ position: { x: 2, y: 2 } });
+    await page.getByText(characterName, { exact: true }).first().click({ position: { x: 2, y: 2 } });
     const editor = page.locator(".mari-editor-shell");
     await expect(editor).toBeVisible();
     await editor
@@ -3272,11 +3269,7 @@ test("Character and persona sheets persist an explicit reference choice and fall
       .getByRole("navigation", { name: "Editor sections" })
       .getByRole("button", { name: "Gallery", exact: true })
       .click();
-    await expect(
-      editor.getByText(
-        "Use the Select button above to enter batch editing mode and apply an action to multiple entries at once.",
-      ),
-    ).toBeVisible();
+    await expect(editor.getByText("Use the Select button above to enter batch editing mode and apply an action to multiple entries at once.")).toBeVisible();
     await editor.getByRole("button", { name: "Select All", exact: true }).click();
     await expect(editor.getByText("1 selected", { exact: true })).toBeVisible();
     await expect(editor.getByRole("button", { name: "Toggle image selection" })).toHaveAttribute(
@@ -3298,10 +3291,7 @@ test("Character and persona sheets persist an explicit reference choice and fall
       .evaluate((button: HTMLButtonElement) => button.click());
     await expect(editor).toHaveCount(0);
     await page.locator('[data-tour="panel-personas"]').click();
-    await page
-      .getByText(personaName, { exact: true })
-      .first()
-      .click({ position: { x: 2, y: 2 } });
+    await page.getByText(personaName, { exact: true }).first().click({ position: { x: 2, y: 2 } });
     const personaEditor = page.locator(".mari-editor-shell");
     await expect(personaEditor).toBeVisible();
     await expect(personaEditor.getByRole("heading", { name: "Character Sheet", exact: true })).toHaveCount(0);
@@ -4463,10 +4453,7 @@ test("empty focused chat composers keep keyboard swipe navigation", async ({ pag
   }
 });
 
-test("mobile transcript swipes navigate Conversation and Roleplay alternatives", async ({
-  page,
-  request,
-}, testInfo) => {
+test("mobile transcript swipes navigate Conversation and Roleplay alternatives", async ({ page, request }, testInfo) => {
   test.skip(!testInfo.project.name.includes("mobile"), "Touch swipe navigation is covered on mobile.");
 
   const fixtures: Array<{ chatId: string; messageId: string; first: string; second: string }> = [];
@@ -6248,13 +6235,13 @@ test("Gallery Illustrate offers active custom image agents", async ({ page, requ
     await expect(menu.getByRole("menuitem", { name: "Illustrator", exact: true })).toBeVisible();
     await expect(menu.getByRole("menuitem", { name: activeAgentName, exact: true })).toBeVisible();
     await expect(menu.getByRole("menuitem", { name: inactiveAgentName, exact: true })).toHaveCount(0);
-    await drawer.getByRole("searchbox", { name: "Search gallery images", exact: true }).dispatchEvent("pointerdown");
+    await drawer
+      .getByRole("searchbox", { name: "Search gallery images", exact: true })
+      .dispatchEvent("pointerdown");
     await expect(menu).toHaveCount(0);
   } finally {
     if (chatId) await request.delete(`/api/chats/${chatId}`).catch(() => undefined);
-    await Promise.all(
-      createdAgentIds.map((agentId) => request.delete(`/api/agents/${agentId}`).catch(() => undefined)),
-    );
+    await Promise.all(createdAgentIds.map((agentId) => request.delete(`/api/agents/${agentId}`).catch(() => undefined)));
   }
 });
 
@@ -7460,8 +7447,13 @@ test("Game combat sheet helpers preserve ability types, card matches, and zero H
   await page.goto("/");
   const result = await page.evaluate(async () => {
     const module = (await import("/src/components/game/GameSurface.tsx")) as unknown as {
-      combatSkillsFromSheet(value: unknown): Array<{ name: string; type: string; description?: string }> | undefined;
-      findGameCombatCard(cards: Array<{ name?: string }>, targetName: string): { name?: string } | undefined;
+      combatSkillsFromSheet(value: unknown):
+        | Array<{ name: string; type: string; description?: string }>
+        | undefined;
+      findGameCombatCard(
+        cards: Array<{ name?: string }>,
+        targetName: string,
+      ): { name?: string } | undefined;
       generatedPartyMemberToCombatant(
         member: Record<string, unknown>,
         index: number,
@@ -7500,7 +7492,11 @@ test("Game combat sheet helpers preserve ability types, card matches, and zero H
         [],
         1,
       ),
-      enemy: module.generatedEnemyToCombatant({ name: "Slime", hp: 0, maxHp: 9, attacks: [], statuses: [] }, 0, 1),
+      enemy: module.generatedEnemyToCombatant(
+        { name: "Slime", hp: 0, maxHp: 9, attacks: [], statuses: [] },
+        0,
+        1,
+      ),
       invalidPartyHp: module.generatedPartyMemberToCombatant(
         { name: "Mika", hp: false, maxHp: 12, attacks: [], statuses: [] },
         0,
@@ -13523,9 +13519,7 @@ test("Lorebook vectorization saves pending eligibility settings first", async ({
       const entries = (await response.json()) as Array<Record<string, unknown>>;
       await route.fulfill({
         response,
-        json: entries.map((candidate) =>
-          candidate.id === entry.id ? { ...candidate, embedding: [0.1, 0.2] } : candidate,
-        ),
+        json: entries.map((candidate) => (candidate.id === entry.id ? { ...candidate, embedding: [0.1, 0.2] } : candidate)),
       });
     });
 
@@ -13533,8 +13527,8 @@ test("Lorebook vectorization saves pending eligibility settings first", async ({
       vectorizeRequestCount += 1;
       const savedResponse = await request.get(`/api/lorebooks/${lorebook.id}`);
       expect(savedResponse.ok()).toBeTruthy();
-      excludedAtVectorization =
-        ((await savedResponse.json()) as { excludeFromVectorization?: boolean }).excludeFromVectorization ?? null;
+      excludedAtVectorization = ((await savedResponse.json()) as { excludeFromVectorization?: boolean })
+        .excludeFromVectorization ?? null;
       reportStoredVector = true;
       await route.fulfill({
         status: 200,
@@ -14853,7 +14847,9 @@ test("home browser hub scales cleanly and opens FAQ as a bookmark window", async
     const [widgetBounds, shortcutBounds] = await Promise.all([widget.boundingBox(), lastShortcut.boundingBox()]);
     expect(widgetBounds).not.toBeNull();
     expect(shortcutBounds).not.toBeNull();
-    expect(shortcutBounds!.y + shortcutBounds!.height).toBeLessThanOrEqual(widgetBounds!.y + widgetBounds!.height + 1);
+    expect(shortcutBounds!.y + shortcutBounds!.height).toBeLessThanOrEqual(
+      widgetBounds!.y + widgetBounds!.height + 1,
+    );
   }
 
   if (mobile) {
@@ -15205,10 +15201,10 @@ test("Professor Mari navigation can be repositioned within Home on desktop", asy
     module.useUIStore.getState().setProfessorMariNavigationEnabled(true);
   });
   await expect(sprite).toBeVisible({ timeout: 1_000 });
-  await expect(
-    page.getByText("Hey, having trouble finding something? Looking for a Chats tab? Let me help!", { exact: true }),
-  ).toBeVisible();
-  await expect.poll(() => page.evaluate(() => localStorage.getItem("marinara:home:professor-position:v1"))).toBeNull();
+  await expect(page.getByText("Hey, having trouble finding something? Looking for a Chats tab? Let me help!", { exact: true })).toBeVisible();
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem("marinara:home:professor-position:v1")))
+    .toBeNull();
   const resetPosition = await sprite.boundingBox();
   expect(resetPosition).not.toBeNull();
   expect(resetPosition!.x).toBeLessThan(contentBounds!.x + contentBounds!.width / 2);
@@ -16565,13 +16561,11 @@ test("mobile topbar remains reachable while sidebars switch", async ({ page }, t
   expect(mobileActionOffsets.every((offset) => offset >= 0)).toBe(true);
   expect(new Set(mobileActionOffsets).size).toBe(mobileActionOrder.length);
   expect(mobileActionOffsets).toEqual([...mobileActionOffsets].sort((left, right) => left - right));
-  const mobileDomActionOrder = await topbar
-    .locator("[data-topbar-hover-key]")
-    .evaluateAll((elements) =>
-      elements
-        .map((element) => (element as HTMLElement).dataset.topbarHoverKey)
-        .filter((key): key is string => Boolean(key)),
-    );
+  const mobileDomActionOrder = await topbar.locator("[data-topbar-hover-key]").evaluateAll((elements) =>
+    elements
+      .map((element) => (element as HTMLElement).dataset.topbarHoverKey)
+      .filter((key): key is string => Boolean(key)),
+  );
   expect(mobileDomActionOrder.slice(0, mobileActionOrder.length)).toEqual(mobileActionOrder);
   const homeIconBounds = await homeButton.locator("svg").boundingBox();
   const chatsIconBounds = await chatsButton.locator("svg").boundingBox();
@@ -16705,7 +16699,9 @@ test("Characters topbar underline uses the Characters pink", async ({ page }) =>
   await expect(underline).toBeVisible();
   await expect
     .poll(() =>
-      underline.evaluate((element) => getComputedStyle(element).getPropertyValue("--mari-panel-gradient-start").trim()),
+      underline.evaluate((element) =>
+        getComputedStyle(element).getPropertyValue("--mari-panel-gradient-start").trim(),
+      ),
     )
     .toBe("#f472b6");
 });
@@ -16767,9 +16763,7 @@ test("mobile Docker update checks offer the selected staging image", async ({ pa
 
   await expect(page.getByText("Switch to Staging/UAT", { exact: true })).toBeVisible();
   await expect(page.getByText("ghcr.io/pasta-devs/marinara-engine:staging", { exact: true })).toBeVisible();
-  await expect(
-    page.getByText(/Set the Compose image to .*:staging, then pull it and restart the container\./),
-  ).toBeVisible();
+  await expect(page.getByText(/Set the Compose image to .*:staging, then pull it and restart the container\./)).toBeVisible();
   await expect(page.getByText(/latest Staging\/UAT target/)).toHaveCount(0);
 });
 

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -63,7 +63,7 @@ import {
 import { resolveLiveConversationStatus } from "../../lib/conversation-presence-status";
 import { Modal } from "../ui/Modal";
 import { Reorder, useDragControls } from "framer-motion";
-import { parseChatMetadata } from "../../lib/chat-display";
+import { getChatDisplayName, parseChatMetadata } from "../../lib/chat-display";
 import {
   compareChatsByActivityDesc,
   compareChatsByCreatedAtAsc,
@@ -395,7 +395,7 @@ export function ChatSidebar() {
         .filter(Boolean);
 
       return (
-        includesTextForMatch(toSearchText(chat.name), query) ||
+        includesTextForMatch(toSearchText(getChatDisplayName(chat)), query) ||
         tags.some((tag) => includesTextForMatch(tag, query)) ||
         characterNames.some((name) => includesTextForMatch(name, query))
       );
@@ -421,9 +421,9 @@ export function ChatSidebar() {
         case "oldest":
           return compareChatsByCreatedAtAsc(a, b);
         case "name-asc":
-          return toSearchText(a.name).localeCompare(toSearchText(b.name));
+          return toSearchText(getChatDisplayName(a)).localeCompare(toSearchText(getChatDisplayName(b)));
         case "name-desc":
-          return toSearchText(b.name).localeCompare(toSearchText(a.name));
+          return toSearchText(getChatDisplayName(b)).localeCompare(toSearchText(getChatDisplayName(a)));
         case "newest":
           return compareChatsByCreatedAtDesc(a, b);
         case "recent":
@@ -896,6 +896,7 @@ export function ChatSidebar() {
   // ── Chat row renderer (shared between unfiled + folder sections) ──
   const renderChatRow = ({ chat, branchCount }: (typeof displayChats)[number]) => {
     const cfg = MODE_CONFIG[chat.mode] ?? MODE_CONFIG.conversation;
+    const displayName = getChatDisplayName(chat);
     const isActive = activeChatId === chat.id || (chat.groupId != null && chat.groupId === activeGroupId);
     const isSelected = selectedChatIds.has(chat.id);
     const charIds = normalizeChatCharacterIds((chat as { characterIds?: unknown }).characterIds);
@@ -1207,7 +1208,7 @@ export function ChatSidebar() {
               isActive ? "mari-chrome-text-strong font-medium" : "mari-chrome-text",
             )}
           >
-            {chat.name}
+            {displayName}
           </span>
           {subtitle && (
             <span className="mari-chrome-accent-text-muted flex items-center gap-1 truncate text-[0.6875rem] leading-tight">
@@ -1237,13 +1238,13 @@ export function ChatSidebar() {
         {/* Delete button */}
         {!multiSelectMode && (
           <button
-            aria-label={localizeUi("chat.branches.deleteLabel", { name: chat.name })}
+            aria-label={localizeUi("chat.branches.deleteLabel", { name: displayName })}
             onClick={async (e) => {
               e.stopPropagation();
               if (branchCount > 1 && chat.groupId) {
                 setDeleteTarget({
                   chatId: chat.id,
-                  chatName: chat.name,
+                  chatName: displayName,
                   groupId: chat.groupId,
                   branchCount,
                 });
@@ -1251,7 +1252,7 @@ export function ChatSidebar() {
                 if (
                   await showConfirmDialog({
                     title: localizeUi("ui.layout.chatsidebar.deleteChat"),
-                    message: localizeUi("dialog.delete.namedPermanent", { name: chat.name }),
+                    message: localizeUi("dialog.delete.namedPermanent", { name: displayName }),
                     confirmLabel: localizeUi("lorebook.editor.batch.delete"),
                     tone: "destructive",
                   })

--- a/packages/server/src/services/capability-packages/capability-persistence.service.ts
+++ b/packages/server/src/services/capability-packages/capability-persistence.service.ts
@@ -89,16 +89,17 @@ function mapBranchMetadata(value: unknown): CapabilityChatRecord["branch"] {
 }
 
 function mapChat(row: typeof chats.$inferSelect): CapabilityChatRecord {
+  const branch = mapBranchMetadata(row.metadata);
   return {
     id: row.id,
-    name: row.name,
+    name: branch?.title ?? row.name,
     mode: row.mode,
     characterIds: parseStringArray(row.characterIds),
     groupId: row.groupId,
     personaId: row.personaId,
     connectionId: row.connectionId,
     metadata: row.metadata,
-    branch: mapBranchMetadata(row.metadata),
+    branch,
     lastMessageAt: row.lastMessageAt,
     updatedAt: row.updatedAt,
   };

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -1053,11 +1053,7 @@ try {
       browserTabAsset?.file,
       join(packagesRoot, "versions", agentSuite.id, agentSuite.version, "suite-tab.png"),
     );
-    assert.equal(
-      browserTabAsset?.data?.toString("utf8"),
-      "x",
-      "Every serve must hand back the exact bytes it hashed",
-    );
+    assert.equal(browserTabAsset?.data?.toString("utf8"), "x", "Every serve must hand back the exact bytes it hashed");
     const repeatAsset = await capabilityPackageManager.packageAsset(agentSuite.id, "suite-tab.png");
     assert.deepEqual(repeatAsset, browserTabAsset, "Repeated resolution must be deterministic");
     assert.equal(
@@ -1438,6 +1434,21 @@ try {
   assert.equal(rollbackChatBefore.name, "Capability persistence rollback fixture");
   assert.deepEqual(rollbackChatBefore.characterIds, []);
   assert.equal(rollbackChatBefore.connectionId, null);
+  const namedBranchChat = await chatsStore.create({
+    name: "Capability branch parent fallback",
+    mode: "roleplay",
+    characterIds: [],
+  });
+  assert.ok(namedBranchChat);
+  await chatsStore.patchMetadata(namedBranchChat.id, {
+    branchName: "NPC_First Kiss",
+    branchParentChatId: rollbackChat.id,
+  });
+  const capabilityBranchChat = await persistence.getChat(namedBranchChat.id);
+  assert.ok(capabilityBranchChat);
+  assert.equal(capabilityBranchChat.name, "NPC_First Kiss");
+  assert.equal(capabilityBranchChat.branch?.title, "NPC_First Kiss");
+  assert.equal(capabilityBranchChat.branch?.parentChatId, rollbackChat.id);
   const gameStates = createGameStateStorage(db);
   const gameStateBase = {
     chatId: rollbackChat.id,

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -1053,7 +1053,11 @@ try {
       browserTabAsset?.file,
       join(packagesRoot, "versions", agentSuite.id, agentSuite.version, "suite-tab.png"),
     );
-    assert.equal(browserTabAsset?.data?.toString("utf8"), "x", "Every serve must hand back the exact bytes it hashed");
+    assert.equal(
+      browserTabAsset?.data?.toString("utf8"),
+      "x",
+      "Every serve must hand back the exact bytes it hashed",
+    );
     const repeatAsset = await capabilityPackageManager.packageAsset(agentSuite.id, "suite-tab.png");
     assert.deepEqual(repeatAsset, browserTabAsset, "Repeated resolution must be deterministic");
     assert.equal(


### PR DESCRIPTION
## Why

Renamed Roleplay branches still appeared under their parent/fallback chat names in the Chats sidebar and capability-package persistence records. Search and alphabetical sorting used the same stale value, making renamed branches hard to find.

Fixes #5268.

## What changed

- reuse the existing branch display-name helper for sidebar rows, search, sorting, and delete copy
- expose the resolved branch title as the capability chat record name while retaining branch metadata
- add focused server and desktop/mobile browser regressions
- add the user-facing changelog entry

## Validation

- [ ] Run `pnpm check`
- [ ] Run the focused capability-package lifecycle regression
- [ ] Manually verify a renamed Roleplay branch appears under its branch name in the desktop Chats sidebar
- [ ] Manually verify sidebar search finds that branch name on desktop
- [ ] Manually verify the same display and search behavior on mobile


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Renamed Roleplay branches now consistently display their configured names in chat navigation, sorting, deletion dialogs, and search results.
  * Capability-package chat records now preserve the correct branch name and parent-chat relationship.

* **Tests**
  * Added coverage for renamed branch display and Roleplay search discovery.
  * Added regression coverage for capability-package branch metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->