### PR TITLE
Keep stale CYOA choices hidden after goto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Jumping to older messages with `/goto` no longer revives stale CYOA choices at the chat tail (#5269).
 - Macro reference guidance now renders the literal `{{macro}}` example, and expanded macro editors and guides stay above Author's Notes, summary, and other floating panels at narrow viewports (#5266, #5267, #5270).
 - The compact music player now stays hidden until Music DJ is installed, and its General Settings switch remains unavailable with a clear explanation until the agent is ready; installing Music DJ unlocks both immediately (#5262).
 - Professor Mari's open chat now follows the user again when they move into another chat or editor, with the interactive floating window on desktop and the quick-return avatar on mobile navigation surfaces (#5263).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -4570,7 +4570,10 @@ test("goto keeps stale CYOA choices out of the chat tail", async ({ page, reques
       localStorage.setItem("marinara-active-chat-id", chatId);
       localStorage.setItem(
         "marinara-engine-ui",
-        JSON.stringify({ state: { hasCompletedOnboarding: true, messagesPerPage: 100 }, version: 87 }),
+        JSON.stringify({
+          state: { hasCompletedOnboarding: true, messagesPerPage: 100, sidebarOpen: false, rightPanelOpen: false },
+          version: 87,
+        }),
       );
     }, imported.chatId);
     await page.goto("/");
@@ -4581,7 +4584,7 @@ test("goto keeps stale CYOA choices out of the chat tail", async ({ page, reques
 
     const composer = page.locator("textarea.mari-chat-input-textarea");
     await composer.fill("/goto 1");
-    await composer.press("Enter");
+    await page.locator("button.mari-chat-send-btn").click();
     await expect(page.getByText("Imported assistant message 1", { exact: true })).toBeVisible();
     await expect(staleChoice).toHaveCount(0);
   } finally {

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -4536,6 +4536,59 @@ test("mobile transcript swipes navigate Conversation and Roleplay alternatives",
   }
 });
 
+test("goto keeps stale CYOA choices out of the chat tail", async ({ page, request }) => {
+  const staleChoiceText = `Wait for the stale path ${Date.now()}`;
+  const transcript = [
+    JSON.stringify({ user_name: "You", character_name: "Guide", chat_metadata: {} }),
+    ...Array.from({ length: 81 }, (_, index) =>
+      JSON.stringify({
+        name: "Guide",
+        is_user: false,
+        mes: `Imported assistant message ${index + 1}`,
+        extra:
+          index === 79
+            ? { cyoaChoices: [{ label: "Wait", text: staleChoiceText }] }
+            : {},
+      }),
+    ),
+  ].join("\n");
+  const importResponse = await request.post("/api/import/st-chat", {
+    multipart: {
+      file: {
+        name: `cyoa-goto-tail-${Date.now()}.jsonl`,
+        mimeType: "application/jsonl",
+        buffer: Buffer.from(transcript),
+      },
+      mode: "roleplay",
+    },
+  });
+  expect(importResponse.ok(), await importResponse.text()).toBeTruthy();
+  const imported = (await importResponse.json()) as { chatId: string };
+
+  try {
+    await page.addInitScript((chatId) => {
+      localStorage.setItem("marinara-active-chat-id", chatId);
+      localStorage.setItem(
+        "marinara-engine-ui",
+        JSON.stringify({ state: { hasCompletedOnboarding: true, messagesPerPage: 100 }, version: 87 }),
+      );
+    }, imported.chatId);
+    await page.goto("/");
+
+    const staleChoice = page.getByText(staleChoiceText, { exact: true });
+    await expect(page.getByText("Imported assistant message 81", { exact: true })).toBeVisible();
+    await expect(staleChoice).toHaveCount(0);
+
+    const composer = page.locator("textarea.mari-chat-input-textarea");
+    await composer.fill("/goto 1");
+    await composer.press("Enter");
+    await expect(page.getByText("Imported assistant message 1", { exact: true })).toBeVisible();
+    await expect(staleChoice).toHaveCount(0);
+  } finally {
+    await request.delete(`/api/chats/${imported.chatId}?force=true`).catch(() => undefined);
+  }
+});
+
 test("typographic quotes do not pull the Roleplay caret behind later text", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Roleplay quote caret behavior is covered on desktop.");
 

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -2302,7 +2302,7 @@ export function ChatRoleplaySurface({
                   buttonClassName="border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-button-bg-active)] text-[var(--marinara-chat-chrome-button-text-active)] hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]"
                 />
 
-                {!isStreaming && <CyoaChoices messages={visibleMessages} />}
+                {!isStreaming && <CyoaChoices messages={messages} />}
 
                 {hasLiveStream && !regenerateMessageId && (
                   <StreamingIndicator


### PR DESCRIPTION
## Why

`/goto` moves Roleplay into an older 80-message render window. The tail-mounted CYOA control was hydrating from that temporary window, so an old assistant message could resurrect its saved choices even when the actual chat tail had newer choice-free messages.

Fixes #5269.

## What changed

- hydrate the tail CYOA control from the full loaded message set instead of the temporary render window
- add a focused 81-message imported-chat regression that jumps across the window boundary
- add the user-facing changelog entry

## Validation

- [ ] Run `pnpm check`
- [ ] Run the focused desktop browser regression
- [ ] Run the focused mobile browser regression
- [ ] Manually verify `/goto` does not show old CYOA choices at the Roleplay chat tail


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where `/goto` could display outdated CYOA choices from later messages when navigating to older chat messages.
  - CYOA choices now remain hidden while a response is streaming and display correctly based on the full conversation history.

- **Tests**
  - Added end-to-end coverage for navigating imported chats with `/goto`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->