### PR TITLE
fix(dev): stop watchers after writer lease conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Development server watchers now exit after losing the file-storage writer lease, preventing abandoned sessions from retrying forever and repeatedly reporting `StorageWriterLeaseError` (#5312).
 - Forced Agent retries such as Echo Chamber now stop from Roleplay's Agents menu, whose Stop Agents action also matches the neutral styling of neighboring actions (#5299).
 - Desktop Mari now changes tabs after finding a requested destination when reduced ambient animations and effects are enabled (#5301).
 - Game branches now restore Journal entries and generated HUD lists, such as Clues, to the selected story point instead of carrying future branch information (#5287).

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
     "mari": "./dist/bin/mari.js"
   },
   "scripts": {
-    "dev": "tsx watch --ignore ./data --ignore ../shared/dist --ignore ./node_modules --ignore ../../node_modules src/index.ts",
+    "dev": "tsx watch --ignore ./data --ignore ../shared/dist --ignore ./node_modules --ignore ../../node_modules src/index.ts --marinara-dev-watch",
     "build": "node ./scripts/build.mjs",
     "start": "node dist/index.js",
     "clean": "node -e \"const fs=require('fs');['dist','tsconfig.tsbuildinfo'].forEach(p=>{try{fs.rmSync(p,{recursive:true,force:true})}catch{}})\"",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,7 @@
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 import { buildApp } from "./app.js";
+import { StorageWriterLeaseError } from "./db/file-backed-store.js";
 import { logger } from "./lib/logger.js";
 import { getHost, getPort, getServerProtocol, loadTlsOptions, logStorageDiagnostics } from "./config/runtime-config.js";
 import { logCsrfTrustSummary } from "./middleware/csrf-protection.js";
@@ -32,6 +33,18 @@ function logFatalProcessError(reason: unknown, message: string): void {
   }
 
   logger.error({ reason }, message);
+}
+
+function stopDevelopmentWatcherAfterLeaseConflict(error: unknown): void {
+  if (!(error instanceof StorageWriterLeaseError) || !process.argv.includes("--marinara-dev-watch")) return;
+  if (process.ppid <= 1) return;
+  try {
+    process.kill(process.ppid, "SIGTERM");
+  } catch (signalError) {
+    if ((signalError as NodeJS.ErrnoException).code !== "ESRCH") {
+      logger.warn(signalError, "[startup] Could not stop the development watcher after a writer lease conflict");
+    }
+  }
 }
 
 async function main() {
@@ -113,5 +126,6 @@ async function main() {
 
 main().catch((err) => {
   logger.error(err, "[startup] Unhandled error during server bootstrap");
+  stopDevelopmentWatcherAfterLeaseConflict(err);
   process.exit(1);
 });

--- a/scripts/regressions/storage-writer-lock.regression.ts
+++ b/scripts/regressions/storage-writer-lock.regression.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { closeDB, getDB } from "../../packages/server/src/db/connection.js";
 import {
   createFileNativeDB,
@@ -12,6 +13,7 @@ import {
 } from "../../packages/server/src/db/file-backed-store.js";
 import { appSettings, lorebookEntries, lorebooks } from "../../packages/server/src/db/schema/index.js";
 import { getMariDbService } from "../../packages/server/src/services/mari-db/mari-db.service.js";
+import { resolvePnpmRunner } from "../pnpm-runner.mjs";
 
 type LeaseRecord = {
   version: 1 | 2;
@@ -24,6 +26,7 @@ type LeaseRecord = {
 
 const previousStorageDir = process.env.FILE_STORAGE_DIR;
 const tempDirs: string[] = [];
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
 function useTempStorage(label: string) {
   const dir = mkdtempSync(join(tmpdir(), `marinara-${label}-`));
@@ -54,6 +57,36 @@ async function exitedPid() {
   return child.pid!;
 }
 
+async function waitForExit(child: ReturnType<typeof spawn>, timeoutMs = 15_000) {
+  return new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolveExit, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error(`Development watcher ${child.pid ?? "unknown"} did not exit`)),
+      timeoutMs,
+    );
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("exit", (code, signal) => {
+      clearTimeout(timeout);
+      resolveExit({ code, signal });
+    });
+  });
+}
+
+function forceStopProcessTree(child: ReturnType<typeof spawn>) {
+  if (!child.pid || child.exitCode !== null || child.signalCode !== null) return;
+  if (process.platform === "win32") {
+    spawnSync("taskkill.exe", ["/pid", String(child.pid), "/t", "/f"], { stdio: "ignore" });
+    return;
+  }
+  try {
+    process.kill(-child.pid, "SIGKILL");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") child.kill("SIGKILL");
+  }
+}
+
 try {
   // The ordinary lorebook path remains durable, while a second live writer
   // for the exact same root fails before loading or mutating any data.
@@ -70,6 +103,39 @@ try {
         error.message.includes(dir),
       "a second live writer is rejected with owner and data-directory details",
     );
+
+    const pnpmRunner = resolvePnpmRunner();
+    const watcher = spawn(
+      pnpmRunner.command,
+      [...pnpmRunner.args, "--filter", "@marinara-engine/server", "dev"],
+      {
+        cwd: repositoryRoot,
+        env: {
+          ...process.env,
+          FILE_STORAGE_DIR: dir,
+          MARINARA_ENV_FILE: join(dir, ".watcher.env"),
+          PORT: String(20_000 + (process.pid % 10_000)),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+        detached: process.platform !== "win32",
+      },
+    );
+    let watcherOutput = "";
+    watcher.stdout?.on("data", (chunk) => {
+      watcherOutput += chunk.toString();
+    });
+    watcher.stderr?.on("data", (chunk) => {
+      watcherOutput += chunk.toString();
+    });
+    try {
+      await waitForExit(watcher);
+      assert.match(watcherOutput, /--marinara-dev-watch/u, "the competing process must use the guarded dev watcher");
+      assert.equal(existsSync(leasePath(dir)), true, "the healthy writer keeps its lease after rejecting the watcher");
+      assert.equal(readJson<LeaseRecord>(ownerPath(dir)).pid, process.pid, "the healthy writer remains the lease owner");
+    } finally {
+      forceStopProcessTree(watcher);
+    }
 
     const timestamp = "2026-08-14T00:00:00.000Z";
     await db

--- a/scripts/regressions/storage-writer-lock.regression.ts
+++ b/scripts/regressions/storage-writer-lock.regression.ts
@@ -114,6 +114,7 @@ try {
           ...process.env,
           FILE_STORAGE_DIR: dir,
           MARINARA_ENV_FILE: join(dir, ".watcher.env"),
+          NODE_ENV: "production",
           PORT: String(20_000 + (process.pid % 10_000)),
         },
         stdio: ["ignore", "pipe", "pipe"],
@@ -131,6 +132,7 @@ try {
     try {
       await waitForExit(watcher);
       assert.match(watcherOutput, /--marinara-dev-watch/u, "the competing process must use the guarded dev watcher");
+      assert.match(watcherOutput, /StorageWriterLeaseError/u, "the watcher must exit because it lost the writer lease");
       assert.equal(existsSync(leasePath(dir)), true, "the healthy writer keeps its lease after rejecting the watcher");
       assert.equal(readJson<LeaseRecord>(ownerPath(dir)).pid, process.pid, "the healthy writer remains the lease owner");
     } finally {


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5312

## Why this change

- Abandoned development watchers remained alive after a storage-lease conflict and retried server startup after every source edit.
- The valid single-writer guard then reported the same `StorageWriterLeaseError` repeatedly even though the healthy server was behaving correctly.

## What changed

- Marked the server child launched by `tsx watch` with a private development-only argument.
- When that child encounters `StorageWriterLeaseError` during bootstrap, it terminates its watcher supervisor so the rejected session cannot remain as a retry loop.
- Normal and production server starts keep the existing storage protection and error behavior.
- Added an integration regression that holds a real writer lease, starts a competing dev watcher, and verifies the watcher exits without disturbing the healthy owner.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated results:

- `pnpm check` — passed.
- `pnpm regression:node -- --filter storage-writer-lock` — passed.
- `pnpm regression:node -- --filter dev-launcher-process` — passed.
- `git diff --check` — passed.

### Manual verification notes

- Observed one healthy server retaining its original writer lease while the competing guarded watcher terminated.
- Removed eight pre-existing orphaned default-data watcher process groups; the healthy server on port 7860 remained available.
- Removed two isolated Playwright server processes left after the earlier UI suite teardown.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

The user-facing fix is recorded under `CHANGELOG.md` `[Unreleased]`. No long-form documentation or release metadata changed.

## UI evidence (if applicable)

- Not applicable; this is development-process lifecycle behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Development server watchers now exit after losing the file-storage writer lease.
  * Prevents abandoned sessions from retrying indefinitely and repeatedly logging lease errors.
  * Preserves the active writer’s storage lease when another development watcher starts.
  * Improved handling of watcher shutdown failures during lease conflicts.

* **Tests**
  * Added regression coverage for competing development watchers and lease ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->