### PR TITLE
fix: sweep open Engine issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Online character browsing now provides an exact page selector alongside the current page and total (#5361).
 - Character, Persona, Lorebook, and Preset editors now place section navigation in the header, using compact desktop tabs and a mobile dropdown, and Conversation Chat Settings now keeps Commands, Illustrator Settings, and Calls as matching remembered collapsible subsections inside Agents (#5355, #5356, Pasta-Devs/Marinara-Agents#480).
 - Settings → Generation now exposes the Character Reference Sheet prompt template, so character and Persona sheet generation can use a saved global override (#5348).
 - Reusable Game Mode setups now preserve World Maps AI draft size, exact place target, and lore grounding choices, with a clear fallback warning when imported lorebooks are unavailable (#5337).
@@ -19,6 +20,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Long formatted replies now batch their streaming paints on iPhone and iPad browsers, preventing WebKit from freezing while preserving the selected reveal speed (#5365).
+- Roleplay CYOA choices now stay consumed after selection, impersonated choices continue into a character reply, clearing trackers also clears the active prompt, sprites can be fully transparent without covering chat choices, and PNG card exports preserve their sprite sets on Marinara re-import (#5362).
 - Character editors now keep independently saved weekly schedules in sync while other card fields still have unsaved changes.
 - Conversation transcript dates, timestamps, and message numbers now follow Chat Chrome Text Color instead of a legacy fixed color (#5357).
 - Conversation schedules and manual status overrides now apply consistently across all chats for the same character, with per-chat schedule opt-outs still supported (#5358).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Android hardware and gesture back now dismisses the topmost menu, editor, dialog, or overlay before leaving the app, with the same behavior available to browser and installed-PWA back navigation (#5366; thanks @luma-inibitor).
 - Long formatted replies now batch their streaming paints on iPhone and iPad browsers, preventing WebKit from freezing while preserving the selected reveal speed (#5365).
 - Roleplay CYOA choices now stay consumed after selection, impersonated choices continue into a character reply, clearing trackers also clears the active prompt, sprites can be fully transparent without covering chat choices, and PNG card exports preserve their sprite sets on Marinara re-import (#5362).
 - Character editors now keep independently saved weekly schedules in sync while other card fields still have unsaved changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Starting a new Roleplay swipe now immediately hides the previous swipe's generated image, while returning to the original swipe restores its own image (#5286).
 - Merged Narrator replies in Roleplay now hide speaker tags and use the default dialogue color when no participating character has a custom dialogue color (#5282).
 - Professor Mari now asks compatible OpenRouter workspace models for JSON responses and treats an explicit request to split lorebook entries as authorization to create the split-off entries as well as update the originals (#5271).
-- Renamed Roleplay branches now use their branch names in the Chats sidebar, sidebar search, alphabetical sorting, and capability-package chat records instead of falling back to their parent chat names (#5268).
+- Renamed Roleplay branches now keep their branch names in the branch selector and capability-package chat records, while the Chats sidebar, search, and alphabetical sorting use each chat's unambiguous name (#5268, #5364).
 - Jumping to older messages with `/goto` no longer revives stale CYOA choices at the chat tail (#5269).
 - Macro reference guidance now renders the literal `{{macro}}` example, and expanded macro editors and guides stay above Author's Notes, summary, and other floating panels at narrow viewports (#5266, #5267, #5270).
 - The compact music player now stays hidden until Music DJ is installed, and its General Settings switch remains unavailable with a clear explanation until the agent is ready; installing Music DJ unlocks both immediately (#5262).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -10236,12 +10236,12 @@ test("Downloaded cards use Marinara destination and lorebook choices", async ({ 
 test("Chub NSFW search uses filtered totals and spaced pagination", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Chub filter behavior is covered once on desktop.");
 
-  const observedSearches: Array<{ query: string; nsfw: string | null }> = [];
+  const observedSearches: Array<{ query: string; nsfw: string | null; page: string | null }> = [];
   await page.route("**/api/bot-browser/chub/search?*", async (route) => {
     const url = new URL(route.request().url());
     const query = url.searchParams.get("q") ?? "";
     const nsfw = url.searchParams.get("nsfw");
-    observedSearches.push({ query, nsfw });
+    observedSearches.push({ query, nsfw, page: url.searchParams.get("page") });
     const isReportedSearch = query === "Kathrin Vaughan" && nsfw === "true";
     await route.fulfill({
       json: {
@@ -10284,7 +10284,11 @@ test("Chub NSFW search uses filtered totals and spaced pagination", async ({ pag
     .click();
   const library = page.locator('[data-component="BotBrowserView"]');
   await expect(library.getByText("96 cards from ChubAI", { exact: true })).toBeVisible();
-  await expect(library.getByText("Page 1 of 2", { exact: true })).toBeVisible();
+  const pageSelector = library.getByRole("combobox", { name: "Page", exact: true });
+  await expect(pageSelector).toHaveValue("1");
+  await pageSelector.selectOption("2");
+  await expect(pageSelector).toHaveValue("2");
+  await expect.poll(() => observedSearches.some((search) => search.query === "" && search.page === "2")).toBe(true);
 
   await library.getByRole("checkbox", { name: "NSFW", exact: true }).check();
   await library.getByPlaceholder("Search characters").fill("Kathrin Vaughan");
@@ -10293,7 +10297,7 @@ test("Chub NSFW search uses filtered totals and spaced pagination", async ({ pag
   await expect(library.getByText("11 cards from ChubAI", { exact: true })).toBeVisible();
   const card = library.getByRole("button", { name: /Kathrin Vaughan/u });
   await expect(card.getByText("NSFW", { exact: true })).toBeVisible();
-  expect(observedSearches).toContainEqual({ query: "Kathrin Vaughan", nsfw: "true" });
+  expect(observedSearches).toContainEqual({ query: "Kathrin Vaughan", nsfw: "true", page: "1" });
 });
 
 test("Character and Persona sidebars find cards by creator", async ({ page, request }, testInfo) => {

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -15913,7 +15913,7 @@ test("chat mode tabs and new-chat actions stay reachable", async ({ page }) => {
   }
 });
 
-test("renamed Roleplay branches use their display name in the Chats sidebar and search", async ({ page, request }) => {
+test("renamed Roleplay branches keep their chat name in the Chats sidebar and search", async ({ page, request }) => {
   const rawName = `Branch parent fallback ${Date.now()}`;
   const displayName = `NPC_First Kiss ${Date.now()}`;
   const chatResponse = await request.post("/api/chats", {
@@ -15935,11 +15935,11 @@ test("renamed Roleplay branches use their display name in the Chats sidebar and 
     await sidebar.locator('[data-tour="chat-mode-roleplay"]').click();
 
     const chatRow = sidebar.locator(`[data-chat-id="${chat.id}"]`);
-    await expect(chatRow).toContainText(displayName);
-    await expect(chatRow).not.toContainText(rawName);
+    await expect(chatRow).toContainText(rawName);
+    await expect(chatRow).not.toContainText(displayName);
 
     const search = sidebar.getByPlaceholder("Search roleplays");
-    await search.fill("First Kiss");
+    await search.fill("Branch parent fallback");
     await expect(chatRow).toBeVisible();
   } finally {
     const cleanupResponse = await request.delete(`/api/chats/${chat.id}?force=true`);

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -30,6 +30,7 @@ import {
   getDefaultAppAccentColor,
   getDefaultAppBackgroundColor,
   getDefaultChatChromeTextColor,
+  MOBILE_SHELL_MEDIA_QUERY,
   useUIStore,
 } from "./stores/ui.store";
 import { useSidecarStore } from "./stores/sidecar.store";
@@ -50,6 +51,8 @@ import { useStorageMigrationNotice } from "./hooks/use-storage-migration-notice"
 import { useCustomNotificationSoundStatus } from "./hooks/use-custom-notification-sound";
 import { useReducedAmbientEffects } from "./hooks/use-reduced-ambient-effects";
 import { installLongTaskWarner } from "./lib/perf-diagnostics";
+import { getStoreBackLayers } from "./lib/back-layers";
+import { initBackNavigation, syncBackNavigation } from "./lib/back-navigation";
 import { setCustomNotificationSoundUrl } from "./lib/notification-sound";
 
 const VERSION_RECOVERY_KEY = "marinara:pwa-version-recovery";
@@ -525,6 +528,23 @@ export function App() {
   // [#3104 diagnostic] warn on long main-thread tasks (see lib/perf-diagnostics.ts)
   useEffect(() => {
     installLongTaskWarner();
+  }, []);
+
+  // Hardware / gesture back dismisses the topmost overlay instead of exiting.
+  useEffect(() => {
+    initBackNavigation(getStoreBackLayers);
+    // Overlay state is persisted, so the app can boot with panels already open.
+    syncBackNavigation();
+    const unsubscribeUI = useUIStore.subscribe(syncBackNavigation);
+    const unsubscribeDialog = useDialogStore.subscribe(syncBackNavigation);
+    // Whether a shell panel counts as an overlay depends on the viewport.
+    const shellQuery = window.matchMedia(MOBILE_SHELL_MEDIA_QUERY);
+    shellQuery.addEventListener("change", syncBackNavigation);
+    return () => {
+      unsubscribeUI();
+      unsubscribeDialog();
+      shellQuery.removeEventListener("change", syncBackNavigation);
+    };
   }, []);
 
   useEffect(() => {

--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -2773,14 +2773,28 @@ export function BotBrowserView() {
                       >
                         {localizeUi("ui.botBrowser.botbrowserview.previous")}
                       </button>
-                      <span className="text-xs text-[var(--muted-foreground)]">
-                        {localizeUi("ui.botBrowser.botbrowserview.page")} {page}
-                        {totalPages > 1 && totalPages < 9000 ? (
-                          <> {localizeUi("ui.botBrowser.botbrowserview.ofValue1", { value1: totalPages })}</>
-                        ) : (
-                          ""
-                        )}
-                      </span>
+                      {totalPages > 1 && totalPages < 9000 ? (
+                        <label className="flex items-center gap-1 text-xs text-[var(--muted-foreground)]">
+                          {localizeUi("ui.botBrowser.botbrowserview.page")}
+                          <select
+                            aria-label={localizeUi("ui.botBrowser.botbrowserview.page")}
+                            value={page}
+                            onChange={(event) => setPage(Number(event.target.value))}
+                            className="mari-chrome-field mari-chrome-field--compact px-2 py-1 text-xs"
+                          >
+                            {Array.from({ length: totalPages }, (_, index) => index + 1).map((pageNumber) => (
+                              <option key={pageNumber} value={pageNumber}>
+                                {pageNumber}
+                              </option>
+                            ))}
+                          </select>
+                          {localizeUi("ui.botBrowser.botbrowserview.ofValue1", { value1: totalPages })}
+                        </label>
+                      ) : (
+                        <span className="text-xs text-[var(--muted-foreground)]">
+                          {localizeUi("ui.botBrowser.botbrowserview.page")} {page}
+                        </span>
+                      )}
                       <button
                         disabled={page >= totalPages && totalPages > 1}
                         onClick={() => setPage((p) => p + 1)}

--- a/packages/client/src/components/chat/CyoaChoices.tsx
+++ b/packages/client/src/components/chat/CyoaChoices.tsx
@@ -152,13 +152,19 @@ export function CyoaChoices({ messages }: Props) {
   const handleChoice = useCallback(
     async (text: string) => {
       if (!activeChatId || isStreaming || isEditing) return;
+      if (persistedChoiceState?.messageId) {
+        await updateMessageExtra.mutateAsync({
+          messageId: persistedChoiceState.messageId,
+          extra: { cyoaChoices: [] },
+        });
+      }
       clearChoicesForActiveChat();
       const queuedSpatialTransition =
         pendingSpatialTransition?.status === "ready" ? pendingSpatialTransition.transition : null;
       if (impersonateCyoaChoices) {
         const { impersonatePresetId, impersonateConnectionId, impersonateBlockAgents, impersonatePromptTemplate } =
           useUIStore.getState();
-        await generate(
+        const impersonated = await generate(
           buildCyoaChoiceSubmissionPayload({
             chatId: activeChatId,
             text,
@@ -171,6 +177,9 @@ export function CyoaChoices({ messages }: Props) {
             },
           }),
         );
+        if (impersonated) {
+          await generate({ chatId: activeChatId, connectionId: null });
+        }
         return;
       }
 
@@ -188,8 +197,10 @@ export function CyoaChoices({ messages }: Props) {
       isEditing,
       pendingSpatialTransition,
       impersonateCyoaChoices,
+      persistedChoiceState?.messageId,
       clearChoicesForActiveChat,
       generate,
+      updateMessageExtra,
     ],
   );
 

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -28,6 +28,7 @@ import { WorldClockIcon, WorldThermometerIcon } from "../ui/WorldStateInstrument
 import { useGameStateStore } from "../../stores/game-state.store";
 import { useAgentStore, EMPTY_AGENT_TYPES, EMPTY_AGENT_FAILURES } from "../../stores/agent.store";
 import { useAgentConfigs, useCustomAgentRuns, type AgentConfigRow } from "../../hooks/use-agents";
+import { useUpdateMessageExtra } from "../../hooks/use-chats";
 import { discardPendingGameStatePatch, useGameStatePatcher } from "../../hooks/use-game-state-patcher";
 import { useUIStore } from "../../stores/ui.store";
 import { useReducedAmbientEffects } from "../../hooks/use-reduced-ambient-effects";
@@ -149,6 +150,7 @@ export function RoleplayHUD({
   const dismissThoughtBubble = useAgentStore((s) => s.dismissThoughtBubble);
   const clearThoughtBubbles = useAgentStore((s) => s.clearThoughtBubbles);
   const resetAgentStore = useAgentStore((s) => s.reset);
+  const updateMessageExtra = useUpdateMessageExtra(chatId);
   const trackerPanelEnabled = useUIStore((s) => s.trackerPanelEnabled);
   const trackerPanelOpen = useUIStore((s) => s.trackerPanelOpen);
   const trackerPanelHideHudWidgets = useUIStore((s) => s.trackerPanelHideHudWidgets);
@@ -220,8 +222,14 @@ export function RoleplayHUD({
     api.patch(`/chats/${chatId}/game-state`, { ...cleared, manual: true, clearOverrides: true }).catch(() => {});
     // Clear committed agent runs & memory from DB + reset client state
     api.delete(`/agents/runs/${chatId}`).catch(() => {});
+    const latestAssistantMessage = [...(injectionSourceMessages ?? [])]
+      .reverse()
+      .find((message) => message.role === "assistant");
+    if (latestAssistantMessage) {
+      updateMessageExtra.mutate({ messageId: latestAssistantMessage.id, extra: { cyoaChoices: [] } });
+    }
     resetAgentStore();
-  }, [chatId, setGameState, resetAgentStore]);
+  }, [chatId, injectionSourceMessages, resetAgentStore, setGameState, updateMessageExtra]);
   const stopAgents = useCallback(
     () => api.post("/generate/abort", { chatId, agentsOnly: true }).then(() => undefined),
     [chatId],

--- a/packages/client/src/components/chat/SpriteOverlay.tsx
+++ b/packages/client/src/components/chat/SpriteOverlay.tsx
@@ -317,7 +317,7 @@ export function SpriteOverlay({
 
   if (visibleSpriteEntries.length === 0) return null;
 
-  const stageZIndexClass = editing ? "z-[35]" : fullBodyOnly ? "z-[5]" : "z-[5] md:z-[15]";
+  const stageZIndexClass = editing ? "z-[35]" : "z-[5]";
   return (
     <div ref={stageRef} className={`pointer-events-none absolute inset-0 overflow-hidden ${stageZIndexClass}`}>
       {visibleSpriteEntries.map((entry) => (

--- a/packages/client/src/components/chat/sprite-display-modes.ts
+++ b/packages/client/src/components/chat/sprite-display-modes.ts
@@ -7,9 +7,9 @@ export const SPRITE_DISPLAY_SCALE_MIN = 0.05;
 export const SPRITE_DISPLAY_SCALE_MAX = 2;
 export const SPRITE_DISPLAY_SCALE_PERCENT_MIN = 5;
 export const SPRITE_DISPLAY_SCALE_PERCENT_MAX = 200;
-export const SPRITE_DISPLAY_OPACITY_MIN = 0.15;
+export const SPRITE_DISPLAY_OPACITY_MIN = 0;
 export const SPRITE_DISPLAY_OPACITY_MAX = 1;
-export const SPRITE_DISPLAY_OPACITY_PERCENT_MIN = 15;
+export const SPRITE_DISPLAY_OPACITY_PERCENT_MIN = 0;
 export const SPRITE_DISPLAY_OPACITY_PERCENT_MAX = 100;
 
 export function normalizeSpriteDisplayModes(value: unknown): SpriteDisplayMode[] {

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -63,7 +63,7 @@ import {
 import { resolveLiveConversationStatus } from "../../lib/conversation-presence-status";
 import { Modal } from "../ui/Modal";
 import { Reorder, useDragControls } from "framer-motion";
-import { getChatDisplayName, parseChatMetadata } from "../../lib/chat-display";
+import { parseChatMetadata } from "../../lib/chat-display";
 import {
   compareChatsByActivityDesc,
   compareChatsByCreatedAtAsc,
@@ -395,7 +395,7 @@ export function ChatSidebar() {
         .filter(Boolean);
 
       return (
-        includesTextForMatch(toSearchText(getChatDisplayName(chat)), query) ||
+        includesTextForMatch(toSearchText(chat.name), query) ||
         tags.some((tag) => includesTextForMatch(tag, query)) ||
         characterNames.some((name) => includesTextForMatch(name, query))
       );
@@ -421,9 +421,9 @@ export function ChatSidebar() {
         case "oldest":
           return compareChatsByCreatedAtAsc(a, b);
         case "name-asc":
-          return toSearchText(getChatDisplayName(a)).localeCompare(toSearchText(getChatDisplayName(b)));
+          return toSearchText(a.name).localeCompare(toSearchText(b.name));
         case "name-desc":
-          return toSearchText(getChatDisplayName(b)).localeCompare(toSearchText(getChatDisplayName(a)));
+          return toSearchText(b.name).localeCompare(toSearchText(a.name));
         case "newest":
           return compareChatsByCreatedAtDesc(a, b);
         case "recent":
@@ -896,7 +896,7 @@ export function ChatSidebar() {
   // ── Chat row renderer (shared between unfiled + folder sections) ──
   const renderChatRow = ({ chat, branchCount }: (typeof displayChats)[number]) => {
     const cfg = MODE_CONFIG[chat.mode] ?? MODE_CONFIG.conversation;
-    const displayName = getChatDisplayName(chat);
+    const displayName = chat.name;
     const isActive = activeChatId === chat.id || (chat.groupId != null && chat.groupId === activeGroupId);
     const isSelected = selectedChatIds.has(chat.id);
     const charIds = normalizeChatCharacterIds((chat as { characterIds?: unknown }).characterIds);

--- a/packages/client/src/components/ui/Modal.tsx
+++ b/packages/client/src/components/ui/Modal.tsx
@@ -14,6 +14,7 @@ import {
 } from "./neutral-surface-styles";
 import { useDialogFocusScope } from "../../hooks/use-dialog-focus-scope";
 import { useBackdropDismiss } from "../../hooks/use-backdrop-dismiss";
+import { useBackDismiss } from "../../hooks/use-back-dismiss";
 import { useLocalizedUiText } from "../../localization/use-localized-ui-text";
 import { useTranslation as useUiTranslation } from "react-i18next";
 
@@ -72,6 +73,12 @@ export function Modal({
   const enterRafRef = useRef<number | null>(null);
   const backdropDismiss = useBackdropDismiss(onClose, closeDisabled);
   useDialogFocusScope(open && mounted, panelRef, initialFocusRef, restoreFocusRef, focusScopePortalSelector);
+  // Hardware / gesture back closes the topmost modal. While closing is disabled
+  // the press is absorbed rather than ignored, matching Escape: an in-flight
+  // operation must not be interrupted by backgrounding the app.
+  useBackDismiss(open, () => {
+    if (!closeDisabled) onClose();
+  });
 
   useEffect(() => {
     if (enterRafRef.current !== null) {

--- a/packages/client/src/hooks/use-back-dismiss.ts
+++ b/packages/client/src/hooks/use-back-dismiss.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from "react";
+import { registerBackLayer } from "../lib/back-navigation";
+
+/**
+ * Makes a mounted overlay dismissable with the hardware / gesture back button.
+ *
+ * Registrations are a LIFO stack, so the most recently opened overlay is the
+ * one a back press closes. `onDismiss` is read through a ref, so an inline
+ * arrow function will not churn the registration.
+ */
+export function useBackDismiss(active: boolean, onDismiss: () => void) {
+  const dismissRef = useRef(onDismiss);
+
+  useEffect(() => {
+    dismissRef.current = onDismiss;
+  });
+
+  useEffect(() => {
+    if (!active) return;
+    return registerBackLayer(() => dismissRef.current());
+  }, [active]);
+}

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -24,6 +24,7 @@ import {
   getRoleplayTypewriterRevealCharsPerSecond,
   getStreamingCharsPerSecond,
   getTypewriterFrameBudget,
+  getTypewriterPaintIntervalMs,
   isGenerationStartBlocked,
   reconcileTypewriterReplacement,
   shouldKeepStreamLiveThroughPostProcessing,
@@ -1479,6 +1480,11 @@ export function useGenerate() {
       // Values 1–99 are literal visible characters per second; 100 is instant.
       const reducedMotionMedia =
         typeof window.matchMedia === "function" ? window.matchMedia("(prefers-reduced-motion: reduce)") : null;
+      const typewriterPaintIntervalMs = getTypewriterPaintIntervalMs(
+        navigator.userAgent,
+        navigator.platform,
+        navigator.maxTouchPoints,
+      );
       const getCharsPerSecond = () => {
         const speed = useUIStore.getState().streamingSpeed;
         return getStreamingCharsPerSecond(
@@ -1562,6 +1568,14 @@ export function useGenerate() {
             return;
           }
           typewriterStarted = true;
+          if (
+            lastTypewriterPaintAt > 0 &&
+            typewriterPaintIntervalMs > 0 &&
+            now - lastTypewriterPaintAt < typewriterPaintIntervalMs
+          ) {
+            rafId = requestAnimationFrame(tick);
+            return;
+          }
           if (!lastTypewriterPaintAt) lastTypewriterPaintAt = now;
           const elapsedMs = Math.min(TYPEWRITER_MAX_FRAME_MS, Math.max(0, now - lastTypewriterPaintAt));
           lastTypewriterPaintAt = now;
@@ -1584,7 +1598,12 @@ export function useGenerate() {
             return;
           }
 
-          const frameBudget = getTypewriterFrameBudget(charsPerSecond, elapsedMs, typewriterRemainder);
+          const frameBudget = getTypewriterFrameBudget(
+            charsPerSecond,
+            elapsedMs,
+            typewriterRemainder,
+            typewriterPaintIntervalMs,
+          );
           typewriterRemainder = frameBudget.accruedCharacters;
           const n = Math.min(Math.floor(typewriterRemainder), frameBudget.maxCharacters, pendingText.length);
           if (n < 1) {

--- a/packages/client/src/lib/back-layers.ts
+++ b/packages/client/src/lib/back-layers.ts
@@ -1,0 +1,93 @@
+// ──────────────────────────────────────────────
+// Derives the back-dismissable layer stack from store state.
+//
+// Read-only over `ui.store` / `dialog.store`; no overlay component has to know
+// this file exists. Ordered outermost → innermost — `back-navigation.ts` closes
+// the last entry.
+// ──────────────────────────────────────────────
+import { MOBILE_SHELL_MEDIA_QUERY, useUIStore } from "../stores/ui.store";
+import { useDialogStore } from "../stores/dialog.store";
+import { dismissActiveDialog, showConfirmDialog } from "./app-dialogs";
+import { translate } from "../localization/i18n";
+import type { BackLayer } from "./back-navigation";
+
+/**
+ * The shell docks the sidebar / right panel / tracker panel on a desktop-sized
+ * viewport and floats them over the content below it (`AppShell.tsx`'s
+ * `shellOverlayMode`). Only the floating form is something back should dismiss:
+ * a docked panel is layout, not an overlay, and treating it as one would leave
+ * a desktop browser permanently unable to navigate away.
+ */
+let shellQuery: MediaQueryList | null = null;
+
+function isShellOverlayMode() {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+  // Held once: this is re-read on every store update, and re-parsing the query
+  // string each time would be needless work on a hot path.
+  shellQuery ??= window.matchMedia(MOBILE_SHELL_MEDIA_QUERY);
+  return shellQuery.matches;
+}
+
+let detailCloseInFlight = false;
+
+/**
+ * Closes the open detail editor the same way the sidebar does — including the
+ * unsaved-changes confirm, so back can never discard an edit silently.
+ */
+async function requestCloseDetails() {
+  if (detailCloseInFlight) return;
+  const ui = useUIStore.getState();
+  if (!ui.hasAnyDetailOpen()) return;
+
+  if (ui.editorDirty) {
+    detailCloseInFlight = true;
+    try {
+      const discard = await showConfirmDialog({
+        title: translate("ui.layout.chatsidebar.unsavedChanges"),
+        message: translate("ui.layout.chatsidebar.youHaveUnsavedChangesDiscardAndContinue"),
+        confirmLabel: translate("ui.agents.agenteditor.discard"),
+        tone: "destructive",
+      });
+      if (!discard) return;
+    } finally {
+      detailCloseInFlight = false;
+    }
+  }
+
+  const current = useUIStore.getState();
+  // A regex editor opened from a character's scoped-regex manager has a real
+  // one-step return path; `closeRegexDetail` walks it back to that character.
+  if (current.regexDetailId && current.regexDetailReturn) current.closeRegexDetail();
+  else current.closeAllDetails();
+}
+
+export function getStoreBackLayers(): BackLayer[] {
+  const ui = useUIStore.getState();
+  const dialog = useDialogStore.getState();
+  const layers: BackLayer[] = [];
+
+  if (isShellOverlayMode()) {
+    if (ui.sidebarOpen) layers.push({ id: "sidebar", close: () => useUIStore.getState().setSidebarOpen(false) });
+    if (ui.rightPanelOpen) layers.push({ id: "right-panel", close: () => useUIStore.getState().closeRightPanel() });
+    if (ui.trackerPanelOpen)
+      layers.push({ id: "tracker-panel", close: () => useUIStore.getState().setTrackerPanelOpen(false) });
+  }
+
+  if (ui.hasAnyDetailOpen())
+    layers.push({
+      id: "detail",
+      close: () => {
+        void requestCloseDetails();
+      },
+    });
+
+  // Store-driven modals also register themselves through `Modal`; the two
+  // handful that render their own shell are only reachable via this entry.
+  if (ui.modal) layers.push({ id: "modal", close: () => useUIStore.getState().closeModal() });
+
+  // Dismissing must go through `app-dialogs`, not `closeDialog()` — the store
+  // holds no resolver, so closing it directly would hang the awaiting caller.
+  if (dialog.dialog) layers.push({ id: "dialog", close: dismissActiveDialog });
+
+  return layers;
+}

--- a/packages/client/src/lib/back-navigation.ts
+++ b/packages/client/src/lib/back-navigation.ts
@@ -1,0 +1,125 @@
+// ──────────────────────────────────────────────
+// Hardware / gesture back → dismiss the topmost overlay
+//
+// The app has no URL router, so nothing ever creates a history entry and the
+// Android WebView's `canGoBack()` is permanently false: every back press falls
+// through to backgrounding the app, even with a panel or editor open.
+//
+// This module keeps at most ONE sentinel history entry alive while any
+// dismissable layer is on screen. A back press pops the sentinel, we close the
+// topmost layer, and re-arm if something is still open. Because it is plain
+// history, browser back, installed-PWA back and mouse-button-4 all get the same
+// behaviour without an APK change.
+// ──────────────────────────────────────────────
+
+export type BackLayer = {
+  /** Diagnostic label; not used for matching. */
+  id: string;
+  close: () => void;
+};
+
+/** Layers derived from store state (see `back-layers.ts`), outermost first. */
+let resolveStoreLayers: () => BackLayer[] = () => [];
+
+/** Layers registered by mounted components, in mount order (LIFO on pop). */
+const registeredLayers: BackLayer[] = [];
+
+let initialized = false;
+let sentinelActive = false;
+/**
+ * Pops we asked for ourselves, awaiting their `popstate`. `history.back()` is
+ * asynchronous, so without this the resulting event would look like a user
+ * press and close a second layer.
+ */
+let pendingSelfPops = 0;
+let registrationSeq = 0;
+
+/** The full stack, outermost → innermost. The last entry is what back closes. */
+export function getBackLayerStack(): BackLayer[] {
+  return [...resolveStoreLayers(), ...registeredLayers];
+}
+
+function armSentinel() {
+  if (sentinelActive) return;
+  sentinelActive = true;
+  window.history.pushState({ marinaraOverlay: true }, "");
+}
+
+function disarmSentinel() {
+  if (!sentinelActive) return;
+  sentinelActive = false;
+  pendingSelfPops += 1;
+  // Consume our own entry so it cannot leak into the back stack.
+  window.history.back();
+}
+
+/** Arm or disarm to match the current stack. Idempotent — safe to over-call. */
+export function syncBackNavigation() {
+  if (!initialized) return;
+  if (getBackLayerStack().length > 0) armSentinel();
+  else disarmSentinel();
+}
+
+function handlePopState() {
+  if (pendingSelfPops > 0) {
+    // Our own cleanup pop; whatever it closed is already closed.
+    pendingSelfPops -= 1;
+    return;
+  }
+  if (!sentinelActive) return; // Not ours — let the WebView/browser handle it.
+  sentinelActive = false;
+
+  const top = getBackLayerStack().at(-1);
+  if (!top) return;
+
+  try {
+    top.close();
+  } catch (error) {
+    console.error("[back-navigation] layer close failed", error);
+  }
+
+  // React-owned layers unregister on effect cleanup, a tick later, so the stack
+  // can still look non-empty here. That only re-arms early; the follow-up sync
+  // from the unregister disarms again.
+  if (getBackLayerStack().length > 0) armSentinel();
+}
+
+export function initBackNavigation(getLayers: () => BackLayer[]) {
+  if (typeof window === "undefined") return;
+  resolveStoreLayers = getLayers;
+  if (initialized) return;
+  initialized = true;
+  window.addEventListener("popstate", handlePopState);
+}
+
+/**
+ * Registers a component-owned layer. Returns the unregister function.
+ * Later registrations sit on top, so the most recently opened overlay is the
+ * one back closes.
+ */
+export function registerBackLayer(close: () => void): () => void {
+  registrationSeq += 1;
+  const layer: BackLayer = { id: `registered-${registrationSeq}`, close };
+  registeredLayers.push(layer);
+  syncBackNavigation();
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    const index = registeredLayers.indexOf(layer);
+    if (index >= 0) registeredLayers.splice(index, 1);
+    syncBackNavigation();
+  };
+}
+
+/** Test seam: drop all state so a regression can drive the module repeatedly. */
+export function __resetBackNavigationForTests() {
+  registeredLayers.length = 0;
+  resolveStoreLayers = () => [];
+  initialized = false;
+  sentinelActive = false;
+  pendingSelfPops = 0;
+  registrationSeq = 0;
+  if (typeof window !== "undefined") window.removeEventListener("popstate", handlePopState);
+}

--- a/packages/client/src/lib/back-navigation.ts
+++ b/packages/client/src/lib/back-navigation.ts
@@ -40,7 +40,9 @@ export function getBackLayerStack(): BackLayer[] {
 }
 
 function armSentinel() {
-  if (sentinelActive) return;
+  // A cleanup back() cannot be cancelled once requested. Wait for its
+  // popstate instead of pushing an entry that the in-flight back would eat.
+  if (sentinelActive || pendingSelfPops > 0) return;
   sentinelActive = true;
   window.history.pushState({ marinaraOverlay: true }, "");
 }
@@ -64,6 +66,7 @@ function handlePopState() {
   if (pendingSelfPops > 0) {
     // Our own cleanup pop; whatever it closed is already closed.
     pendingSelfPops -= 1;
+    if (pendingSelfPops === 0 && getBackLayerStack().length > 0) armSentinel();
     return;
   }
   if (!sentinelActive) return; // Not ours — let the WebView/browser handle it.

--- a/packages/client/src/lib/generation-stream-policy.ts
+++ b/packages/client/src/lib/generation-stream-policy.ts
@@ -47,6 +47,13 @@ const ROLEPLAY_SLOWDOWN_RESPONSE_MS = 120;
 const ROLEPLAY_SPEEDUP_RESPONSE_MS = 480;
 const TYPEWRITER_TARGET_FRAME_MS = 1000 / 60;
 const TYPEWRITER_MAX_CATCH_UP_FRAMES = 2;
+const IOS_TYPEWRITER_TARGET_FRAME_MS = 1000 / 20;
+
+/** iOS browsers all use WebKit, where repainting growing Markdown at 60 FPS can freeze long streams. */
+export function getTypewriterPaintIntervalMs(userAgent: string, platform: string, maxTouchPoints: number): number {
+  const isIosWebKit = /iP(?:ad|hone|od)/iu.test(userAgent) || (platform === "MacIntel" && maxTouchPoints > 1);
+  return isIosWebKit ? IOS_TYPEWRITER_TARGET_FRAME_MS : 0;
+}
 
 /** Keep send actions guarded while leaving the draft field itself editable. */
 export function isGenerationSendBlocked(input: GenerationSendBlockInput): boolean {
@@ -96,13 +103,17 @@ export function getTypewriterFrameBudget(
   charsPerSecond: number,
   elapsedMs: number,
   carriedRemainder: number,
+  paintIntervalMs = TYPEWRITER_TARGET_FRAME_MS,
 ): TypewriterFrameBudget {
   const newlyAccruedCharacters = (charsPerSecond * Math.max(0, elapsedMs)) / 1000;
   return {
     accruedCharacters: carriedRemainder + newlyAccruedCharacters,
     maxCharacters: Math.max(
       1,
-      Math.ceil((charsPerSecond * TYPEWRITER_TARGET_FRAME_MS * TYPEWRITER_MAX_CATCH_UP_FRAMES) / 1000),
+      Math.ceil(
+        (charsPerSecond * Math.max(TYPEWRITER_TARGET_FRAME_MS, paintIntervalMs) * TYPEWRITER_MAX_CATCH_UP_FRAMES) /
+          1000,
+      ),
     ),
   };
 }

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -19,6 +19,7 @@ import {
   PROFESSOR_MARI_ID,
   CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS,
   findImageStyleProfile,
+  MAX_FILE_SIZES,
 } from "@marinara-engine/shared";
 import type { CharacterData, ConversationCallCharacterVideoClipKind, ExportEnvelope } from "@marinara-engine/shared";
 import { createCharactersStorage, type PersonaStorageRow } from "../services/storage/characters.storage.js";
@@ -55,7 +56,7 @@ import {
   uploadConversationCallCharacterVideoClip,
 } from "../services/conversation/call-character-videos.service.js";
 import { removeSavedVideoFromDisk } from "../services/video/video-generation.js";
-import { writeFile, mkdir, readFile, readdir, unlink } from "fs/promises";
+import { writeFile, mkdir, readFile, readdir, stat, unlink } from "fs/promises";
 import { join } from "path";
 import { DATA_DIR } from "../utils/data-dir.js";
 import { createWriteStream, existsSync, rmSync, unlinkSync } from "fs";
@@ -70,7 +71,7 @@ import { logger, logDebugOverride } from "../lib/logger.js";
 import { isDebugAgentsEnabled } from "../config/runtime-config.js";
 import { parseLibraryPageQuery } from "../utils/list-pagination.js";
 import { importSTLorebook } from "../services/import/st-lorebook.importer.js";
-import { embeddedSpriteSizesAreWithinLimits } from "../services/import/marinara.importer.js";
+import { embeddedSpriteSizesAreWithinLimits, MAX_EMBEDDED_SPRITE_COUNT } from "../services/import/marinara.importer.js";
 import {
   clearEmbeddedLorebookFromCharacter,
   embedLorebookIntoCharacter,
@@ -587,7 +588,15 @@ async function copyGalleryImageToAvatar(
 // Read every sprite file in data/sprites/<id>/ and return it as
 // { filename, data } so import can restore the same expression set under a
 // new id.
-async function readSpritesForId(id: string): Promise<Array<{ filename: string; data: string }>> {
+async function readSpritesForId(id: string): Promise<Array<{ filename: string; data: string }>>;
+async function readSpritesForId(
+  id: string,
+  enforcePortableLimits: true,
+): Promise<Array<{ filename: string; data: string }> | null>;
+async function readSpritesForId(
+  id: string,
+  enforcePortableLimits = false,
+): Promise<Array<{ filename: string; data: string }> | null> {
   const dir = join(DATA_DIR, "sprites", id);
   if (!existsSync(dir)) return [];
   let entries: string[];
@@ -597,9 +606,30 @@ async function readSpritesForId(id: string): Promise<Array<{ filename: string; d
     return [];
   }
   const sprites: Array<{ filename: string; data: string }> = [];
+  const byteLengths: number[] = [];
+  let totalBytes = 0;
   for (const entry of entries) {
+    if (enforcePortableLimits) {
+      try {
+        const fileSize = (await stat(assertInsideDir(dir, join(dir, entry)))).size;
+        if (fileSize > MAX_FILE_SIZES.SPRITE || totalBytes + fileSize > MAX_FILE_SIZES.CHARACTER_CARD) {
+          return null;
+        }
+      } catch {
+        continue;
+      }
+    }
     const dataUrl = await readImageAsDataUrl(dir, entry);
-    if (dataUrl) sprites.push({ filename: entry, data: dataUrl });
+    if (dataUrl) {
+      if (enforcePortableLimits) {
+        if (sprites.length >= MAX_EMBEDDED_SPRITE_COUNT) return null;
+        const byteLength = Buffer.byteLength(dataUrl.slice(dataUrl.indexOf(",") + 1), "base64");
+        if (!embeddedSpriteSizesAreWithinLimits([...byteLengths, byteLength])) return null;
+        byteLengths.push(byteLength);
+        totalBytes += byteLength;
+      }
+      sprites.push({ filename: entry, data: dataUrl });
+    }
   }
   return sprites;
 }
@@ -689,12 +719,6 @@ export function buildCompatibleCharacterExport(data: any, sprites: Array<{ filen
     spec_version: "2.0",
     data: { ...data, extensions },
   };
-}
-
-export function compatibleSpriteExportIsWithinLimits(sprites: ReadonlyArray<{ data: string }>): boolean {
-  return embeddedSpriteSizesAreWithinLimits(
-    sprites.map(({ data }) => Buffer.byteLength(data.slice(data.indexOf(",") + 1), "base64")),
-  );
 }
 
 async function buildNativePersonaEnvelope(
@@ -1936,8 +1960,8 @@ export async function charactersRoutes(app: FastifyInstance) {
     if (!char) return reply.status(404).send({ error: "Character not found" });
 
     const charData = JSON.parse(char.data);
-    const sprites = await readSpritesForId(char.id);
-    if (!compatibleSpriteExportIsWithinLimits(sprites)) {
+    const sprites = await readSpritesForId(char.id, true);
+    if (!sprites) {
       return reply.status(413).send({ error: "Sprite collection exceeds compatible PNG export limits" });
     }
     const v2Envelope = buildCompatibleCharacterExport(charData, sprites);

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -70,6 +70,7 @@ import { logger, logDebugOverride } from "../lib/logger.js";
 import { isDebugAgentsEnabled } from "../config/runtime-config.js";
 import { parseLibraryPageQuery } from "../utils/list-pagination.js";
 import { importSTLorebook } from "../services/import/st-lorebook.importer.js";
+import { embeddedSpriteSizesAreWithinLimits } from "../services/import/marinara.importer.js";
 import {
   clearEmbeddedLorebookFromCharacter,
   embedLorebookIntoCharacter,
@@ -688,6 +689,12 @@ export function buildCompatibleCharacterExport(data: any, sprites: Array<{ filen
     spec_version: "2.0",
     data: { ...data, extensions },
   };
+}
+
+export function compatibleSpriteExportIsWithinLimits(sprites: ReadonlyArray<{ data: string }>): boolean {
+  return embeddedSpriteSizesAreWithinLimits(
+    sprites.map(({ data }) => Buffer.byteLength(data.slice(data.indexOf(",") + 1), "base64")),
+  );
 }
 
 async function buildNativePersonaEnvelope(
@@ -1929,7 +1936,11 @@ export async function charactersRoutes(app: FastifyInstance) {
     if (!char) return reply.status(404).send({ error: "Character not found" });
 
     const charData = JSON.parse(char.data);
-    const v2Envelope = buildCompatibleCharacterExport(charData, await readSpritesForId(char.id));
+    const sprites = await readSpritesForId(char.id);
+    if (!compatibleSpriteExportIsWithinLimits(sprites)) {
+      return reply.status(413).send({ error: "Sprite collection exceeds compatible PNG export limits" });
+    }
+    const v2Envelope = buildCompatibleCharacterExport(charData, sprites);
     const charaBase64 = Buffer.from(JSON.stringify(v2Envelope), "utf-8").toString("base64");
 
     // Read avatar image or create a minimal 1x1 transparent PNG fallback

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -673,10 +673,16 @@ async function buildNativeCharacterEnvelope(
   } satisfies ExportEnvelope;
 }
 
-function buildCompatibleCharacterExport(data: any) {
+export function buildCompatibleCharacterExport(data: any, sprites: Array<{ filename: string; data: string }> = []) {
   const extensions = parseCharacterDataRecord(data?.extensions);
   delete extensions.characterSheetImageId;
   extensions.useCharacterSheetAsReference = false;
+  if (sprites.length > 0) {
+    extensions.marinara = {
+      ...parseCharacterDataRecord(extensions.marinara),
+      sprites,
+    };
+  }
   return {
     spec: "chara_card_v2",
     spec_version: "2.0",
@@ -1923,7 +1929,7 @@ export async function charactersRoutes(app: FastifyInstance) {
     if (!char) return reply.status(404).send({ error: "Character not found" });
 
     const charData = JSON.parse(char.data);
-    const v2Envelope = buildCompatibleCharacterExport(charData);
+    const v2Envelope = buildCompatibleCharacterExport(charData, await readSpritesForId(char.id));
     const charaBase64 = Buffer.from(JSON.stringify(v2Envelope), "utf-8").toString("base64");
 
     // Read avatar image or create a minimal 1x1 transparent PNG fallback

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -674,7 +674,7 @@ async function buildNativeCharacterEnvelope(
 }
 
 export function buildCompatibleCharacterExport(data: any, sprites: Array<{ filename: string; data: string }> = []) {
-  const extensions = parseCharacterDataRecord(data?.extensions);
+  const extensions = { ...parseCharacterDataRecord(data?.extensions) };
   delete extensions.characterSheetImageId;
   extensions.useCharacterSheetAsReference = false;
   if (sprites.length > 0) {

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -16,6 +16,7 @@ import {
   normalizeTrackerCardColorConfig,
   personaCreateInputSchema,
   lorebookFilterModeSchema,
+  MAX_FILE_SIZES,
 } from "@marinara-engine/shared";
 import type {
   CharacterData,
@@ -97,6 +98,20 @@ interface SavedAvatar {
   filePath: string;
 }
 
+export const MAX_EMBEDDED_SPRITE_COUNT = 256;
+const MAX_EMBEDDED_SPRITE_DATA_CHARS = Math.ceil(MAX_FILE_SIZES.SPRITE / 3) * 4 + 128;
+
+export function embeddedSpriteSizesAreWithinLimits(byteLengths: readonly number[]): boolean {
+  if (byteLengths.length > MAX_EMBEDDED_SPRITE_COUNT) return false;
+  let totalBytes = 0;
+  for (const byteLength of byteLengths) {
+    if (!Number.isSafeInteger(byteLength) || byteLength < 0 || byteLength > MAX_FILE_SIZES.SPRITE) return false;
+    totalBytes += byteLength;
+    if (totalBytes > MAX_FILE_SIZES.CHARACTER_CARD) return false;
+  }
+  return true;
+}
+
 // Decode an `avatar` data URL carried in a native export, validate it as a
 // real image, and write it under data/avatars/. The filesystem path lets a
 // caller remove the file if attaching it to the imported row fails.
@@ -141,24 +156,50 @@ export async function restoreSprites(sprites: unknown, id: string): Promise<void
     return;
   }
   if (sprites.length === 0) return;
-  const dir = join(DATA_DIR, "sprites", id);
-  await mkdir(dir, { recursive: true });
-  // Track names we've already written this batch so two exported sprites
-  // whose stems sanitize to the same string (e.g. "happy!" and "happy?" both
-  // collapsing to "happy_") don't silently overwrite each other.
-  const usedNames = new Set<string>();
+  if (sprites.length > MAX_EMBEDDED_SPRITE_COUNT) {
+    logger.warn("Skipped %d embedded sprites for %s; limit is %d", sprites.length, id, MAX_EMBEDDED_SPRITE_COUNT);
+    return;
+  }
+  const prepared: Array<{
+    index: number;
+    rawName: string;
+    decoded: NonNullable<ReturnType<typeof decodeImageDataUrl>>;
+  }> = [];
+  const preparedByteLengths: number[] = [];
   for (const [index, sprite] of sprites.entries()) {
     if (!sprite || typeof sprite !== "object") {
       logger.warn("Skipped invalid sprite entry %d for %s", index, id);
       continue;
     }
     const entry = sprite as Record<string, unknown>;
+    if (typeof entry.data === "string" && entry.data.length > MAX_EMBEDDED_SPRITE_DATA_CHARS) {
+      logger.warn("Skipped oversized embedded sprite collection for %s", id);
+      return;
+    }
     const decoded = decodeImageDataUrl(entry.data);
     if (!decoded) {
       logger.warn("Skipped sprite %d with invalid image data for %s", index, id);
       continue;
     }
-    const rawName = typeof entry.filename === "string" ? entry.filename : "";
+    preparedByteLengths.push(decoded.buffer.length);
+    if (!embeddedSpriteSizesAreWithinLimits(preparedByteLengths)) {
+      logger.warn("Skipped embedded sprites exceeding import byte limits for %s", id);
+      return;
+    }
+    prepared.push({
+      index,
+      rawName: typeof entry.filename === "string" ? entry.filename : "",
+      decoded,
+    });
+  }
+  if (prepared.length === 0) return;
+  const dir = join(DATA_DIR, "sprites", id);
+  await mkdir(dir, { recursive: true });
+  // Track names we've already written this batch so two exported sprites
+  // whose stems sanitize to the same string (e.g. "happy!" and "happy?" both
+  // collapsing to "happy_") don't silently overwrite each other.
+  const usedNames = new Set<string>();
+  for (const { decoded, index, rawName } of prepared) {
     const stem =
       rawName
         .replace(/\\/g, "/")

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -134,7 +134,7 @@ function readLorebookScope(value: unknown): { mode: "all" | "disabled" | "specif
 // by writing each one under data/sprites/<id>/. Filenames are sanitized to
 // just an expression stem + an extension matching the actual image bytes, so
 // a malicious export can't traverse out of the sprites dir.
-async function restoreSprites(sprites: unknown, id: string): Promise<void> {
+export async function restoreSprites(sprites: unknown, id: string): Promise<void> {
   if (sprites === undefined || sprites === null) return;
   if (!Array.isArray(sprites)) {
     logger.warn("Skipped invalid sprite collection for %s", id);

--- a/packages/server/src/services/import/st-character.importer.ts
+++ b/packages/server/src/services/import/st-character.importer.ts
@@ -24,9 +24,22 @@ import { DATA_DIR } from "../../utils/data-dir.js";
 import { isAllowedImageBuffer } from "../../utils/security.js";
 import AdmZip from "adm-zip";
 import { normalizeTimestampOverrides, type TimestampOverrides } from "./import-timestamps.js";
+import { restoreSprites } from "./marinara.importer.js";
 
 const AVATAR_DIR = join(DATA_DIR, "avatars");
 const IMPORT_METADATA_KEY = "importMetadata";
+
+/** Remove Marinara sprite binaries from card metadata before the normalized card is stored. */
+export function takeEmbeddedMarinaraSprites(raw: Record<string, unknown>): unknown {
+  const cardData = raw.data && typeof raw.data === "object" ? (raw.data as Record<string, unknown>) : raw;
+  if (!cardData.extensions || typeof cardData.extensions !== "object") return undefined;
+  const extensions = cardData.extensions as Record<string, unknown>;
+  if (!extensions.marinara || typeof extensions.marinara !== "object") return undefined;
+  const marinara = extensions.marinara as Record<string, unknown>;
+  const sprites = marinara.sprites;
+  delete marinara.sprites;
+  return sprites;
+}
 
 function ensureAvatarDir() {
   if (!existsSync(AVATAR_DIR)) {
@@ -188,6 +201,7 @@ export async function importSTCharacter(raw: Record<string, unknown>, db: DB, op
   const normalizedTimestamps = normalizeTimestampOverrides(options?.timestampOverrides);
   const shouldImportEmbeddedLorebook = options?.importEmbeddedLorebook ?? true;
   const tagImportMode = options?.tagImportMode ?? "all";
+  const embeddedMarinaraSprites = takeEmbeddedMarinaraSprites(raw);
 
   // Extract avatar data URL if present (from PNG import)
   const avatarDataUrl = raw._avatarDataUrl as string | null;
@@ -345,6 +359,14 @@ export async function importSTCharacter(raw: Record<string, unknown>, db: DB, op
         }
       }
       if (created > 0) logger.info("Imported %d embedded regex script(s) for character %s", created, charId);
+    }
+  }
+
+  if (charId && embeddedMarinaraSprites !== undefined) {
+    try {
+      await restoreSprites(embeddedMarinaraSprites, charId);
+    } catch (err) {
+      logger.warn(err, "Skipped optional embedded sprite restore for %s", charId);
     }
   }
 

--- a/scripts/regressions/agent-runtime.regression.ts
+++ b/scripts/regressions/agent-runtime.regression.ts
@@ -119,6 +119,7 @@ const EXPECTED_AGENT_RESULT_TYPE_VALUES = [
   "game_map_update",
   "game_state_transition",
   "prompt_patch",
+  "character_activity_update",
   "frontend_theme_update",
   "about_me_update",
 ] as const;

--- a/scripts/regressions/back-navigation.regression.ts
+++ b/scripts/regressions/back-navigation.regression.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+
+// The back-navigation sentinel is what makes the Android hardware/gesture back
+// button dismiss an overlay instead of backgrounding the app. Its whole job is
+// bookkeeping — keep exactly one history entry alive while something is open,
+// and never mistake our own cleanup pop for a user press. These checks pin that
+// bookkeeping; the failure modes it guards against (double-pop, stack leak) are
+// invisible in a browser until the back stack is already wrong.
+
+type Listener = () => void;
+
+class FakeHistory {
+  depth = 0;
+  pushes = 0;
+  private queue: Array<() => void> = [];
+  private listeners = new Set<Listener>();
+
+  pushState() {
+    this.depth += 1;
+    this.pushes += 1;
+  }
+
+  /** `history.back()` is asynchronous — the popstate lands on a later task. */
+  back() {
+    this.queue.push(() => {
+      if (this.depth > 0) this.depth -= 1;
+      for (const listener of [...this.listeners]) listener();
+    });
+  }
+
+  addListener(listener: Listener) {
+    this.listeners.add(listener);
+  }
+
+  removeListener(listener: Listener) {
+    this.listeners.delete(listener);
+  }
+
+  listenerCount() {
+    return this.listeners.size;
+  }
+
+  /** Deliver every queued pop, including any queued while draining. */
+  flush() {
+    let guard = 0;
+    while (this.queue.length) {
+      assert.ok((guard += 1) < 50, "history queue never drained");
+      const task = this.queue.shift()!;
+      task();
+    }
+  }
+
+  /** A user pressing back: pop and notify, synchronously. */
+  userBack() {
+    if (this.depth > 0) this.depth -= 1;
+    for (const listener of [...this.listeners]) listener();
+    this.flush();
+  }
+}
+
+let history = new FakeHistory();
+
+const fakeWindow = {
+  history: {
+    pushState: (...args: unknown[]) => history.pushState(),
+    back: () => history.back(),
+  },
+  addEventListener: (type: string, listener: Listener) => {
+    if (type === "popstate") history.addListener(listener);
+  },
+  removeEventListener: (type: string, listener: Listener) => {
+    if (type === "popstate") history.removeListener(listener);
+  },
+};
+
+(globalThis as Record<string, unknown>).window = fakeWindow;
+
+const { initBackNavigation, syncBackNavigation, registerBackLayer, getBackLayerStack, __resetBackNavigationForTests } =
+  await import("../../packages/client/src/lib/back-navigation.js");
+
+type Layer = { id: string; close: () => void };
+
+let storeLayers: Layer[] = [];
+
+function reset() {
+  __resetBackNavigationForTests();
+  history = new FakeHistory();
+  storeLayers = [];
+  initBackNavigation(() => storeLayers);
+}
+
+/** Opens a store-derived layer that removes itself when closed. */
+function openLayer(id: string, onClose?: () => void): { closed: number } {
+  const record = { closed: 0 };
+  storeLayers.push({
+    id,
+    close: () => {
+      record.closed += 1;
+      storeLayers = storeLayers.filter((layer) => layer.id !== id);
+      onClose?.();
+      syncBackNavigation();
+    },
+  });
+  syncBackNavigation();
+  return record;
+}
+
+// ── 1. Nothing open: back is not ours ──
+reset();
+syncBackNavigation();
+assert.equal(history.pushes, 0, "arming with an empty stack");
+assert.equal(history.depth, 0);
+history.userBack();
+assert.equal(history.depth, 0, "a press with nothing open must fall through");
+
+// ── 2. One layer arms exactly one entry, and only one ──
+reset();
+openLayer("sidebar");
+assert.equal(history.pushes, 1);
+syncBackNavigation();
+syncBackNavigation();
+assert.equal(history.pushes, 1, "sync is idempotent");
+assert.equal(history.depth, 1);
+
+// ── 3. Back closes the layer and does not re-arm ──
+const sidebar = openLayer("second"); // stack: sidebar, second
+history.userBack();
+assert.equal(sidebar.closed, 1, "topmost layer closed");
+assert.equal(getBackLayerStack().length, 1, "only the topmost closes");
+// ── 4. …and re-arms while something is still open ──
+assert.equal(history.depth, 1, "sentinel re-armed for the remaining layer");
+
+// ── 5. Closing through the UI consumes the sentinel without closing a layer ──
+reset();
+const viaUi = openLayer("panel");
+assert.equal(history.depth, 1);
+storeLayers = [];
+syncBackNavigation(); // the UI closed it; disarm
+history.flush(); // deliver the self-pop
+assert.equal(viaUi.closed, 0, "self-pop must not close a layer (selfPop guard)");
+assert.equal(history.depth, 0, "sentinel consumed, not leaked");
+
+// ── 6. Repeated open/close cycles do not grow the stack ──
+reset();
+for (let cycle = 0; cycle < 5; cycle += 1) {
+  openLayer(`cycle-${cycle}`);
+  assert.equal(history.depth, 1, "at most one sentinel is ever alive");
+  storeLayers = [];
+  syncBackNavigation();
+  history.flush();
+  assert.equal(history.depth, 0, `cycle ${cycle} leaked a history entry`);
+}
+
+// ── 7. A press while disarmed is ignored ──
+reset();
+const ignored = openLayer("ghost");
+storeLayers = []; // layer vanished without a sync
+history.userBack();
+assert.equal(ignored.closed, 0);
+
+// ── 8. Two layers closing in one update disarms exactly once ──
+reset();
+openLayer("a");
+openLayer("b");
+assert.equal(history.depth, 1);
+storeLayers = [];
+syncBackNavigation();
+history.flush();
+assert.equal(history.depth, 0, "disarmed exactly once for a multi-layer close");
+
+// ── 9. Double init registers one listener ──
+reset();
+initBackNavigation(() => storeLayers);
+initBackNavigation(() => storeLayers);
+assert.equal(history.listenerCount(), 1, "duplicate popstate listeners");
+
+// ── 10. A throwing close leaves the sentinel usable ──
+reset();
+storeLayers.push({
+  id: "explodes",
+  close: () => {
+    throw new Error("boom");
+  },
+});
+syncBackNavigation();
+const realConsoleError = console.error;
+console.error = () => {}; // the throw below is deliberate; keep the lane output clean
+history.userBack();
+console.error = realConsoleError;
+const recovered = openLayer("after-throw");
+history.userBack();
+assert.equal(recovered.closed, 1, "back still works after a close() threw");
+
+// ── 11. Registered component layers sit on top of store layers ──
+reset();
+const store = openLayer("store-layer");
+let registeredClosed = 0;
+const unregister = registerBackLayer(() => {
+  registeredClosed += 1;
+});
+assert.deepEqual(
+  getBackLayerStack().map((layer) => layer.id.replace(/-\d+$/, "")),
+  ["store-layer", "registered"],
+  "registered layers are innermost",
+);
+history.userBack();
+assert.equal(registeredClosed, 1, "back closed the registered layer");
+assert.equal(store.closed, 0, "the store layer underneath is untouched");
+unregister();
+history.flush();
+
+// ── 12. Unregistering the last layer consumes the sentinel ──
+reset();
+const release = registerBackLayer(() => {});
+assert.equal(history.depth, 1);
+release();
+release(); // idempotent
+history.flush();
+assert.equal(history.depth, 0);
+
+console.log("back-navigation regression checks passed");

--- a/scripts/regressions/back-navigation.regression.ts
+++ b/scripts/regressions/back-navigation.regression.ts
@@ -218,4 +218,16 @@ release(); // idempotent
 history.flush();
 assert.equal(history.depth, 0);
 
+// ── 13. A follow-up layer opened before a cleanup pop re-arms afterward ──
+reset();
+openLayer("first-modal");
+storeLayers = [];
+syncBackNavigation(); // queue the cleanup pop
+const followUp = openLayer("follow-up-modal");
+assert.equal(history.pushes, 1, "an in-flight cleanup must not consume a newly pushed sentinel");
+history.flush();
+assert.equal(history.depth, 1, "the follow-up layer is armed after cleanup finishes");
+history.userBack();
+assert.equal(followUp.closed, 1, "back closes the follow-up layer instead of exiting");
+
 console.log("back-navigation regression checks passed");

--- a/scripts/regressions/experience-generation.regression.ts
+++ b/scripts/regressions/experience-generation.regression.ts
@@ -268,16 +268,29 @@ try {
 
   console.log("experience-generation regression passed");
 } finally {
-  try {
-    for (const chatId of createdChatIds) await chats.remove(chatId).catch(() => undefined);
+  let cleanupFailed = false;
+  let firstCleanupError: unknown;
+  const runCleanup = async (cleanup: () => Promise<unknown>) => {
     try {
-      if (createdConnectionId) await connections.remove(createdConnectionId);
-    } finally {
-      if (previousMainFallbackId) await connections.update(previousMainFallbackId, { fallbackForMain: true });
+      await cleanup();
+    } catch (error) {
+      if (!cleanupFailed) firstCleanupError = error;
+      cleanupFailed = true;
     }
-  } finally {
-    await app.close();
-    await new Promise<void>((resolve) => mockProvider.close(() => resolve()));
-    await closeDB();
+  };
+
+  for (const chatId of createdChatIds) await runCleanup(() => chats.remove(chatId));
+  if (createdConnectionId) await runCleanup(() => connections.remove(createdConnectionId));
+  if (previousMainFallbackId) {
+    await runCleanup(() => connections.update(previousMainFallbackId, { fallbackForMain: true }));
   }
+  await runCleanup(() => app.close());
+  await runCleanup(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        mockProvider.close((error) => (error ? reject(error) : resolve()));
+      }),
+  );
+  await runCleanup(closeDB);
+  if (cleanupFailed) throw firstCleanupError;
 }

--- a/scripts/regressions/experience-generation.regression.ts
+++ b/scripts/regressions/experience-generation.regression.ts
@@ -103,6 +103,8 @@ async function createExperienceChat(name: string, mode = "game", stamp = true) {
   return chat;
 }
 
+let scenarioFailed = false;
+let scenarioError: unknown;
 try {
   previousMainFallbackId = (await connections.getFallbackForMain())?.id ?? null;
   const conn = await connections.create({
@@ -265,32 +267,45 @@ try {
       await limited.close();
     }
   }
-
-  console.log("experience-generation regression passed");
-} finally {
-  let cleanupFailed = false;
-  let firstCleanupError: unknown;
-  const runCleanup = async (cleanup: () => Promise<unknown>) => {
-    try {
-      await cleanup();
-    } catch (error) {
-      if (!cleanupFailed) firstCleanupError = error;
-      cleanupFailed = true;
-    }
-  };
-
-  for (const chatId of createdChatIds) await runCleanup(() => chats.remove(chatId));
-  if (createdConnectionId) await runCleanup(() => connections.remove(createdConnectionId));
-  if (previousMainFallbackId) {
-    await runCleanup(() => connections.update(previousMainFallbackId, { fallbackForMain: true }));
-  }
-  await runCleanup(() => app.close());
-  await runCleanup(
-    () =>
-      new Promise<void>((resolve, reject) => {
-        mockProvider.close((error) => (error ? reject(error) : resolve()));
-      }),
-  );
-  await runCleanup(closeDB);
-  if (cleanupFailed) throw firstCleanupError;
+} catch (error) {
+  scenarioFailed = true;
+  scenarioError = error;
 }
+
+let cleanupFailed = false;
+let firstCleanupError: unknown;
+const runCleanup = async (cleanup: () => Promise<unknown>) => {
+  try {
+    await cleanup();
+  } catch (error) {
+    if (!cleanupFailed) firstCleanupError = error;
+    cleanupFailed = true;
+  }
+};
+
+for (const chatId of createdChatIds) await runCleanup(() => chats.remove(chatId));
+if (createdConnectionId) await runCleanup(() => connections.remove(createdConnectionId));
+if (previousMainFallbackId) {
+  await runCleanup(() => connections.update(previousMainFallbackId, { fallbackForMain: true }));
+}
+await runCleanup(() => app.close());
+await runCleanup(
+  () =>
+    new Promise<void>((resolve, reject) => {
+      mockProvider.close((error) => (error ? reject(error) : resolve()));
+    }),
+);
+await runCleanup(closeDB);
+
+if (scenarioFailed) {
+  if (cleanupFailed) {
+    throw new AggregateError(
+      [scenarioError, firstCleanupError],
+      "Experience-generation regression and cleanup both failed",
+      { cause: scenarioError },
+    );
+  }
+  throw scenarioError;
+}
+if (cleanupFailed) throw firstCleanupError;
+console.log("experience-generation regression passed");

--- a/scripts/regressions/experience-generation.regression.ts
+++ b/scripts/regressions/experience-generation.regression.ts
@@ -29,6 +29,7 @@ const chats = createChatsStorage(db);
 const connections = createConnectionsStorage(db);
 const createdChatIds: string[] = [];
 let createdConnectionId: string | null = null;
+let previousMainFallbackId: string | null = null;
 
 // ── Mock OpenAI-compatible provider ──────────────────────────────────────────
 type Scenario = "happy" | "repair" | "truncated" | "garbage" | "empty-then-stream" | "slow-happy";
@@ -55,7 +56,8 @@ const mockProvider = createServer(async (request, response) => {
     );
   };
   if (scenario === "happy") return respond(VALID_BRIEF);
-  if (scenario === "repair") return attempt === 1 ? respond("Sure! Here is your world, in prose.") : respond(VALID_BRIEF);
+  if (scenario === "repair")
+    return attempt === 1 ? respond("Sure! Here is your world, in prose.") : respond(VALID_BRIEF);
   if (scenario === "truncated") return respond('{"version":1,"theme":"sci-fi', "length");
   if (scenario === "empty-then-stream") {
     // Buffered path: empty content stamped finish_reason "length" — the exact
@@ -102,12 +104,16 @@ async function createExperienceChat(name: string, mode = "game", stamp = true) {
 }
 
 try {
+  previousMainFallbackId = (await connections.getFallbackForMain())?.id ?? null;
   const conn = await connections.create({
     name: "experience-generation mock",
     provider: "custom",
     baseUrl: mockBaseUrl,
     apiKey: "test",
     model: "mock-model",
+    // Keep the route's fallback wrapper from escaping this fixture into a
+    // developer's configured fallback when the empty-response case runs.
+    fallbackForMain: true,
   } as Parameters<typeof connections.create>[0]);
   createdConnectionId = conn.id;
 
@@ -264,6 +270,9 @@ try {
 } finally {
   for (const chatId of createdChatIds) await chats.remove(chatId).catch(() => undefined);
   if (createdConnectionId) await connections.remove(createdConnectionId).catch(() => undefined);
+  if (previousMainFallbackId) {
+    await connections.update(previousMainFallbackId, { fallbackForMain: true }).catch(() => undefined);
+  }
   await app.close();
   await new Promise<void>((resolve) => mockProvider.close(() => resolve()));
   await closeDB();

--- a/scripts/regressions/experience-generation.regression.ts
+++ b/scripts/regressions/experience-generation.regression.ts
@@ -268,12 +268,16 @@ try {
 
   console.log("experience-generation regression passed");
 } finally {
-  for (const chatId of createdChatIds) await chats.remove(chatId).catch(() => undefined);
-  if (createdConnectionId) await connections.remove(createdConnectionId).catch(() => undefined);
-  if (previousMainFallbackId) {
-    await connections.update(previousMainFallbackId, { fallbackForMain: true }).catch(() => undefined);
+  try {
+    for (const chatId of createdChatIds) await chats.remove(chatId).catch(() => undefined);
+    try {
+      if (createdConnectionId) await connections.remove(createdConnectionId);
+    } finally {
+      if (previousMainFallbackId) await connections.update(previousMainFallbackId, { fallbackForMain: true });
+    }
+  } finally {
+    await app.close();
+    await new Promise<void>((resolve) => mockProvider.close(() => resolve()));
+    await closeDB();
   }
-  await app.close();
-  await new Promise<void>((resolve) => mockProvider.close(() => resolve()));
-  await closeDB();
 }

--- a/scripts/regressions/manual-agent-retry-resolution.regression.ts
+++ b/scripts/regressions/manual-agent-retry-resolution.regression.ts
@@ -118,7 +118,7 @@ assert.match(retryToolWiringSource, /!spotifyToolNames\.has\(toolName\)/);
 assert.match(retryToolWiringSource, /gameSpotifyMusicEnabled:\s*activeMusicPlayerSource !== null/);
 assert.match(
   retryToolWiringSource,
-  /emitMetadataPatch:\s*\(patch\)\s*=>\s*sendSseEvent\(reply,\s*\{\s*type:\s*"metadata_patch",\s*data:\s*patch\s*\}\)/,
+  /emitMetadataPatch:\s*\(patch\)\s*=>\s*\{[\s\S]{0,120}assertRetrySetupActive\(\);[\s\S]{0,120}sendSseEvent\(reply,\s*\{\s*type:\s*"metadata_patch",\s*data:\s*patch\s*\}\);[\s\S]{0,40}\}/,
 );
 assert.match(retryToolWiringSource, /observeSpotifyPlaybackBeforePlay:\s*true/);
 

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -33,7 +33,11 @@ import {
   CUSTOM_AGENT_RESULT_TYPE_IDS,
 } from "../../packages/client/src/lib/custom-agent-result-examples.js";
 import { estimateGameSessionHistoryTokens } from "../../packages/client/src/lib/game-session-history.js";
-import { validateCharacterGalleryReferences } from "../../packages/server/src/routes/characters.routes.js";
+import {
+  buildCompatibleCharacterExport,
+  validateCharacterGalleryReferences,
+} from "../../packages/server/src/routes/characters.routes.js";
+import { takeEmbeddedMarinaraSprites } from "../../packages/server/src/services/import/st-character.importer.js";
 import {
   orderConversationRespondersByDelay,
   remainingConversationPresenceDelay,
@@ -219,8 +223,13 @@ import {
   mergeLorebookKeeperUpdateContent,
   persistLorebookKeeperUpdates,
   readLorebookKeeperUpdateOrder,
+  resolveLorebookKeeperTarget,
   tryClaimCustomLorebookReadBehindRun,
 } from "../../packages/server/src/routes/generate/lorebook-keeper-utils.js";
+import {
+  SPRITE_DISPLAY_OPACITY_MIN,
+  SPRITE_DISPLAY_OPACITY_PERCENT_MIN,
+} from "../../packages/client/src/components/chat/sprite-display-modes.js";
 import { runImageGenerationRequest } from "../../packages/server/src/services/image/image-generation-queue.js";
 import {
   buildSwarmUiGenerationBody,
@@ -480,6 +489,48 @@ assert.equal(replacedCharacterCard.extensions.nameColor, "#123456", "Local displ
 const characterRoutesSource = readFileSync(
   join(REPOSITORY_ROOT, "packages/server/src/routes/characters.routes.ts"),
   "utf8",
+);
+const stCharacterImporterSource = readFileSync(
+  join(REPOSITORY_ROOT, "packages/server/src/services/import/st-character.importer.ts"),
+  "utf8",
+);
+const portableSprites = [
+  { filename: "happy.png", data: "data:image/png;base64,iVBORw0KGgo=" },
+  { filename: "full_idle.webp", data: "data:image/webp;base64,UklGRg==" },
+];
+const compatibleSpriteCard = buildCompatibleCharacterExport(
+  { name: "Portable Sprite Card", extensions: { marinara: { retained: true } } },
+  portableSprites,
+);
+assert.deepEqual(
+  (compatibleSpriteCard.data.extensions.marinara as Record<string, unknown>).sprites,
+  portableSprites,
+  "compatible PNG metadata must carry the character sprite set",
+);
+const importedSpriteCard = structuredClone(compatibleSpriteCard) as unknown as Record<string, unknown>;
+assert.deepEqual(
+  takeEmbeddedMarinaraSprites(importedSpriteCard),
+  portableSprites,
+  "Marinara must recover its embedded sprite set from a compatible PNG card",
+);
+const importedSpriteExtensions = (importedSpriteCard.data as Record<string, unknown>).extensions as Record<
+  string,
+  unknown
+>;
+assert.equal(
+  Object.hasOwn(importedSpriteExtensions.marinara as Record<string, unknown>, "sprites"),
+  false,
+  "embedded sprite binaries must be removed before character metadata is stored",
+);
+assert.match(
+  characterRoutesSource,
+  /buildCompatibleCharacterExport\(charData, await readSpritesForId\(char\.id\)\)/u,
+  "PNG export must load sprites into the compatible card envelope",
+);
+assert.match(
+  stCharacterImporterSource,
+  /await restoreSprites\(embeddedMarinaraSprites, charId\)/u,
+  "PNG import must restore embedded sprites under the newly imported character ID",
 );
 const ownedGalleryUpdate = {
   extensions: { characterSheetImageId: "owned-image", useCharacterSheetAsReference: true },
@@ -4067,11 +4118,14 @@ assert.equal(orLogicLorebookEntry.selectiveLogic, "or");
 
   const routedEntries: Array<Record<string, unknown>> = [];
   const createdBooks: Array<Record<string, unknown>> = [];
+  const routedBooks: Array<Record<string, unknown>> = [{ id: "book-world", name: "My World — World Lore" }];
   const routedStore = {
-    list: async () => [{ id: "book-world", name: "My World — World Lore" }],
+    list: async () => routedBooks,
     create: async (input: Record<string, unknown>) => {
       createdBooks.push(input);
-      return { id: "book-scene", ...input };
+      const created = { id: "book-scene", ...input };
+      routedBooks.push(created);
+      return created;
     },
     listEntries: async () => [],
     createEntry: async (input: Record<string, unknown>) => {
@@ -4102,6 +4156,17 @@ assert.equal(orLogicLorebookEntry.selectiveLogic, "or");
   );
   assert.equal(createdBooks[0]?.name, "Campaign — Scene Log", "a missing configured alias creates its named book");
   assert.equal(createdBooks[0]?.chatId, "chat-439", "auto-created routing books link to the active chat");
+  const nextRunTarget = await resolveLorebookKeeperTarget({
+    lorebooksStore: routedStore as any,
+    chatId: "chat-439",
+    characterIds: [],
+    activeLorebookIds: [],
+    preferredTargetLorebookId: "book-world",
+  });
+  assert.ok(
+    nextRunTarget.writableLorebookIds.includes("book-scene"),
+    "a routing book created for one run must remain writable on the next run instead of being duplicated",
+  );
 }
 
 assert.equal(
@@ -5132,6 +5197,18 @@ const roleplayHudSource = readFileSync(
   new URL("../../packages/client/src/components/chat/RoleplayHUD.tsx", import.meta.url),
   "utf8",
 );
+const cyoaChoicesSource = readFileSync(
+  new URL("../../packages/client/src/components/chat/CyoaChoices.tsx", import.meta.url),
+  "utf8",
+);
+const spriteOverlaySource = readFileSync(
+  new URL("../../packages/client/src/components/chat/SpriteOverlay.tsx", import.meta.url),
+  "utf8",
+);
+const spritesRoutesSource = readFileSync(
+  new URL("../../packages/server/src/routes/sprites.routes.ts", import.meta.url),
+  "utf8",
+);
 const narratorUiStoreSource = readFileSync(
   new URL("../../packages/client/src/stores/ui.store.ts", import.meta.url),
   "utf8",
@@ -5219,6 +5296,33 @@ assert.equal(
   roleplayHudSource.match(/!reduceAmbientEffects && "animate-\[inventory-cycle_0\.4s_ease-out\]"/gu)?.length,
   2,
   "Roleplay tracker and inventory widgets must suppress mount animations with reduced ambient effects",
+);
+assert.match(
+  roleplayHudSource,
+  /latestAssistantMessage[\s\S]{0,240}extra: \{ cyoaChoices: \[\] \}/u,
+  "clearing Roleplay tracker state must also clear the persisted active CYOA prompt",
+);
+assert.match(
+  cyoaChoicesSource,
+  /extra: \{ cyoaChoices: \[\] \}[\s\S]{0,900}if \(impersonated\)[\s\S]{0,160}connectionId: null/u,
+  "selecting a CYOA prompt must consume it permanently and follow impersonation with a character reply",
+);
+assert.match(
+  spriteOverlaySource,
+  /const stageZIndexClass = editing \? "z-\[35\]" : "z-\[5\]"/u,
+  "non-editing sprites must remain below the Roleplay transcript and its CYOA controls",
+);
+assert.equal(SPRITE_DISPLAY_OPACITY_MIN, 0, "sprite opacity must support a fully transparent endpoint");
+assert.equal(SPRITE_DISPLAY_OPACITY_PERCENT_MIN, 0, "sprite opacity controls must expose zero percent");
+assert.match(
+  assignedSweepChatAreaSource,
+  /savedUrl \?\? \(chat\.mode === "roleplay" \? useUIStore\.getState\(\)\.defaultRoleplayBackground : null\)/u,
+  "new Roleplay chats must inherit the explicitly selected default background",
+);
+assert.match(
+  spritesRoutesSource,
+  /const backupDir = join\(dir, "\.cleanup-backups", backupId\)[\s\S]{0,1800}copyFile\(inputPath, join\(backupDir, filename\)\)[\s\S]{0,500}writeFile\(outputPath, output\.buffer\)/u,
+  "sprite cleanup must keep the original outside the active sprite set while the cleaned file becomes active",
 );
 assert.match(
   chatMessageSource,
@@ -8588,7 +8692,7 @@ assert.equal(({} as { tags?: string[] }).tags, undefined, "Background metadata m
   );
   assert.match(
     connectionEditorSource,
-    /setRemoteModels\(\[\]\);\s*setRemoteLoras\(\[\]\);\s*setFetchError\(null\);/u,
+    /setRemoteModels\(\[\]\);[\s\S]{0,120}setRemoteLoras\(\[\]\);[\s\S]{0,120}setFetchError\(null\);/u,
     "Changing media providers must clear stale remote LoRA choices",
   );
   assert.match(

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -36,6 +36,7 @@ import { estimateGameSessionHistoryTokens } from "../../packages/client/src/lib/
 import { MAX_FILE_SIZES } from "../../packages/shared/src/constants/defaults.js";
 import {
   buildCompatibleCharacterExport,
+  compatibleSpriteExportIsWithinLimits,
   validateCharacterGalleryReferences,
 } from "../../packages/server/src/routes/characters.routes.js";
 import {
@@ -540,7 +541,7 @@ assert.equal(
 );
 assert.match(
   characterRoutesSource,
-  /buildCompatibleCharacterExport\(charData, await readSpritesForId\(char\.id\)\)/u,
+  /if \(!compatibleSpriteExportIsWithinLimits\(sprites\)\)[\s\S]*buildCompatibleCharacterExport\(charData, sprites\)/u,
   "PNG export must load sprites into the compatible card envelope",
 );
 assert.match(
@@ -550,8 +551,23 @@ assert.match(
 );
 assert.equal(embeddedSpriteSizesAreWithinLimits([MAX_FILE_SIZES.SPRITE]), true);
 assert.equal(embeddedSpriteSizesAreWithinLimits([MAX_FILE_SIZES.SPRITE + 1]), false);
-assert.equal(embeddedSpriteSizesAreWithinLimits([MAX_FILE_SIZES.CHARACTER_CARD, 1]), false);
+assert.equal(
+  embeddedSpriteSizesAreWithinLimits(Array(4).fill(MAX_FILE_SIZES.SPRITE)),
+  false,
+  "aggregate sprite bytes must be limited independently of the per-sprite ceiling",
+);
 assert.equal(embeddedSpriteSizesAreWithinLimits(Array(MAX_EMBEDDED_SPRITE_COUNT + 1).fill(0)), false);
+const portableExportSprite = { data: `data:image/png;base64,${Buffer.alloc(16).toString("base64")}` };
+assert.equal(
+  compatibleSpriteExportIsWithinLimits([portableExportSprite]),
+  true,
+  "compatible PNG export accepts sprite sets that its importer can restore",
+);
+assert.equal(
+  compatibleSpriteExportIsWithinLimits(Array(MAX_EMBEDDED_SPRITE_COUNT + 1).fill(portableExportSprite)),
+  false,
+  "compatible PNG export rejects sprite sets that its importer would skip",
+);
 const ownedGalleryUpdate = {
   extensions: { characterSheetImageId: "owned-image", useCharacterSheetAsReference: true },
 };

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -36,7 +36,6 @@ import { estimateGameSessionHistoryTokens } from "../../packages/client/src/lib/
 import { MAX_FILE_SIZES } from "../../packages/shared/src/constants/defaults.js";
 import {
   buildCompatibleCharacterExport,
-  compatibleSpriteExportIsWithinLimits,
   validateCharacterGalleryReferences,
 } from "../../packages/server/src/routes/characters.routes.js";
 import {
@@ -541,8 +540,13 @@ assert.equal(
 );
 assert.match(
   characterRoutesSource,
-  /if \(!compatibleSpriteExportIsWithinLimits\(sprites\)\)[\s\S]*buildCompatibleCharacterExport\(charData, sprites\)/u,
-  "PNG export must load sprites into the compatible card envelope",
+  /const sprites = await readSpritesForId\(char\.id, true\);[\s\S]*if \(!sprites\)[\s\S]*status\(413\)[\s\S]*buildCompatibleCharacterExport\(charData, sprites\)/u,
+  "PNG export must reject sprite collections that cannot round-trip before building the card envelope",
+);
+assert.match(
+  characterRoutesSource,
+  /if \(enforcePortableLimits\)[\s\S]*await stat[\s\S]*embeddedSpriteSizesAreWithinLimits[\s\S]*return null;[\s\S]*readImageAsDataUrl/u,
+  "compatible PNG export must stop reading sprites as soon as a portable size limit is exceeded",
 );
 assert.match(
   stCharacterImporterSource,
@@ -557,17 +561,6 @@ assert.equal(
   "aggregate sprite bytes must be limited independently of the per-sprite ceiling",
 );
 assert.equal(embeddedSpriteSizesAreWithinLimits(Array(MAX_EMBEDDED_SPRITE_COUNT + 1).fill(0)), false);
-const portableExportSprite = { data: `data:image/png;base64,${Buffer.alloc(16).toString("base64")}` };
-assert.equal(
-  compatibleSpriteExportIsWithinLimits([portableExportSprite]),
-  true,
-  "compatible PNG export accepts sprite sets that its importer can restore",
-);
-assert.equal(
-  compatibleSpriteExportIsWithinLimits(Array(MAX_EMBEDDED_SPRITE_COUNT + 1).fill(portableExportSprite)),
-  false,
-  "compatible PNG export rejects sprite sets that its importer would skip",
-);
 const ownedGalleryUpdate = {
   extensions: { characterSheetImageId: "owned-image", useCharacterSheetAsReference: true },
 };

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -33,10 +33,15 @@ import {
   CUSTOM_AGENT_RESULT_TYPE_IDS,
 } from "../../packages/client/src/lib/custom-agent-result-examples.js";
 import { estimateGameSessionHistoryTokens } from "../../packages/client/src/lib/game-session-history.js";
+import { MAX_FILE_SIZES } from "../../packages/shared/src/constants/defaults.js";
 import {
   buildCompatibleCharacterExport,
   validateCharacterGalleryReferences,
 } from "../../packages/server/src/routes/characters.routes.js";
+import {
+  embeddedSpriteSizesAreWithinLimits,
+  MAX_EMBEDDED_SPRITE_COUNT,
+} from "../../packages/server/src/services/import/marinara.importer.js";
 import { takeEmbeddedMarinaraSprites } from "../../packages/server/src/services/import/st-character.importer.js";
 import {
   orderConversationRespondersByDelay,
@@ -498,10 +503,21 @@ const portableSprites = [
   { filename: "happy.png", data: "data:image/png;base64,iVBORw0KGgo=" },
   { filename: "full_idle.webp", data: "data:image/webp;base64,UklGRg==" },
 ];
-const compatibleSpriteCard = buildCompatibleCharacterExport(
-  { name: "Portable Sprite Card", extensions: { marinara: { retained: true } } },
-  portableSprites,
+const compatibleSpriteSource = {
+  name: "Portable Sprite Card",
+  extensions: {
+    characterSheetImageId: "local-gallery-id",
+    useCharacterSheetAsReference: true,
+    marinara: { retained: true },
+  },
+};
+const compatibleSpriteCard = buildCompatibleCharacterExport(compatibleSpriteSource, portableSprites);
+assert.equal(
+  compatibleSpriteSource.extensions.characterSheetImageId,
+  "local-gallery-id",
+  "compatible export must not mutate local-only source extensions",
 );
+assert.equal(compatibleSpriteSource.extensions.useCharacterSheetAsReference, true);
 assert.deepEqual(
   (compatibleSpriteCard.data.extensions.marinara as Record<string, unknown>).sprites,
   portableSprites,
@@ -532,6 +548,10 @@ assert.match(
   /await restoreSprites\(embeddedMarinaraSprites, charId\)/u,
   "PNG import must restore embedded sprites under the newly imported character ID",
 );
+assert.equal(embeddedSpriteSizesAreWithinLimits([MAX_FILE_SIZES.SPRITE]), true);
+assert.equal(embeddedSpriteSizesAreWithinLimits([MAX_FILE_SIZES.SPRITE + 1]), false);
+assert.equal(embeddedSpriteSizesAreWithinLimits([MAX_FILE_SIZES.CHARACTER_CARD, 1]), false);
+assert.equal(embeddedSpriteSizesAreWithinLimits(Array(MAX_EMBEDDED_SPRITE_COUNT + 1).fill(0)), false);
 const ownedGalleryUpdate = {
   extensions: { characterSheetImageId: "owned-image", useCharacterSheetAsReference: true },
 };

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -10681,8 +10681,10 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       });
       const result = await executeAgent(config as any, context, provider as any, "regression-model");
       const system = calls[0]?.[0]?.content ?? "";
-      assert.match(system, /Persona: Mari\nCurrent state:/u);
-      assert.match(system, /"self": \{/u);
+      const user = calls[0]?.[1]?.content ?? "";
+      assert.equal(system, "Return a physical-state delta as JSON.");
+      assert.match(user, /Persona: Mari\nCurrent state:/u);
+      assert.match(user, /"self":\{/u);
       assert.equal(callOptions[0]?.temperature, 0);
       assert.equal(result.success, true);
       assert.deepEqual(result.data, previousState);
@@ -10703,7 +10705,9 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         firstRun.provider as any,
         "regression-model",
       );
-      assert.match(firstRun.calls[0]?.[0]?.content ?? "", /Current state:\n\{\}/u);
+      const firstRunUser = firstRun.calls[0]?.[1]?.content ?? "";
+      assert.match(firstRunUser, /^Persona: Mari\nNarration:/u);
+      assert.doesNotMatch(firstRunUser, /Current state:/u);
       assert.deepEqual(firstRunResult.data, { characters: [] });
 
       const invalidRun = makeCapturingProvider(`{"changed":true,"delta":{"self":{"body":{"fake":{}}}}}`);

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -10682,6 +10682,8 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       const result = await executeAgent(config as any, context, provider as any, "regression-model");
       const system = calls[0]?.[0]?.content ?? "";
       const user = calls[0]?.[1]?.content ?? "";
+      assert.equal(calls[0]?.[0]?.role, "system");
+      assert.equal(calls[0]?.[1]?.role, "user");
       assert.equal(system, "Return a physical-state delta as JSON.");
       assert.match(user, /Persona: Mari\nCurrent state:/u);
       assert.match(user, /"self":\{/u);
@@ -10706,6 +10708,8 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         "regression-model",
       );
       const firstRunUser = firstRun.calls[0]?.[1]?.content ?? "";
+      assert.equal(firstRun.calls[0]?.[0]?.role, "system");
+      assert.equal(firstRun.calls[0]?.[1]?.role, "user");
       assert.match(firstRunUser, /^Persona: Mari\nNarration:/u);
       assert.doesNotMatch(firstRunUser, /Current state:/u);
       assert.deepEqual(firstRunResult.data, { characters: [] });

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -4,6 +4,7 @@ import {
   getRoleplayTypewriterRevealCharsPerSecond,
   getStreamingCharsPerSecond,
   getTypewriterFrameBudget,
+  getTypewriterPaintIntervalMs,
   isGenerationSendBlocked,
   isGenerationStartBlocked,
   isMessageShadowedByLiveStream,
@@ -1263,6 +1264,34 @@ assert.ok(
   delayedFrameBudget.maxCharacters <= 3,
   "a delayed frame must not dump its entire reveal debt as one chunky typewriter burst",
 );
+assert.equal(
+  getTypewriterPaintIntervalMs(
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15",
+    "iPhone",
+    5,
+  ),
+  50,
+  "iPhone WebKit should batch stream paints to 20 FPS",
+);
+assert.equal(
+  getTypewriterPaintIntervalMs("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15)", "MacIntel", 5),
+  50,
+  "desktop-mode iPadOS should receive the same stream paint protection",
+);
+assert.equal(
+  getTypewriterPaintIntervalMs("Mozilla/5.0 (Linux; Android 16)", "Linux armv8l", 5),
+  0,
+  "non-iOS browsers should retain the native animation cadence",
+);
+let simulatedIosRemainder = 0;
+let simulatedIosCharacters = 0;
+for (let frame = 0; frame < 20; frame += 1) {
+  const budget = getTypewriterFrameBudget(90, 50, simulatedIosRemainder, 50);
+  const revealedCharacters = Math.min(Math.floor(budget.accruedCharacters), budget.maxCharacters);
+  simulatedIosRemainder = budget.accruedCharacters - revealedCharacters;
+  simulatedIosCharacters += revealedCharacters;
+}
+assert.equal(simulatedIosCharacters, 90, "batched iOS paints must preserve the selected reveal speed");
 assert.match(
   echoChamberPanelSource,
   /behavior: streamingChatId === activeChatId \? "auto" : "smooth"/u,


### PR DESCRIPTION
## Linked issues

Closes #5361
Closes #5362
Closes #5363
Closes #5364
Closes #5365
Closes #5366

## Why this change

The current issue queue contains several small but disruptive interaction and persistence bugs across the online card browser, Roleplay, streaming, and Android navigation. This sweep fixes their shared user-facing symptoms in one staging PR while retaining existing helpers and native browser behavior.

## What changed

- Added direct page selection to the online character-card browser and reset pagination when search criteria change.
- Made CYOA choices disappear persistently after selection or tracker clearing, and continued impersonated choices into the character reply automatically.
- Kept expression sprites below CYOA prompts, allowed true zero opacity, and preserved sprites through PNG card export/import.
- Locked the already-correct favorite-background and non-card cleanup-backup behavior with regression coverage.
- Confirmed auto-created Lorebook Keeper category books remain chat-linked and reusable on the next run, preventing duplicate creation.
- Restored chat names in the Roleplay sidebar while retaining branch names in the branch selector.
- Batched iOS typewriter paints at 20 FPS without reducing the configured stream speed.
- Made Android hardware and gesture back dismiss the topmost modal or overlay before the WebView can exit.
- Updated stale regression expectations so the complete suite tests current agent and prompt contracts in isolation.

The Beholder honorable mention in #5362 has no agent version, diagnostics, or reproducible provider payload. Existing Beholder work remains owned by #5281, #5284, and #5305; this PR does not duplicate that active stack.

The Android navigation implementation is the contributor patch from @luma-inibitor, cherry-picked with original authorship preserved.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated validation completed locally:

- `pnpm check`
- `pnpm test` — 142/142 regressions passed
- `pnpm --filter @marinara-engine/client lint`
- `pnpm --filter @marinara-engine/server lint`
- Targeted open-issue, Roleplay streaming, spatial-context, and Android back-navigation regressions
- Desktop Chromium Playwright coverage for exact browser pagination and Roleplay sidebar names — 2/2 passed

### Manual verification notes

- Manually verify exact online-browser page selection on mobile and desktop.
- Manually verify CYOA choice persistence, impersonation follow-up, tracker clearing, and sprite layering/opacity.
- Manually verify PNG sprite round-trip with a real character card.
- Manually verify iOS streaming on a long formatted Roleplay response.
- Manually verify Roleplay chat and branch labels.
- Manually verify Android hardware and gesture back dismissal for stacked menus and overlays.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `docs-i18n` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

`CHANGELOG.md` includes user-facing entries. No user documentation, translation pack, or version metadata changes are required.

## UI evidence

Automated browser evidence covers the new exact-page selector and the distinction between chat names and branch names. Hardware-specific iOS and Android behavior remains listed above for manual device verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added page-number selection for online character search results.
  - Added mobile back-navigation support for dismissing open panels, dialogs, and editors.
  - Improved streaming text performance on iOS and iPadOS.
  - Character-card exports and imports now preserve compatible embedded sprites.

- **Bug Fixes**
  - Fixed CYOA choice cleanup and follow-up generation.
  - Roleplay branch names now display and search consistently.
  - Improved sprite layering, opacity controls, and export/import validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->