### PR TITLE
fix(chat settings): neutralize stop generation action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Chat Settings now presents its transient Stop Active Generation action like the neighboring neutral controls instead of making it look like an enabled destructive preference.
 - Android APK chats now keep their intended message text size instead of letting WebView enlarge Conversation, Roleplay, and Game prose, the New Chat parameter toggle stays inside its card at larger text sizes, and card versioning switches now match the alignment and inactive color of other settings toggles (#5315, #5316, #5318).
 - Development server watchers now exit after losing the file-storage writer lease, preventing abandoned sessions from retrying forever and repeatedly reporting `StorageWriterLeaseError` (#5312).
 - Forced Agent retries such as Echo Chamber now stop from Roleplay's Agents menu, whose Stop Agents action also matches the neutral styling of neighboring actions (#5299).

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -7051,7 +7051,7 @@ export function ChatSettingsDrawer({
                       type="button"
                       onClick={() => void handleStopActiveGeneration()}
                       disabled={stoppingGeneration}
-                      className="flex min-h-10 w-full items-center justify-between gap-3 rounded-lg bg-red-500/10 px-3 py-2.5 text-left text-red-300 ring-1 ring-red-500/25 transition-colors hover:bg-red-500/15 disabled:cursor-not-allowed disabled:opacity-60"
+                      className="flex min-h-10 w-full items-center justify-between gap-3 rounded-lg bg-[var(--secondary)] px-3 py-2.5 text-left transition-colors hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       <div className="min-w-0 flex-1">
                         <span className="text-[0.6875rem] font-medium">
@@ -7059,14 +7059,14 @@ export function ChatSettingsDrawer({
                             ? localizeUi("ui.chat.chatsettingsdrawer.stoppingGeneration")
                             : localizeUi("ui.chat.chatsettingsdrawer.stopActiveGeneration")}
                         </span>
-                        <p className="text-[0.625rem] leading-relaxed text-red-200/70">
+                        <p className="text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
                           {localizeUi("ui.chat.chatsettingsdrawer.stopActiveGenerationDescription")}
                         </p>
                       </div>
                       {stoppingGeneration ? (
-                        <Loader2 size="0.8125rem" className="shrink-0 animate-spin" />
+                        <Loader2 size="0.8125rem" className="shrink-0 animate-spin text-[var(--muted-foreground)]" />
                       ) : (
-                        <X size="0.8125rem" className="shrink-0" />
+                        <X size="0.8125rem" className="shrink-0 text-[var(--muted-foreground)]" />
                       )}
                     </button>
                   )}

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -9352,6 +9352,18 @@ assert.equal(({} as { tags?: string[] }).tags, undefined, "Background metadata m
   assert.match(settingsDrawerSource, /\/generate\/status\/\$\{encodeURIComponent\(chat\.id\)\}/u);
   assert.match(settingsDrawerSource, /isRoleplayMode && \(activeGeneration \|\| stoppingGeneration\)/u);
   assert.match(settingsDrawerSource, /await abortGenerationForChat\(chat\.id, controller\)/u);
+  const stopGenerationActionStart = settingsDrawerSource.indexOf(
+    "{isRoleplayMode && (activeGeneration || stoppingGeneration) && (",
+  );
+  const agentSuiteActionStart = settingsDrawerSource.indexOf(
+    "onClick={() => setShowAgentSuiteModal(true)}",
+    stopGenerationActionStart,
+  );
+  assert.ok(stopGenerationActionStart >= 0 && agentSuiteActionStart > stopGenerationActionStart);
+  const stopGenerationActionSource = settingsDrawerSource.slice(stopGenerationActionStart, agentSuiteActionStart);
+  assert.match(stopGenerationActionSource, /bg-\[var\(--secondary\)\][\s\S]*hover:bg-\[var\(--accent\)\]/u);
+  assert.match(stopGenerationActionSource, /text-\[var\(--muted-foreground\)\]/u);
+  assert.doesNotMatch(stopGenerationActionSource, /red-/u);
   assert.equal(
     (
       settingsDrawerSource.match(


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #5319

## Why this change

- The transient Stop Active Generation action used red destructive styling, which made it look like a persistent setting the user had enabled. It should read as a contextual action alongside the other neutral Chat Settings controls.

## What changed

- Reused the drawer's existing secondary, accent, and muted theme tokens for the action.
- Preserved the existing conditional visibility and stop behavior.
- Added a focused source regression guard and an `[Unreleased]` changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated validation performed before submission:

- `pnpm check`
- `node ./scripts/run-regressions.mjs --filter scripts/regressions/open-issues.regression.ts`
- `pnpm --filter @marinara-engine/client lint`
- `git diff --check`

### Manual verification notes

- Manual browser verification remains for the maintainer: start a Roleplay generation or agent run, open Chat Settings, and confirm the transient action matches neighboring controls in light and dark themes.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

A user-facing `[Unreleased]` changelog entry is included. No user documentation, translated documentation, or version files changed.

## UI evidence (if applicable)

- No screenshot attached; manual visual verification is called out above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Chat Settings “Stop Active Generation” action with a neutral visual style instead of destructive red styling.
  * Improved consistency across the button, description text, and icons.
* **Tests**
  * Added regression coverage to verify the updated styling and hover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->