### PR TITLE
fix(security): preserve Claude subscription isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Claude Subscription custom parameters can no longer override the provider's text-only Agent SDK isolation; model-generation overrides remain supported while tool, process, environment, filesystem, and session controls stay provider-owned (#5351).
 - Manual and range-backfilled Roleplay summaries now participate in semantic retrieval alongside automatic summaries, keeping relevant history without pinning every manual entry in context (#5346).
 - SwarmUI image generation now uses its progress-streaming WebSocket route, preventing long generations from losing an otherwise idle HTTP connection (#5347).
 - Game transcript exports now materialize narration edits and deletions in active messages and alternate swipes, omit fully deleted messages, and remove stale segment-overlay metadata from JSONL (#5349).

--- a/packages/server/src/services/llm/providers/claude-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/claude-subscription.provider.ts
@@ -47,15 +47,20 @@ import { ResumeSessionStore, resumeScratchCwd } from "./claude-subscription/sess
 const CACHE_WRITE_COST_MULTIPLIER = 1.25;
 const CACHE_READ_COST_MULTIPLIER = 0.1;
 
-/**
- * SDK option keys the resume path owns exclusively. A connection's
- * `customParameters` must never set these: a forged `resume`/`sessionStore`
- * could inject an attacker-controlled transcript, and a forged `cwd` controls
- * where the SDK subprocess runs. They are stripped unconditionally after
- * `applyCustomParameters` and re-applied only from provider-derived values
- * (see `chat()`).
- */
-const RESERVED_SDK_OPTION_KEYS = ["resume", "cwd", "sessionStore"] as const;
+/** Model-generation SDK options that Custom Parameters may tune. Everything
+ * else owns process, tool, filesystem, environment, or session behavior and
+ * must remain under the provider's text-only isolation policy. */
+const CUSTOMIZABLE_SDK_OPTION_KEYS = [
+  "betas",
+  "effort",
+  "fallbackModel",
+  "maxBudgetUsd",
+  "maxThinkingTokens",
+  "model",
+  "outputFormat",
+  "taskBudget",
+  "thinking",
+] as const;
 
 /**
  * Lazy import wrapper. The SDK is heavy and pulls in optional native pieces;
@@ -453,20 +458,26 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
       ...(this.apiKey ? { ANTHROPIC_API_KEY: this.apiKey } : {}),
     };
 
-    const reserved = sdkOptions as Record<string, unknown>;
-    this.applyCustomParameters(reserved, options);
+    const sdkOptionRecord = sdkOptions as Record<string, unknown>;
+    const customGenerationOptions: Record<string, unknown> = {};
+    for (const key of CUSTOMIZABLE_SDK_OPTION_KEYS) {
+      if (Object.prototype.hasOwnProperty.call(sdkOptionRecord, key)) {
+        customGenerationOptions[key] = sdkOptionRecord[key];
+      }
+    }
+    this.applyCustomParameters(customGenerationOptions, options);
+    for (const key of CUSTOMIZABLE_SDK_OPTION_KEYS) {
+      if (Object.prototype.hasOwnProperty.call(customGenerationOptions, key)) {
+        sdkOptionRecord[key] = customGenerationOptions[key];
+      }
+    }
 
-    // RESERVED keys are load-bearing for the resume path's contract: the SDK
-    // loads the injected history from `sessionStore.load()` and resumes the
-    // session by ID. Strip any caller-supplied values unconditionally — a
-    // connection's customParameters must not reach the SDK even on the fold
-    // path and the empty-history resume sub-path, where the guard below stays
-    // closed.
-    for (const key of RESERVED_SDK_OPTION_KEYS) delete reserved[key];
+    // Resume wiring is always provider-derived. Custom Parameters are filtered
+    // above, so no caller-supplied process or session option reaches the SDK.
     if (resumeSessionId && resumeCwd && sessionStore) {
-      reserved["resume"] = resumeSessionId;
-      reserved["cwd"] = resumeCwd;
-      reserved["sessionStore"] = sessionStore;
+      sdkOptionRecord["resume"] = resumeSessionId;
+      sdkOptionRecord["cwd"] = resumeCwd;
+      sdkOptionRecord["sessionStore"] = sessionStore;
     }
 
     let inputTokens = 0;

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -962,6 +962,58 @@ assert.equal(
     assert.ok(subscriptionOptions);
     assert.deepEqual(subscriptionOptions.thinking, { type: "adaptive", display: "summarized" });
     assert.equal(subscriptionOptions.effort, "xhigh");
+
+    assert.equal(
+      await collectProviderOutputForMessages(
+        provider,
+        [
+          { role: "system", content: "Keep the caller-owned system prompt." },
+          { role: "user", content: "test" },
+        ],
+        {
+          model: "claude-opus-5",
+          stream: true,
+          customParameters: {
+            fallbackModel: "claude-sonnet-4-6",
+            maxBudgetUsd: 2,
+            tools: { type: "preset", preset: "claude_code" },
+            skills: "all",
+            maxTurns: 20,
+            allowedTools: ["Bash"],
+            mcpServers: { unsafe: { command: "/bin/false" } },
+            pathToClaudeCodeExecutable: "/bin/false",
+            extraArgs: { "dangerously-skip-permissions": null },
+            permissionMode: "acceptEdits",
+            settingSources: ["user", "project", "local"],
+            settings: "/tmp/untrusted-settings.json",
+            env: { ENABLE_CLAUDEAI_MCP_SERVERS: "true", UNTRUSTED_VALUE: "present" },
+            cwd: "/tmp",
+            systemPrompt: { type: "preset", preset: "claude_code" },
+          },
+        },
+      ),
+      "Subscription reply",
+    );
+    assert.ok(subscriptionOptions);
+    assert.equal(subscriptionOptions.fallbackModel, "claude-sonnet-4-6");
+    assert.equal(subscriptionOptions.maxBudgetUsd, 2);
+    assert.deepEqual(subscriptionOptions.tools, []);
+    assert.deepEqual(subscriptionOptions.skills, []);
+    assert.equal(subscriptionOptions.maxTurns, 1);
+    assert.equal("allowedTools" in subscriptionOptions, false);
+    assert.equal("mcpServers" in subscriptionOptions, false);
+    assert.equal("pathToClaudeCodeExecutable" in subscriptionOptions, false);
+    assert.equal("extraArgs" in subscriptionOptions, false);
+    assert.equal(subscriptionOptions.permissionMode, "bypassPermissions");
+    assert.deepEqual(subscriptionOptions.settingSources, []);
+    assert.deepEqual(subscriptionOptions.settings, { fastMode: false });
+    assert.equal(subscriptionOptions.cwd, undefined);
+    assert.equal(subscriptionOptions.systemPrompt, "Keep the caller-owned system prompt.");
+    assert.equal(
+      (subscriptionOptions.env as Record<string, unknown>).ENABLE_CLAUDEAI_MCP_SERVERS,
+      "false",
+    );
+    assert.equal("UNTRUSTED_VALUE" in (subscriptionOptions.env as Record<string, unknown>), false);
   } finally {
     __setSdkForTesting(null);
   }


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target staging. Only SpicyMarinara may promote this repository staging branch or a same-repository hotfix branch to main.

## Linked issue

Closes #5351

## Why this change

Claude Subscription is documented and implemented as a text-only provider, but raw Custom Parameters reached Agent SDK options after the provider set its isolation controls. Execution-capable values could therefore replace the intended zero-tool boundary.

## What changed

- Apply Claude Subscription Custom Parameters through a small generation-only SDK option allowlist.
- Keep process, tool, MCP, environment, filesystem, prompt, settings, and session controls provider-owned.
- Preserve supported model, fallback, thinking/effort, budget, beta, and structured-output overrides.
- Add a provider-boundary regression and an Unreleased changelog entry.

## Validation

- [ ] pnpm check passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed CONTRIBUTING.md

### Automated evidence

- pnpm check: passed
- Provider compatibility regression: passed
- Security regression filter: 12 of 12 passed
- Custom-tool isolation: passed
- Professor Mari shell sandbox: passed with macOS Seatbelt
- Runtime integrity: passed
- Capability package lifecycle: passed
- pnpm audit at low threshold: no known vulnerabilities
- Full Node lane: 128 of 139 passed; remaining staging/environment failures include tests that correctly refused the live server writer lease and unrelated stale source assertions.

### Manual verification notes

- Manually verify a Claude Subscription connection generates successfully with benign model-generation Custom Parameters.
- Manually verify imported local-model connections continue receiving their existing Custom Parameters. This patch does not touch OpenAI-compatible local providers.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the docs-i18n branch updated to match, or a docs-i18n follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

CHANGELOG.md is updated. No user documentation or version-bearing files changed.

## UI evidence (if applicable)

No UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened Claude Subscription settings so provider-managed session, filesystem, tool, environment, and process options can’t be overridden by custom parameters.
  * Continued supporting approved model-generation options, including fallback and budget settings.
  * Preserved caller-provided system prompts while restricting unsafe tool, skill, permission, environment, and turn-limit settings.
* **Documentation**
  * Added an Unreleased changelog entry describing the updated customization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->