### PR TITLE
Fix Professor Mari lorebook edit commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Professor Mari now asks compatible OpenRouter workspace models for JSON responses and treats an explicit request to split lorebook entries as authorization to create the split-off entries as well as update the originals (#5271).
 - Macro reference guidance now renders the literal `{{macro}}` example, and expanded macro editors and guides stay above Author's Notes, summary, and other floating panels at narrow viewports (#5266, #5267, #5270).
 - The compact music player now stays hidden until Music DJ is installed, and its General Settings switch remains unavailable with a clear explanation until the agent is ready; installing Music DJ unlocks both immediately (#5262).
 - Professor Mari's open chat now follows the user again when they move into another chat or editor, with the interactive floating window on desktop and the quick-return avatar on mobile navigation surfaces (#5263).

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -194,6 +194,10 @@ const SKIPPED_DIRS = new Set([
   ".gradle",
 ]);
 
+export function professorMariWorkspaceResponseFormat(provider: string): ChatOptions["responseFormat"] | undefined {
+  return provider === "openrouter" ? { type: "json_object" } : undefined;
+}
+
 export const PROFESSOR_MARI_APP_DATA_ACTIONS = [
   "character.list",
   "character.get",
@@ -1746,6 +1750,19 @@ function explicitlyNamedMutationEntities(text: string): Set<string> {
   return entities;
 }
 
+function authorizesLorebookEntrySplit(
+  text: string,
+  entity: string | null,
+  category: WorkspaceMutationCategory,
+): boolean {
+  return (
+    entity === "lorebook" &&
+    (category === "create" || category === "update") &&
+    /\bsplit\b/iu.test(text) &&
+    /\blorebooks?(?:\s+entries?)?\b/iu.test(text)
+  );
+}
+
 export function workspaceMutationAuthorizationIssue(
   command: WorkspaceCommandCall,
   context: { directUserText: string; previousAssistantText?: string | null },
@@ -1762,6 +1779,7 @@ export function workspaceMutationAuthorizationIssue(
   }
 
   const category = workspaceMutationCategory(command);
+  const commandEntity = appDataMutationEntity(command);
   if (SHORT_MUTATION_CONFIRMATION.test(directUserText)) {
     const previousAssistantText = normalizeAuthorizationText(context.previousAssistantText ?? "");
     const previousCategories = explicitlyRequestedMutationCategories(previousAssistantText);
@@ -1780,25 +1798,26 @@ export function workspaceMutationAuthorizationIssue(
   const authorizationScope = genericAuthorization
     ? directUserText.replace(GENERIC_MUTATION_AUTHORIZATION_CLAUSE, "").trim()
     : authorization;
+  const lorebookEntrySplit = authorizesLorebookEntrySplit(authorizationScope, commandEntity, category);
   if (
     INFORMATIONAL_REQUEST_START.test(authorizationScope) &&
     !DIRECT_MUTATION_AFTER_INFORMATION.test(authorizationScope)
   ) {
     return "Mutation blocked before execution: informational and how-to requests do not authorize workspace changes.";
   }
-  if (!MUTATION_INTENT_PATTERNS[category].test(authorizationScope)) {
+  if (!MUTATION_INTENT_PATTERNS[category].test(authorizationScope) && !lorebookEntrySplit) {
     return `Mutation blocked before execution: the quoted user instruction does not authorize a ${category} operation.`;
   }
   if (genericAuthorization) {
     const explicitCategories = explicitlyRequestedMutationCategories(authorizationScope);
-    if (explicitCategories.length !== 1 || explicitCategories[0] !== category) {
+    const splitOnlyAddsTheImpliedCreate = lorebookEntrySplit && explicitCategories.every((entry) => entry === "update");
+    if (!splitOnlyAddsTheImpliedCreate && (explicitCategories.length !== 1 || explicitCategories[0] !== category)) {
       const requestedCategories =
         explicitCategories.length > 0 ? explicitCategories.join(" and ") : "no single explicit operation";
       return `Mutation blocked before execution: the active user message authorizes ${requestedCategories}, not ${category}.`;
     }
   }
 
-  const commandEntity = appDataMutationEntity(command);
   const namedEntities = explicitlyNamedMutationEntities(authorizationScope);
   if (commandEntity && namedEntities.size > 0 && !namedEntities.has(commandEntity)) {
     return `Mutation blocked before execution: the user named ${Array.from(namedEntities).join(", ")}, not ${commandEntity}.`;
@@ -2639,6 +2658,7 @@ ${sections.join("\n\n")}
       cachingAtDepth: connection.cachingAtDepth ?? 5,
       serviceTier: normalizeServiceTier(defaultParameters?.serviceTier),
       openrouterProvider: connection.openrouterProvider,
+      responseFormat: professorMariWorkspaceResponseFormat(connection.provider),
       customParameters: mergeCustomParameters(customParameters, null),
       enabledParameters: normalizeGenerationParameterSendMap(defaultParameters?.enabledParameters),
       reasoningEffort,

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -783,6 +783,7 @@ import { scanForActivatedEntries } from "../../packages/server/src/services/lore
 import { processActivatedEntries } from "../../packages/server/src/services/lorebook/prompt-injector.js";
 import {
   parseAssistantWorkspaceAction,
+  professorMariWorkspaceResponseFormat,
   resolveWorkspaceMutationVerification,
   workspaceMutationAuthorizationIssue,
   workspaceActionNeedsVerification,
@@ -10821,6 +10822,9 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
   {
     name: "Professor Mari recovers malformed small-model app-data calls",
     run() {
+      assert.deepEqual(professorMariWorkspaceResponseFormat("openrouter"), { type: "json_object" });
+      assert.equal(professorMariWorkspaceResponseFormat("anthropic"), undefined);
+
       const missingEnvelopeClosers = parseAssistantWorkspaceAction(
         '{"say":"","commands":[{"name":"app_data","arguments":{"action":"character.create","data":{"name":"Stheno Test"},"apply":true}}',
       );
@@ -11086,6 +11090,47 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
           },
         ),
         null,
+      );
+
+      const splitAuthorization = "I authorize you to split and modify the lorebook entries.";
+      for (const action of ["lorebook.addEntry", "lorebook.updateEntry"]) {
+        assert.equal(
+          workspaceMutationAuthorizationIssue(
+            {
+              id: `split-${action}`,
+              name: "app_data",
+              authorization: splitAuthorization,
+              arguments: { action, lorebookId: "book-id", entryId: "entry-id", apply: true },
+            },
+            { directUserText: splitAuthorization },
+          ),
+          null,
+          `lorebook splitting must authorize ${action}`,
+        );
+      }
+      assert.match(
+        workspaceMutationAuthorizationIssue(
+          {
+            id: "split-delete-entry",
+            name: "app_data",
+            authorization: splitAuthorization,
+            arguments: { action: "lorebook.deleteEntry", entryId: "entry-id", apply: true },
+          },
+          { directUserText: splitAuthorization },
+        ) ?? "",
+        /delete operation/iu,
+      );
+      assert.match(
+        workspaceMutationAuthorizationIssue(
+          {
+            id: "split-create-character",
+            name: "app_data",
+            authorization: splitAuthorization,
+            arguments: { action: "character.create", data: { name: "Unrelated" }, apply: true },
+          },
+          { directUserText: splitAuthorization },
+        ) ?? "",
+        /create operation/iu,
       );
       for (const proposal of [
         "Do you want me to fix Dottore's appearance?",


### PR DESCRIPTION
## Why

Professor Mari workspace runs can stall when an OpenRouter model emits prose instead of the required JSON command frame. Separately, the mutation gate treated splitting a lorebook entry as only an update, then blocked the `lorebook.addEntry` command needed to save the split-off content.

Fixes #5271.

## What changed

- request JSON-object responses for Professor Mari workspace calls made through OpenRouter
- recognize an explicit lorebook-entry split as authorization for the implied create and update operations
- keep delete and unrelated-entity mutation boundaries unchanged
- add focused prompt/authorization regressions and a changelog entry

## Validation

- [ ] Run `pnpm check`
- [ ] Run the focused prompt regression
- [ ] Manually verify an OpenRouter Professor Mari workspace response uses the JSON command protocol
- [ ] Manually verify an authorized lorebook split can update the original entry and create split-off entries
- [ ] Manually verify the same wording does not authorize deletion or unrelated entity creation
