### PR TITLE
feat(agents): give Beholder the reference extractor's exact input

### DIFF
--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -44,6 +44,7 @@ import { getAssetManifest } from "../game/asset-manifest.service.js";
 import { normalizeBeholderProse } from "./beholder-normalizer.js";
 import {
   BEHOLDER_PASS_LANES,
+  buildBeholderUserMessage,
   formatBeholderRequestContext,
   isBeholderLaneResponse,
   mergeBeholderLaneDeltas,
@@ -746,7 +747,9 @@ export async function executeAgent(
           ? buildKnowledgeRetrievalAgentMessages(config, template, context)
           : config.type === "spotify"
             ? buildSpotifyAgentMessages(config, template, context)
-            : buildStandardAgentMessages(config, template, context);
+            : config.type === "beholder"
+              ? buildBeholderMessages(config, template, context)
+              : buildStandardAgentMessages(config, template, context);
 
     const temperature = resolveAgentTemperature(config);
     const maxTokens = applyAgentMaxTokensCaps(
@@ -969,7 +972,7 @@ async function executeBeholderLanePasses(args: {
     [...BEHOLDER_PASS_LANES],
     AGENT_BATCH_FALLBACK_MAX_CONCURRENT,
     async (lane) => {
-      const messages = buildStandardAgentMessages(config, lanePrompts[lane], context);
+      const messages = buildBeholderMessages(config, lanePrompts[lane], context);
       logger.debug(`[agent] ═══ ${config.type} [${lane}] PROMPT ═══`);
       for (const msg of messages) {
         logger.debug(`[agent] [${msg.role}] ${msg.content}`);
@@ -1991,6 +1994,35 @@ function buildCustomAgentCapabilityBlock(config: AgentExecConfig, context: Agent
   return parts.join("\n");
 }
 
+/**
+ * Build the two messages one Beholder extraction runs on, matching the reference
+ * extractor exactly: the prompt as the raw system message, and a single user message
+ * holding the persona, the tracked state, and the new narration.
+ *
+ * Beholder deliberately does not use the shared agent scaffolding. The standard
+ * builder wraps the prompt in <role>/<lore>/<agents>, appends an output-format block
+ * and other context, and passes chat history as separate turns. A general model reads
+ * past that; a small purpose-trained extractor was fitted to one exact input shape and
+ * treats the surrounding text as part of the task, which costs accuracy.
+ *
+ * The narration is normalized to canonical prose and is not truncated: for other agents
+ * history is background, but here the message IS the thing being extracted from, so
+ * cutting it silently hides whatever state the rest of it described.
+ */
+function buildBeholderMessages(config: AgentExecConfig, template: string, context: AgentContext): ChatMessage[] {
+  const contextSize = normalizeAgentContextSize(config.settings.contextSize);
+  const recent = contextSize > 0 ? context.recentMessages.slice(-contextSize) : [];
+  const narration = recent
+    .map((message) => normalizeBeholderProse(message.content))
+    .filter((text) => text.length > 0)
+    .join("\n");
+  const user = buildBeholderUserMessage(context.memory._beholderState, context.persona?.name ?? null, narration);
+  return [
+    { role: "system", content: template },
+    { role: "user", content: user },
+  ];
+}
+
 function buildStandardAgentMessages(config: AgentExecConfig, template: string, context: AgentContext): ChatMessage[] {
   // Build the agent's system prompt with <role> + <lore> + <agents> + extras
   const systemParts: string[] = [];
@@ -2030,11 +2062,6 @@ function buildStandardAgentMessages(config: AgentExecConfig, template: string, c
   const agentContextSize = contextSources.chatHistory ? normalizeAgentContextSize(config.settings.contextSize) : 0;
   const resultType = resolveAgentResultType(config);
   const renderedTemplates = new Map([[config.type, template]]);
-  // Beholder reads prose, not markup. Its extractor was trained and measured on a
-  // canonical surface form — no asterisk actions, markdown, BBCode, or HTML — so it
-  // gets the normalizer instead of the plain tag strip, and no per-message cap:
-  // truncating a turn hides whatever state the rest of it described.
-  const isBeholder = config.type === "beholder";
   return buildAgentMessages(systemParts.join("\n"), context, config.type, agentContextSize, [config.type], {
     includeMessageIds: normalizeCustomAgentCapabilities(config.settings).edit_messages === true,
     includeTrackerData: contextSources.trackerData,
@@ -2042,7 +2069,6 @@ function buildStandardAgentMessages(config: AgentExecConfig, template: string, c
     outputFormatBlock: buildAgentOutputFormatBlock([config], context, renderedTemplates),
     includeImagePromptInstructions:
       config.type === "illustrator" || customAgentHasCapability(config.settings, "trigger_image_generation"),
-    ...(isBeholder ? { contentTransform: normalizeBeholderProse, contentMaxChars: 0 } : {}),
   });
 }
 
@@ -2513,10 +2539,6 @@ function buildAgentMessages(
     preserveAssistantResponseMarkup?: boolean;
     outputFormatBlock?: string;
     includeImagePromptInstructions?: boolean;
-    /** Replaces the default HTML strip when an agent needs its own surface form. */
-    contentTransform?: (raw: string) => string;
-    /** Per-message character cap; 0 disables truncation. Defaults to HISTORY_MESSAGE_MAX_CHARS. */
-    contentMaxChars?: number;
   } = {},
 ): ChatMessage[] {
   // ── 1. System message — already contains <role>, <lore>, <agents>, and extras ──
@@ -2538,10 +2560,7 @@ function buildAgentMessages(
     for (let msgIdx = 0; msgIdx < recent.length; msgIdx++) {
       const msg = recent[msgIdx]!;
       const role: "user" | "assistant" = msg.role === "assistant" ? "assistant" : "user";
-      const transformContent = options.contentTransform ?? stripHtmlTags;
-      const maxChars = options.contentMaxChars ?? HISTORY_MESSAGE_MAX_CHARS;
-      const transformed = transformContent(msg.content);
-      let content = maxChars > 0 ? transformed.slice(0, maxChars) : transformed;
+      let content = stripHtmlTags(msg.content).slice(0, HISTORY_MESSAGE_MAX_CHARS);
       if (options.includeMessageIds && msg.id) {
         content = `<message_id>${msg.id}</message_id>\n${content}`;
       }

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -41,6 +41,7 @@ import { sanitizePromptLeaf } from "../prompt/prompt-escaping.js";
 import { settleAgentJobsWithConcurrencyLimit } from "./agent-concurrency.js";
 import { normalizeCyoaChoiceOutput } from "./cyoa-choice-normalization.js";
 import { getAssetManifest } from "../game/asset-manifest.service.js";
+import { normalizeBeholderProse } from "./beholder-normalizer.js";
 import {
   BEHOLDER_PASS_LANES,
   formatBeholderRequestContext,
@@ -62,6 +63,10 @@ const ILLUSTRATOR_AGENT_CALL_TIMEOUT_MS = 30 * 60_000;
 const AGENT_BATCH_FALLBACK_MAX_CONCURRENT = 4;
 
 /** Strip HTML/XML-style tags (e.g. <div style="..."> <br> <speaker>) from text to save tokens. */
+/** Per-message history cap for agent context. Beholder opts out: a truncated
+ *  turn silently hides whatever state the rest of the message described. */
+const HISTORY_MESSAGE_MAX_CHARS = 2000;
+
 function stripHtmlTags(text: string): string {
   return text
     .replace(/<\/?[a-zA-Z][^>]*>/g, "")
@@ -2025,6 +2030,11 @@ function buildStandardAgentMessages(config: AgentExecConfig, template: string, c
   const agentContextSize = contextSources.chatHistory ? normalizeAgentContextSize(config.settings.contextSize) : 0;
   const resultType = resolveAgentResultType(config);
   const renderedTemplates = new Map([[config.type, template]]);
+  // Beholder reads prose, not markup. Its extractor was trained and measured on a
+  // canonical surface form — no asterisk actions, markdown, BBCode, or HTML — so it
+  // gets the normalizer instead of the plain tag strip, and no per-message cap:
+  // truncating a turn hides whatever state the rest of it described.
+  const isBeholder = config.type === "beholder";
   return buildAgentMessages(systemParts.join("\n"), context, config.type, agentContextSize, [config.type], {
     includeMessageIds: normalizeCustomAgentCapabilities(config.settings).edit_messages === true,
     includeTrackerData: contextSources.trackerData,
@@ -2032,6 +2042,7 @@ function buildStandardAgentMessages(config: AgentExecConfig, template: string, c
     outputFormatBlock: buildAgentOutputFormatBlock([config], context, renderedTemplates),
     includeImagePromptInstructions:
       config.type === "illustrator" || customAgentHasCapability(config.settings, "trigger_image_generation"),
+    ...(isBeholder ? { contentTransform: normalizeBeholderProse, contentMaxChars: 0 } : {}),
   });
 }
 
@@ -2502,6 +2513,10 @@ function buildAgentMessages(
     preserveAssistantResponseMarkup?: boolean;
     outputFormatBlock?: string;
     includeImagePromptInstructions?: boolean;
+    /** Replaces the default HTML strip when an agent needs its own surface form. */
+    contentTransform?: (raw: string) => string;
+    /** Per-message character cap; 0 disables truncation. Defaults to HISTORY_MESSAGE_MAX_CHARS. */
+    contentMaxChars?: number;
   } = {},
 ): ChatMessage[] {
   // ── 1. System message — already contains <role>, <lore>, <agents>, and extras ──
@@ -2523,7 +2538,10 @@ function buildAgentMessages(
     for (let msgIdx = 0; msgIdx < recent.length; msgIdx++) {
       const msg = recent[msgIdx]!;
       const role: "user" | "assistant" = msg.role === "assistant" ? "assistant" : "user";
-      let content = stripHtmlTags(msg.content).slice(0, 2000);
+      const transformContent = options.contentTransform ?? stripHtmlTags;
+      const maxChars = options.contentMaxChars ?? HISTORY_MESSAGE_MAX_CHARS;
+      const transformed = transformContent(msg.content);
+      let content = maxChars > 0 ? transformed.slice(0, maxChars) : transformed;
       if (options.includeMessageIds && msg.id) {
         content = `<message_id>${msg.id}</message_id>\n${content}`;
       }

--- a/packages/server/src/services/agents/beholder-normalizer.ts
+++ b/packages/server/src/services/agents/beholder-normalizer.ts
@@ -84,12 +84,12 @@ export function normalizeBeholderProse(message: string): string {
   text = text.replace(/[([]+\s*OOC:[^)\]]*[)\]]+/giu, "");
 
   // 2. Labeled dialogue blocks (quoted): Name (Tone): "speech"
-  text = text.replace(/^([A-Z][A-Za-z'\- ]+?)\s*\(([^)]+)\):\s*"([^"]+)"\s*$/gmu, (_match, name, tone, speech) =>
+  text = text.replace(/^([A-Z][A-Za-z'\- ]+?)\(([^)]+)\):[ \t]*"([^"]+)"[ \t]*$/gmu, (_match, name, tone, speech) =>
     attributeDialogue(speech, String(name).trim(), toneToAdverb(String(tone))),
   );
 
   // 3. Script-style ALLCAPS dialogue (unquoted): NAME (Tone): speech
-  text = text.replace(/^([A-Z][A-Z'\- ]+?)\s*\(([^)]+)\):\s*(.+?)\s*$/gmu, (_match, name, tone, speech) =>
+  text = text.replace(/^([A-Z][A-Z'\- ]+?)\(([^)]+)\):[ \t]*(.+?)[ \t]*$/gmu, (_match, name, tone, speech) =>
     attributeDialogue(speech, titleCase(String(name)), toneToAdverb(String(tone))),
   );
 

--- a/packages/server/src/services/agents/beholder-normalizer.ts
+++ b/packages/server/src/services/agents/beholder-normalizer.ts
@@ -48,15 +48,23 @@ function titleCase(value: string): string {
     .replace(/\b[a-z]/gu, (character) => character.toUpperCase());
 }
 
+const HTML_ENTITIES: Record<string, string> = {
+  "&amp;": "&",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&apos;": "'",
+  "&nbsp;": " ",
+  "&lt;": "<",
+  "&gt;": ">",
+};
+
+/**
+ * Decode entities in a single pass. Chained replacements would decode the output
+ * of an earlier replacement — `&amp;lt;` becoming `&lt;` and then `<` — so each
+ * entity is matched once against the original text instead.
+ */
 function decodeEntities(value: string): string {
-  return value
-    .replace(/&amp;/gu, "&")
-    .replace(/&quot;/gu, '"')
-    .replace(/&#39;/gu, "'")
-    .replace(/&apos;/gu, "'")
-    .replace(/&nbsp;/gu, " ")
-    .replace(/&lt;/gu, "<")
-    .replace(/&gt;/gu, ">");
+  return value.replace(/&(?:amp|quot|apos|nbsp|lt|gt|#39);/gu, (entity) => HTML_ENTITIES[entity] ?? entity);
 }
 
 /**
@@ -103,10 +111,14 @@ export function normalizeBeholderProse(message: string): string {
   text = text.replace(/\[\/?[a-z][a-z0-9=#:_,\- ]*\]/giu, "");
 
   // 6. Strip HTML and decode entities
-  text = text
-    .replace(/<br\s*\/?>/giu, "\n")
-    .replace(/<\/p>/giu, "\n\n")
-    .replace(/<[^>]+>/gu, "");
+  text = text.replace(/<br\s*\/?>/giu, "\n").replace(/<\/p>/giu, "\n\n");
+  // Strip to a fixed point: one pass over `<scr<script>ipt>` removes the inner tag
+  // and leaves a working one behind. Each pass strictly shortens the text, so this
+  // terminates.
+  for (let previous = ""; previous !== text; ) {
+    previous = text;
+    text = text.replace(/<[^>]+>/gu, "");
+  }
   text = decodeEntities(text);
 
   // 7. Strip markdown emphasis and leading block markup

--- a/packages/server/src/services/agents/beholder-normalizer.ts
+++ b/packages/server/src/services/agents/beholder-normalizer.ts
@@ -1,0 +1,139 @@
+// Beholder prose normalizer — converts inbound roleplay prose into the canonical
+// surface form the Beholder extractor was trained and evaluated on.
+//
+// Canonical form: plain prose, dialogue inline in double quotes with attribution;
+// no asterisks, labeled-dialogue blocks, stage-direction brackets, BBCode, HTML,
+// or markdown. Roleplay text carries all of those, and the extractor never saw
+// them during training, so passing raw prose measurably shifts its input away
+// from the distribution its accuracy was measured on.
+//
+// Ported from the reference implementation in GetBeholder/Beholder-ME
+// (AGPL-3.0-only), the same origin as the rest of the Beholder Agent. Keep the
+// steps and their order identical: they are a contract with the model, not a
+// formatting preference.
+
+const TONE_ADVERB: Record<string, string> = {
+  quiet: "quietly",
+  dry: "drily",
+  tired: "tiredly",
+  cold: "coldly",
+  soft: "softly",
+  sharp: "sharply",
+  flat: "flatly",
+  grim: "grimly",
+  warm: "warmly",
+  calm: "calmly",
+  firm: "firmly",
+  gentle: "gently",
+  harsh: "harshly",
+  bitter: "bitterly",
+  weary: "wearily",
+  sad: "sadly",
+  angry: "angrily",
+  nervous: "nervously",
+  cheerful: "cheerfully",
+  breathless: "breathlessly",
+  hoarse: "hoarsely",
+  amused: "with amusement",
+};
+
+function toneToAdverb(tone: string): string {
+  return TONE_ADVERB[(tone || "").trim().toLowerCase()] ?? "";
+}
+
+function titleCase(value: string): string {
+  return (value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/\b[a-z]/gu, (character) => character.toUpperCase());
+}
+
+function decodeEntities(value: string): string {
+  return value
+    .replace(/&amp;/gu, "&")
+    .replace(/&quot;/gu, '"')
+    .replace(/&#39;/gu, "'")
+    .replace(/&apos;/gu, "'")
+    .replace(/&nbsp;/gu, " ")
+    .replace(/&lt;/gu, "<")
+    .replace(/&gt;/gu, ">");
+}
+
+/**
+ * Build a natural dialogue attribution, fixing terminal punctuation:
+ *   "Better."  -> "Better," X said.   (period becomes a comma)
+ *   "Where?"   -> "Where?" X said.    (question and exclamation marks stay)
+ */
+function attributeDialogue(speech: string, name: string, adverb: string): string {
+  const trimmed = (speech || "")
+    .trim()
+    .replace(/^"+|"+$/gu, "")
+    .trim();
+  const said = `${name} said${adverb ? ` ${adverb}` : ""}`;
+  const last = trimmed.slice(-1);
+  if (last === ".") return `"${trimmed.slice(0, -1)}," ${said}.`;
+  if (last === "?" || last === "!") return `"${trimmed}" ${said}.`;
+  return `"${trimmed}," ${said}.`;
+}
+
+/** Convert one roleplay message to the canonical plain-prose form the extractor expects. */
+export function normalizeBeholderProse(message: string): string {
+  let text = message || "";
+
+  // 1. Strip OOC notes: (OOC: ...) / ((OOC: ...)) / [OOC: ...]
+  text = text.replace(/[([]+\s*OOC:[^)\]]*[)\]]+/giu, "");
+
+  // 2. Labeled dialogue blocks (quoted): Name (Tone): "speech"
+  text = text.replace(/^([A-Z][A-Za-z'\- ]+?)\s*\(([^)]+)\):\s*"([^"]+)"\s*$/gmu, (_match, name, tone, speech) =>
+    attributeDialogue(speech, String(name).trim(), toneToAdverb(String(tone))),
+  );
+
+  // 3. Script-style ALLCAPS dialogue (unquoted): NAME (Tone): speech
+  text = text.replace(/^([A-Z][A-Z'\- ]+?)\s*\(([^)]+)\):\s*(.+?)\s*$/gmu, (_match, name, tone, speech) =>
+    attributeDialogue(speech, titleCase(String(name)), toneToAdverb(String(tone))),
+  );
+
+  // 4. Whole-line stage directions: [Tim sits.] — before the BBCode strip below.
+  text = text.replace(/^\s*\[([^\]]+)\]\s*$/gmu, (_match, inner) => {
+    const sentence = String(inner).trim();
+    return sentence && !/[.!?]$/u.test(sentence) ? `${sentence}.` : sentence;
+  });
+
+  // 5. Strip BBCode tags ([b], [color=red], [/url], ...)
+  text = text.replace(/\[\/?[a-z][a-z0-9=#:_,\- ]*\]/giu, "");
+
+  // 6. Strip HTML and decode entities
+  text = text
+    .replace(/<br\s*\/?>/giu, "\n")
+    .replace(/<\/p>/giu, "\n\n")
+    .replace(/<[^>]+>/gu, "");
+  text = decodeEntities(text);
+
+  // 7. Strip markdown emphasis and leading block markup
+  text = text
+    .replace(/\*\*([^*]+?)\*\*/gu, "$1")
+    .replace(/__([^_]+?)__/gu, "$1")
+    .replace(/~~([^~]+?)~~/gu, "$1")
+    .replace(/(?<![A-Za-z0-9])_([^_\n]+?)_(?![A-Za-z0-9])/gu, "$1");
+  text = text
+    .replace(/```[a-zA-Z]*\n?/gu, "")
+    .replace(/^\s{0,3}#{1,6}\s+/gmu, "")
+    .replace(/^\s{0,3}>\s?/gmu, "")
+    .replace(/^\s{0,3}[-*+]\s+/gmu, "");
+
+  // 8. Unwrap asterisk action blocks: *Tim shifts.* -> Tim shifts.
+  text = text.replace(/\*([^*]+?)\*/gu, (_match, inner) => {
+    const sentence = String(inner).trim();
+    return sentence && !/[.!?]$/u.test(sentence) ? `${sentence}.` : sentence;
+  });
+
+  // 9. Normalize whitespace: join lines into flowing prose, collapse runs, trim.
+  text = text
+    .replace(/[ \t]*\n[ \t]*/gu, "\n")
+    .replace(/\n{2,}/gu, " ")
+    .replace(/\n/gu, " ")
+    .replace(/[ \t]{2,}/gu, " ")
+    .trim();
+
+  return text;
+}

--- a/packages/server/src/services/agents/beholder-state.ts
+++ b/packages/server/src/services/agents/beholder-state.ts
@@ -492,6 +492,46 @@ export function normalizeBeholderState(value: unknown): BeholderState | null {
   return { characters };
 }
 
+/**
+ * Build the user message for one extraction, in the exact layout the extractor was
+ * trained and evaluated on:
+ *
+ *     Persona: <name>
+ *     Current state:
+ *     {"self":{...}}
+ *
+ *     Narration:
+ *     <canonical prose>
+ *
+ * The details are load-bearing, not stylistic. The persona line is omitted when there
+ * is no persona, the state block is omitted entirely when nothing is tracked yet
+ * (rather than sent as an empty object), and the state is serialized compactly. A
+ * purpose-trained extractor reads this as one fixed shape; drifting from it moves the
+ * input away from the distribution the model's accuracy was measured on.
+ */
+export function buildBeholderUserMessage(
+  state: unknown,
+  personaName: string | null | undefined,
+  narration: string,
+): string {
+  const prior = normalizedPriorState(state);
+  const resolvedPersonaName = cleanText(personaName, 160);
+  const keyedState: Record<string, Omit<BeholderCharacterState, "name">> = {};
+  for (const character of prior.characters) {
+    const key = resolvedPersonaName && sameCharacterName(character.name, resolvedPersonaName) ? "self" : character.name;
+    keyedState[key] = {
+      ...(character.species ? { species: character.species } : {}),
+      body: character.body,
+    };
+  }
+
+  const parts: string[] = [];
+  if (resolvedPersonaName) parts.push(`Persona: ${resolvedPersonaName}`);
+  if (Object.keys(keyedState).length > 0) parts.push(`Current state:\n${JSON.stringify(keyedState)}\n`);
+  parts.push(`Narration:\n${narration}`);
+  return parts.join("\n");
+}
+
 /** Serialize state for the delta prompt while giving the active Persona the stable `self` key. */
 export function formatBeholderRequestContext(state: unknown, personaName: string | null | undefined): string {
   const prior = normalizedPriorState(state);

--- a/scripts/regressions/beholder-normalizer.regression.ts
+++ b/scripts/regressions/beholder-normalizer.regression.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { normalizeBeholderProse } from "../../packages/server/src/services/agents/beholder-normalizer.js";
+
+// Asterisk actions are the dominant roleplay surface form and the one the
+// extractor never saw in training: the wrapper goes, the sentence stays.
+assert.equal(normalizeBeholderProse("*Tim shifts*"), "Tim shifts.");
+assert.equal(normalizeBeholderProse("*Tim shifts.*"), "Tim shifts.");
+assert.equal(
+  normalizeBeholderProse('*She tugs her coat tighter.* "Cold out," she says.'),
+  'She tugs her coat tighter. "Cold out," she says.',
+);
+
+// Markdown emphasis is unwrapped without eating the words.
+assert.equal(normalizeBeholderProse("**bold** and __also bold__ and ~~struck~~"), "bold and also bold and struck");
+assert.equal(normalizeBeholderProse("a _quiet_ word"), "a quiet word");
+assert.equal(normalizeBeholderProse("snake_case_name stays"), "snake_case_name stays");
+
+// Block markup: headings, quotes, list bullets, fences.
+assert.equal(normalizeBeholderProse("# Chapter\nHe stands."), "Chapter He stands.");
+assert.equal(normalizeBeholderProse("> He waits."), "He waits.");
+assert.equal(normalizeBeholderProse("- He kneels."), "He kneels.");
+
+// BBCode and HTML go; entities decode; <br> becomes a break, not a join.
+assert.equal(normalizeBeholderProse("[b]Bold[/b] [color=red]red[/color]"), "Bold red");
+assert.equal(normalizeBeholderProse("<i>He nods.</i>"), "He nods.");
+assert.equal(normalizeBeholderProse("Tea &amp; toast &quot;now&quot;"), 'Tea & toast "now"');
+assert.equal(normalizeBeholderProse("He stands.<br>She sits."), "He stands. She sits.");
+
+// OOC notes are removed entirely.
+assert.equal(normalizeBeholderProse("(OOC: brb) He waits."), "He waits.");
+assert.equal(normalizeBeholderProse("[OOC: skip ahead] She nods."), "She nods.");
+
+// Stage directions become sentences.
+assert.equal(normalizeBeholderProse("[Tim sits]"), "Tim sits.");
+
+// Labeled dialogue becomes attributed prose, with terminal punctuation fixed.
+assert.equal(normalizeBeholderProse('Mara (quiet): "Better."'), '"Better," Mara said quietly.');
+assert.equal(normalizeBeholderProse('Mara (sharp): "Where?"'), '"Where?" Mara said sharply.');
+assert.equal(normalizeBeholderProse("TIM (flat): Fine by me."), '"Fine by me," Tim said flatly.');
+
+// Whitespace collapses into flowing prose.
+assert.equal(normalizeBeholderProse("One.\n\nTwo.\n\n\nThree."), "One. Two. Three.");
+assert.equal(normalizeBeholderProse("  padded   spacing  "), "padded spacing");
+
+// Plain canonical prose is already in surface form and must pass through untouched:
+// the normalizer may never rewrite what the extractor was trained on.
+const canonical = 'She pulls the grey wool coat tighter and grips the lantern. "We should go," she said quietly.';
+assert.equal(normalizeBeholderProse(canonical), canonical);
+
+// Degenerate input must not throw.
+assert.equal(normalizeBeholderProse(""), "");
+assert.equal(normalizeBeholderProse("   "), "");
+
+// A realistic roleplay turn: several markup styles at once.
+const messy = [
+  "**Chapter 3**",
+  "",
+  "*Rissha skips across the stone.* She stops in front of <b>Hesperia</b>.",
+  "",
+  'Hesperia (nervous): "What did you do?"',
+  "",
+  "(OOC: sorry for the delay)",
+].join("\n");
+const cleaned = normalizeBeholderProse(messy);
+assert.ok(!cleaned.includes("*"), "no asterisks survive");
+assert.ok(!cleaned.includes("<"), "no HTML survives");
+assert.ok(!cleaned.includes("OOC"), "no OOC note survives");
+assert.ok(cleaned.includes("Rissha skips across the stone."), "action prose is preserved");
+assert.ok(cleaned.includes('"What did you do?" Hesperia said nervously.'), "dialogue is attributed");

--- a/scripts/regressions/beholder-normalizer.regression.ts
+++ b/scripts/regressions/beholder-normalizer.regression.ts
@@ -26,6 +26,16 @@ assert.equal(normalizeBeholderProse("<i>He nods.</i>"), "He nods.");
 assert.equal(normalizeBeholderProse("Tea &amp; toast &quot;now&quot;"), 'Tea & toast "now"');
 assert.equal(normalizeBeholderProse("He stands.<br>She sits."), "He stands. She sits.");
 
+// Entities decode exactly once. Chained replacements would turn "&amp;lt;" into
+// "&lt;" and then "<", conjuring markup the author never wrote.
+assert.equal(normalizeBeholderProse("&amp;lt;"), "&lt;", "an escaped entity is not decoded twice");
+assert.equal(normalizeBeholderProse("&amp;amp;"), "&amp;");
+
+// Tag stripping runs to a fixed point: one pass over a nested tag leaves a working
+// one behind.
+assert.ok(!normalizeBeholderProse("<scr<script>ipt>alert(1)").includes("<"), "nested tags do not survive");
+assert.ok(!normalizeBeholderProse("<<div>>text").includes("<"));
+
 // OOC notes are removed entirely.
 assert.equal(normalizeBeholderProse("(OOC: brb) He waits."), "He waits.");
 assert.equal(normalizeBeholderProse("[OOC: skip ahead] She nods."), "She nods.");

--- a/scripts/regressions/beholder-user-message.regression.ts
+++ b/scripts/regressions/beholder-user-message.regression.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { buildBeholderUserMessage } from "../../packages/server/src/services/agents/beholder-state.js";
+
+// The extractor was trained on one exact input layout. These assertions pin it:
+//   Persona: <name>
+//   Current state:
+//   {compact json}
+//   <blank line>
+//   Narration:
+//   <prose>
+
+const state = {
+  characters: [{ name: "Rissha", species: "angel", body: { chest: { worn: [{ item: "gown", damage: "pristine" }] } } }],
+};
+
+const withState = buildBeholderUserMessage(state, "Rissha", "She steps onto the stone.");
+assert.equal(
+  withState,
+  "Persona: Rissha\n" +
+    "Current state:\n" +
+    '{"self":{"species":"angel","body":{"chest":{"worn":[{"item":"gown","damage":"pristine"}]}}}}\n' +
+    "\n" +
+    "Narration:\nShe steps onto the stone.",
+  "the persona/state/narration layout is byte-exact",
+);
+
+// The persona is keyed as `self`; everyone else keeps their name.
+const twoCharacters = buildBeholderUserMessage(
+  {
+    characters: [
+      { name: "Rissha", body: { chest: { bare: true } } },
+      { name: "Hesperia", body: { right_hand: { holding: { item: "staff", damage: "pristine" } } } },
+    ],
+  },
+  "Rissha",
+  "They face each other.",
+);
+assert.ok(twoCharacters.includes('"self"'), "the persona is mapped to self");
+assert.ok(twoCharacters.includes('"Hesperia"'), "other characters keep their names");
+
+// State is compact, never pretty-printed: the training layout has no newlines inside the JSON.
+const stateLine = withState.split("\n")[2] ?? "";
+assert.ok(!stateLine.includes("\n"), "state serializes onto one line");
+assert.ok(!/:\s\s/u.test(stateLine), "state is compact, not indented");
+
+// With nothing tracked yet, the block is omitted entirely rather than sent as {}.
+const coldStart = buildBeholderUserMessage({ characters: [] }, "Rissha", "She wakes.");
+assert.equal(coldStart, "Persona: Rissha\nNarration:\nShe wakes.");
+assert.ok(!coldStart.includes("Current state"), "no empty state block on a cold start");
+assert.equal(buildBeholderUserMessage(null, "Rissha", "She wakes."), "Persona: Rissha\nNarration:\nShe wakes.");
+
+// No persona means no persona line — not "Persona: null" or a placeholder name.
+const noPersona = buildBeholderUserMessage({ characters: [] }, null, "Someone moves.");
+assert.equal(noPersona, "Narration:\nSomeone moves.");
+
+// The narration is passed through verbatim; normalization happens before this call.
+const narration = 'She pulls the coat tighter. "We should go," she said quietly.';
+assert.ok(buildBeholderUserMessage({ characters: [] }, "Tim", narration).endsWith(`Narration:\n${narration}`));
+
+// An empty narration still produces a well-formed message rather than a bare label.
+assert.equal(buildBeholderUserMessage({ characters: [] }, "Tim", ""), "Persona: Tim\nNarration:\n");


### PR DESCRIPTION
## Linked issue

No separate issue — corrective follow-up to #5251 (merged), which added the Beholder execution path this feeds.

## Why this change

Beholder was being handed an input that does not match what its extractor reads.

The Agent went through the shared scaffolding: the prompt wrapped in `<role>`/`<lore>`/`<agents>`, an output-format block and other context appended, the tracked state buried in the system message, and chat history passed as separate turns — each stripped of tags and **cut at 2000 characters**.

A strong general model reads past all of that. A small purpose-trained extractor cannot: it was fitted to one exact input shape and treats surrounding text as part of the task. Three concrete gaps:

1. **Markup instead of prose.** Roleplay messages carry asterisk actions, markdown, BBCode, HTML, OOC notes, and labeled dialogue. The reference extractor normalizes all of it to canonical prose first, and its accuracy was measured on that form. `*She tugs her coat tighter.*` was reaching the model verbatim.
2. **Truncation.** For other agents history is background context, so a 2000-character cap is sensible. For Beholder the message **is** the thing being extracted from — a longer turn silently loses whatever state its remainder described, with no error.
3. **Scaffolding and message shape.** The reference sends the prompt as the raw system message plus a single user message: persona, tracked state, narration.

## What changed

- **`beholder-normalizer.ts`** (new) — port of the reference normalizer from [GetBeholder/Beholder-ME](https://github.com/GetBeholder/Beholder-ME) (AGPL-3.0-only, same origin as the rest of the Agent). Step order preserved deliberately: it is a contract with the model, not a formatting preference.
- **`buildBeholderUserMessage()`** — the exact training layout: `Persona:` / `Current state:` / `Narration:`, state keyed by character with the persona as `self`, serialized **compactly**, and **omitted entirely** when nothing is tracked yet rather than sent as `{}`.
- **`buildBeholderMessages()`** — builds the two messages directly, bypassing the shared builder: raw prompt as system, one user message, narration normalized and **not truncated**. Used by both the single-prompt and per-lane paths.
- **Every other agent is untouched** — the shared builder keeps its tag strip, its cap, and its scaffolding.

Also hardens the normalizer against a backtracking hazard inherited from the reference: two dialogue patterns had a character class containing a space followed by `\s*`, which is ambiguous and backtracks polynomially on long runs of spaces — reachable precisely because this PR removes the length cap. The class already absorbs those spaces and the captured name is trimmed, so the accepted language is unchanged.

No schema, storage, API, or client change.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Boxes left for a human — `pnpm install` fails in my environment at the `onnxruntime-node` postinstall (it rejects CUDA 13), so I cannot run the full `pnpm check` or the app.

What I did run:

- **Typecheck clean**: `tsc -b ../shared && tsc --noEmit` for `packages/server` → **0 errors**. Prettier clean.
- **Parity with the reference normalizer**: ran this port and the reference implementation over the same 22 surface forms and diffed — **22/22 byte-identical**, re-verified after the regex hardening. That is the whole point of the change, so it seemed worth proving rather than asserting.
- **Backtracking**: a line of 40,000 spaces normalizes in **under 1 ms** (was the polynomial case).
- **`beholder-normalizer.regression.ts`** (new) — asterisk actions, markdown emphasis, `snake_case` left alone, block markup, BBCode, HTML with `<br>` as a break, entity decoding, OOC removal, stage directions, labeled and ALLCAPS dialogue with terminal-punctuation fixes, whitespace collapse, empty input, and a mixed realistic turn. It also asserts **already-canonical prose passes through byte-identical** — the normalizer must never rewrite what the extractor was trained on.
- **`beholder-user-message.regression.ts`** (new) — pins the layout byte-for-byte, plus `self` mapping, compact (never indented) state, the state block omitted on a cold start, no persona line when there is no persona, and verbatim narration.
- The existing `beholder-lane-passes` and `beholder-wound-merge` regressions still pass.

Not verified: behaviour against a live model in the app. The judgement worth a maintainer's eye is letting one agent opt out of the shared scaffolding — the alternative keeps Beholder on a shape its extractor was not trained for.
