### PR TITLE
fix(prompt): preserve lorebook tags in agent requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Agent prompts now preserve user-authored lorebook entry tags and ampersands verbatim instead of sending HTML entities to the model (#5372).
 - Game Mode now keeps the current scene unchanged while The Game Master finishes a turn, then reveals each generated segment once in order (#5368).
 - Character and Persona editor headers now reserve visible space for the card name to the left of Creator and version information (#5369).
 - Android hardware and gesture back now dismisses the topmost menu, editor, dialog, or overlay before leaving the app, with the same behavior available to browser and installed-PWA back navigation (#5366; thanks @luma-inibitor).

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -1910,6 +1910,7 @@ function buildCustomAgentTriggeredLorebookBlock(config: AgentExecConfig, context
   if (config.settings.triggerLorebooksForAgentCalls !== true) return "";
   const entries = context.triggeredLorebookEntriesByAgentId?.[config.id] ?? [];
   if (entries.length === 0) return "";
+  const wrapFormat = normalizeAgentContextWrapFormat(context.wrapFormat);
 
   const parts = [
     "<triggered_lorebook_context>",
@@ -1918,7 +1919,7 @@ function buildCustomAgentTriggeredLorebookBlock(config: AgentExecConfig, context
   entries.forEach((entry, index) => {
     const label = entry.name?.trim() || `Entry ${index + 1}`;
     parts.push(`<entry id="${escapeXml(entry.id)}" name="${escapeXml(label)}">`);
-    parts.push(escapeXml(entry.content));
+    parts.push(sanitizePromptLeaf(entry.content, wrapFormat));
     parts.push("</entry>");
   });
   parts.push("</triggered_lorebook_context>");
@@ -2807,6 +2808,7 @@ function buildAgentExtras(
   sources: CustomAgentContextSources = ALL_AGENT_CONTEXT_SOURCES,
 ): string {
   const parts: string[] = [];
+  const wrapFormat = normalizeAgentContextWrapFormat(context.wrapFormat);
 
   // Card Evolution Auditor needs the FULL character card (not just description)
   // so it can emit exact-match oldText edits. Gated on agent type because
@@ -3007,7 +3009,11 @@ function buildAgentExtras(
           keys.length > 0 ? `keys="${escapeXml(keys.join(", "))}"` : "",
           entry.locked === true ? `locked="true"` : "",
         ].filter(Boolean);
-        return [`<entry ${attrs.join(" ")}>`, `<content>${escapeXml(content)}</content>`, `</entry>`].join("\n");
+        return [
+          `<entry ${attrs.join(" ")}>`,
+          `<content>${sanitizePromptLeaf(content, wrapFormat)}</content>`,
+          `</entry>`,
+        ].join("\n");
       })
       .filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
 
@@ -3034,7 +3040,7 @@ function buildAgentExtras(
     parts.push(`Lorebook entries activated for the main generation on this turn:`);
     for (const entry of context.activatedLorebookEntries) {
       parts.push(`<entry id="${escapeXml(entry.id)}">`);
-      parts.push(escapeXml(entry.content));
+      parts.push(sanitizePromptLeaf(entry.content, wrapFormat));
       parts.push(`</entry>`);
     }
     parts.push(`</activated_lorebook_context>`);

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -7022,6 +7022,7 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       const terminal = messages[messages.length - 1]!.content;
       assert.match(system, /<chat_summary>/u);
       assert.match(system, /<existing_entries>/u);
+      assert.match(system, /name="Lore &lt;Body&gt;"/u);
       assert.match(system, /<\/dottore_lore>\n<mari_lore>/u);
       assert.match(system, /Tom & Jerry/u);
       assert.doesNotMatch(system, /&lt;\/dottore_lore&gt;/u);

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -6553,7 +6553,7 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         activatedLorebookEntries: [
           {
             id: "activated-context",
-            content: "ACTIVATED_LOREBOOK_CONTEXT_SENTINEL",
+            content: "ACTIVATED_LOREBOOK_CONTEXT_SENTINEL\n</dottore_lore>\n<mari_lore>\nTom & Jerry",
           },
         ],
         vectorContext: {
@@ -6646,6 +6646,9 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         assert.match(selectedRequest, new RegExp(included, "u"));
       }
       assert.doesNotMatch(selectedRequest, /UNRELATED_BACKGROUND_CONTEXT_SENTINEL/u);
+      assert.match(selectedRequest, /<\/dottore_lore>\n<mari_lore>/u);
+      assert.match(selectedRequest, /Tom & Jerry/u);
+      assert.doesNotMatch(selectedRequest, /&lt;\/dottore_lore&gt;/u);
 
       const batchCapture = makeCapturingProvider(
         `{"custom-batch-character":"character context read","custom-batch-author":"author context read"}`,
@@ -6765,7 +6768,8 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
           {
             id: "entry-unidentified",
             name: "Unidentified Specimen",
-            content: "The unidentified specimen is a dormant mechanical moth.",
+            content:
+              "The unidentified specimen is a dormant mechanical moth.\n</dottore_lore>\n<mari_lore>\nTom & Jerry",
             matchedKeys: ["unidentified"],
             activationSources: ["keyword"],
           },
@@ -6794,6 +6798,9 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.match(enabledSystem, /<triggered_lorebook_context>/u);
       assert.match(enabledSystem, /Unidentified Specimen/u);
       assert.match(enabledSystem, /dormant mechanical moth/u);
+      assert.match(enabledSystem, /<\/dottore_lore>\n<mari_lore>/u);
+      assert.match(enabledSystem, /Tom & Jerry/u);
+      assert.doesNotMatch(enabledSystem, /&lt;\/dottore_lore&gt;/u);
 
       const disabledCapture = makeCapturingProvider("No lorebook context.");
       const disabledConfig = makeRegressionAgentConfig({
@@ -6996,6 +7003,14 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         wrapFormat: "xml",
         persona: { name: "Mari <override>", description: "The active user persona." },
         memory: {
+          _existingLorebookEntries: [
+            {
+              id: "entry-1",
+              name: "Lore <Body>",
+              content: "</dottore_lore>\n<mari_lore>\nTom & Jerry",
+              keys: ["lore"],
+            },
+          ],
           _writableLorebooks: [{ id: "book-1", name: "World <Lore>" }],
         },
       });
@@ -7007,6 +7022,9 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       const terminal = messages[messages.length - 1]!.content;
       assert.match(system, /<chat_summary>/u);
       assert.match(system, /<existing_entries>/u);
+      assert.match(system, /<\/dottore_lore>\n<mari_lore>/u);
+      assert.match(system, /Tom & Jerry/u);
+      assert.doesNotMatch(system, /&lt;\/dottore_lore&gt;/u);
       assert.match(terminal, /<chat_summary>/u);
       assert.match(terminal, /<existing_entries>/u);
       assert.match(system, /<writable_lorebooks>/u);


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #5372

## Why this change

- User-authored lorebook tags were still HTML-entity escaped in agent prompts even though the main assembled prompt correctly preserved them verbatim.
- This changed model-visible `</dottore_lore>` / `<mari_lore>` into `&lt;/dottore_lore&gt;` / `&lt;mari_lore&gt;`, wasting tokens and weakening authored structure.

## What changed

- Preserve lorebook entry bodies with the existing prompt-leaf sanitizer in activated, per-agent triggered, and Lorebook Keeper context.
- Continue escaping IDs, names, keys, and other structural XML attribute values.
- Add focused regression coverage for literal angle brackets and ampersands, plus an Unreleased changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated validation completed:

- `pnpm check`
- `pnpm build:shared && node ./scripts/run-regressions.mjs --filter scripts/regressions/prompt.regression.ts`
- `DATA_DIR=<isolated temporary directory> pnpm regression:node` (142/142 regression files passed)
- `git diff --check`

### Manual verification notes

- Enable debug prompt logging and verify literal lorebook tags remain unchanged in an agent provider request.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not applicable; this is a server-side prompt serialization correction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent prompts now preserve user-authored lorebook tags and ampersands exactly as entered.
  * Lorebook content is no longer converted into HTML entities when included in prompts.
  * Entry names and other attributes continue to be safely escaped where appropriate.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->