### PR TITLE
docs(agents): document Beholder's two prompt templates

### DIFF
--- a/docs/agents/built-in-agents.md
+++ b/docs/agents/built-in-agents.md
@@ -121,7 +121,11 @@ Tracks each character's current clothing by body slot, held items, wounds, missi
 - **Phase**: Post-Processing.
 - **Where it works**: Roleplay only.
 - **Key settings**: add or remove it under **Chat Settings → Agents → Tracker Agents**; open **Configure Beholder** there to choose its connection, model, prompt, context, and output limits. **Add as Prompt Section** is on by default.
-- **Model recommendation**: use a SOTA model such as OpenAI GPT-5.5+, Claude Opus 4.8+, or Kimi K3+ for reliable full-state tracking.
+- **Model recommendation**: pick the prompt template that matches the model behind Beholder's connection. The two shipped templates are not interchangeable — each is written for a different kind of model.
+  - **SOTA model — one prompt** (default): one call covering every tracked field. Use a strong general model such as OpenAI GPT-5.5+, Claude Opus 4.8+, or Kimi K3+.
+  - **Beholder local model — five passes**: five narrow calls, one per tracked lane, for the purpose-trained [Beholder](https://huggingface.co/GetBeholder/Beholder-GGUF) extractor served locally (for example `Beholder-Q8_0.gguf` behind koboldcpp or llama.cpp). That model is trained to answer one lane at a time, so the single-prompt template is off-distribution for it and returns partial state. Engine unions the five per-lane results into one update. Runs fully offline at no cost.
+
+  Beholder cannot detect which model sits behind a connection, so this stays a manual choice. A mismatch is not fatal but degrades extraction: a SOTA model handles either template, while the local model needs the five-pass one.
 - **Origin**: adapted into Engine's native Agent runtime from [GetBeholder/Beholder-ME](https://github.com/GetBeholder/Beholder-ME), licensed AGPL-3.0-only. The official package does not load the legacy extension's DOM, polling, or local-storage runtime.
 
 ### Persona Stats


### PR DESCRIPTION
## Linked issue

No separate issue — documentation follow-up to #5251 (merged), which added the multi-pass Beholder execution path this describes. Pairs with Marinara-Agents package `beholder` 1.2.x, which ships the template.

## Why this change

The Beholder entry still tells the reader to use a SOTA model, full stop. Since #5251 the Agent also drives a locally hosted per-lane extractor through a five-pass template, and nothing in the docs says that exists or when to pick it. A reader following the current text has no way to know the local option is there — or, worse, points the local model at the single-prompt template and concludes Beholder is broken.

## What changed

`docs/agents/built-in-agents.md`, Beholder section only:

- **Model recommendation** now describes both shipped templates instead of one:
  - *SOTA model — one prompt* (default) — unchanged advice, one call covering every field.
  - *Beholder local model — five passes* — five narrow calls for the purpose-trained extractor served locally, with a link to the model and a note that Engine unions the per-lane results.
- States plainly that the choice is **manual**, because Beholder cannot see which model is behind a connection, and describes what a mismatch actually costs (degraded extraction, not a hard failure).

No other section touched. Docs only — no code, no behaviour change.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Markdown-only change to one section, so the app checkboxes above do not apply and I have not ticked them.

What I did check: the section renders as intended (nested bullets under **Model recommendation**, trailing paragraph attached to the list item), and both links resolve — the model repo returns 200, as does the `Beholder-Q8_0.gguf` file it names. The existing `GetBeholder/Beholder-ME` origin line is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated model recommendation guidance with separate templates for standard and local extraction workflows.
  * Documented model requirements, multi-pass result aggregation, offline support, and manual template selection considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->