### PR TITLE
fix: normalize Android chat controls and text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
-- Android APK chats now keep their intended message text size instead of letting WebView enlarge Conversation, Roleplay, and Game prose, and card versioning switches now match the alignment and inactive color of other settings toggles (#5315, #5316).
+- Android APK chats now keep their intended message text size instead of letting WebView enlarge Conversation, Roleplay, and Game prose, the New Chat parameter toggle stays inside its card at larger text sizes, and card versioning switches now match the alignment and inactive color of other settings toggles (#5315, #5316, #5318).
 - Development server watchers now exit after losing the file-storage writer lease, preventing abandoned sessions from retrying forever and repeatedly reporting `StorageWriterLeaseError` (#5312).
 - Forced Agent retries such as Echo Chamber now stop from Roleplay's Agents menu, whose Stop Agents action also matches the neutral styling of neighboring actions (#5299).
 - Desktop Mari now changes tabs after finding a requested destination when reduced ambient animations and effects are enabled (#5301).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Android APK chats now keep their intended message text size instead of letting WebView enlarge Conversation, Roleplay, and Game prose, and card versioning switches now match the alignment and inactive color of other settings toggles (#5315, #5316).
 - Development server watchers now exit after losing the file-storage writer lease, preventing abandoned sessions from retrying forever and repeatedly reporting `StorageWriterLeaseError` (#5312).
 - Forced Agent retries such as Echo Chamber now stop from Roleplay's Agents menu, whose Stop Agents action also matches the neutral styling of neighboring actions (#5299).
 - Desktop Mari now changes tabs after finding a requested destination when reduced ambient animations and effects are enabled (#5301).

--- a/android/app/src/main/java/com/marinara/engine/MainActivity.java
+++ b/android/app/src/main/java/com/marinara/engine/MainActivity.java
@@ -256,6 +256,7 @@ public class MainActivity extends Activity {
         settings.setMediaPlaybackRequiresUserGesture(false);
         settings.setMixedContentMode(WebSettings.MIXED_CONTENT_NEVER_ALLOW);
         settings.setCacheMode(WebSettings.LOAD_DEFAULT);
+        settings.setTextZoom(100);
         settings.setUserAgentString(settings.getUserAgentString() + " MarinaraEngine/Android");
 
         webView.addJavascriptInterface(new MarinaraAndroidBridge(), "MarinaraAndroidNative");

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -1636,35 +1636,18 @@ function MetadataTab({
                 text={localizeUi("ui.characters.metadatatab.versionNumberForTrackingChangesToThisCharacterDefinition")}
               />
             </span>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={formData.extensions.versioningEnabled !== false}
-              onClick={() => {
-                const enabled = formData.extensions.versioningEnabled !== false;
-                updateExtension("versioningEnabled", !enabled);
-                if (enabled === false && !formData.character_version.trim()) updateField("character_version", "1.0");
+            <SettingsSwitch
+              checked={formData.extensions.versioningEnabled !== false}
+              onChange={(enabled) => {
+                updateExtension("versioningEnabled", enabled);
+                if (enabled && !formData.character_version.trim()) updateField("character_version", "1.0");
               }}
-              className="inline-flex min-h-11 items-center gap-2 rounded-md px-1 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]/40"
+              label={localizeUi("ui.cardversionhistory.automaticVersioning")}
+              labelPosition="end"
               title={localizeUi("ui.cardversionhistory.automaticVersioningDescription")}
-            >
-              <span
-                className={cn(
-                  "relative h-5 w-9 rounded-full border transition-colors",
-                  formData.extensions.versioningEnabled !== false
-                    ? "border-[var(--primary)] bg-[var(--primary)]"
-                    : "border-[var(--border)] bg-[var(--secondary)]",
-                )}
-              >
-                <span
-                  className={cn(
-                    "absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-[var(--background)] shadow-sm transition-transform",
-                    formData.extensions.versioningEnabled !== false && "translate-x-4",
-                  )}
-                />
-              </span>
-              {localizeUi("ui.cardversionhistory.automaticVersioning")}
-            </button>
+              className="min-h-11 gap-2 rounded-md px-1 py-0"
+              labelClassName="text-xs font-medium text-[var(--muted-foreground)]"
+            />
           </div>
           <input
             value={formData.character_version}

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -722,9 +722,9 @@ function SetupGenerationParametersPanel({
       <button
         type="button"
         onClick={() => onEnabledChange(!enabled)}
-        className="flex w-full items-center justify-between gap-3 text-left"
+        className="flex min-w-0 w-full items-center justify-between gap-3 text-left"
       >
-        <div>
+        <div className="min-w-0 flex-1">
           <span className="block text-xs font-medium text-[var(--foreground)]">
             {localizeUi("ui.chat.setupgenerationparameterspanel.customizeParameters")}
           </span>
@@ -734,7 +734,7 @@ function SetupGenerationParametersPanel({
         </div>
         <div
           className={cn(
-            "h-5 w-9 rounded-full p-0.5 transition-colors",
+            "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
             enabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
           )}
         >

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -3676,36 +3676,20 @@ function PersonaMetadataTab({
                 )}
               />
             </span>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={formData.versioningEnabled}
-              onClick={() => {
-                updateField("versioningEnabled", !formData.versioningEnabled);
-                if (!formData.versioningEnabled && !formData.personaVersion.trim()) {
+            <SettingsSwitch
+              checked={formData.versioningEnabled}
+              onChange={(enabled) => {
+                updateField("versioningEnabled", enabled);
+                if (enabled && !formData.personaVersion.trim()) {
                   updateField("personaVersion", "1.0");
                 }
               }}
-              className="inline-flex min-h-11 items-center gap-2 rounded-md px-1 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]/40"
+              label={localizeUi("ui.cardversionhistory.automaticVersioning")}
+              labelPosition="end"
               title={localizeUi("ui.cardversionhistory.automaticVersioningDescription")}
-            >
-              <span
-                className={cn(
-                  "relative h-5 w-9 rounded-full border transition-colors",
-                  formData.versioningEnabled
-                    ? "border-[var(--primary)] bg-[var(--primary)]"
-                    : "border-[var(--border)] bg-[var(--secondary)]",
-                )}
-              >
-                <span
-                  className={cn(
-                    "absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-[var(--background)] shadow-sm transition-transform",
-                    formData.versioningEnabled && "translate-x-4",
-                  )}
-                />
-              </span>
-              {localizeUi("ui.cardversionhistory.automaticVersioning")}
-            </button>
+              className="min-h-11 gap-2 rounded-md px-1 py-0"
+              labelClassName="text-xs font-medium text-[var(--muted-foreground)]"
+            />
           </div>
           <input
             value={formData.personaVersion}

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -5529,6 +5529,10 @@ const androidMainActivitySource = readFileSync(
   new URL("../../android/app/src/main/java/com/marinara/engine/MainActivity.java", import.meta.url),
   "utf8",
 );
+const configureWebViewStart = androidMainActivitySource.indexOf("private void configureWebView()");
+const configureWebViewEnd = androidMainActivitySource.indexOf("private void tryConnect()", configureWebViewStart);
+assert.ok(configureWebViewStart >= 0 && configureWebViewEnd > configureWebViewStart);
+const configureWebViewSource = androidMainActivitySource.slice(configureWebViewStart, configureWebViewEnd);
 const gameJournalSource = readFileSync(
   new URL("../../packages/client/src/components/game/GameJournal.tsx", import.meta.url),
   "utf8",
@@ -5816,7 +5820,7 @@ assert.match(
 );
 assert.match(androidMainActivitySource, /MediaStore\.Images\.Media\.getContentUri/u);
 assert.match(
-  androidMainActivitySource,
+  configureWebViewSource,
   /settings\.setTextZoom\(100\);/u,
   "The Android wrapper must not inherit oversized WebView text zoom",
 );
@@ -5831,7 +5835,10 @@ assert.match(
   "Persona versioning must use the shared aligned settings switch",
 );
 assert.match(
-  chatSetupWizardSource,
+  chatSetupWizardSource.slice(
+    chatSetupWizardSource.indexOf("function SetupGenerationParametersPanel"),
+    chatSetupWizardSource.indexOf("export function ChatSetupWizard"),
+  ),
   /className="flex min-w-0 w-full items-center justify-between gap-3 text-left"[\s\S]*className="min-w-0 flex-1"[\s\S]*"h-5 w-9 shrink-0 rounded-full/u,
   "The New Chat parameter toggle must stay within its card when Android enlarges text",
 );

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -5486,6 +5486,10 @@ const personaEditorSource = readFileSync(
   new URL("../../packages/client/src/components/personas/PersonaEditor.tsx", import.meta.url),
   "utf8",
 );
+const chatSetupWizardSource = readFileSync(
+  new URL("../../packages/client/src/components/chat/ChatSetupWizard.tsx", import.meta.url),
+  "utf8",
+);
 const convoProfileFieldsSource = readFileSync(
   new URL("../../packages/client/src/components/characters/ConvoProfileFields.tsx", import.meta.url),
   "utf8",
@@ -5825,6 +5829,11 @@ assert.match(
   personaEditorSource,
   /<SettingsSwitch\s+checked=\{formData\.versioningEnabled\}/u,
   "Persona versioning must use the shared aligned settings switch",
+);
+assert.match(
+  chatSetupWizardSource,
+  /className="flex min-w-0 w-full items-center justify-between gap-3 text-left"[\s\S]*className="min-w-0 flex-1"[\s\S]*"h-5 w-9 shrink-0 rounded-full/u,
+  "The New Chat parameter toggle must stay within its card when Android enlarges text",
 );
 assert.match(
   characterEditorSource,

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -5490,6 +5490,10 @@ const chatSetupWizardSource = readFileSync(
   new URL("../../packages/client/src/components/chat/ChatSetupWizard.tsx", import.meta.url),
   "utf8",
 );
+const setupGenerationParametersStart = chatSetupWizardSource.indexOf("function SetupGenerationParametersPanel");
+const chatSetupWizardEnd = chatSetupWizardSource.indexOf("export function ChatSetupWizard");
+assert.ok(setupGenerationParametersStart >= 0 && chatSetupWizardEnd > setupGenerationParametersStart);
+const setupGenerationParametersSource = chatSetupWizardSource.slice(setupGenerationParametersStart, chatSetupWizardEnd);
 const convoProfileFieldsSource = readFileSync(
   new URL("../../packages/client/src/components/characters/ConvoProfileFields.tsx", import.meta.url),
   "utf8",
@@ -5835,10 +5839,7 @@ assert.match(
   "Persona versioning must use the shared aligned settings switch",
 );
 assert.match(
-  chatSetupWizardSource.slice(
-    chatSetupWizardSource.indexOf("function SetupGenerationParametersPanel"),
-    chatSetupWizardSource.indexOf("export function ChatSetupWizard"),
-  ),
+  setupGenerationParametersSource,
   /className="flex min-w-0 w-full items-center justify-between gap-3 text-left"[\s\S]*className="min-w-0 flex-1"[\s\S]*"h-5 w-9 shrink-0 rounded-full/u,
   "The New Chat parameter toggle must stay within its card when Android enlarges text",
 );

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -5812,6 +5812,21 @@ assert.match(
 );
 assert.match(androidMainActivitySource, /MediaStore\.Images\.Media\.getContentUri/u);
 assert.match(
+  androidMainActivitySource,
+  /settings\.setTextZoom\(100\);/u,
+  "The Android wrapper must not inherit oversized WebView text zoom",
+);
+assert.match(
+  characterEditorSource,
+  /<SettingsSwitch\s+checked=\{formData\.extensions\.versioningEnabled !== false\}/u,
+  "Character versioning must use the shared aligned settings switch",
+);
+assert.match(
+  personaEditorSource,
+  /<SettingsSwitch\s+checked=\{formData\.versioningEnabled\}/u,
+  "Persona versioning must use the shared aligned settings switch",
+);
+assert.match(
   characterEditorSource,
   /"mari-editor-avatar-tile group relative"/u,
   "The Metadata avatar preview must contain absolutely positioned saved crops",


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5315
Closes #5316
Closes #5318

## Why this change

- Android WebView can enlarge chat prose beyond the explicit app typography, making Conversation, Roleplay, and Game messages impractically large in the APK wrapper.
- Enlarged Android text can force the New Chat parameter toggle outside its card because the adjacent description does not shrink.
- Character and Persona versioning use a bespoke toggle whose inactive color and thumb treatment drift from the shared settings control.

## What changed

- Pin Android WebView text zoom to the app's authored typography.
- Let the New Chat parameter description shrink while keeping its toggle inside the card.
- Reuse the shared settings switch for card versioning.
- Add focused regression guards and an Unreleased changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated verification completed by the authoring agent:

- `pnpm check`
- `node ./scripts/run-regressions.mjs --filter scripts/regressions/open-issues.regression.ts`
- `gradle :app:compileDebugJavaWithJavac`
- Full `pnpm regression:ui`: 235 passed, 107 skipped, and 18 unrelated existing/stale expectations failed; issue-adjacent Android bridge, mobile layout, Character editor, and Persona editor cases passed.

### Manual verification notes

- Manually verify Conversation, Roleplay, and Game message typography on an Android APK.
- Manually enable Customize Parameters in New Conversation and New Roleplay at Android width and confirm the toggle stays inside its card.
- Manually verify Character and Persona versioning switches in dark and light themes.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Before evidence for the parameter overflow is attached to #5318.
- The signed Discord CDN images on #5315 and #5316 have expired.
- After evidence is pending manual Android verification because no controllable local browser session was available to the authoring agent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Android text sizing to maintain consistent message readability.
  * Improved the New Chat parameter toggle layout at larger text sizes.
  * Corrected alignment and inactive-state colors for automatic versioning controls.
  * Standardized versioning switches across character and persona editors.
* **Tests**
  * Added regression coverage for Android text scaling, responsive toggle layouts, and versioning controls.
* **Documentation**
  * Documented these fixes in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->