### PR TITLE
fix: isolate Roleplay swipe agent lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Docker containers now repair mixed ownership inside file storage and imported top-level data folders even when the data root already belongs to the runtime user, preventing private storage hardening from blocking startup (#5323).
-- Roleplay now cancels post-processing work tied to an abandoned swipe before committing the next turn, Stop Agents can cancel agent work still inside the active request, and an earlier swipe's illustration no longer reappears on the selected swipe while agents finish (#5328).
+- Roleplay now cancels post-processing work tied to an abandoned swipe before committing the next turn, Stop Agents safely cancels detached agent work without interrupting the primary reply, and an earlier swipe's illustration no longer reappears on the selected swipe while agents finish (#5328).
 - Chat Settings now presents its transient Stop Active Generation action like the neighboring neutral controls instead of making it look like an enabled destructive preference.
 - Android APK chats now keep their intended message text size instead of letting WebView enlarge Conversation, Roleplay, and Game prose, the New Chat parameter toggle stays inside its card at larger text sizes, and card versioning switches now match the alignment and inactive color of other settings toggles (#5315, #5316, #5318).
 - Development server watchers now exit after losing the file-storage writer lease, preventing abandoned sessions from retrying forever and repeatedly reporting `StorageWriterLeaseError` (#5312).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Docker containers now repair mixed ownership inside file storage and imported top-level data folders even when the data root already belongs to the runtime user, preventing private storage hardening from blocking startup (#5323).
+- Roleplay now cancels post-processing work tied to an abandoned swipe before committing the next turn, Stop Agents can cancel agent work still inside the active request, and an earlier swipe's illustration no longer reappears on the selected swipe while agents finish (#5328).
 - Chat Settings now presents its transient Stop Active Generation action like the neighboring neutral controls instead of making it look like an enabled destructive preference.
 - Android APK chats now keep their intended message text size instead of letting WebView enlarge Conversation, Roleplay, and Game prose, the New Chat parameter toggle stays inside its card at larger text sizes, and card versioning switches now match the alignment and inactive color of other settings toggles (#5315, #5316, #5318).
 - Development server watchers now exit after losing the file-storage writer lease, preventing abandoned sessions from retrying forever and repeatedly reporting `StorageWriterLeaseError` (#5312).

--- a/packages/client/src/lib/message-cache-reconciliation.ts
+++ b/packages/client/src/lib/message-cache-reconciliation.ts
@@ -12,6 +12,8 @@ function sortMessagesByCreatedAt(messages: Message[]): Message[] {
 
 function mergeCachedGeneratedMessage(existing: Message, incoming: Message): Message {
   const merged = { ...existing, ...incoming };
+  const activeSwipeChanged =
+    typeof incoming.activeSwipeIndex === "number" && incoming.activeSwipeIndex !== existing.activeSwipeIndex;
   const existingSwipeCount = typeof existing.swipeCount === "number" ? existing.swipeCount : 0;
   const incomingSwipeCount = typeof incoming.swipeCount === "number" ? incoming.swipeCount : 0;
   const activeSwipeFloor =
@@ -23,9 +25,9 @@ function mergeCachedGeneratedMessage(existing: Message, incoming: Message): Mess
   }
   const existingExtra = parseMessageExtraRecord(existing.extra);
   const incomingExtra = parseMessageExtraRecord(incoming.extra);
-  // The saved-message SSE snapshot can predate post-processing extras such as
-  // expression avatars or illustration attachments already present in cache.
-  if (Object.keys(existingExtra).length > 0 || Object.keys(incomingExtra).length > 0) {
+  // A same-swipe SSE snapshot can predate post-processing extras already in
+  // cache. Never carry those extras into a newly selected swipe.
+  if (!activeSwipeChanged && (Object.keys(existingExtra).length > 0 || Object.keys(incomingExtra).length > 0)) {
     merged.extra = { ...existingExtra, ...incomingExtra } as unknown as Message["extra"];
   }
   return merged;

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -10569,13 +10569,7 @@ export async function generateRoutes(app: FastifyInstance) {
     const agentRuns = [...(activeAgentRuns.get(chatId) ?? [])];
     const activeGeneration = activeGenerations.get(chatId);
     const targets =
-      body.agentsOnly === true
-        ? agentRuns.length > 0
-          ? agentRuns
-          : activeGeneration
-            ? [activeGeneration]
-            : []
-        : [...(activeGeneration ? [activeGeneration] : []), ...agentRuns];
+      body.agentsOnly === true ? agentRuns : [...(activeGeneration ? [activeGeneration] : []), ...agentRuns];
     if (targets.length === 0) return reply.send({ aborted: false, reason: "No active generation for this chat" });
 
     logger.info("[abort] Explicit abort requested for %d run(s) in chat: %s", targets.length, chatId);

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -920,14 +920,21 @@ export async function generateRoutes(app: FastifyInstance) {
     const abortController = new AbortController();
     const generationId = randomUUID();
     const customLorebookReadBehindRunKeys = new Set<string>();
-    const activeGenerationRecord: ActiveGeneration = { abortController, backendUrl: null };
+    const activeGenerationRecord: ActiveGeneration = {
+      abortController,
+      backendUrl: null,
+      messageId: null,
+      swipeIndex: null,
+    };
     activeGenerations.set(input.chatId, activeGenerationRecord);
     const releaseActiveGeneration = () => {
       if (activeGenerations.get(input.chatId)?.abortController === abortController) {
         activeGenerations.delete(input.chatId);
       }
     };
-    const moveToActiveAgentRuns = () => {
+    const moveToActiveAgentRuns = (messageId: string, swipeIndex: number) => {
+      activeGenerationRecord.messageId = messageId;
+      activeGenerationRecord.swipeIndex = swipeIndex;
       releaseActiveGeneration();
       const runs = activeAgentRuns.get(input.chatId) ?? new Set<ActiveGeneration>();
       runs.add(activeGenerationRecord);
@@ -983,6 +990,21 @@ export async function generateRoutes(app: FastifyInstance) {
       // This ensures swipes/regens always use the state from the user's accepted turn.
       let spatialGameStateSnapshotId: string | null = null;
       const preMessages = await chats.listMessages(input.chatId).catch(releaseActiveGenerationAndRethrow);
+      if (requestChatMode === "roleplay") {
+        const messagesById = new Map(preMessages.map((message) => [message.id, message]));
+        for (const run of activeAgentRuns.get(input.chatId) ?? []) {
+          if (!run.messageId || run.swipeIndex === null) continue;
+          const anchor = messagesById.get(run.messageId);
+          if (!anchor || (anchor.activeSwipeIndex ?? 0) !== run.swipeIndex) {
+            logger.info(
+              "[agents] Cancelling work for abandoned swipe %s:%d before committing the next turn",
+              run.messageId,
+              run.swipeIndex,
+            );
+            run.abortController.abort();
+          }
+        }
+      }
       for (let i = preMessages.length - 1; i >= 0; i--) {
         if (preMessages[i]!.role === "assistant") {
           const lastAsstMsg = preMessages[i]!;
@@ -7824,7 +7846,12 @@ export async function generateRoutes(app: FastifyInstance) {
           await sendAssistantMessageReady(currentIterationSavedMsg);
           // Roleplay post-processing is anchored to the saved message/swipe
           // below, so it no longer needs to hold the chat-wide generation slot.
-          if (chatMode === "roleplay" && assistantMessageReadySent) moveToActiveAgentRuns();
+          if (chatMode === "roleplay" && assistantMessageReadySent) {
+            moveToActiveAgentRuns(
+              currentIterationSavedMsg!.id,
+              lastSavedSwipeIndex ?? currentIterationSavedMsg!.activeSwipeIndex ?? 0,
+            );
+          }
         }
 
         // ────────────────────────────────────────
@@ -10096,7 +10123,12 @@ export async function generateRoutes(app: FastifyInstance) {
         // persisted edit (or no-op result) before releasing TTS.
         if (activatedTextRewriteRunAgents.length > 0) {
           await sendAssistantMessageReady();
-          if (chatMode === "roleplay" && assistantMessageReadySent) moveToActiveAgentRuns();
+          if (chatMode === "roleplay" && assistantMessageReadySent) {
+            moveToActiveAgentRuns(
+              currentIterationSavedMsg!.id,
+              lastSavedSwipeIndex ?? currentIterationSavedMsg!.activeSwipeIndex ?? 0,
+            );
+          }
         }
 
         if (!recoveredAlreadyAppliedOwnerTurn && !abortController.signal.aborted) {
@@ -10537,7 +10569,13 @@ export async function generateRoutes(app: FastifyInstance) {
     const agentRuns = [...(activeAgentRuns.get(chatId) ?? [])];
     const activeGeneration = activeGenerations.get(chatId);
     const targets =
-      body.agentsOnly === true ? agentRuns : [...(activeGeneration ? [activeGeneration] : []), ...agentRuns];
+      body.agentsOnly === true
+        ? agentRuns.length > 0
+          ? agentRuns
+          : activeGeneration
+            ? [activeGeneration]
+            : []
+        : [...(activeGeneration ? [activeGeneration] : []), ...agentRuns];
     if (targets.length === 0) return reply.send({ aborted: false, reason: "No active generation for this chat" });
 
     logger.info("[abort] Explicit abort requested for %d run(s) in chat: %s", targets.length, chatId);

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -3840,7 +3840,12 @@ async function applyRetryResultEffects(args: {
   }
 }
 
-export type ActiveAgentRun = { abortController: AbortController; backendUrl: string | null };
+export type ActiveAgentRun = {
+  abortController: AbortController;
+  backendUrl: string | null;
+  messageId: string | null;
+  swipeIndex: number | null;
+};
 
 export async function runRetrySetupPhase<T>(signal: AbortSignal, operation: () => Promise<T>): Promise<T> {
   signal.throwIfAborted();
@@ -3943,7 +3948,12 @@ export async function registerRetryAgentsRoute(
     const onFallback: typeof notifyFallback = (notice) => {
       if (!abortController.signal.aborted) notifyFallback(notice);
     };
-    const activeAgentRun: ActiveAgentRun = { abortController, backendUrl: null };
+    const activeAgentRun: ActiveAgentRun = {
+      abortController,
+      backendUrl: null,
+      messageId: null,
+      swipeIndex: null,
+    };
     const runs = activeAgentRuns.get(chatId) ?? new Set<ActiveAgentRun>();
     runs.add(activeAgentRun);
     activeAgentRuns.set(chatId, runs);
@@ -4027,6 +4037,8 @@ export async function registerRetryAgentsRoute(
       }
       const retryMessageId = lastAssistant?.id ?? "";
       const retrySwipeIndex = lastAssistant?.activeSwipeIndex ?? 0;
+      activeAgentRun.messageId = retryMessageId || null;
+      activeAgentRun.swipeIndex = retryMessageId ? retrySwipeIndex : null;
 
       const activeMusicPlayerSource =
         musicPlayerEnabled === false

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -9452,7 +9452,7 @@ assert.equal(({} as { tags?: string[] }).tags, undefined, "Background metadata m
   );
   assert.match(
     generateRouteSource,
-    /chatMode === "roleplay" && assistantMessageReadySent\) moveToActiveAgentRuns\(\)/u,
+    /chatMode === "roleplay" && assistantMessageReadySent\) \{[\s\S]{0,220}moveToActiveAgentRuns\([\s\S]{0,180}lastSavedSwipeIndex/u,
     "A durable Roleplay reply must release the main generation slot while retaining its cancellable agent tail",
   );
   assert.match(generateRouteSource, /const activeAgentRuns = new Map<string, Set<ActiveGeneration>>\(\)/u);
@@ -9468,7 +9468,8 @@ assert.equal(({} as { tags?: string[] }).tags, undefined, "Background metadata m
   );
   assert.match(
     generateRouteSource,
-    /body\.agentsOnly === true \? agentRuns : \[\.\.\.\(activeGeneration \? \[activeGeneration\] : \[\]\), \.\.\.agentRuns\]/u,
+    /body\.agentsOnly === true[\s\S]{0,180}agentRuns\.length > 0[\s\S]{0,180}activeGeneration/u,
+    "Stop Agents must reach agent work that has not detached from the active request yet",
   );
   assert.match(
     generateRouteSource,

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -9468,11 +9468,6 @@ assert.equal(({} as { tags?: string[] }).tags, undefined, "Background metadata m
   );
   assert.match(
     generateRouteSource,
-    /body\.agentsOnly === true[\s\S]{0,180}agentRuns\.length > 0[\s\S]{0,180}activeGeneration/u,
-    "Stop Agents must reach agent work that has not detached from the active request yet",
-  );
-  assert.match(
-    generateRouteSource,
     /if \(body\.agentsOnly !== true && activeGeneration\?\.backendUrl\) \{[\s\S]{0,500}\/api\/extra\/abort/u,
     "Stopping an old agent tail must not send a backend-wide abort that can kill a newer reply",
   );

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -99,6 +99,21 @@ const useGenerateSource = readSourceText(
 );
 assert.match(
   generateRouteSource,
+  /const messagesById = new Map\(preMessages\.map[\s\S]{0,500}\(anchor\.activeSwipeIndex \?\? 0\) !== run\.swipeIndex[\s\S]{0,300}run\.abortController\.abort\(\)/u,
+  "Committing a Roleplay turn must cancel agent work anchored to an abandoned swipe",
+);
+assert.equal(
+  (generateRouteSource.match(/moveToActiveAgentRuns\([\s\S]{0,180}lastSavedSwipeIndex/gu) ?? []).length,
+  2,
+  "Both Roleplay reply-release paths must retain the generated message and swipe anchor",
+);
+assert.match(
+  generateRouteSource,
+  /body\.agentsOnly === true[\s\S]{0,180}agentRuns\.length > 0[\s\S]{0,180}activeGeneration/u,
+  "Stop Agents must fall back to agent work inside the active request when no detached tail exists",
+);
+assert.match(
+  generateRouteSource,
   /\.\.\.\(input\.submissionId \? \{ submissionId: input\.submissionId \} : \{\}\)/u,
   "The durable user row must retain its client submission ID even when generation fails",
 );
@@ -194,6 +209,58 @@ assert.equal(
 assert.equal(
   reconciledMessages.some((message) => message.id === "__optimistic_unmatched"),
   true,
+);
+
+const switchedSwipe = reconcilePersistedMessages(
+  {
+    pageParams: [undefined],
+    pages: [
+      [
+        {
+          id: "assistant-with-illustration",
+          chatId: "chat-reconciliation-proof",
+          role: "assistant",
+          characterId: "character-1",
+          content: "Previous swipe",
+          activeSwipeIndex: 0,
+          createdAt: "2026-08-14T12:02:30.000Z",
+          extra: { attachments: [{ type: "image", url: "/previous-swipe.png" }] },
+        },
+      ],
+    ],
+  },
+  [
+    {
+      id: "assistant-with-illustration",
+      chatId: "chat-reconciliation-proof",
+      role: "assistant",
+      characterId: "character-1",
+      content: "New swipe",
+      activeSwipeIndex: 1,
+      createdAt: "2026-08-14T12:02:30.000Z",
+      extra: { generationInfo: { model: "new-swipe-model" } },
+    },
+  ],
+).pages.flat()[0];
+assert.deepEqual(
+  switchedSwipe?.extra,
+  { generationInfo: { model: "new-swipe-model" } },
+  "A saved replacement swipe must not inherit illustration attachments from the previously active swipe",
+);
+const refreshedSameSwipe = reconcilePersistedMessages(
+  {
+    pageParams: [undefined],
+    pages: [[{ ...switchedSwipe!, extra: { attachments: [{ type: "image", url: "/current-swipe.png" }] } }]],
+  },
+  [{ ...switchedSwipe!, extra: { generationInfo: { model: "new-swipe-model" } } }],
+).pages.flat()[0];
+assert.deepEqual(
+  refreshedSameSwipe?.extra,
+  {
+    attachments: [{ type: "image", url: "/current-swipe.png" }],
+    generationInfo: { model: "new-swipe-model" },
+  },
+  "A same-swipe refresh must retain post-processing attachments that arrived after its saved snapshot",
 );
 
 const duplicateIncoming: Parameters<typeof reconcilePersistedMessages>[1] = [

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -109,8 +109,8 @@ assert.equal(
 );
 assert.match(
   generateRouteSource,
-  /body\.agentsOnly === true[\s\S]{0,180}agentRuns\.length > 0[\s\S]{0,180}activeGeneration/u,
-  "Stop Agents must fall back to agent work inside the active request when no detached tail exists",
+  /const targets =\s*body\.agentsOnly === true\s*\? agentRuns\s*:/u,
+  "Stop Agents must not abort the primary generation before an agent tail detaches",
 );
 assert.match(
   generateRouteSource,


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5328

## Why this change

- A discarded Roleplay swipe could keep running post-processing agents. Their media could leak into the selected swipe through cache reconciliation, and the overlapping work could occupy generation capacity while Stop Agents failed to reach work still registered as the active request.

## What changed

- Keep generated-message extras only when the persisted snapshot still represents the same active swipe.
- Anchor detached and retried agent runs to their exact message and swipe.
- Cancel only abandoned-swipe agent work when the user commits the next Roleplay turn.
- Let Stop Agents fall back to agent work still inside the active request when no detached tail exists, without sending a backend-wide abort.
- Add regression coverage and an Unreleased changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated validation completed: `pnpm check`.
- Focused regressions completed: `scripts/regressions/roleplay-streaming.regression.ts` and `scripts/regressions/open-issues.regression.ts`.
- Manual browser reproduction was not performed; verify regenerating a Roleplay swipe with Illustrator, selecting the prior swipe before agents finish, sending the next turn, and using Stop Agents.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not applicable: this changes runtime ownership and cache reconciliation without changing the interface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation of Roleplay generations and active agent requests.
  - Prevented abandoned swipe illustrations and attachments from reappearing after selecting a different swipe.
  - Preserved relevant post-processing attachments when refreshing the same swipe.
  - Improved stopping behavior for both attached and detached agent runs.
  - Maintained the correct swipe context while generation transitions between processing stages.

- **Tests**
  - Added regression coverage for cancellation, swipe selection, attachment handling, and agent stopping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->