### PR TITLE
Filtered ModelList for NovelAI Image, disabled the fetch button, added Nai Diffusion 5 full/curated to Image_Gen_Model: Known Model[], provided barebones nai v5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Chat Settings now shows the current chat ID with a one-click copy action, making exact chats easy to reference in Professor Mari and other tools (#5235).
 - Conversation and Roleplay automatic summaries can now keep recent summaries in context while semantically retrieving relevant older summaries for long-running chats (#5240).
 - Text Rules now has an opt-in "Color Character Names in Text" toggle that colors character names inline in message text using each character's assigned name color, with support for gradient colors, name aliases, and a "Force Solid Colors for Inline Names" sub-toggle for users who prefer simpler inline readability. Names inside dialogue quotes are skipped, and only characters added to the chat are eligible (inspired by the AI Dungeon "Dungeon Extension v2" extension) (#5321).
+- Added `nai-diffusion-5-full` and `nai-diffusion-5-curated` to `IMAGE_GEN_MODELS` in `model-lists.ts` with display names "NAI Diffusion 5 Full" and "NAI Diffusion 5 Curated" (#5343).
 
 ### Fixed
 
@@ -46,6 +47,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Automatic backups, manual backups, and profile exports no longer fail at an artificial 8,192-entry ZIP ceiling; archive size and path-safety protections remain enforced (#5239).
 - Professor Mari now accepts an explicit authorization clause together with the concrete character or lorebook edit in the same user message, while preserving operation and entity safeguards (#5245).
 - Windows installer sources now refuse to download or install a release unless they were built or invoked with its exact commit pin, preserving the existing verified path used by official release executables.
+- NovelAI Diffusion v5 models (`nai-diffusion-5-full`, `nai-diffusion-5-curated`) now generate images successfully instead of returning a 500 error, by extending the V4+ model regex in `image-generation.ts` and `game-asset-generation.ts` to match v5 model IDs and route them through the `params_version: 3` code path (#5343).
+- NovelAI image connection model dropdown now shows only `nai-` prefixed models instead of the entire app-wide image model catalog, and the "Fetch from API" button is hidden for NovelAI connections since the `/oa/v1/models` endpoint returns text models, not image models (#5344).
 
 ## [2.4.3]
 

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -410,6 +410,7 @@ export function ConnectionEditor() {
   const modelDropdownRef = useRef<HTMLDivElement>(null);
   const modelSearchInputRef = useRef<HTMLInputElement>(null);
   const comfyWorkflowTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const fetchScopeRef = useRef(0);
 
   // Remote models fetched from provider API
   const [remoteModels, setRemoteModels] = useState<RemoteConnectionModel[]>([]);
@@ -697,9 +698,7 @@ export function ConnectionEditor() {
     if (localProvider === "video_generation" && selectedVideoProvider === "nanogpt") return [];
     if (localProvider === "image_generation" && selectedImageService === "novelai")
       return (MODEL_LISTS[localProvider] ?? []).filter((m) => m.id.startsWith("nai-"));
-    {
-      return MODEL_LISTS[localProvider] ?? [];
-    }
+    return MODEL_LISTS[localProvider] ?? [];
   }, [localProvider, selectedVideoProvider, selectedImageService]);
 
   // Merge known models with remote models (remote first, deduped)
@@ -730,6 +729,7 @@ export function ConnectionEditor() {
   useEffect(() => {
     setRemoteModels([]);
     setRemoteLoras([]);
+    fetchScopeRef.current++;
     setFetchError(null);
   }, [localProvider, selectedImageService]);
 
@@ -1256,8 +1256,10 @@ export function ConnectionEditor() {
         return;
       }
     }
+    const scope = fetchScopeRef.current;
     fetchModels.mutate(connectionDetailId, {
       onSuccess: (data) => {
+        if (fetchScopeRef.current !== scope) return;
         const result = data as { models: RemoteConnectionModel[]; loras?: RemoteConnectionModel[] };
         setRemoteModels(result.models);
         setRemoteLoras(result.loras ?? []);
@@ -1268,6 +1270,7 @@ export function ConnectionEditor() {
         });
       },
       onError: (err) => {
+        if (fetchScopeRef.current !== scope) return;
         setFetchError(err instanceof Error ? err.message : "Failed to fetch models");
       },
     });

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -695,9 +695,11 @@ export function ConnectionEditor() {
   // Model list for current provider
   const providerModels = useMemo(() => {
     if (localProvider === "video_generation" && selectedVideoProvider === "nanogpt") return [];
-    if (localProvider === "image_generation" && selectedImageService === "novelai")  return (MODEL_LISTS[localProvider] ?? []).filter((m) => m.id.startsWith("nai-")); {
-    return MODEL_LISTS[localProvider] ?? [];
-}
+    if (localProvider === "image_generation" && selectedImageService === "novelai")
+      return (MODEL_LISTS[localProvider] ?? []).filter((m) => m.id.startsWith("nai-"));
+    {
+      return MODEL_LISTS[localProvider] ?? [];
+    }
   }, [localProvider, selectedVideoProvider]);
 
   // Merge known models with remote models (remote first, deduped)
@@ -2111,35 +2113,35 @@ export function ConnectionEditor() {
                 <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-80 overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl">
                   {/* Fetch from API button */}
                   {!(localProvider === "image_generation" && selectedImageService === "novelai") && (
-                  <div className="sticky top-0 z-10 border-b border-[var(--border)] bg-[var(--card)] p-2">
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleFetchModels();
-                      }}
-                      disabled={fetchModels.isPending}
-                      className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-sky-400/10 px-3 py-2 text-xs font-medium text-sky-400 transition-all hover:bg-sky-400/20 active:scale-[0.98] disabled:opacity-50"
-                    >
-                      {fetchModels.isPending ? (
-                        <Loader2 size="0.75rem" className="animate-spin" />
-                      ) : (
-                        <Globe size="0.75rem" />
+                    <div className="sticky top-0 z-10 border-b border-[var(--border)] bg-[var(--card)] p-2">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleFetchModels();
+                        }}
+                        disabled={fetchModels.isPending}
+                        className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-sky-400/10 px-3 py-2 text-xs font-medium text-sky-400 transition-all hover:bg-sky-400/20 active:scale-[0.98] disabled:opacity-50"
+                      >
+                        {fetchModels.isPending ? (
+                          <Loader2 size="0.75rem" className="animate-spin" />
+                        ) : (
+                          <Globe size="0.75rem" />
+                        )}
+                        {fetchModels.isPending
+                          ? localizeUi("ui.connections.connectioneditor.fetching")
+                          : modelFetchButtonLabel}
+                      </button>
+                      {fetchError && (
+                        <p className="mt-1.5 text-[0.625rem] text-[var(--marinara-editor-accent)]">{fetchError}</p>
                       )}
-                      {fetchModels.isPending
-                        ? localizeUi("ui.connections.connectioneditor.fetching")
-                        : modelFetchButtonLabel}
-                    </button>
-                    {fetchError && (
-                      <p className="mt-1.5 text-[0.625rem] text-[var(--marinara-editor-accent)]">{fetchError}</p>
-                    )}
-                    {remoteModels.length > 0 && !fetchError && (
-                      <p className="mt-1 text-[0.625rem] text-emerald-400">
-                        {remoteModels.length} {localizeUi("ui.connections.connectioneditor.model_1d06a0d")}
-                        {remoteModels.length !== 1 ? localizeUi("ui.noodle.stageprofileview.s") : ""}{" "}
-                        {localizeUi("ui.connections.connectioneditor.availableFrom")} {modelFetchSourceLabel}
-                      </p>
-                    )}
-                  </div>
+                      {remoteModels.length > 0 && !fetchError && (
+                        <p className="mt-1 text-[0.625rem] text-emerald-400">
+                          {remoteModels.length} {localizeUi("ui.connections.connectioneditor.model_1d06a0d")}
+                          {remoteModels.length !== 1 ? localizeUi("ui.noodle.stageprofileview.s") : ""}{" "}
+                          {localizeUi("ui.connections.connectioneditor.availableFrom")} {modelFetchSourceLabel}
+                        </p>
+                      )}
+                    </div>
                   )}
                   {localProvider === "custom" ? (
                     <div className="p-3">

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -1247,6 +1247,8 @@ export function ConnectionEditor() {
 
   const handleFetchModels = useCallback(async () => {
     if (!connectionDetailId) return;
+    const requestScope = fetchScopeRef.current;
+    const requestConnectionId = connectionDetailId;
     setFetchError(null);
     // Save first if dirty so the server has the right baseUrl/apiKey/provider
     if (dirty) {
@@ -1256,10 +1258,10 @@ export function ConnectionEditor() {
         return;
       }
     }
-    const scope = fetchScopeRef.current;
-    fetchModels.mutate(connectionDetailId, {
+    if (fetchScopeRef.current !== requestScope) return;
+    fetchModels.mutate(requestConnectionId, {
       onSuccess: (data) => {
-        if (fetchScopeRef.current !== scope) return;
+        if (fetchScopeRef.current !== requestScope) return;
         const result = data as { models: RemoteConnectionModel[]; loras?: RemoteConnectionModel[] };
         setRemoteModels(result.models);
         setRemoteLoras(result.loras ?? []);
@@ -1270,7 +1272,7 @@ export function ConnectionEditor() {
         });
       },
       onError: (err) => {
-        if (fetchScopeRef.current !== scope) return;
+        if (fetchScopeRef.current !== requestScope) return;
         setFetchError(err instanceof Error ? err.message : "Failed to fetch models");
       },
     });

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -700,7 +700,7 @@ export function ConnectionEditor() {
     {
       return MODEL_LISTS[localProvider] ?? [];
     }
-  }, [localProvider, selectedVideoProvider]);
+  }, [localProvider, selectedVideoProvider, selectedImageService]);
 
   // Merge known models with remote models (remote first, deduped)
   const allModels = useMemo(() => {
@@ -731,7 +731,7 @@ export function ConnectionEditor() {
     setRemoteModels([]);
     setRemoteLoras([]);
     setFetchError(null);
-  }, [localProvider]);
+  }, [localProvider, selectedImageService]);
 
   useEffect(() => {
     if (!showModelDropdown) return;

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -731,7 +731,7 @@ export function ConnectionEditor() {
     setRemoteLoras([]);
     fetchScopeRef.current++;
     setFetchError(null);
-  }, [localProvider, selectedImageService]);
+  }, [localProvider, selectedImageService, connectionDetailId]);
 
   useEffect(() => {
     if (!showModelDropdown) return;

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -695,7 +695,9 @@ export function ConnectionEditor() {
   // Model list for current provider
   const providerModels = useMemo(() => {
     if (localProvider === "video_generation" && selectedVideoProvider === "nanogpt") return [];
+    if (localProvider === "image_generation" && selectedImageService === "novelai")  return (MODEL_LISTS[localProvider] ?? []).filter((m) => m.id.startsWith("nai-")); {
     return MODEL_LISTS[localProvider] ?? [];
+}
   }, [localProvider, selectedVideoProvider]);
 
   // Merge known models with remote models (remote first, deduped)
@@ -2108,6 +2110,7 @@ export function ConnectionEditor() {
               {showModelDropdown && (
                 <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-80 overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl">
                   {/* Fetch from API button */}
+                  {!(localProvider === "image_generation" && selectedImageService === "novelai") && (
                   <div className="sticky top-0 z-10 border-b border-[var(--border)] bg-[var(--card)] p-2">
                     <button
                       onClick={(e) => {
@@ -2137,7 +2140,7 @@ export function ConnectionEditor() {
                       </p>
                     )}
                   </div>
-
+                  )}
                   {localProvider === "custom" ? (
                     <div className="p-3">
                       <p className="mb-2 text-[0.625rem] text-[var(--muted-foreground)]">

--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -149,7 +149,9 @@ export function supportsSceneIllustrationStructuredCharacterPrompts(
 ): boolean {
   if (resolveSceneIllustrationImageBackend(req) !== "novelai") return false;
   if (!req.imgBaseUrl.toLowerCase().includes("novelai.net")) return false;
-  return /^nai-diffusion-(?:4(?:-(?:curated-preview|full))?|4-5(?:-(?:curated|full))?)$/i.test(req.imgModel.trim());
+  return /^nai-diffusion-(?:4(?:-(?:curated-preview|full))?|4-5(?:-(?:curated|full))?|5(?:-(?:curated|full))?)$/i.test(
+    req.imgModel.trim(),
+  );
 }
 
 export function resolveSceneIllustrationReferenceImageLimit(

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -1918,7 +1918,9 @@ async function generateArli(baseUrl: string, apiKey: string, request: ImageGenRe
 }
 
 const NOVELAI_V4_PROMPT_HINT =
-  "NovelAI V4/V4.5/V5 prompts support roughly 512 T5 tokens and reject most Unicode prompt characters; try a shorter ASCII prompt without emoji or non-Latin text.";
+  "NovelAI V4/V4.5 prompts support roughly 512 T5 tokens and reject most Unicode prompt characters; try a shorter ASCII prompt without emoji or non-Latin text.";
+const NOVELAI_V5_PROMPT_HINT =
+  "NovelAI V5 prompts support up to 1471 tokens (Full) or 703 tokens (Curated) and accept Unicode text including Japanese and Chinese; try a shorter prompt.";
 const NOVELAI_SIZE_MULTIPLE = 64;
 const NOVELAI_MIN_DIMENSION = 64;
 const NOVELAI_MAX_DIMENSION = 2048;
@@ -1983,7 +1985,9 @@ export function resolveNovelAiRequestSize(
   defaults: NovelAiDefaults = resolveNovelAiDefaults(request),
 ): { width: number; height: number } {
   const model = request.model || "nai-diffusion-4-5-full";
-  const scenePrompt = isNovelAiV4Model(model) ? sanitizeNovelAiV4Prompt(request.prompt) : request.prompt;
+  const scenePrompt = isNovelAiV4Model(model)
+    ? sanitizeNovelAiV4Prompt(request.prompt, isNovelAiV5Model(model))
+    : request.prompt;
   return resolveNovelAiSize(request, scenePrompt, defaults);
 }
 
@@ -1997,8 +2001,12 @@ function isNovelAiV4Model(model: string): boolean {
   );
 }
 
+function isNovelAiV5Model(model: string): boolean {
+  return /^nai-diffusion-5(?:-(?:curated|full))?$/i.test(model.trim());
+}
+
 function isNovelAiPreciseReferenceModel(model: string): boolean {
-  return /^nai-diffusion-(?:4-5|5)(?:-(?:curated|full))?$/i.test(model.trim());
+  return /^nai-diffusion-(?:4-5)(?:-(?:curated|full))?$/i.test(model.trim());
 }
 
 function collectNovelAiReferenceImages(request: ImageGenRequest): string[] {
@@ -2110,7 +2118,7 @@ function cloneNovelAiRequestForMetadata(body: Record<string, unknown>): Record<s
   return metadataBody;
 }
 
-function sanitizeNovelAiV4Prompt(value: string): string {
+function sanitizeNovelAiV4Prompt(value: string, allowUnicode = false): string {
   return value
     .replace(/[\u2018\u2019\u201A\u201B]/g, "'")
     .replace(/[\u201C\u201D\u201E\u201F]/g, '"')
@@ -2120,7 +2128,7 @@ function sanitizeNovelAiV4Prompt(value: string): string {
     .replace(/[\u200B-\u200D\uFEFF]/g, "")
     .normalize("NFKD")
     .replace(/[\u0300-\u036f]/g, "")
-    .replace(/[^\x09\x0A\x0D\x20-\x7E]/g, " ")
+    .replace(/[^\x09\x0A\x0D\x20-\x7E]/g, allowUnicode ? "$&" : " ")
     .replace(/[ \t]+/g, " ")
     .replace(/\s*\n\s*/g, "\n")
     .trim();
@@ -2129,10 +2137,10 @@ function sanitizeNovelAiV4Prompt(value: string): string {
 function prepareNovelAiPrompt(value: string, fieldName: string, model: string): string {
   if (!isNovelAiV4Model(model)) return value;
 
-  const sanitized = sanitizeNovelAiV4Prompt(value);
+  const sanitized = sanitizeNovelAiV4Prompt(value, isNovelAiV5Model(model));
   if (value.trim() && !sanitized) {
     throw new Error(
-      `NovelAI ${fieldName} contains only unsupported V4/V4.5/V5 prompt characters. ${NOVELAI_V4_PROMPT_HINT}`,
+      `NovelAI ${fieldName} contains only unsupported ${isNovelAiV5Model(model) ? "V5" : "V4/V4.5"} prompt characters. ${isNovelAiV5Model(model) ? NOVELAI_V5_PROMPT_HINT : NOVELAI_V4_PROMPT_HINT}`,
     );
   }
   return sanitized;
@@ -2251,7 +2259,7 @@ async function generateNovelAI(baseUrl: string, apiKey: string, request: ImageGe
     ? [styleReferenceImage, ...characterReferenceImages]
     : characterReferenceImages;
   if (referenceImages.length > 0 && !isNovelAiPreciseReferenceModel(model)) {
-    throw new Error("NovelAI precise reference images require a V4.5 or V5 model such as nai-diffusion-4-5-full or nai-diffusion-5-full.");
+    throw new Error("NovelAI precise reference images require a V4.5 model such as nai-diffusion-4-5-full.");
   }
   const directorReferenceImages = await prepareNovelAiDirectorReferenceImages(referenceImages);
   const characterPromptPayload = buildNovelAiV4CharacterPromptPayload(request.characterPrompts, model);
@@ -2335,7 +2343,7 @@ async function generateNovelAI(baseUrl: string, apiKey: string, request: ImageGe
 
   if (!resp.ok) {
     const errText = await resp.text().catch(() => "Unknown error");
-    const hint = isV4 ? ` ${NOVELAI_V4_PROMPT_HINT}` : "";
+    const hint = isV4 ? ` ${isNovelAiV5Model(model) ? NOVELAI_V5_PROMPT_HINT : NOVELAI_V4_PROMPT_HINT}` : "";
     const referenceDetail = hasReferences ? ` with ${directorReferenceImages.length} precise reference image(s)` : "";
     throw new Error(
       `NovelAI image generation failed (${resp.status})${referenceDetail}: ${sanitizeErrorText(errText)}${hint}`,

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -1918,7 +1918,7 @@ async function generateArli(baseUrl: string, apiKey: string, request: ImageGenRe
 }
 
 const NOVELAI_V4_PROMPT_HINT =
-  "NovelAI V4/V4.5 prompts support roughly 512 T5 tokens and reject most Unicode prompt characters; try a shorter ASCII prompt without emoji or non-Latin text.";
+  "NovelAI V4/V4.5/V5 prompts support roughly 512 T5 tokens and reject most Unicode prompt characters; try a shorter ASCII prompt without emoji or non-Latin text.";
 const NOVELAI_SIZE_MULTIPLE = 64;
 const NOVELAI_MIN_DIMENSION = 64;
 const NOVELAI_MAX_DIMENSION = 2048;
@@ -2132,7 +2132,7 @@ function prepareNovelAiPrompt(value: string, fieldName: string, model: string): 
   const sanitized = sanitizeNovelAiV4Prompt(value);
   if (value.trim() && !sanitized) {
     throw new Error(
-      `NovelAI ${fieldName} contains only unsupported V4/V4.5 prompt characters. ${NOVELAI_V4_PROMPT_HINT}`,
+      `NovelAI ${fieldName} contains only unsupported V4/V4.5/V5 prompt characters. ${NOVELAI_V4_PROMPT_HINT}`,
     );
   }
   return sanitized;
@@ -2251,7 +2251,7 @@ async function generateNovelAI(baseUrl: string, apiKey: string, request: ImageGe
     ? [styleReferenceImage, ...characterReferenceImages]
     : characterReferenceImages;
   if (referenceImages.length > 0 && !isNovelAiPreciseReferenceModel(model)) {
-    throw new Error("NovelAI precise reference images require a V4.5 model such as nai-diffusion-4-5-full.");
+    throw new Error("NovelAI precise reference images require a V4.5 or V5 model such as nai-diffusion-4-5-full or nai-diffusion-5-full.");
   }
   const directorReferenceImages = await prepareNovelAiDirectorReferenceImages(referenceImages);
   const characterPromptPayload = buildNovelAiV4CharacterPromptPayload(request.characterPrompts, model);

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -1992,11 +1992,13 @@ export function resolveNovelAiStyleReferenceSecondaryStrength(fidelity: number):
 }
 
 function isNovelAiV4Model(model: string): boolean {
-  return /^nai-diffusion-(?:4(?:-(?:curated-preview|full))?|4-5(?:-(?:curated|full))?)$/i.test(model.trim());
+  return /^nai-diffusion-(?:4(?:-(?:curated-preview|full))?|4-5(?:-(?:curated|full))?|5(?:-(?:curated|full))?)$/i.test(
+    model.trim(),
+  );
 }
 
 function isNovelAiPreciseReferenceModel(model: string): boolean {
-  return /^nai-diffusion-4-5(?:-(?:curated|full))?$/i.test(model.trim());
+  return /^nai-diffusion-(?:4-5|5)(?:-(?:curated|full))?$/i.test(model.trim());
 }
 
 function collectNovelAiReferenceImages(request: ImageGenRequest): string[] {

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -2126,7 +2126,7 @@ function sanitizeNovelAiV4Prompt(value: string, allowUnicode = false): string {
     .replace(/\u2026/g, "...")
     .replace(/\u00A0/g, " ")
     .replace(/[\u200B-\u200D\uFEFF]/g, "")
-    .normalize("NFKD")
+    .normalize(allowUnicode ? "NFC" : "NFKD")
     .replace(/[\u0300-\u036f]/g, "")
     .replace(/[^\x09\x0A\x0D\x20-\x7E]/g, allowUnicode ? "$&" : " ")
     .replace(/[ \t]+/g, " ")

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -883,9 +883,12 @@ const IMAGE_GEN_MODELS: KnownModel[] = [
   ...ZAI_IMAGE_MODELS,
   ...ATLAS_CLOUD_IMAGE_MODELS,
   // NovelAI
-  { id: "nai-diffusion-4-curated-preview", name: "NAI Diffusion 4 Curated", context: 0, maxOutput: 0 },
-  { id: "nai-diffusion-4-5-full", name: "NAI Diffusion 4.5 Full", context: 0, maxOutput: 0 },
   { id: "nai-diffusion-3", name: "NAI Diffusion 3 (Anime V3)", context: 0, maxOutput: 0 },
+  { id: "nai-diffusion-4-curated-preview", name: "NAI Diffusion 4 Curated", context: 0, maxOutput: 0 },
+  { id: "nai-diffusion-4-5-curated", name: "NAI Diffusion 4.5 Curated", context: 0, maxOutput: 0 },
+  { id: "nai-diffusion-4-5-full", name: "NAI Diffusion 4.5 Full", context: 0, maxOutput: 0 },
+  { id: "nai-diffusion-5-curated", name: "NAI Diffusion 5 Curated", context: 0, maxOutput: 0 },
+  { id: "nai-diffusion-5-full", name: "NAI Diffusion 5 Full", context: 0, maxOutput: 0 },
   // Pollinations (model-free, but include as placeholder)
   { id: "pollinations", name: "Pollinations (Auto)", context: 0, maxOutput: 0 },
 ];


### PR DESCRIPTION
Name: Nai Diffusion v5 support (no reference images YET), Filtered Dropdown ModelList for NovelAI Image, disabled the fetch button, added Nai Diffusion 5 full/curated to Image_Gen_Model: Known Model[] (the model list), 


## Disclaimer
This was fully vibe-coded by Mari using GLM 5.2 Thinking, and my very human suggestions and testing. However, since the code changes are very minor, i think it's okay?

> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #5344 - NovelAI's Model List Dropdown and Fetch button
Closes #5343 - NovelAI Diffusion v5 support + added both new models to the Known Model array.

## Why this change

- NovelAI released Diffusion v5 (nai-diffusion-5-full, nai-diffusion-5-curated). Marinara Engine's hardcoded regex did not recognize v5 model IDs as V4+ models, causing a 500 error on image generation because the request was sent using the legacy pre-V4 parameter format instead of params_version: 3 with v4_prompt / v4_negative_prompt structures.
- The new v5 models were not yet added to IMAGE_GEN_MODELS in model-lists.ts.
- The NovelAI image connection model dropdown showed the entire app-wide IMAGE_GEN_MODELS catalog (all providers) instead of only NovelAI-relevant models. The "Fetch from API" button hit the base URL with no path appended (empty modelsEndpoint), got a plain text OK body, and failed JSON parsing with "Failed to fetch models: OK".
- NovelAI's https://image.novelai.net/oa/v1/models returns text models (xialong-v1, glm-4-6), not image models, so it cannot be used to populate the image model list.

## What changed

- Extended the isNovelAiV4Model regex in packages/server/src/services/image/image-generation.ts to match nai-diffusion-5-full and nai-diffusion-5-curated so v5 models are routed through the V4+ code path.
- Applied the same regex fix to the duplicated pattern in packages/server/src/services/game-asset-generation.ts.
- Added nai-diffusion-5-full and nai-diffusion-5-curated entries to IMAGE_GEN_MODELS in packages/shared/src/constants/model-lists.ts with display names "NAI Diffusion 5 Full" and "NAI Diffusion 5 Curated".
- Added isNovelAiV5Model predicate to image-generation.ts to identify V5 model IDs.
- Added allowUnicode parameter to sanitizeNovelAiV4Prompt so V5 prompts skip the ASCII strip and preserve Japanese/Chinese/Cyrillic text.
- Split NOVELAI_V4_PROMPT_HINT into separate V4/V4.5 and V5 hints with accurate token limits (V4.5: ~505 tokens, V5 Curated: 703, V5 Full: 1471) and correct Unicode guidance per model.
- Made the empty-prompt and HTTP error messages model-aware, showing the correct hint based on the selected model.
- Filtered the providerModels memo in packages/client/src/components/connections/ConnectionEditor.tsx to return only nai- prefixed models when the image source is NovelAI.
- Added selectedImageService to the providerModels memo dependency array so the dropdown recomputes when switching image services.
- Wrapped the "Fetch from API" button block in ConnectionEditor.tsx with a guard that hides it for NovelAI image connections, since the endpoint returns text models and the fetch is not useful.
- Added a fetchScopeRef stale-response guard so in-flight fetch results from a previous image service are dropped when the user switches services mid-fetch.

### Notes
- NovelAI Diffusion v5 does not support Precise Reference yet. The isNovelAiPreciseReferenceModel check remains V4.5-only, so attempting precise reference with a V5 model correctly returns the existing error message: "NovelAI precise reference images require a V4.5 model such as nai-diffusion-4-5-full."

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally - My pnpm check fails on prettier for 1200+ regardless of my branch, even on staging. since i don't know the fix yet, i can't fully check this. However, this PR fails on the exact same spot as staging, so there's that.
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Created a NovelAI image generation connection, confirmed the model dropdown shows only nai- prefixed models (NAI Diffusion 3, 4.5 Full, 5 Full, 5 Curated). Models from other providers (grok, stability, etc.) no longer appear.
- Confirmed the "Fetch from API" button is no longer visible for NovelAI connections.
- Tested nai-diffusion-5-full using the "Test Image" button in connection settings. Generation succeeded with no 500 error.
- Tested nai-diffusion-5-full using the Illustrate button inside a roleplay chat. Generation succeeded.
- Light/dark mode and mobile viewport testing skipped: the changes are backend regex patterns and a dropdown filter condition, with no new UI components or styling.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

### Dropdown Menu
Before
<img width="435" height="263" alt="novelai model list old" src="https://github.com/user-attachments/assets/6b993528-a79f-4414-85ae-17496b5c8a98" />
After
<img width="435" height="263" alt="novelai model list" src="https://github.com/user-attachments/assets/d90e15a5-04da-4a69-a41b-d327405018be" />

### Nai-diffusion-5 support
Before
<img width="435" height="435" alt="novel ai v5 missing support" src="https://github.com/user-attachments/assets/fa8e8cfc-0c42-4949-8dbc-4efefb2e45fd" />
After
<img width="435" height="597" alt="nai v5 support" src="https://github.com/user-attachments/assets/65c619e0-992a-44d9-90ab-040476c3babf" />
<img width="468" height="597" alt="illustrator prove" src="https://github.com/user-attachments/assets/581e66ff-8e4f-47b7-9a5b-9864e176e886" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for NovelAI Diffusion 5, including Curated and Full models.
- Updated image generation and character prompt workflows for Diffusion 5.
- Added the latest NovelAI models to the available model list.

## Improvements
- Improved Diffusion 5 prompt handling, including Unicode support and validation guidance.
- NovelAI connections now show only compatible local models.
- Hid unsupported model-fetch controls and cleared outdated model data when changing image services.
- Improved model ordering to make newer NovelAI versions easier to find.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->