### PR TITLE
fix: repair mixed Docker data ownership before dropping privileges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Docker containers now repair mixed ownership inside file storage and imported top-level data folders even when the data root already belongs to the runtime user, preventing private storage hardening from blocking startup (#5323).
 - Chat Settings now presents its transient Stop Active Generation action like the neighboring neutral controls instead of making it look like an enabled destructive preference.
 - Android APK chats now keep their intended message text size instead of letting WebView enlarge Conversation, Roleplay, and Game prose, the New Chat parameter toggle stays inside its card at larger text sizes, and card versioning switches now match the alignment and inactive color of other settings toggles (#5315, #5316, #5318).
 - Development server watchers now exit after losing the file-storage writer lease, preventing abandoned sessions from retrying forever and repeatedly reporting `StorageWriterLeaseError` (#5312).

--- a/scripts/docker-entrypoint.mjs
+++ b/scripts/docker-entrypoint.mjs
@@ -1,7 +1,7 @@
-import { existsSync, lchownSync, lstatSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
+import { lchownSync, lstatSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { constants as osConstants } from "node:os";
-import { isAbsolute, join, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 
 const DEFAULT_COMMAND = ["node", "packages/server/dist/index.js"];
 
@@ -57,15 +57,45 @@ function resolveStoragePath(value) {
   return isAbsolute(value) ? value : resolve(process.cwd(), value);
 }
 
-function shouldRepairOwnership(path, uid, gid) {
-  if (!existsSync(path)) return true;
+function isSameOrDescendant(parent, candidate) {
+  const nestedPath = relative(parent, candidate);
+  return nestedPath === "" || (nestedPath !== ".." && !nestedPath.startsWith(`..${sep}`) && !isAbsolute(nestedPath));
+}
+
+function minimizeOwnershipRoots(paths) {
+  const roots = [...new Set(paths.map((path) => resolve(path)))].sort(
+    (left, right) => left.length - right.length || left.localeCompare(right),
+  );
+  return roots.filter(
+    (candidate, index) => !roots.slice(0, index).some((parent) => isSameOrDescendant(parent, candidate)),
+  );
+}
+
+function hasExpectedOwnership(path, uid, gid) {
   const stat = lstatSync(path);
-  return stat.uid !== uid || stat.gid !== gid;
+  return stat.uid === uid && stat.gid === gid;
+}
+
+function findOwnershipRepairRoots(dataDir, fileStorageDir, uid, gid) {
+  // A moved or restored data directory still gets the original full-tree repair. When its root is already correct,
+  // limit discovery to common top-level imports while always checking storage, whose permission hardening is recursive.
+  if (!hasExpectedOwnership(dataDir, uid, gid)) {
+    return minimizeOwnershipRoots([dataDir, fileStorageDir]);
+  }
+
+  const repairRoots = [fileStorageDir];
+  for (const child of readdirSync(dataDir)) {
+    const childPath = join(dataDir, child);
+    if (resolve(childPath) === resolve(fileStorageDir)) continue;
+    if (!hasExpectedOwnership(childPath, uid, gid)) repairRoots.push(childPath);
+  }
+  return minimizeOwnershipRoots(repairRoots);
 }
 
 function chownRecursive(path, uid, gid) {
   const stack = [path];
   let firstError = null;
+  let repairedEntries = 0;
 
   while (stack.length > 0) {
     const current = stack.pop();
@@ -73,7 +103,10 @@ function chownRecursive(path, uid, gid) {
 
     try {
       const stat = lstatSync(current);
-      lchownSync(current, uid, gid);
+      if (stat.uid !== uid || stat.gid !== gid) {
+        lchownSync(current, uid, gid);
+        repairedEntries += 1;
+      }
       if (!stat.isDirectory() || stat.isSymbolicLink()) continue;
 
       for (const child of readdirSync(current)) {
@@ -85,6 +118,7 @@ function chownRecursive(path, uid, gid) {
   }
 
   if (firstError) throw firstError;
+  return repairedEntries;
 }
 
 function prepareDataDirectories(uid, gid) {
@@ -98,10 +132,11 @@ function prepareDataDirectories(uid, gid) {
 
   if (process.env.MARINARA_SKIP_DATA_CHOWN === "true") return;
 
-  for (const dir of dirs) {
-    if (!shouldRepairOwnership(dir, uid, gid)) continue;
-    log(`Repairing ownership for ${dir}`);
-    chownRecursive(dir, uid, gid);
+  for (const dir of findOwnershipRepairRoots(dataDir, fileStorageDir, uid, gid)) {
+    const repairedEntries = chownRecursive(dir, uid, gid);
+    if (repairedEntries > 0) {
+      log(`Repaired ownership for ${repairedEntries} ${repairedEntries === 1 ? "entry" : "entries"} under ${dir}`);
+    }
   }
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5323

## Why this change

- Marinara's Docker entrypoint only runs its recursive ownership repair when a configured data or storage root has the wrong owner. A volume can instead have correctly owned roots with mismatched descendants, so the app drops to its non-root runtime identity without repairing them. Private-storage hardening then cannot tighten those descendants and startup fails with `EPERM`.
- During startup, Marinara applies private permissions throughout the configured storage tree, so an ownership mismatch anywhere inside it can prevent startup. Applying the same deep scan to all of `/app/data` would unnecessarily traverse large galleries and media folders, so this extends the existing repair more selectively: retain the full-tree repair for a moved or restored data root, deeply check the configured storage tree, and recursively repair mismatched immediate children commonly introduced by copying or restoring folders into an existing data directory.

## What changed

- Added ownership discovery for mismatched immediate children when the data root is already correct, plus a deep check of the configured file-storage tree so nested mismatches cannot be hidden by a correctly owned storage root.
- Changed ownership only for mismatched entries and deduplicated overlapping repair paths, so nested storage is not traversed twice and correctly owned non-storage trees do not receive a deep scan.
- Preserved the existing full-tree repair when the data root belongs to a different UID/GID, along with runtime user resolution and `MARINARA_SKIP_DATA_CHOWN`.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- A disposable named-volume test using the exact Node 24 base pinned by the regular Dockerfile verified a correctly owned data root with mismatched storage and top-level descendants. The entrypoint repaired only those entries before the command ran as UID/GID 1000.
- The same disposable Docker fixture was changed to a completely root-owned restored data folder. The existing full-tree repair remained effective, storage was not traversed twice, and the command again ran as UID/GID 1000.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker startup handling for mixed file-storage ownership.
  * Imported top-level data folders are now correctly repaired when the data root already belongs to the runtime user.
  * Ownership repairs now target only mismatched files and folders, reducing unnecessary changes.
  * Startup logs report the number of ownership repairs performed.

* **Documentation**
  * Added an unreleased changelog entry describing the Docker startup repairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->