### PR TITLE
Fix ElevenLabs connection test URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- ElevenLabs audio connections now test the documented `/v1/models` endpoint, so the default base URL no longer returns a misleading 404 (#5339).
 - Docker containers now repair mixed ownership inside file storage and imported top-level data folders even when the data root already belongs to the runtime user, preventing private storage hardening from blocking startup (#5323).
 - Roleplay now cancels post-processing work tied to an abandoned swipe before committing the next turn, Stop Agents safely cancels detached agent work without interrupting the primary reply, and an earlier swipe's illustration no longer reappears on the selected swipe while agents finish (#5328).
 - Chat Settings now presents its transient Stop Active Generation action like the neighboring neutral controls instead of making it look like an enabled destructive preference.

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -279,10 +279,11 @@ export function buildConnectionTestCatalogUrl(
   modelsEndpoint = "/models",
   audioSource?: string | null,
 ): string {
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
   if (provider === "audio" && (audioSource || "elevenlabs") === "elevenlabs") {
-    return `${baseUrl.replace(/\/v\d+$/, "")}/v1/models`;
+    return `${normalizedBaseUrl.replace(/\/v\d+$/, "")}/v1/models`;
   }
-  return `${baseUrl}${modelsEndpoint}`;
+  return `${normalizedBaseUrl}${modelsEndpoint}`;
 }
 
 function normalizeConnectionTestBaseUrl(baseUrl: string, provider: string): string {

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -273,6 +273,18 @@ export function buildGoogleModelsPageUrl(baseUrl: string, modelsEndpoint: string
   return `${baseUrl}${modelsEndpoint}?pageSize=1000` + (pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : "");
 }
 
+export function buildConnectionTestCatalogUrl(
+  baseUrl: string,
+  provider: string,
+  modelsEndpoint = "/models",
+  audioSource?: string | null,
+): string {
+  if (provider === "audio" && (audioSource || "elevenlabs") === "elevenlabs") {
+    return `${baseUrl.replace(/\/v\d+$/, "")}/v1/models`;
+  }
+  return `${baseUrl}${modelsEndpoint}`;
+}
+
 function normalizeConnectionTestBaseUrl(baseUrl: string, provider: string): string {
   if (provider === "google") return normalizeGoogleGenerativeLanguageBaseUrl(baseUrl);
   if (provider !== "image_generation") return baseUrl.replace(/\/+$/, "");
@@ -688,7 +700,12 @@ export async function connectionsRoutes(app: FastifyInstance) {
       } else if (conn.provider === "google_vertex") {
         testUrl = buildGoogleVertexModelUrl(baseUrl, conn.model, "models");
       } else {
-        testUrl = `${baseUrl}${provider?.modelsEndpoint || "/models"}`;
+        testUrl = buildConnectionTestCatalogUrl(
+          baseUrl,
+          conn.provider,
+          provider?.modelsEndpoint || "/models",
+          conn.audioSource,
+        );
       }
 
       const testHeaders =

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -3733,14 +3733,14 @@ const googleModelsPageUrl = buildGoogleModelsPageUrl(
   "next page/token",
 );
 assert.equal(
-  buildConnectionTestCatalogUrl("https://api.elevenlabs.io", "audio", "/models", "elevenlabs"),
+  buildConnectionTestCatalogUrl("https://api.elevenlabs.io/", "audio", "/models", "elevenlabs"),
   "https://api.elevenlabs.io/v1/models",
-  "ElevenLabs audio connection tests must use the versioned models endpoint",
+  "ElevenLabs audio connection tests must normalize a trailing slash and use the versioned models endpoint",
 );
 assert.equal(
-  buildConnectionTestCatalogUrl("https://api.elevenlabs.io/v1", "audio", "/models", "elevenlabs"),
+  buildConnectionTestCatalogUrl("https://api.elevenlabs.io/v1/", "audio", "/models", "elevenlabs"),
   "https://api.elevenlabs.io/v1/models",
-  "An explicitly versioned ElevenLabs URL must not duplicate the API version",
+  "An explicitly versioned ElevenLabs URL with a trailing slash must not duplicate the API version",
 );
 assert.equal(
   buildConnectionTestCatalogUrl("https://api.openai.com/v1", "audio", "/models", "openai"),

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -264,7 +264,10 @@ import { characterOverrideDb } from "../../packages/server/src/services/professo
 import { createLorebooksStorage } from "../../packages/server/src/services/storage/lorebooks.storage.js";
 import { createNoodleStorage } from "../../packages/server/src/services/storage/noodle.storage.js";
 import { createChatPresetsStorage } from "../../packages/server/src/services/storage/chat-presets.storage.js";
-import { buildGoogleModelsPageUrl } from "../../packages/server/src/routes/connections.routes.js";
+import {
+  buildConnectionTestCatalogUrl,
+  buildGoogleModelsPageUrl,
+} from "../../packages/server/src/routes/connections.routes.js";
 import { normalizeGoogleGenerativeLanguageBaseUrl } from "../../packages/server/src/services/llm/providers/google.provider.js";
 import {
   buildReferencedCharacterContext,
@@ -3728,6 +3731,21 @@ const googleModelsPageUrl = buildGoogleModelsPageUrl(
   "https://gemini-proxy.example.test/v1beta",
   "/models",
   "next page/token",
+);
+assert.equal(
+  buildConnectionTestCatalogUrl("https://api.elevenlabs.io", "audio", "/models", "elevenlabs"),
+  "https://api.elevenlabs.io/v1/models",
+  "ElevenLabs audio connection tests must use the versioned models endpoint",
+);
+assert.equal(
+  buildConnectionTestCatalogUrl("https://api.elevenlabs.io/v1", "audio", "/models", "elevenlabs"),
+  "https://api.elevenlabs.io/v1/models",
+  "An explicitly versioned ElevenLabs URL must not duplicate the API version",
+);
+assert.equal(
+  buildConnectionTestCatalogUrl("https://api.openai.com/v1", "audio", "/models", "openai"),
+  "https://api.openai.com/v1/models",
+  "Other audio sources keep their configured models endpoint",
 );
 assert.equal(
   normalizeGoogleGenerativeLanguageBaseUrl("https://generativelanguage.googleapis.com/v1"),


### PR DESCRIPTION
## Why

The generic connection test appended `/models` to the default ElevenLabs API root, producing a misleading 404 even though generation builds the provider URLs correctly. Users had to manually add `/v1` to make the test pass.

Fixes #5339.

## What changed

- build the ElevenLabs audio connection probe against `/v1/models`
- accept both unversioned and already-versioned saved ElevenLabs base URLs without duplicating `/v1`
- add focused regression coverage for ElevenLabs and non-ElevenLabs audio catalog URLs
- document the fix in the changelog

## Test plan

- [ ] Run `pnpm check`
- [ ] Run `pnpm build:shared && node ./scripts/run-regressions.mjs --filter scripts/regressions/open-issues.regression.ts`
- [ ] Manually verify an ElevenLabs audio connection with `https://api.elevenlabs.io` tests successfully with a valid API key
- [ ] Manually verify an ElevenLabs audio connection already ending in `/v1` does not request `/v1/v1/models`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ElevenLabs connection testing by checking the `/v1/models` endpoint, including when versioned URLs are configured.
  - Prevented duplicate version segments in ElevenLabs model URLs.
  - Preserved existing audio connection behavior for other providers.

- **Tests**
  - Added regression coverage for ElevenLabs and OpenAI connection endpoint handling.

- **Documentation**
  - Updated the unreleased changelog with the connection testing improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->