### PR TITLE
fix(game): preserve reusable world map draft options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Reusable Game Mode setups now preserve World Maps AI draft size, exact place target, and lore grounding choices, with a clear fallback warning when imported lorebooks are unavailable (#5337).
 - Custom pre-generation agents can now opt in to choose the active characters for the current Conversation or Roleplay reply, keeping unused character cards out of that turn's prompt (#5310).
 - Lorebook Keeper can now route entries to exact writable lorebook names or configured aliases, auto-create missing category books, and preserve the selected destination through write approval while keeping one-book behavior unchanged when no target is returned (Pasta-Devs/Marinara-Agents#439).
 - File-native storage now shards every registered table by its stable owner or primary key, so routine saves no longer rewrite any global table monolith; upgrades preserve the previous files and retain the existing crash, corruption, and downgrade recovery safeguards (#5302).

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -52,6 +52,7 @@ import {
   type GameGmMode,
   type GameSpotifySourceType,
   normalizeSpotifySourceType,
+  resolveGameSpatialMapDraftOptions,
   type GenerationParameters,
   type SpatialMapGroundingMode,
   type SpatialMapDraftSize,
@@ -249,12 +250,6 @@ const SPATIAL_MAP_DRAFT_SIZE_OPTIONS: Array<{
   { value: "large", targetLocationCount: 28, label: "Large", detail: "About 28 places" },
 ];
 const SPATIAL_CUSTOM_TARGET_LOCATION_LIMIT = 40;
-
-function spatialMapDraftSizeForTargetLocationCount(targetLocationCount: number): SpatialMapDraftSize {
-  if (targetLocationCount <= 8) return "small";
-  if (targetLocationCount <= 16) return "medium";
-  return "large";
-}
 
 function normalizeSpatialMapTargetLocationCount(value: string): number | null {
   const parsed = Number(value);
@@ -1109,6 +1104,10 @@ export function GameSetupWizard({
       setGameSystemPromptEdited(Boolean(importedCustomPrompt));
       setGameSpecialInstructions(config.gameSpecialInstructions?.trim() || "");
       const importedSpatialMapInstructions = config.spatialMapInstructions?.trim() || "";
+      const importedSpatialMapDraftOptions = resolveGameSpatialMapDraftOptions(
+        config.spatialMapDraftSize,
+        config.spatialMapTargetLocationCount,
+      );
       setDraftSpatialMap(
         hierarchicalMapsInstalled &&
           (config.gameWorldMapMode === "hierarchical" || Boolean(importedSpatialMapInstructions)),
@@ -1117,10 +1116,10 @@ export function GameSetupWizard({
       setTemplateSpatialMap(false);
       setSpatialTemplateSelection(null);
       setSpatialTemplatePickerOpen(false);
-      setSpatialMapDraftSize("medium");
-      setSpatialMapTargetLocationCount(16);
-      setSpatialMapTargetLocationCountInput("16");
-      setSpatialMapGroundingMode("setup");
+      setSpatialMapDraftSize(importedSpatialMapDraftOptions.size);
+      setSpatialMapTargetLocationCount(importedSpatialMapDraftOptions.targetLocationCount);
+      setSpatialMapTargetLocationCountInput(String(importedSpatialMapDraftOptions.targetLocationCount));
+      setSpatialMapGroundingMode(config.spatialMapGroundingMode ?? "setup");
       setSpatialMapInstructions(importedSpatialMapInstructions);
 
       const warningCount = imported.warnings.length;
@@ -1167,6 +1166,12 @@ export function GameSetupWizard({
         enableAgents && hierarchicalMapsInstalled && (draftSpatialMap || manualSpatialMap || templateSpatialMap)
           ? "hierarchical"
           : "standard",
+      spatialMapDraftSize:
+        enableAgents && hierarchicalMapsInstalled && draftSpatialMap ? spatialMapDraftSize : undefined,
+      spatialMapTargetLocationCount:
+        enableAgents && hierarchicalMapsInstalled && draftSpatialMap ? spatialMapTargetLocationCount : undefined,
+      spatialMapGroundingMode:
+        enableAgents && hierarchicalMapsInstalled && draftSpatialMap ? spatialMapGroundingMode : undefined,
       rating,
       gmMode,
       gmCharacterId: gmMode === "character" && gmCharacterId ? gmCharacterId : undefined,
@@ -3172,7 +3177,7 @@ export function GameSetupWizard({
                                 const normalized = normalizeSpatialMapTargetLocationCount(raw);
                                 if (normalized !== null) {
                                   setSpatialMapTargetLocationCount(normalized);
-                                  setSpatialMapDraftSize(spatialMapDraftSizeForTargetLocationCount(normalized));
+                                  setSpatialMapDraftSize(resolveGameSpatialMapDraftOptions(undefined, normalized).size);
                                 }
                               }}
                               onBlur={() => {
@@ -3182,7 +3187,7 @@ export function GameSetupWizard({
                                 if (normalized !== null) {
                                   setSpatialMapTargetLocationCount(normalized);
                                   setSpatialMapTargetLocationCountInput(String(normalized));
-                                  setSpatialMapDraftSize(spatialMapDraftSizeForTargetLocationCount(normalized));
+                                  setSpatialMapDraftSize(resolveGameSpatialMapDraftOptions(undefined, normalized).size);
                                 }
                               }}
                               className={cn(

--- a/packages/client/src/lib/game-setup-share.ts
+++ b/packages/client/src/lib/game-setup-share.ts
@@ -4,6 +4,7 @@ import {
   GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID,
   STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE_ID,
   generationParametersSchema,
+  resolveGameSpatialMapDraftOptions,
   type GameInitialSetupConnectionSnapshot,
   type GameInitialSetupLabels,
   type GameInitialSetupSnapshot,
@@ -228,6 +229,31 @@ function parseShareConfig(value: unknown): GameSetupConfig {
     throw new Error("This file has an invalid world map mode.");
   }
   if (
+    value.spatialMapDraftSize !== undefined &&
+    value.spatialMapDraftSize !== "small" &&
+    value.spatialMapDraftSize !== "medium" &&
+    value.spatialMapDraftSize !== "large"
+  ) {
+    throw new Error("This file has an invalid Spatial Map Draft Size value.");
+  }
+  if (
+    value.spatialMapTargetLocationCount !== undefined &&
+    (typeof value.spatialMapTargetLocationCount !== "number" ||
+      !Number.isInteger(value.spatialMapTargetLocationCount) ||
+      value.spatialMapTargetLocationCount < 1 ||
+      value.spatialMapTargetLocationCount > 40)
+  ) {
+    throw new Error("This file has an invalid Spatial Map Target Location Count value.");
+  }
+  if (
+    value.spatialMapGroundingMode !== undefined &&
+    value.spatialMapGroundingMode !== "setup" &&
+    value.spatialMapGroundingMode !== "lore_strict" &&
+    value.spatialMapGroundingMode !== "lore_expand"
+  ) {
+    throw new Error("This file has an invalid Spatial Map Grounding Mode value.");
+  }
+  if (
     value.spotifySourceType !== undefined &&
     value.spotifySourceType !== "liked" &&
     value.spotifySourceType !== "playlist" &&
@@ -252,6 +278,10 @@ function parseShareConfig(value: unknown): GameSetupConfig {
     throw new Error("This file has invalid HUD widgets.");
   }
   const generationParameters = parseGenerationParameters(value.generationParameters);
+  const spatialMapDraftOptions =
+    value.spatialMapDraftSize !== undefined || value.spatialMapTargetLocationCount !== undefined
+      ? resolveGameSpatialMapDraftOptions(value.spatialMapDraftSize, value.spatialMapTargetLocationCount)
+      : null;
 
   return {
     ...(value as unknown as GameSetupConfig),
@@ -264,6 +294,22 @@ function parseShareConfig(value: unknown): GameSetupConfig {
     rating,
     partyCharacterIds: [...value.partyCharacterIds],
     generationParameters,
+    ...(spatialMapDraftOptions
+      ? {
+          spatialMapDraftSize: spatialMapDraftOptions.size,
+          spatialMapTargetLocationCount: spatialMapDraftOptions.targetLocationCount,
+        }
+      : {}),
+  };
+}
+
+function normalizeShareConfig(config: GameSetupConfig): GameSetupConfig {
+  if (config.spatialMapDraftSize === undefined && config.spatialMapTargetLocationCount === undefined) return config;
+  const options = resolveGameSpatialMapDraftOptions(config.spatialMapDraftSize, config.spatialMapTargetLocationCount);
+  return {
+    ...config,
+    spatialMapDraftSize: options.size,
+    spatialMapTargetLocationCount: options.targetLocationCount,
   };
 }
 
@@ -271,6 +317,7 @@ export function buildGameSetupShareFile(
   source: GameSetupShareSource,
   exportedAt = new Date().toISOString(),
 ): GameSetupShareFile {
+  const config = normalizeShareConfig(source.config);
   const labels: GameInitialSetupLabels | undefined = source.labels
     ? {
         characterNames: source.labels.characterNames ? { ...source.labels.characterNames } : undefined,
@@ -287,8 +334,8 @@ export function buildGameSetupShareFile(
     gameName: source.gameName,
     gmConnectionId: source.fallbackGmConnectionId ?? null,
     setup: {
-      config: source.config,
-      effectiveGenerationParameters: source.effectiveGenerationParameters ?? source.config.generationParameters ?? null,
+      config,
+      effectiveGenerationParameters: source.effectiveGenerationParameters ?? config.generationParameters ?? null,
       preferences: source.preferences?.trim() || null,
       connections: source.connections
         ? {
@@ -446,6 +493,11 @@ export function resolveGameSetupImport(
     warnings.push(`${describeSavedResource(sourceName, "A saved lorebook")} is unavailable and was skipped.`);
     return [];
   });
+  let spatialMapGroundingMode = sourceConfig.spatialMapGroundingMode;
+  if (spatialMapGroundingMode && spatialMapGroundingMode !== "setup" && activeLorebookIds.length === 0) {
+    warnings.push("The World map build-from lorebooks are unavailable; using Game setup instead.");
+    spatialMapGroundingMode = "setup";
+  }
 
   const promptPresetName = sourceConfig.promptPresetId
     ? labels?.promptPresetNames?.[sourceConfig.promptPresetId]
@@ -491,6 +543,7 @@ export function resolveGameSetupImport(
       videoConnectionId: videoConnectionId ?? undefined,
       audioConnectionId: audioConnectionId ?? undefined,
       activeLorebookIds: [...new Set(activeLorebookIds)],
+      spatialMapGroundingMode,
       promptPresetId,
     },
     preferences: file.setup.preferences ?? "",
@@ -605,7 +658,14 @@ function generationParameterRows(parameters: Partial<GenerationParameters> | nul
 }
 
 export function buildGameSetupSummarySections(source: GameSetupShareSource): GameSetupSummarySection[] {
-  const { config, preferences, labels, connections } = source;
+  const { preferences, labels, connections } = source;
+  const config = normalizeShareConfig(source.config);
+  const spatialMapGroundingLabel =
+    config.spatialMapGroundingMode === "lore_strict"
+      ? "Strict lore"
+      : config.spatialMapGroundingMode === "lore_expand"
+        ? "Lore + AI"
+        : "Game setup";
   const party = config.partyCharacterIds.length
     ? config.partyCharacterIds
         .map((id) => labels?.characterNames?.[id]?.trim())
@@ -722,6 +782,19 @@ export function buildGameSetupSummarySections(source: GameSetupShareSource): Gam
       rows: [
         { label: "Active lorebooks", value: lorebooks },
         { label: "World map creation prompt", value: config.spatialMapInstructions?.trim() || "None" },
+        ...(config.gameWorldMapMode === "hierarchical"
+          ? [
+              {
+                label: "World map size",
+                value: titleCaseToken(config.spatialMapDraftSize ?? "medium"),
+              },
+              {
+                label: "World map place target",
+                value: String(config.spatialMapTargetLocationCount ?? 16),
+              },
+              { label: "World map build from", value: spatialMapGroundingLabel },
+            ]
+          : []),
         { label: "HUD widgets", value: formatWidgets(config) },
         { label: "Music DJ", value: formatMusicSource(config) },
         { label: "Lorebook Keeper", value: config.enableLorebookKeeper ? "On" : "Off" },

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -165,6 +165,7 @@ import {
   normalizeIllustratorImagesPerGeneration,
   resolveGameImageDynamicPromptEnabled,
   resolveGameSetupArtStylePrompt,
+  resolveGameSpatialMapDraftOptions,
   BUILT_IN_AGENT_IDS,
   STORYBOARD_AGENT_ID,
   SPOTIFY_RECENT_TRACK_HISTORY_LIMIT,
@@ -1745,6 +1746,9 @@ const gameSetupConfigSchema = z.object({
   combatStyle: z.enum(["classic", "tactical"]).optional(),
   spatialMapInstructions: z.string().max(4000).optional(),
   gameWorldMapMode: z.enum(["standard", "hierarchical"]).optional(),
+  spatialMapDraftSize: z.enum(["small", "medium", "large"]).optional(),
+  spatialMapTargetLocationCount: z.number().int().min(1).max(40).optional(),
+  spatialMapGroundingMode: z.enum(["setup", "lore_strict", "lore_expand"]).optional(),
   playerGoals: z.string().max(2000).default(""),
   gmMode: z.enum(["standalone", "character"]),
   rating: z.enum(["sfw", "nsfw"]).default("sfw"),
@@ -6302,6 +6306,14 @@ export async function gameRoutes(app: FastifyInstance) {
     logger.info("[game/create] Received request");
     const parsedCreateGameInput = createGameSchema.parse(req.body);
     const { name, connectionId, promptPresetId, chatId, preferences, shareLabels } = parsedCreateGameInput;
+    const normalizedSpatialMapDraftOptions =
+      parsedCreateGameInput.setupConfig.spatialMapDraftSize !== undefined ||
+      parsedCreateGameInput.setupConfig.spatialMapTargetLocationCount !== undefined
+        ? resolveGameSpatialMapDraftOptions(
+            parsedCreateGameInput.setupConfig.spatialMapDraftSize,
+            parsedCreateGameInput.setupConfig.spatialMapTargetLocationCount,
+          )
+        : null;
     const selectedPromptPresetId = promptPresetId || parsedCreateGameInput.setupConfig.promptPresetId || null;
     const customHudWidgets = sanitizeGameHudWidgets(parsedCreateGameInput.setupConfig.customHudWidgets);
     const gameSystemPrompt = parsedCreateGameInput.setupConfig.gameSystemPrompt?.trim() || null;
@@ -6337,6 +6349,12 @@ export async function gameRoutes(app: FastifyInstance) {
         requestedWorldMapMode === "hierarchical" && parsedCreateGameInput.setupConfig.enableAgents === true
           ? "hierarchical"
           : "standard",
+      ...(normalizedSpatialMapDraftOptions
+        ? {
+            spatialMapDraftSize: normalizedSpatialMapDraftOptions.size,
+            spatialMapTargetLocationCount: normalizedSpatialMapDraftOptions.targetLocationCount,
+          }
+        : {}),
       enableSpriteGeneration: visualGenerationEnabled || undefined,
       gameStoryboardAutoIllustrationsEnabled: visualGenerationEnabled
         ? storyboardIllustrationsEnabled

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -4,6 +4,7 @@
 import type { GenerationParameters } from "./prompt.js";
 import type { CombatItemEffect, CombatMechanic, CombatDialogueCue } from "./combat-encounter.js";
 import type { SpotifySourceType } from "./spotify.js";
+import type { SpatialMapDraftSize, SpatialMapGroundingMode } from "./spatial-context.js";
 
 /** The four main states a game can be in during a session. */
 export type GameActiveState = "exploration" | "dialogue" | "combat" | "travel_rest";
@@ -23,6 +24,24 @@ export type GameSessionStatus = "setup" | "active" | "concluded";
 
 /** Which system owns the campaign-scale map when a new game begins. */
 export type GameWorldMapMode = "standard" | "hierarchical";
+
+export const GAME_SPATIAL_MAP_DRAFT_PRESET_TARGETS: Readonly<Record<SpatialMapDraftSize, number>> = {
+  small: 8,
+  medium: 16,
+  large: 28,
+};
+
+/** Keep the exact target authoritative while preserving the matching draft-size bucket. */
+export function resolveGameSpatialMapDraftOptions(
+  size: SpatialMapDraftSize | undefined,
+  targetLocationCount: number | undefined,
+): { size: SpatialMapDraftSize; targetLocationCount: number } {
+  const target = targetLocationCount ?? GAME_SPATIAL_MAP_DRAFT_PRESET_TARGETS[size ?? "medium"];
+  return {
+    size: target <= 8 ? "small" : target <= 16 ? "medium" : "large",
+    targetLocationCount: target,
+  };
+}
 
 /** Spotify source constraints for Game Mode DJ selection. */
 export type GameSpotifySourceType = SpotifySourceType;
@@ -189,6 +208,12 @@ export interface GameSetupConfig {
   spatialMapInstructions?: string;
   /** Campaign-scale map authority selected during New Game. Older saves default to "standard". */
   gameWorldMapMode?: GameWorldMapMode;
+  /** Size bucket selected for the initial World Maps AI draft. */
+  spatialMapDraftSize?: SpatialMapDraftSize;
+  /** Exact number of places requested for the initial World Maps AI draft. */
+  spatialMapTargetLocationCount?: number;
+  /** Sources the initial World Maps AI draft may use. */
+  spatialMapGroundingMode?: SpatialMapGroundingMode;
   /** Character ID to use as GM (only when gmMode is "character") */
   gmCharacterId?: string | null;
   /** Party member IDs; library character IDs or `npc:<slug>` tracked-NPC IDs. */

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -6790,6 +6790,10 @@ const sharedGameSetupSource: GameSetupShareSource = {
     difficulty: "normal",
     combatStyle: "tactical",
     spatialMapInstructions: "Build a shifting tower with a market ward and flooded catacombs.",
+    gameWorldMapMode: "hierarchical",
+    spatialMapDraftSize: "large",
+    spatialMapTargetLocationCount: 10,
+    spatialMapGroundingMode: "lore_expand",
     rating: "nsfw",
     playerGoals: "Become an elite dungeon conqueror",
     gmMode: "standalone",
@@ -6852,6 +6856,9 @@ assert.match(sharedGameSetup, /Use clear progression and frequent loot rewards/u
 assert.match(sharedGameSetup, /Dungeon Lore/u);
 assert.match(sharedGameSetup, /Combat style: Tactical/u);
 assert.match(sharedGameSetup, /Build a shifting tower with a market ward and flooded catacombs\./u);
+assert.match(sharedGameSetup, /World map size: Medium/u);
+assert.match(sharedGameSetup, /World map place target: 10/u);
+assert.match(sharedGameSetup, /World map build from: Lore \+ AI/u);
 assert.match(sharedGameSetup, /"startingValue": 3/u);
 assert.doesNotMatch(
   sharedGameSetup,
@@ -6898,6 +6905,9 @@ assert.equal(
   resolvedGameSetup.config.spatialMapInstructions,
   "Build a shifting tower with a market ward and flooded catacombs.",
 );
+assert.equal(resolvedGameSetup.config.spatialMapDraftSize, "medium");
+assert.equal(resolvedGameSetup.config.spatialMapTargetLocationCount, 10);
+assert.equal(resolvedGameSetup.config.spatialMapGroundingMode, "lore_expand");
 assert.equal(resolvedGameSetup.gmConnectionId, "gm-connection-new-id");
 assert.equal(resolvedGameSetup.config.imageConnectionId, "image-connection-new-id");
 assert.equal(resolvedGameSetup.config.videoConnectionId, "video-connection-new-id");
@@ -6923,7 +6933,43 @@ assert.equal(unresolvedGameSetup.gmConnectionId, null);
 assert.deepEqual(unresolvedGameSetup.config.partyCharacterIds, []);
 assert.equal(unresolvedGameSetup.config.personaId, null);
 assert.deepEqual(unresolvedGameSetup.config.activeLorebookIds, []);
+assert.equal(unresolvedGameSetup.config.spatialMapGroundingMode, "setup");
+assert.ok(unresolvedGameSetup.warnings.some((warning) => /World map[\s\S]*Game setup/u.test(warning)));
 assert.ok(unresolvedGameSetup.warnings.length >= 5);
+
+for (const [size, targetLocationCount] of [
+  ["small", 8],
+  ["medium", 16],
+  ["large", 28],
+] as const) {
+  const presetMapSetup = parseGameSetupShareFileJson(
+    JSON.stringify(
+      buildGameSetupShareFile({
+        ...sharedGameSetupSource,
+        config: {
+          ...sharedGameSetupSource.config,
+          spatialMapDraftSize: size,
+          spatialMapTargetLocationCount: undefined,
+        },
+      }),
+    ),
+  );
+  assert.equal(presetMapSetup.setup.config.spatialMapDraftSize, size);
+  assert.equal(presetMapSetup.setup.config.spatialMapTargetLocationCount, targetLocationCount);
+}
+
+for (const groundingMode of ["setup", "lore_strict", "lore_expand"] as const) {
+  const groundedMapSetup = parseGameSetupShareFileJson(
+    JSON.stringify({
+      ...exportedGameSetup,
+      setup: {
+        ...exportedGameSetup.setup,
+        config: { ...exportedGameSetup.setup.config, spatialMapGroundingMode: groundingMode },
+      },
+    }),
+  );
+  assert.equal(groundedMapSetup.setup.config.spatialMapGroundingMode, groundingMode);
+}
 const providerOnlyGameSetup = resolveGameSetupImport(parsedGameSetup, {
   characters: [],
   personas: [],
@@ -6974,6 +7020,27 @@ assert.throws(
     ),
   /invalid Spatial Map Instructions value/u,
 );
+for (const invalidConfig of [
+  { spatialMapDraftSize: "enormous" },
+  { spatialMapTargetLocationCount: 0 },
+  { spatialMapTargetLocationCount: 41 },
+  { spatialMapTargetLocationCount: 10.5 },
+  { spatialMapGroundingMode: "internet" },
+]) {
+  assert.throws(
+    () =>
+      parseGameSetupShareFileJson(
+        JSON.stringify({
+          ...exportedGameSetup,
+          setup: {
+            ...exportedGameSetup.setup,
+            config: { ...exportedGameSetup.setup.config, ...invalidConfig },
+          },
+        }),
+      ),
+    /invalid (Spatial Map Draft Size|Spatial Map Target Location Count|Spatial Map Grounding Mode) value/u,
+  );
+}
 assert.throws(
   () =>
     parseGameSetupShareFileJson(

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -5932,12 +5932,26 @@ assert.match(
   "New Game setup must preserve the selected custom place target in its post-setup map plan",
 );
 assert.match(
+  gameSetupWizardSource,
+  /setSpatialMapTargetLocationCount\(importedSpatialMapDraftOptions\.targetLocationCount\)/u,
+  "New Game setup imports must restore the saved World Maps place target",
+);
+assert.match(
+  gameSetupWizardSource,
+  /setSpatialMapGroundingMode\(config\.spatialMapGroundingMode \?\? "setup"\)/u,
+  "New Game setup imports must restore the saved World Maps grounding mode",
+);
+assert.match(
   gameSurfaceSource,
   /targetLocationCount:\s*plan\.targetLocationCount/u,
   "Game setup must send the custom place target to World Maps draft generation",
 );
 assert.match(gameTypesSource, /enableAgents\?: boolean;/u);
 assert.match(gameRoutesSource, /enableAgents: z\.boolean\(\)\.optional\(\)/u);
+assert.match(
+  gameRoutesSource,
+  /spatialMapTargetLocationCount: z\.number\(\)\.int\(\)\.min\(1\)\.max\(40\)\.optional\(\)/u,
+);
 assert.match(gameRoutesSource, /"\/:chatId\/journal\/entries\/:entryIndex"/u);
 assert.match(gameRoutesSource, /enableAgents: setupConfig\.enableAgents === true/u);
 assert.match(gameRoutesSource, /gameStoryboardsEnabled: setupConfig\.gameStoryboardsEnabled/u);


### PR DESCRIPTION
## Linked issue

Closes #5337

## Why this change

- Reusable Game Mode setup exports lost the selected World Maps draft size, exact place target, and build-from mode, so importing a setup could silently generate a different map.

## What changed

- Store the three World Maps AI draft choices as optional fields in the existing Game setup contract.
- Normalize the size bucket from the exact place target during export, import, and server creation so the values cannot disagree.
- Restore saved choices in New Game and fall back to Game setup with a clear warning when no referenced lorebook can be restored.
- Include the map draft choices in the readable setup summary and cover legacy defaults, presets, custom targets, grounding modes, and invalid input.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated proof run:

- `pnpm check`
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts`
- `pnpm --filter @marinara-engine/server lint`
- `git diff --check`

### Manual verification notes

- Manual browser file-picker verification was not performed. The deterministic regression exercises every preset, a custom target, every grounding mode, invalid values, legacy defaults, summary output, and the unavailable-lorebook fallback.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

The user-facing change is recorded under `CHANGELOG.md` `[Unreleased]`; no guide under `docs/` changes.

## UI evidence (if applicable)

- Not applicable: this preserves values in existing controls and adds no visual surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reusable Game Mode setups now preserve World Map draft size, exact target location count, and lore-grounding settings.
  - World Map setup summaries display the selected size, target count, and grounding source.
  - Imported setups restore and validate supported map configuration options.

- **Improvements**
  - Invalid map settings are normalized during import and game creation.
  - If an imported lorebook is unavailable, the setup falls back to setup-based grounding and displays a warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->