### PR TITLE
fix: address assigned generation and export issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Settings → Generation now exposes the Character Reference Sheet prompt template, so character and Persona sheet generation can use a saved global override (#5348).
 - Reusable Game Mode setups now preserve World Maps AI draft size, exact place target, and lore grounding choices, with a clear fallback warning when imported lorebooks are unavailable (#5337).
 - Custom pre-generation agents can now opt in to choose the active characters for the current Conversation or Roleplay reply, keeping unused character cards out of that turn's prompt (#5310).
 - Lorebook Keeper can now route entries to exact writable lorebook names or configured aliases, auto-create missing category books, and preserve the selected destination through write approval while keeping one-book behavior unchanged when no target is returned (Pasta-Devs/Marinara-Agents#439).
@@ -17,6 +18,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Manual and range-backfilled Roleplay summaries now participate in semantic retrieval alongside automatic summaries, keeping relevant history without pinning every manual entry in context (#5346).
+- SwarmUI image generation now uses its progress-streaming WebSocket route, preventing long generations from losing an otherwise idle HTTP connection (#5347).
+- Game transcript exports now materialize narration edits and deletions in active messages and alternate swipes, omit fully deleted messages, and remove stale segment-overlay metadata from JSONL (#5349).
+- Game Storyboard planning now always receives character appearance context; the Attach Card Appearance setting remains scoped to the final render prompt and reference attachments (Pasta-Devs/Marinara-Agents#478).
 - ElevenLabs audio connections now test the documented `/v1/models` endpoint, so the default base URL no longer returns a misleading 404 (#5339).
 - Docker containers now repair mixed ownership inside file storage and imported top-level data folders even when the data root already belongs to the runtime user, preventing private storage hardening from blocking startup (#5323).
 - Roleplay now cancels post-processing work tied to an abandoned swipe before committing the next turn, Stop Agents safely cancels detached agent work without interrupting the primary reply, and an earlier swipe's illustration no longer reappears on the selected swipe while agents finish (#5328).

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -30,6 +30,8 @@ import { createGameSceneVideosStorage } from "../services/storage/game-scene-vid
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js";
 import { createNoodleStorage } from "../services/storage/noodle.storage.js";
+import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
+import { CHARACTERS_REFERENCE_SHEET, loadPrompt } from "../services/prompt-overrides/index.js";
 import { generateImage } from "../services/image/image-generation.js";
 import {
   resolveConnectionImageDefaults,
@@ -490,17 +492,15 @@ const AVATAR_GENERATION_HARD_NEGATIVE_PROMPT =
 const CHARACTER_SHEET_HARD_NEGATIVE_PROMPT =
   "text, captions, logos, watermarks, decorative borders, unrelated characters, extra limbs, inconsistent faces, cropped-off body parts";
 
-function buildAvatarGenerationPrompt(body: AvatarGenerationBody, profileSubjectTags: string): string {
+async function buildAvatarGenerationPrompt(
+  promptOverridesStorage: ReturnType<typeof createPromptOverridesStorage>,
+  body: AvatarGenerationBody,
+  profileSubjectTags: string,
+): Promise<string> {
   const name = body.name?.trim() || "Character";
   const appearance = body.appearance?.trim() || name;
   if (body.purpose === "character-sheet") {
-    return [
-      `Create a polished production character design sheet for ${name}.`,
-      `Canonical appearance: ${appearance}.`,
-      "Show multiple consistent views of the same character: one large full-body hero view, front and back turnaround views in neutral poses, close-up face and costume details, important accessories, and a compact color palette on a clean neutral background.",
-      "Keep the same face, body proportions, hairstyle, outfit construction, colors, accessories, and distinguishing features in every view.",
-      "Show only this character and keep every body view fully in frame.",
-    ].join(" ");
+    return loadPrompt(promptOverridesStorage, CHARACTERS_REFERENCE_SHEET, { name, appearance });
   }
   if (profileSubjectTags.trim()) return `Canonical appearance for ${name}: ${appearance}.`;
   return `Create a polished character avatar portrait for ${name}. Canonical appearance: ${appearance}. Composition: centered face-and-shoulders portrait, readable expression, clear silhouette, suitable as a chat avatar.`;
@@ -829,6 +829,7 @@ export async function charactersRoutes(app: FastifyInstance) {
   const personaGallery = createPersonaGalleryStorage(app.db);
   const lorebooksStorage = createLorebooksStorage(app.db);
   const connections = createConnectionsStorage(app.db);
+  const promptOverridesStorage = createPromptOverridesStorage(app.db);
   const characterUpdateQueues = new Map<string, Promise<unknown>>();
   const personaUpdateQueues = new Map<string, Promise<unknown>>();
 
@@ -899,7 +900,7 @@ export async function charactersRoutes(app: FastifyInstance) {
       ).subjectTags[isCharacterSheet ? "illustration" : "avatar"] ?? "";
     const compiled = compileImagePrompt({
       kind: isCharacterSheet ? "illustration" : "avatar",
-      prompt: buildAvatarGenerationPrompt(body, profileSubjectTags),
+      prompt: await buildAvatarGenerationPrompt(promptOverridesStorage, body, profileSubjectTags),
       styleProfiles: imageSettings.styleProfiles,
       styleProfileId: body.styleProfileId,
       imageDefaults,
@@ -985,7 +986,7 @@ export async function charactersRoutes(app: FastifyInstance) {
         }
       : compileImagePrompt({
           kind: isCharacterSheet ? "illustration" : "avatar",
-          prompt: buildAvatarGenerationPrompt(body, profileSubjectTags),
+          prompt: await buildAvatarGenerationPrompt(promptOverridesStorage, body, profileSubjectTags),
           styleProfiles: imageSettings.styleProfiles,
           styleProfileId: body.styleProfileId,
           imageDefaults,

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -69,6 +69,7 @@ import {
 } from "../services/spatial-context/projection.js";
 import { createSpatialContextStorage } from "../services/storage/spatial-context.storage.js";
 import { restoreBranchHudLists, trimJournalForBranch } from "../services/game/branch-state.js";
+import { applyAllSegmentEdits, applyMessageSegmentEdits } from "../services/game/segment-edits.js";
 import type { Journal } from "../services/game/journal.service.js";
 import { createRegexScriptsStorage } from "../services/storage/regex-scripts.storage.js";
 import { processLorebooks } from "../services/lorebook/index.js";
@@ -3417,6 +3418,9 @@ export async function chatsRoutes(app: FastifyInstance) {
     delete sanitized.branchParentChatId;
     delete sanitized.branchParentMessageId;
     delete sanitized.branchMessageId;
+    for (const key of Object.keys(sanitized)) {
+      if (key.startsWith("segmentEdit:") || key.startsWith("segmentDelete:")) delete sanitized[key];
+    }
     if ("gameJournal" in sanitized) {
       sanitized.gameJournal = sanitizeGameJournalForExport(sanitized.gameJournal, knownNpcNames);
     }
@@ -3441,9 +3445,11 @@ export async function chatsRoutes(app: FastifyInstance) {
     options: { includeReasoning?: boolean } = {},
   ) => {
     const includeReasoning = options.includeReasoning === true;
-    const msgs = await storage.listMessages(chat.id);
+    const rawMessages = await storage.listMessages(chat.id);
     const charIds = parseExportCharacterIds(chat.characterIds);
     const metadata = parseExportMetadata(chat.metadata);
+    const msgs = rawMessages.map((message) => ({ ...message }));
+    if (chat.mode === "game") applyAllSegmentEdits(msgs, metadata, rawMessages);
     const messageIndexById = new Map(msgs.map((message, index) => [message.id, index]));
     const spatialContextHistory = (await createSpatialContextStorage().listForChat(chat.id))
       .map((snapshot) => ({
@@ -3574,7 +3580,13 @@ export async function chatsRoutes(app: FastifyInstance) {
               content:
                 swipe.index === msg.activeSwipeIndex
                   ? activeContent
-                  : resolveExportMessageContent({ content: swipe.content, characterId: msg.characterId }),
+                  : resolveExportMessageContent({
+                      content:
+                        chat.mode === "game" && (msg.role === "assistant" || msg.role === "narrator")
+                          ? applyMessageSegmentEdits(swipe.content, metadata, msg.id)
+                          : swipe.content,
+                      characterId: msg.characterId,
+                    }),
               extra:
                 swipe.index === msg.activeSwipeIndex
                   ? messageExtra

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -11644,7 +11644,7 @@ export async function gameRoutes(app: FastifyInstance) {
         charAvatarByName: storyboardCharacterContext.charAvatarByName,
         charDescriptionByName: storyboardCharacterContext.charDescriptionByName,
         includeReferenceImages: false,
-        includeCharacterDescriptions: includeCharacterAppearance,
+        includeCharacterDescriptions: true,
         maxReferenceImages: 0,
       });
       const storyboardAppearanceContextBlock = buildGameIllustratorAppearanceContextBlock(

--- a/packages/server/src/services/game/segment-edits.ts
+++ b/packages/server/src/services/game/segment-edits.ts
@@ -546,6 +546,45 @@ export function applySegmentEdits(
   return anyApplied ? output.join("\n\n") : content;
 }
 
+function collectSegmentOverlays(chatMeta: Record<string, unknown>) {
+  const editsByMessage = new Map<string, Record<number, SegmentEditValue>>();
+  const deletesByMessage = new Map<string, Set<number>>();
+  for (const [key, value] of Object.entries(chatMeta)) {
+    const isEdit = key.startsWith("segmentEdit:");
+    const isDelete = key.startsWith("segmentDelete:");
+    if (!isEdit && !isDelete) continue;
+    if (isDelete && value !== true && value !== "true") continue;
+    const parts = key.slice(isEdit ? "segmentEdit:".length : "segmentDelete:".length);
+    const lastColon = parts.lastIndexOf(":");
+    if (lastColon < 0) continue;
+    const messageId = parts.slice(0, lastColon);
+    const segmentIndex = Number.parseInt(parts.slice(lastColon + 1), 10);
+    if (Number.isNaN(segmentIndex)) continue;
+
+    if (isEdit) {
+      const edit = normalizeSegmentEditValue(value);
+      if (!edit) continue;
+      const edits = editsByMessage.get(messageId) ?? {};
+      edits[segmentIndex] = edit;
+      editsByMessage.set(messageId, edits);
+    } else {
+      const deleted = deletesByMessage.get(messageId) ?? new Set<number>();
+      deleted.add(segmentIndex);
+      deletesByMessage.set(messageId, deleted);
+    }
+  }
+  return { editsByMessage, deletesByMessage };
+}
+
+export function applyMessageSegmentEdits(
+  content: string,
+  chatMeta: Record<string, unknown>,
+  messageId: string,
+): string {
+  const { editsByMessage, deletesByMessage } = collectSegmentOverlays(chatMeta);
+  return applySegmentEdits(content, editsByMessage.get(messageId) ?? {}, deletesByMessage.get(messageId) ?? new Set());
+}
+
 /**
  * Collect segment edit overlays from chat metadata and apply them to the
  * corresponding messages.
@@ -559,41 +598,7 @@ export function applyAllSegmentEdits(
   chatMeta: Record<string, unknown>,
   allDbMessages: Array<{ id: string; role: string }>,
 ): void {
-  // Collect edits grouped by messageId
-  const editsByMessage = new Map<string, Record<number, SegmentEditValue>>();
-  const deletesByMessage = new Map<string, Set<number>>();
-  for (const [key, value] of Object.entries(chatMeta)) {
-    const isEdit = key.startsWith("segmentEdit:");
-    const isDelete = key.startsWith("segmentDelete:");
-    if (!isEdit && !isDelete) continue;
-    if (isDelete && value !== true && value !== "true") continue;
-    // Format: segment(Edit|Delete):messageId:segmentIndex
-    const parts = key.slice(isEdit ? "segmentEdit:".length : "segmentDelete:".length);
-    const lastColon = parts.lastIndexOf(":");
-    if (lastColon < 0) continue;
-    const messageId = parts.slice(0, lastColon);
-    const segIdx = parseInt(parts.slice(lastColon + 1), 10);
-    if (isNaN(segIdx)) continue;
-
-    if (isEdit) {
-      const edit = normalizeSegmentEditValue(value);
-      if (!edit) continue;
-      let edits = editsByMessage.get(messageId);
-      if (!edits) {
-        edits = {};
-        editsByMessage.set(messageId, edits);
-      }
-      edits[segIdx] = edit;
-      continue;
-    }
-
-    let deleted = deletesByMessage.get(messageId);
-    if (!deleted) {
-      deleted = new Set<number>();
-      deletesByMessage.set(messageId, deleted);
-    }
-    deleted.add(segIdx);
-  }
+  const { editsByMessage, deletesByMessage } = collectSegmentOverlays(chatMeta);
 
   if (editsByMessage.size === 0 && deletesByMessage.size === 0) return;
 

--- a/packages/server/src/services/generation/roleplay-summary-retrieval.ts
+++ b/packages/server/src/services/generation/roleplay-summary-retrieval.ts
@@ -54,7 +54,7 @@ export function resolveRoleplayChatSummary(
   return retainedEntries.length === entries.length ? summary : compileChatSummaryEntries(retainedEntries);
 }
 
-/** Keep manual and recent Roleplay summaries active while recalling only relevant older automatic entries. */
+/** Keep recent Roleplay summaries active while recalling only relevant older entries. */
 export async function resolveRoleplayChatSummaryForPrompt(args: {
   chatMode: string;
   chatMetadata: Record<string, unknown>;
@@ -77,16 +77,16 @@ export async function resolveRoleplayChatSummaryForPrompt(args: {
     normalizeChatSummaryEntries(args.chatMetadata.summaryEntries),
     args.excludeMessageIds ?? [],
   );
-  const automatedEntries = entries.filter((entry) => entry.enabled && entry.origin === "automated");
-  if (automatedEntries.length <= SEMANTIC_SUMMARY_RECENT_ENTRY_COUNT) return fallbackSummary;
+  const enabledEntries = entries.filter((entry) => entry.enabled);
+  if (enabledEntries.length <= SEMANTIC_SUMMARY_RECENT_ENTRY_COUNT) return fallbackSummary;
 
-  const newestAutomatedIds = new Set(
-    [...automatedEntries]
+  const newestEntryIds = new Set(
+    [...enabledEntries]
       .sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt))
       .slice(-SEMANTIC_SUMMARY_RECENT_ENTRY_COUNT)
       .map((entry) => entry.id),
   );
-  const olderEntries = automatedEntries.filter((entry) => !newestAutomatedIds.has(entry.id));
+  const olderEntries = enabledEntries.filter((entry) => !newestEntryIds.has(entry.id));
 
   try {
     const [queryEmbeddings, summaryEmbeddings] = await Promise.all([
@@ -121,9 +121,7 @@ export async function resolveRoleplayChatSummaryForPrompt(args: {
     );
 
     return compileChatSummaryEntries(
-      entries.filter(
-        (entry) => entry.origin !== "automated" || newestAutomatedIds.has(entry.id) || relevantOlderIds.has(entry.id),
-      ),
+      enabledEntries.filter((entry) => newestEntryIds.has(entry.id) || relevantOlderIds.has(entry.id)),
     );
   } catch (error) {
     logger.warn(error, "[roleplay-summary] Semantic retrieval failed; keeping all summaries in context");

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -551,6 +551,7 @@ export function stageImageToDisk(chatId: string, base64: string, ext: string): S
 // ── Provider Implementations ──
 
 const MAX_IMAGE_RESPONSE_BYTES = 30 * 1024 * 1024;
+const SWARMUI_MAX_TRACKED_IMAGES = 16;
 const LOCAL_IMAGE_BACKENDS = new Set(["comfyui", "swarmui", "automatic1111"]);
 const NANOGPT_REFERENCE_IMAGE_LIMIT = 3;
 const NANOGPT_MAX_REQUEST_BYTES = 4 * 1024 * 1024;
@@ -3467,7 +3468,12 @@ async function generateSwarmUiImageReference(
       if (!isRecord(message)) return;
       if (typeof message.image === "string" && message.image.trim()) {
         const index = Number.parseInt(String(message.batch_index ?? images.size), 10);
-        images.set(Number.isNaN(index) ? images.size : index, message.image.trim());
+        const resolvedIndex = Number.isNaN(index) ? images.size : index;
+        if (!images.has(resolvedIndex) && images.size >= SWARMUI_MAX_TRACKED_IMAGES) {
+          finish(new Error("SwarmUI generation returned too many image messages"));
+          return;
+        }
+        images.set(resolvedIndex, message.image.trim());
       }
       if (Array.isArray(message.discard_indices)) {
         for (const index of message.discard_indices) {

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -8,6 +8,7 @@ import { createHash, createHmac, randomBytes } from "crypto";
 import { existsSync, mkdirSync, readdirSync, renameSync, unlinkSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { inflateRawSync } from "zlib";
+import { WebSocket } from "undici";
 import { DATA_DIR } from "../../utils/data-dir.js";
 import { newId } from "../../utils/id-generator.js";
 import {
@@ -224,8 +225,6 @@ function resolveImageBackend(source: string, baseUrl: string, serviceHint: strin
 /** Default 30-minute timeout for image generation API calls (overridable via env). */
 const IMAGE_GEN_TIMEOUT = Number(process.env.IMAGE_GEN_TIMEOUT_MS ?? 1_800_000);
 const COMFYUI_GEN_TIMEOUT_SECONDS = Number(process.env.COMFYUI_GEN_TIMEOUT ?? 2400);
-const SWARMUI_KEEP_ALIVE_INITIAL_DELAY_MS = 10_000;
-
 export function resolveComfyUiImageGenerationTimeoutMs(
   imageTimeoutMs = IMAGE_GEN_TIMEOUT,
   comfyUiTimeoutSeconds = COMFYUI_GEN_TIMEOUT_SECONDS,
@@ -3384,6 +3383,106 @@ export function parseSwarmUiImageReference(value: unknown): string {
   return image.trim();
 }
 
+async function generateSwarmUiImageReference(
+  base: string,
+  apiKey: string,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+): Promise<string> {
+  const socketUrl = new URL(`${base}/API/GenerateText2ImageWS`);
+  if (socketUrl.protocol === "https:") socketUrl.protocol = "wss:";
+  else if (socketUrl.protocol === "http:") socketUrl.protocol = "ws:";
+  else throw new Error(`SwarmUI requires an HTTP or HTTPS base URL, received ${socketUrl.protocol}`);
+  await validateOutboundUrl(socketUrl, {
+    allowLocal: true,
+    allowedProtocols: ["wss:", "ws:"],
+    flagName: "IMAGE_LOCAL_URLS_ENABLED",
+  });
+
+  return new Promise<string>((resolve, reject) => {
+    const images = new Map<number, string>();
+    const discarded = new Set<number>();
+    const socket = new WebSocket(socketUrl, { headers: swarmUiHeaders(apiKey) });
+    let settled = false;
+
+    const closeSocket = () => {
+      try {
+        socket.close();
+      } catch {
+        // The connection may have failed before the opening handshake completed.
+      }
+    };
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", abort);
+      closeSocket();
+      if (error) {
+        reject(error);
+        return;
+      }
+      const image = [...images.entries()]
+        .filter(([index]) => !discarded.has(index))
+        .sort(([left], [right]) => left - right)[0]?.[1];
+      if (!image) {
+        reject(new Error("SwarmUI completed without an image output"));
+        return;
+      }
+      resolve(image);
+    };
+    const abort = () => {
+      finish(signal.reason instanceof Error ? signal.reason : new Error("SwarmUI generation aborted"));
+    };
+
+    signal.addEventListener("abort", abort, { once: true });
+    if (signal.aborted) {
+      abort();
+      return;
+    }
+
+    socket.addEventListener("open", () => {
+      if (!settled) socket.send(JSON.stringify(body));
+    });
+    socket.addEventListener("message", (event) => {
+      if (typeof event.data !== "string") {
+        finish(new Error("SwarmUI generation returned a non-text WebSocket message"));
+        return;
+      }
+      if (Buffer.byteLength(event.data) > MAX_IMAGE_RESPONSE_BYTES) {
+        finish(new Error("SwarmUI generation returned an oversized WebSocket message"));
+        return;
+      }
+      let message: unknown;
+      try {
+        message = JSON.parse(event.data) as unknown;
+      } catch {
+        finish(new Error("SwarmUI generation returned invalid JSON"));
+        return;
+      }
+      const apiError = swarmUiApiError(message);
+      if (apiError) {
+        finish(new Error(`SwarmUI API error: ${apiError}`));
+        return;
+      }
+      if (!isRecord(message)) return;
+      if (typeof message.image === "string" && message.image.trim()) {
+        const index = Number.parseInt(String(message.batch_index ?? images.size), 10);
+        images.set(Number.isNaN(index) ? images.size : index, message.image.trim());
+      }
+      if (Array.isArray(message.discard_indices)) {
+        for (const index of message.discard_indices) {
+          if (typeof index === "number" && Number.isInteger(index)) discarded.add(index);
+        }
+      }
+      if (message.socket_intention === "close") finish();
+    });
+    socket.addEventListener("error", () => finish(new Error("SwarmUI WebSocket connection failed")));
+    socket.addEventListener("close", () => {
+      if (!settled) finish(images.size > 0 ? undefined : new Error("SwarmUI WebSocket closed before completion"));
+    });
+  });
+}
+
 async function generateSwarmUI(baseUrl: string, apiKey: string, request: ImageGenRequest): Promise<ImageGenResult> {
   const base = baseUrl.replace(/\/+$/, "");
   const sessionId = await createSwarmUiSession(base, apiKey, request);
@@ -3397,31 +3496,7 @@ async function generateSwarmUI(baseUrl: string, apiKey: string, request: ImageGe
     "[debug/image/swarmui] final request payload:\n%s",
     JSON.stringify(debugBody, null, 2),
   );
-  const response = await localImageBackendFetch(
-    `${base}/API/GenerateText2Image`,
-    {
-      method: "POST",
-      headers: swarmUiHeaders(apiKey),
-      body: JSON.stringify(body),
-      signal: imageRequestSignal(request),
-    },
-    {
-      timeoutMs: resolveComfyUiImageGenerationTimeoutMs(),
-      keepAliveInitialDelayMs: SWARMUI_KEEP_ALIVE_INITIAL_DELAY_MS,
-    },
-  );
-  const text = await response.text();
-  if (!response.ok) {
-    throw new Error(`SwarmUI generation failed (${response.status}): ${sanitizeErrorText(text)}`);
-  }
-
-  let result: unknown;
-  try {
-    result = JSON.parse(text) as unknown;
-  } catch {
-    throw new Error("SwarmUI generation returned invalid JSON");
-  }
-  const imageReference = parseSwarmUiImageReference(result);
+  const imageReference = await generateSwarmUiImageReference(base, apiKey, body, imageRequestSignal(request));
   if (imageReference.startsWith("data:")) return decodeImageDataUrl(imageReference);
   const imageUrl = new URL(imageReference, `${base}/`).toString();
   return downloadImageUrl(imageUrl, request.privateImageResultOrigin, request.signal);

--- a/packages/server/src/services/prompt-overrides/index.ts
+++ b/packages/server/src/services/prompt-overrides/index.ts
@@ -6,6 +6,7 @@ export { renderTemplate, validateTemplate } from "./template.js";
 export type { TemplateValidationResult } from "./template.js";
 export {
   PROMPT_OVERRIDE_REGISTRY,
+  CHARACTERS_REFERENCE_SHEET,
   SPRITES_ANIMATED_PORTRAIT,
   SPRITES_EXPRESSION_SHEET,
   SPRITES_SINGLE_PORTRAIT,
@@ -34,6 +35,7 @@ export {
 export type {
   PromptOverrideKeyDef,
   PromptVariable,
+  CharactersReferenceSheetCtx,
   SpritesExpressionSheetCtx,
   SpritesSinglePortraitCtx,
   SpritesAnimatedPortraitCtx,

--- a/packages/server/src/services/prompt-overrides/registry.ts
+++ b/packages/server/src/services/prompt-overrides/registry.ts
@@ -6,6 +6,7 @@
 // ──────────────────────────────────────────────
 import type { PromptOverrideKeyDef } from "./types.js";
 
+import { CHARACTERS_REFERENCE_SHEET } from "./registry/characters.js";
 import {
   SPRITES_ANIMATED_PORTRAIT,
   SPRITES_EXPRESSION_SHEET,
@@ -34,6 +35,7 @@ import {
 import { NOODLE_IMAGE_POST, NOODLE_TIMELINE_BASE, NOODLE_TIMELINE_VOICE } from "./registry/noodle.js";
 
 export const PROMPT_OVERRIDE_REGISTRY = [
+  CHARACTERS_REFERENCE_SHEET,
   SPRITES_EXPRESSION_SHEET,
   SPRITES_SINGLE_PORTRAIT,
   SPRITES_ANIMATED_PORTRAIT,
@@ -79,6 +81,7 @@ export function listPromptOverrideKeys(): string[] {
 
 // Re-export the typed key defs for direct import at call sites.
 export {
+  CHARACTERS_REFERENCE_SHEET,
   SPRITES_EXPRESSION_SHEET,
   SPRITES_SINGLE_PORTRAIT,
   SPRITES_ANIMATED_PORTRAIT,
@@ -102,6 +105,7 @@ export {
   NOODLE_TIMELINE_BASE,
   NOODLE_TIMELINE_VOICE,
 };
+export type { CharactersReferenceSheetCtx } from "./registry/characters.js";
 export type {
   SpritesExpressionSheetCtx,
   SpritesSinglePortraitCtx,

--- a/packages/server/src/services/prompt-overrides/registry/characters.ts
+++ b/packages/server/src/services/prompt-overrides/registry/characters.ts
@@ -1,0 +1,32 @@
+import type { PromptOverrideKeyDef } from "../types.js";
+
+export interface CharactersReferenceSheetCtx extends Record<string, string | number | undefined> {
+  name: string;
+  appearance: string;
+}
+
+export const CHARACTERS_REFERENCE_SHEET: PromptOverrideKeyDef<CharactersReferenceSheetCtx> = {
+  key: "characters.referenceSheet",
+  label: "Character Reference Sheet",
+  description: "Production character reference sheet used by character and Persona gallery generation.",
+  variables: [
+    { name: "name", description: "Character or Persona name.", example: "Mira" },
+    {
+      name: "appearance",
+      description: "Canonical appearance description.",
+      example: "long brown hair, amber eyes, dark travel coat",
+    },
+  ],
+  defaultBuilder: (ctx) =>
+    [
+      `Create a polished production character design sheet for ${ctx.name}.`,
+      `Canonical appearance: ${ctx.appearance}.`,
+      "Show multiple consistent views of the same character: one large full-body hero view, front and back turnaround views in neutral poses, close-up face and costume details, important accessories, and a compact color palette on a clean neutral background.",
+      "Keep the same face, body proportions, hairstyle, outfit construction, colors, accessories, and distinguishing features in every view.",
+      "Show only this character and keep every body view fully in frame.",
+    ].join(" "),
+  exampleContext: {
+    name: "Mira",
+    appearance: "long brown hair, amber eyes, dark travel coat",
+  },
+};

--- a/scripts/regressions/chat-branch-lineage.regression.ts
+++ b/scripts/regressions/chat-branch-lineage.regression.ts
@@ -374,6 +374,55 @@ try {
     assert.equal(key in exportedMetadata.marinara_metadata, false);
   }
 
+  const exportGame = await create("Visible narration export", "game");
+  const editedExportMessage = await addMessage(
+    exportGame.id,
+    "Narration: Original first segment.\n\nNarration: Removed second segment.",
+    "assistant",
+  );
+  await app.inject({
+    method: "POST",
+    url: `/api/chats/${exportGame.id}/messages/${editedExportMessage.id}/swipes`,
+    payload: {
+      content: "Narration: Alternate first segment.\n\nNarration: Removed alternate segment.",
+      silent: true,
+    },
+  });
+  const deletedExportMessage = await addMessage(exportGame.id, "Narration: Entirely removed message.", "assistant");
+  const segmentMetadata = {
+    [`segmentEdit:${editedExportMessage.id}:0`]: { content: "Visible edited segment." },
+    [`segmentDelete:${editedExportMessage.id}:1`]: true,
+    [`segmentDelete:${deletedExportMessage.id}:0`]: true,
+  };
+  const exportMetadataResponse = await app.inject({
+    method: "PATCH",
+    url: `/api/chats/${exportGame.id}/metadata`,
+    payload: segmentMetadata,
+  });
+  assert.equal(exportMetadataResponse.statusCode, 200);
+
+  const gameJsonlExport = await app.inject({
+    method: "GET",
+    url: `/api/chats/${exportGame.id}/export?format=jsonl`,
+  });
+  assert.equal(gameJsonlExport.statusCode, 200);
+  const gameJsonlLines = gameJsonlExport.body.split("\n").map((line: string) => JSON.parse(line));
+  assert.equal(gameJsonlLines.length, 2, "an entirely deleted Game message must be omitted from JSONL");
+  assert.equal(gameJsonlLines[1].mes, "Visible edited segment.");
+  assert.deepEqual(gameJsonlLines[1].swipes, ["Visible edited segment.", "Visible edited segment."]);
+  for (const key of Object.keys(segmentMetadata)) {
+    assert.equal(key in gameJsonlLines[0].chat_metadata, false);
+    assert.equal(key in gameJsonlLines[0].chat_metadata.marinara_metadata, false);
+  }
+
+  const gameTextExport = await app.inject({
+    method: "GET",
+    url: `/api/chats/${exportGame.id}/export?format=text`,
+  });
+  assert.equal(gameTextExport.statusCode, 200);
+  assert.match(gameTextExport.body, /Visible edited segment\./u);
+  assert.doesNotMatch(gameTextExport.body, /Removed second segment|Entirely removed message/u);
+
   const malformed = await create("Malformed metadata");
   const malformedMetadataResponse = await app.inject({
     method: "PATCH",

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -4780,7 +4780,7 @@ const cases: RegressionCase[] = [
     },
   },
   {
-    name: "Storyboard appearance is gated and injected once across planner and fallback paths",
+    name: "Storyboard appearance always reaches the planner and is injected once into render prompts",
     async run() {
       const appearance = "auburn hair, green eyes, leather jacket";
       const description = "A verbose roleplay card description that must not be sent as visual appearance.";
@@ -5124,8 +5124,8 @@ const cases: RegressionCase[] = [
       assert.doesNotMatch(gameSurfaceSource, /useGamePromptTemplate/u);
       assert.match(gameRouteSource, /characterAppearanceContextBlock:\s*storyboardAppearanceContextBlock/u);
       assert.equal(gameRouteSource.match(/^\s+characterAppearanceContextBlock,\s*$/gmu)?.length, 2);
-      assert.equal(gameRouteSource.match(/includeCharacterDescriptions:\s*true,/gu)?.length ?? 0, 0);
-      assert.equal(gameRouteSource.match(/includeCharacterDescriptions:\s*includeCharacterAppearance,/gu)?.length, 5);
+      assert.equal(gameRouteSource.match(/includeCharacterDescriptions:\s*true,/gu)?.length, 1);
+      assert.equal(gameRouteSource.match(/includeCharacterDescriptions:\s*includeCharacterAppearance,/gu)?.length, 4);
       assert.equal(
         gameRouteSource.match(
           /includeCharacterDescriptions:\s*includeCharacterAppearanceAtRender && characterPrompts\.length === 0,/gu,

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -811,6 +811,7 @@ import {
 import { parseRouterResponse } from "../../packages/server/src/services/agents/knowledge-router.js";
 import type { PromptOverridesStorage } from "../../packages/server/src/services/storage/prompt-overrides.storage.js";
 import {
+  CHARACTERS_REFERENCE_SHEET,
   listPromptOverrideKeys,
   loadPrompt,
   ROLEPLAY_GALLERY_VIDEO_DIRECTOR,
@@ -4710,6 +4711,20 @@ const cases: RegressionCase[] = [
         },
       });
       assert.deepEqual(missingPersonaSheetAndAvatar, { base64: "persona-sprite-bytes", source: "sprite" });
+
+      assert.equal(listPromptOverrideKeys().includes(CHARACTERS_REFERENCE_SHEET.key), true);
+      assert.match(
+        CHARACTERS_REFERENCE_SHEET.defaultBuilder({ name: "Mira", appearance: "long brown hair" }),
+        /production character design sheet for Mira.*Canonical appearance: long brown hair/u,
+      );
+      const charactersRouteSource = readFileSync(
+        new URL("../../packages/server/src/routes/characters.routes.ts", import.meta.url),
+        "utf8",
+      );
+      assert.match(
+        charactersRouteSource,
+        /loadPrompt\(promptOverridesStorage, CHARACTERS_REFERENCE_SHEET, \{ name, appearance \}\)/u,
+      );
     },
   },
   {

--- a/scripts/regressions/regeneration-context.regression.ts
+++ b/scripts/regressions/regeneration-context.regression.ts
@@ -85,42 +85,51 @@ const semanticSummaryEntries = [
   {
     id: "manual-anchor",
     origin: "manual",
-    content: "Mari wrote down the permanent relationship anchor.",
+    content: "Mari wrote down an unrelated relationship anchor.",
     enabled: true,
     createdAt: "2026-07-01T08:00:00.000Z",
     updatedAt: "2026-07-01T08:00:00.000Z",
   },
   {
-    id: "relevant-old-summary",
-    origin: "automated",
+    id: "relevant-manual-summary",
+    origin: "manual",
     content: "The dragon pact was sealed beneath the red moon.",
     enabled: true,
     createdAt: "2026-07-02T08:00:00.000Z",
     updatedAt: "2026-07-02T08:00:00.000Z",
   },
   {
+    id: "relevant-backfill-summary",
+    origin: "manual",
+    sourceMode: "range",
+    content: "The dragon pact requires a silver offering at dawn.",
+    enabled: true,
+    createdAt: "2026-07-03T08:00:00.000Z",
+    updatedAt: "2026-07-03T08:00:00.000Z",
+  },
+  {
     id: "irrelevant-old-summary",
     origin: "automated",
     content: "They spent a quiet afternoon baking bread.",
     enabled: true,
-    createdAt: "2026-07-03T08:00:00.000Z",
-    updatedAt: "2026-07-03T08:00:00.000Z",
+    createdAt: "2026-07-04T08:00:00.000Z",
+    updatedAt: "2026-07-04T08:00:00.000Z",
   },
   {
     id: "recent-summary-one",
     origin: "automated",
     content: "They reached the mountain pass.",
     enabled: true,
-    createdAt: "2026-07-04T08:00:00.000Z",
-    updatedAt: "2026-07-04T08:00:00.000Z",
+    createdAt: "2026-07-05T08:00:00.000Z",
+    updatedAt: "2026-07-05T08:00:00.000Z",
   },
   {
     id: "recent-summary-two",
     origin: "automated",
     content: "A storm forced them into the same shelter.",
     enabled: true,
-    createdAt: "2026-07-05T08:00:00.000Z",
-    updatedAt: "2026-07-05T08:00:00.000Z",
+    createdAt: "2026-07-06T08:00:00.000Z",
+    updatedAt: "2026-07-06T08:00:00.000Z",
   },
 ];
 const semanticSummaryMetadata = {
@@ -151,12 +160,12 @@ const selectedSemanticSummary = await resolveRoleplayChatSummaryForPrompt({
 assert.equal(
   selectedSemanticSummary,
   [
-    semanticSummaryEntries[0]!.content,
     semanticSummaryEntries[1]!.content,
-    semanticSummaryEntries[3]!.content,
+    semanticSummaryEntries[2]!.content,
     semanticSummaryEntries[4]!.content,
+    semanticSummaryEntries[5]!.content,
   ].join("\n\n"),
-  "semantic Roleplay summaries must retain manual and recent entries while retrieving only relevant older automatic entries",
+  "semantic Roleplay summaries must retrieve relevant manual and backfilled entries while retaining recent entries",
 );
 assert.equal(
   await resolveRoleplayChatSummaryForPrompt({
@@ -309,10 +318,9 @@ try {
   assert.deepEqual(retainedSwipeExtra.conversationStartForCharacterIds, ["new-character"]);
   assert.deepEqual(retainedSwipeExtra.hiddenFromAICharacterIds, ["private-character"]);
   await chatStorage.setActiveSwipe(swipeMetadataMessage.id, 1);
-  const switchedMessageExtra = JSON.parse((await chatStorage.getMessage(swipeMetadataMessage.id))!.extra as string) as Record<
-    string,
-    unknown
-  >;
+  const switchedMessageExtra = JSON.parse(
+    (await chatStorage.getMessage(swipeMetadataMessage.id))!.extra as string,
+  ) as Record<string, unknown>;
   assert.deepEqual(switchedMessageExtra.conversationStartForCharacterIds, ["new-character"]);
   assert.deepEqual(switchedMessageExtra.hiddenFromAICharacterIds, ["private-character"]);
   assert.equal(switchedMessageExtra.isConversationStart, true);

--- a/scripts/regressions/swarmui-timeout.regression.ts
+++ b/scripts/regressions/swarmui-timeout.regression.ts
@@ -28,8 +28,9 @@ function encodeWebSocketText(value: unknown): Buffer {
   return Buffer.concat([header, payload]);
 }
 
-function readClientTextFrame(buffer: Buffer): { payload: string; consumed: number } | null {
+function readClientFrame(buffer: Buffer): { payload: string | null; consumed: number } | null {
   if (buffer.length < 2) return null;
+  const opcode = buffer[0]! & 0x0f;
   let payloadLength = buffer[1]! & 0x7f;
   let cursor = 2;
   if (payloadLength === 126) {
@@ -52,7 +53,7 @@ function readClientTextFrame(buffer: Buffer): { payload: string; consumed: numbe
   if (mask) {
     for (let index = 0; index < payload.length; index++) payload[index] ^= mask[index % 4]!;
   }
-  return { payload: payload.toString("utf8"), consumed: cursor + payloadLength };
+  return { payload: opcode === 0x1 ? payload.toString("utf8") : null, consumed: cursor + payloadLength };
 }
 
 const server = createServer((request, response) => {
@@ -92,13 +93,17 @@ server.on("upgrade", (request, socket, head) => {
   let generationStarted = false;
   const consume = (chunk?: Buffer) => {
     if (chunk) buffered = Buffer.concat([buffered, chunk]);
-    const frame = readClientTextFrame(buffered);
-    if (!frame || generationStarted) return;
-    generationStarted = true;
-    generationBody = JSON.parse(frame.payload) as Record<string, unknown>;
-    setTimeout(() => socket.write(encodeWebSocketText({ gen_progress: { overall_percent: 0.5 } })), 60);
-    setTimeout(() => socket.write(encodeWebSocketText({ image: "View/generated.png", batch_index: "0" })), 120);
-    setTimeout(() => socket.write(encodeWebSocketText({ socket_intention: "close" })), 130);
+    while (!generationStarted) {
+      const frame = readClientFrame(buffered);
+      if (!frame) return;
+      buffered = buffered.subarray(frame.consumed);
+      if (frame.payload === null) continue;
+      generationStarted = true;
+      generationBody = JSON.parse(frame.payload) as Record<string, unknown>;
+      setTimeout(() => socket.write(encodeWebSocketText({ gen_progress: { overall_percent: 0.5 } })), 60);
+      setTimeout(() => socket.write(encodeWebSocketText({ image: "View/generated.png", batch_index: "0" })), 120);
+      setTimeout(() => socket.write(encodeWebSocketText({ socket_intention: "close" })), 130);
+    }
   };
   consume();
   socket.on("data", consume);

--- a/scripts/regressions/swarmui-timeout.regression.ts
+++ b/scripts/regressions/swarmui-timeout.regression.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { createServer } from "node:http";
-import { Socket } from "node:net";
+import type { Socket } from "node:net";
 
 const previousImageTimeout = process.env.IMAGE_GEN_TIMEOUT_MS;
 const previousComfyTimeout = process.env.COMFYUI_GEN_TIMEOUT;
@@ -11,19 +12,59 @@ const png = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
   "base64",
 );
-const requestPorts = new Map<string, number>();
+let httpGenerationRequests = 0;
+let webSocketPath = "";
+let webSocketCookie = "";
+let generationBody: Record<string, unknown> | null = null;
+const upgradedSockets = new Set<Socket>();
+
+function encodeWebSocketText(value: unknown): Buffer {
+  const payload = Buffer.from(JSON.stringify(value));
+  if (payload.length < 126) return Buffer.concat([Buffer.from([0x81, payload.length]), payload]);
+  const header = Buffer.alloc(4);
+  header[0] = 0x81;
+  header[1] = 126;
+  header.writeUInt16BE(payload.length, 2);
+  return Buffer.concat([header, payload]);
+}
+
+function readClientTextFrame(buffer: Buffer): { payload: string; consumed: number } | null {
+  if (buffer.length < 2) return null;
+  let payloadLength = buffer[1]! & 0x7f;
+  let cursor = 2;
+  if (payloadLength === 126) {
+    if (buffer.length < 4) return null;
+    payloadLength = buffer.readUInt16BE(2);
+    cursor = 4;
+  } else if (payloadLength === 127) {
+    if (buffer.length < 10) return null;
+    const length = buffer.readBigUInt64BE(2);
+    if (length > BigInt(Number.MAX_SAFE_INTEGER)) throw new Error("Regression WebSocket frame is too large");
+    payloadLength = Number(length);
+    cursor = 10;
+  }
+  const masked = (buffer[1]! & 0x80) !== 0;
+  const maskLength = masked ? 4 : 0;
+  if (buffer.length < cursor + maskLength + payloadLength) return null;
+  const mask = masked ? buffer.subarray(cursor, cursor + 4) : null;
+  cursor += maskLength;
+  const payload = Buffer.from(buffer.subarray(cursor, cursor + payloadLength));
+  if (mask) {
+    for (let index = 0; index < payload.length; index++) payload[index] ^= mask[index % 4]!;
+  }
+  return { payload: payload.toString("utf8"), consumed: cursor + payloadLength };
+}
+
 const server = createServer((request, response) => {
-  if (request.url && request.socket.remotePort) requestPorts.set(request.url, request.socket.remotePort);
   if (request.url === "/API/GetNewSession") {
     response.setHeader("Content-Type", "application/json");
     response.end(JSON.stringify({ session_id: "regression-session" }));
     return;
   }
   if (request.url === "/API/GenerateText2Image") {
-    setTimeout(() => {
-      response.setHeader("Content-Type", "application/json");
-      response.end(JSON.stringify({ images: ["View/generated.png"] }));
-    }, 120);
+    httpGenerationRequests += 1;
+    response.statusCode = 500;
+    response.end("The streaming endpoint must be used");
     return;
   }
   if (request.url === "/View/generated.png") {
@@ -35,21 +76,38 @@ const server = createServer((request, response) => {
   response.end();
 });
 
+server.on("upgrade", (request, socket, head) => {
+  webSocketPath = request.url ?? "";
+  webSocketCookie = request.headers.cookie ?? "";
+  const key = request.headers["sec-websocket-key"];
+  assert.equal(typeof key, "string");
+  const accept = createHash("sha1").update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`).digest("base64");
+  socket.write(
+    `HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ${accept}\r\n\r\n`,
+  );
+  upgradedSockets.add(socket);
+  socket.once("close", () => upgradedSockets.delete(socket));
+
+  let buffered = Buffer.from(head);
+  let generationStarted = false;
+  const consume = (chunk?: Buffer) => {
+    if (chunk) buffered = Buffer.concat([buffered, chunk]);
+    const frame = readClientTextFrame(buffered);
+    if (!frame || generationStarted) return;
+    generationStarted = true;
+    generationBody = JSON.parse(frame.payload) as Record<string, unknown>;
+    setTimeout(() => socket.write(encodeWebSocketText({ gen_progress: { overall_percent: 0.5 } })), 60);
+    setTimeout(() => socket.write(encodeWebSocketText({ image: "View/generated.png", batch_index: "0" })), 120);
+    setTimeout(() => socket.write(encodeWebSocketText({ socket_intention: "close" })), 130);
+  };
+  consume();
+  socket.on("data", consume);
+});
+
 await new Promise<void>((resolve, reject) => {
   server.once("error", reject);
   server.listen(0, "127.0.0.1", resolve);
 });
-
-const keepAliveCalls: Array<{ delay: number; localPort?: number }> = [];
-const originalSetKeepAlive = Socket.prototype.setKeepAlive;
-Socket.prototype.setKeepAlive = function (enable = false, initialDelay = 0) {
-  if (enable) {
-    const call = { delay: initialDelay, localPort: this.localPort };
-    keepAliveCalls.push(call);
-    if (!call.localPort) this.once("connect", () => (call.localPort = this.localPort));
-  }
-  return originalSetKeepAlive.call(this, enable, initialDelay);
-};
 
 try {
   const address = server.address();
@@ -62,28 +120,18 @@ try {
     2_400_000,
     "SwarmUI and ComfyUI share the longer configured image-generation deadline",
   );
-  const result = await generateImage("swarmui", `http://127.0.0.1:${address.port}`, "", "swarmui", {
+  const result = await generateImage("swarmui", `http://127.0.0.1:${address.port}`, "regression-token", "swarmui", {
     prompt: "timeout regression",
   });
   assert.equal(result.mimeType, "image/png");
   assert.equal(result.base64, png.toString("base64"));
-  const generationPort = requestPorts.get("/API/GenerateText2Image");
-  assert.ok(generationPort, "the regression server must observe the SwarmUI generation request");
-  assert.ok(
-    keepAliveCalls.some((call) => call.localPort === generationPort && call.delay === 10_000),
-    "SwarmUI generation must probe an idle TCP connection before the reported 30-second network timeout",
-  );
-  for (const path of ["/API/GetNewSession", "/View/generated.png"]) {
-    const port = requestPorts.get(path);
-    assert.ok(port, `the regression server must observe ${path}`);
-    assert.equal(
-      keepAliveCalls.some((call) => call.localPort === port && call.delay === 10_000),
-      false,
-      `${path} must retain ordinary fetch transport behavior`,
-    );
-  }
+  assert.equal(httpGenerationRequests, 0, "SwarmUI generation must not use the idle HTTP route");
+  assert.equal(webSocketPath, "/API/GenerateText2ImageWS");
+  assert.match(webSocketCookie, /(?:^|;\s*)swarm_token=regression-token(?:;|$)/u);
+  assert.equal(generationBody?.session_id, "regression-session");
+  assert.equal(generationBody?.prompt, "timeout regression");
 } finally {
-  Socket.prototype.setKeepAlive = originalSetKeepAlive;
+  for (const socket of upgradedSockets) socket.destroy();
   await new Promise<void>((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve()));
   });


### PR DESCRIPTION
## Linked issues

Closes #5346
Closes #5347
Closes #5348
Closes #5349
Fixes Pasta-Devs/Marinara-Agents#478

## Why this change

These assigned issues expose five user-facing gaps: manual and backfilled summaries bypass semantic retrieval, long SwarmUI generations can lose an idle HTTP connection, the character reference-sheet prompt cannot be customized in Generation settings, Game JSONL exports preserve stale segment overlays instead of the visible narration, and the Storyboard planner can lose character appearance context.

## What changed

- Rank every enabled Roleplay summary in semantic retrieval, including manual and range-backfilled entries, while retaining the two newest entries.
- Move SwarmUI image generation to the official progress-streaming WebSocket route and retain token authentication, cancellation, response bounds, and final image validation.
- Register the existing Character Reference Sheet prompt under Settings → Generation and use its saved override in preview and generation.
- Materialize Game narration edits and deletions into text and JSONL exports, including alternate swipes, while stripping stale overlay metadata.
- Keep Storyboard planner appearance context independent of the final-render attachment toggle.
- Document all user-facing changes in `CHANGELOG.md`.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Automated evidence

- `pnpm check` — passed
- `scripts/regressions/regeneration-context.regression.ts` — passed
- `scripts/regressions/chat-branch-lineage.regression.ts` — passed
- `scripts/regressions/swarmui-timeout.regression.ts` — passed
- Relevant cases in `pnpm regression:prompt` pass: Character/Persona sheets and Storyboard appearance. The complete prompt lane still reports the pre-existing Beholder state-context assertion on current `staging`.

### Manual verification notes

- Manually verify Character Reference Sheet appears under Settings → Generation and a saved override affects preview and generation.
- Manually verify a long-running SwarmUI generation completes without an idle read timeout.
- Manually verify Game text/JSONL export matches edited narration and omits deleted narration.
- Manually verify storyboard planning still receives appearance when Attach Card Appearance is disabled.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

`CHANGELOG.md` is updated. No version-bearing files or user documentation under `docs/` changed.

## UI evidence (if applicable)

No new UI component or layout. The existing Generation prompt editor renders the newly registered prompt entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Character Reference Sheet prompt override in **Settings → Generation** for customizable, consistent character designs.
  - Improved SwarmUI image generation with real-time WebSocket progress and more reliable result handling.

- **Bug Fixes**
  - Improved semantic retrieval for relevant manual and backfilled summaries.
  - Chat exports now preserve segment edits, swipes, and deletions while removing internal metadata.
  - Game Storyboard planning now consistently includes character appearance details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->