### PR TITLE
fix(ui): keep game scenes ordered and editor names visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Game Mode now keeps the current scene unchanged while The Game Master finishes a turn, then reveals each generated segment once in order (#5368).
+- Character and Persona editor headers now reserve visible space for the card name to the left of Creator and version information (#5369).
 - Android hardware and gesture back now dismisses the topmost menu, editor, dialog, or overlay before leaving the app, with the same behavior available to browser and installed-PWA back navigation (#5366; thanks @luma-inibitor).
 - Long formatted replies now batch their streaming paints on iPhone and iPad browsers, preventing WebKit from freezing while preserving the selected reveal speed (#5365).
 - Roleplay CYOA choices now stay consumed after selection, impersonated choices continue into a character reply, clearing trackers also clears the active prompt, sprites can be fully transparent without covering chat choices, and PNG card exports preserve their sprite sets on Marinara re-import (#5362).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -3152,6 +3152,7 @@ test("Character and Persona avatar actions stay separated and visually balanced"
     expect(titleInputBox).not.toBeNull();
     expect(bylineBox).not.toBeNull();
     if (titleLineBox && titleInputBox && bylineBox) {
+      expect(titleInputBox.width).toBeGreaterThanOrEqual(48);
       expect(titleInputBox.x + titleInputBox.width).toBeLessThanOrEqual(bylineBox.x + 1);
       expect(bylineBox.x + bylineBox.width).toBeLessThanOrEqual(titleLineBox.x + titleLineBox.width + 1);
       expect(Math.abs(titleInputBox.y + titleInputBox.height - (bylineBox.y + bylineBox.height))).toBeLessThanOrEqual(

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -2364,7 +2364,7 @@ export function useGenerate() {
                 heldTextRewriteMessage = heldMessage;
                 receivedContent = true;
                 persistedMessages.set(heldMessage.id, heldMessage);
-                if (!streamingEnabled || !shouldDisplayRawStream) {
+                if (!isGameGeneration && (!streamingEnabled || !shouldDisplayRawStream)) {
                   upsertPersistedMessages(qc, params.chatId, [heldMessage]);
                 }
                 break;
@@ -2376,7 +2376,10 @@ export function useGenerate() {
               if (!keepStreamLiveThroughPostProcessing) {
                 rememberContinuedMessageContent(savedMessage);
               }
-              upsertPersistedMessages(qc, params.chatId, [savedMessage]);
+              // Game Narration reveals the saved row segment by segment after
+              // the whole GM pipeline settles. Publishing it now jumps ahead
+              // of that reveal; the final authoritative refresh below owns it.
+              if (!isGameGeneration) upsertPersistedMessages(qc, params.chatId, [savedMessage]);
               break;
             }
 
@@ -2447,7 +2450,7 @@ export function useGenerate() {
               // would insert it into the cache alongside the StreamingIndicator,
               // causing a duplicate flash. The finally block's authoritative
               // refresh will pick up the selfie attachment from DB.
-              if (!streamingEnabled) {
+              if (!streamingEnabled && !isGameGeneration) {
                 await refreshMessagesAuthoritatively(qc, params.chatId, persistedMessages.values());
               }
               break;
@@ -2562,7 +2565,7 @@ export function useGenerate() {
               // would insert it into the cache alongside the StreamingIndicator,
               // causing a duplicate flash. The finally block's authoritative
               // refresh will pick up the illustration attachment from DB.
-              if (!streamingEnabled) {
+              if (!streamingEnabled && !isGameGeneration) {
                 await refreshMessagesAuthoritatively(qc, params.chatId, persistedMessages.values());
               }
               void qc.invalidateQueries({ queryKey: ["gallery", params.chatId] });

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -1750,6 +1750,7 @@
 
 .mari-editor-title-line .mari-editor-title-input {
   width: auto;
+  min-width: 4rem;
   max-width: 100%;
   flex: 0 1 auto;
   overflow: hidden;

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -1383,11 +1383,44 @@ assert.equal(
   "regeneration owns the existing row in place and must not hide it",
 );
 const messageSavedHandlerSource =
-  useGenerateSource.match(/case "message_saved": \{[\s\S]*?case "schedule_updated":/u)?.[0] ?? "";
+  useGenerateSource.match(/case "message_saved": \{[\s\S]*?case "assistant_message_ready":/u)?.[0] ?? "";
 assert.match(
   messageSavedHandlerSource,
-  /if \(!keepStreamLiveThroughPostProcessing\) \{[\s\S]*?rememberContinuedMessageContent\(savedMessage\);[\s\S]*?\}[\s\S]*?if \(!isGameGeneration\) upsertPersistedMessages\(qc, params\.chatId, \[savedMessage\]\);/u,
+  /if \(!keepStreamLiveThroughPostProcessing\) \{[\s\S]*?rememberContinuedMessageContent\(savedMessage\);[\s\S]*?\}/u,
+  "saved Roleplay replies should retain their continuation handoff",
+);
+const messageSavedCacheUpdateCount = (messageSavedHandlerSource.match(/upsertPersistedMessages\(/gu) ?? []).length;
+assert.equal(
+  messageSavedCacheUpdateCount,
+  2,
   "saved Roleplay replies should enter the cache while Game replies wait for the final scene handoff",
+);
+assert.equal(
+  (
+    messageSavedHandlerSource.match(
+      /if \(!isGameGeneration(?: && \(!streamingEnabled \|\| !shouldDisplayRawStream\))?\) (?:\{\s*)?upsertPersistedMessages\(qc, params\.chatId, \[(?:heldMessage|savedMessage)\]\);/gu,
+    ) ?? []
+  ).length,
+  messageSavedCacheUpdateCount,
+  "every message_saved cache update should remain behind a Game-mode guard",
+);
+const selfieHandlerSource = useGenerateSource.match(/case "selfie": \{[\s\S]*?case "selfie_error":/u)?.[0] ?? "";
+assert.match(
+  selfieHandlerSource,
+  /if \(!streamingEnabled && !isGameGeneration\) \{[\s\S]*?refreshMessagesAuthoritatively/u,
+  "selfies should not refresh the visible cache during Game generation",
+);
+const illustrationHandlerSource =
+  useGenerateSource.match(/case "illustration": \{[\s\S]*?case "illustration_queued":/u)?.[0] ?? "";
+assert.match(
+  illustrationHandlerSource,
+  /if \(!streamingEnabled && !isGameGeneration\) \{[\s\S]*?refreshMessagesAuthoritatively/u,
+  "illustrations should not refresh the visible cache during Game generation",
+);
+assert.match(
+  useGenerateSource,
+  /if \(isGameGeneration\) \{[\s\S]*?await refreshMessagesAuthoritatively\(qc, params\.chatId, persistedForRefresh\);[\s\S]*?setStreaming\(false\);/u,
+  "Game generation should publish the authoritative scene before releasing its presentation stream",
 );
 const updateMessageHookSource =
   useChatsSource.match(/export function useUpdateMessage[\s\S]*?export function useUpdateMessageExtra/u)?.[0] ?? "";

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -1386,8 +1386,8 @@ const messageSavedHandlerSource =
   useGenerateSource.match(/case "message_saved": \{[\s\S]*?case "schedule_updated":/u)?.[0] ?? "";
 assert.match(
   messageSavedHandlerSource,
-  /if \(!keepStreamLiveThroughPostProcessing\) \{[\s\S]*?rememberContinuedMessageContent\(savedMessage\);[\s\S]*?\}[\s\S]*?upsertPersistedMessages\(qc, params\.chatId, \[savedMessage\]\);/u,
-  "a saved Roleplay reply must remain cached while its live presentation is shadowing it",
+  /if \(!keepStreamLiveThroughPostProcessing\) \{[\s\S]*?rememberContinuedMessageContent\(savedMessage\);[\s\S]*?\}[\s\S]*?if \(!isGameGeneration\) upsertPersistedMessages\(qc, params\.chatId, \[savedMessage\]\);/u,
+  "saved Roleplay replies should enter the cache while Game replies wait for the final scene handoff",
 );
 const updateMessageHookSource =
   useChatsSource.match(/export function useUpdateMessage[\s\S]*?export function useUpdateMessageExtra/u)?.[0] ?? "";


### PR DESCRIPTION
## Linked issue

Closes #5368
Closes #5369

## Why this change

- Game Mode exposed a durably saved assistant row before the GM pipeline finished, causing a later segment to appear early and then repeat during the ordered reveal.
- Character and Persona editor metadata could reserve enough intermediate-width header space to collapse the entity name.

## What changed

- Hold Game Mode assistant rows out of the visible message cache until the existing final authoritative refresh.
- Reserve a small visible minimum width for editor names while retaining the existing ellipsis behavior.
- Extend the focused streaming and responsive editor regressions.
- Add Unreleased changelog entries for both user-facing fixes.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Inspected the reporter video and confirmed the early Game segment appears while the GM status is still active, then appears again during the final ordered reveal.
- Ran the focused Game/Roleplay stream lifecycle regression.
- Opened both Character and Persona editors in desktop and mobile Playwright projects and verified their names retain visible header width before Creator/version metadata.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence

- Before: #5368 reporter video shows the later Sol segment appearing during the active GM pipeline.
- After: the focused desktop and mobile editor browser proof requires the name input to retain at least 48 px before Creator/version metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Game Mode now preserves the current scene until the Game Master completes a turn.
  - Generated segments are revealed sequentially for a smoother experience.
  - Intermediate generation results no longer appear before processing is complete.
  - Character and Persona editor headers reserve enough space for card names.
- **Usability**
  - Editor title fields maintain a minimum width for improved readability and easier editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->