### PR TITLE
fix(ui): complete small chat issue sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Fresh Professor Mari chats on Home now explain how to select a connection until the first message is sent (#5375).
 - Online character browsing now provides an exact page selector alongside the current page and total (#5361).
 - Character, Persona, Lorebook, and Preset editors now place section navigation in the header, using compact desktop tabs and a mobile dropdown, and Conversation Chat Settings now keeps Commands, Illustrator Settings, and Calls as matching remembered collapsible subsections inside Agents (#5355, #5356, Pasta-Devs/Marinara-Agents#480).
 - Settings → Generation now exposes the Character Reference Sheet prompt template, so character and Persona sheet generation can use a saved global override (#5348).
@@ -20,6 +21,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Chat branches now retain their locally configured sprite layout and display preferences (#5374).
+- Agent category headers in the setup wizard now fully cover scrolling agent details, keeping both readable (#5371).
 - Agent prompts now preserve user-authored lorebook entry tags and ampersands verbatim instead of sending HTML entities to the model (#5372).
 - Game Mode now keeps the current scene unchanged while The Game Master finishes a turn, then reveals each generated segment once in order (#5368).
 - Character and Persona editor headers now reserve visible space for the card name to the left of Creator and version information (#5369).

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -3027,7 +3027,7 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
                   const activeCount = section.agents.filter((agent) => activeAgentIds.includes(agent.id)).length;
                   return (
                     <div key={section.category} className="border-b border-[var(--border)]/70 last:border-b-0">
-                      <div className="sticky top-0 z-10 flex items-center justify-between bg-[var(--secondary)]/95 px-3 py-1.5 backdrop-blur-sm">
+                      <div className="sticky top-0 z-10 flex items-center justify-between bg-[var(--secondary)] px-3 py-1.5">
                         <span className="text-[0.625rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
                           {section.title}
                         </span>

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -3748,7 +3748,11 @@ export function HomeProfessorMariChat({
   }, []);
 
   const displayMessages = useMemo(() => [createWelcomeMessage(chatId), ...messages], [chatId, messages]);
-  const showConnectionFirstHint = !sending && !messages.some((message) => message.role === "user");
+  const showConnectionFirstHint =
+    chatId !== null &&
+    loadedMessagesChatId === chatId &&
+    !sending &&
+    !messages.some((message) => message.role === "user");
 
   useEffect(() => {
     if (!mobileFocusMode) return;
@@ -3978,6 +3982,7 @@ export function HomeProfessorMariChat({
     qc.setQueryData(chatKeys.detail(chat.id), chat);
     await api.post("/professor-mari/workspace/reset", { clearHistory: true });
     setMessages([]);
+    setLoadedMessagesChatId(chat.id);
     setDraft("");
     clearMariChips();
     setWorkspaceActive(false);

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -3748,6 +3748,7 @@ export function HomeProfessorMariChat({
   }, []);
 
   const displayMessages = useMemo(() => [createWelcomeMessage(chatId), ...messages], [chatId, messages]);
+  const showConnectionFirstHint = !sending && !messages.some((message) => message.role === "user");
 
   useEffect(() => {
     if (!mobileFocusMode) return;
@@ -5120,6 +5121,11 @@ export function HomeProfessorMariChat({
         ) : (
           <>
             {displayMessages.map(renderDisplayMessage)}
+            {showConnectionFirstHint && (
+              <p className="px-3 py-1 text-center text-xs text-[var(--muted-foreground)]">
+                {localizeUi("ui.chat.homeprofessormarichat.selectAConnectionFirst")}
+              </p>
+            )}
             {workspaceTimeline.length === 0 && workspaceTimelineActive && !showDottoreSupport && (
               <WorkspaceStatusEvent content={workspaceActivity ?? "Thinking..."} />
             )}
@@ -5869,6 +5875,11 @@ export function HomeProfessorMariChat({
                           ) : (
                             <>
                               {displayMessages.map(renderDisplayMessage)}
+                              {showConnectionFirstHint && (
+                                <p className="px-3 py-1 text-center text-xs text-[var(--muted-foreground)]">
+                                  {localizeUi("ui.chat.homeprofessormarichat.selectAConnectionFirst")}
+                                </p>
+                              )}
                               {workspaceTimeline.length === 0 && workspaceTimelineActive && !showDottoreSupport && (
                                 <WorkspaceStatusEvent content={workspaceActivity ?? "Thinking..."} />
                               )}

--- a/packages/client/src/components/chat/local-sprite-visual-settings.ts
+++ b/packages/client/src/components/chat/local-sprite-visual-settings.ts
@@ -176,6 +176,12 @@ export function loadLocalSpriteVisualSettings(chatId: string | null | undefined)
   return readAllLocalSpriteVisualSettings()[chatId] ?? {};
 }
 
+export function copyLocalSpriteVisualSettings(sourceChatId: string, targetChatId: string): void {
+  const source = loadLocalSpriteVisualSettings(sourceChatId);
+  if (Object.keys(source).length === 0) return;
+  saveLocalSpriteVisualSettings(targetChatId, source);
+}
+
 export function saveLocalSpriteVisualSettings(
   chatId: string,
   patch: Partial<LocalSpriteVisualSettings>,

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -21,6 +21,7 @@ import { clearBrowserRuntimeCaches } from "../lib/browser-runtime";
 import { shouldRefetchMessagesOnReconnect } from "../lib/message-page-cache";
 import { normalizeHydratedMessage } from "../lib/message-hydration";
 import { isMessageHidden } from "../lib/message-visibility";
+import { copyLocalSpriteVisualSettings } from "../components/chat/local-sprite-visual-settings";
 import { lorebookKeys } from "./use-lorebooks";
 import { achievementKeys, trackAchievementEvent } from "./use-achievements";
 import type {
@@ -1385,6 +1386,7 @@ export function useBranchChat() {
       api.post<Chat>(`/chats/${chatId}/branch`, { upToMessageId }),
     onSuccess: (newChat, { chatId }) => {
       if (newChat) {
+        copyLocalSpriteVisualSettings(chatId, newChat.id);
         qc.setQueryData(chatKeys.detail(newChat.id), newChat);
         qc.setQueryData<Chat[]>(chatKeys.list(), (existing) => syncCachedBranch(existing, chatId, newChat));
 

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -3601,6 +3601,7 @@
   "ui.chat.homeprofessormarichat.restartSavesTheCurrentChatHere": "Restart saves the current chat here.",
   "ui.chat.homeprofessormarichat.restoredThePreviousAppDataSnapshot": "Restored the previous app data snapshot.",
   "ui.chat.homeprofessormarichat.revertedTheSelectedEntry": "Reverted the entry.",
+  "ui.chat.homeprofessormarichat.selectAConnectionFirst": "Select a connection first by clicking the chainlink icon in the input box below!",
   "ui.chat.homeprofessormarichat.selectChats": "Select",
   "ui.chat.homeprofessormarichat.selectConnection": "Select connection",
   "ui.chat.homeprofessormarichat.selectedChats_one": "{{count}} chat selected",

--- a/scripts/regressions/issue-sweep-5371-5375.regression.ts
+++ b/scripts/regressions/issue-sweep-5371-5375.regression.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const chatSetupWizardSource = readFileSync(
+  new URL("../../packages/client/src/components/chat/ChatSetupWizard.tsx", import.meta.url),
+  "utf8",
+);
+const agentHeaderStart = chatSetupWizardSource.indexOf('className="sticky top-0 z-10 flex items-center justify-between');
+assert.ok(agentHeaderStart >= 0, "The agent category header must remain sticky");
+const agentHeaderSource = chatSetupWizardSource.slice(agentHeaderStart, agentHeaderStart + 220);
+assert.match(
+  agentHeaderSource,
+  /bg-\[var\(--secondary\)\](?:\s|")/u,
+  "Sticky agent category headers must be opaque so list text cannot show through them",
+);
+assert.doesNotMatch(agentHeaderSource, /backdrop-blur/u);
+
+const professorMariHomeSource = readFileSync(
+  new URL("../../packages/client/src/components/chat/HomeProfessorMariChat.tsx", import.meta.url),
+  "utf8",
+);
+assert.match(
+  professorMariHomeSource,
+  /const showConnectionFirstHint = !messages\.some\(\(message\) => message\.role === "user"\);/u,
+  "Professor Mari's connection guidance must remain visible until the first user message",
+);
+assert.equal(
+  professorMariHomeSource.match(/showConnectionFirstHint &&/gu)?.length,
+  2,
+  "Both Professor Mari transcript layouts must show the fresh-chat connection guidance",
+);
+
+const englishLocale = JSON.parse(
+  readFileSync(new URL("../../packages/client/src/localization/locales/en.json", import.meta.url), "utf8"),
+) as Record<string, string>;
+assert.equal(
+  englishLocale["ui.chat.homeprofessormarichat.selectAConnectionFirst"],
+  "Select a connection first by clicking the chainlink icon in the input box below!",
+);
+
+const chatsHookSource = readFileSync(
+  new URL("../../packages/client/src/hooks/use-chats.ts", import.meta.url),
+  "utf8",
+);
+assert.match(
+  chatsHookSource,
+  /copyLocalSpriteVisualSettings\(chatId, newChat\.id\)/u,
+  "Creating a branch must copy the source chat's local sprite setup",
+);
+
+const spriteStorage = new Map<string, string>();
+Object.defineProperty(globalThis, "window", {
+  configurable: true,
+  value: {
+    localStorage: {
+      getItem: (key: string) => spriteStorage.get(key) ?? null,
+      setItem: (key: string, value: string) => spriteStorage.set(key, value),
+    },
+  },
+});
+
+try {
+  const spriteSettingsModule = await import(
+    "../../packages/client/src/components/chat/local-sprite-visual-settings.js"
+  );
+  const copyLocalSpriteVisualSettings = Reflect.get(spriteSettingsModule, "copyLocalSpriteVisualSettings") as unknown;
+  assert.ok(
+    typeof copyLocalSpriteVisualSettings === "function",
+    "The local sprite settings helper must expose branch copying",
+  );
+
+  spriteSettingsModule.saveLocalSpriteVisualSettings("source-chat", {
+    spritePosition: "left",
+    spritePlacements: { "character-1": { x: 24, y: 92 } },
+    expressionSpriteScale: 1.25,
+    expressionAvatarsEnabled: false,
+  });
+  copyLocalSpriteVisualSettings("source-chat", "branch-chat");
+
+  assert.deepEqual(
+    spriteSettingsModule.loadLocalSpriteVisualSettings("branch-chat"),
+    spriteSettingsModule.loadLocalSpriteVisualSettings("source-chat"),
+    "A branch must inherit the source chat's local sprite position, placement, scale, and avatar settings",
+  );
+} finally {
+  Reflect.deleteProperty(globalThis, "window");
+}
+
+console.info("Issue sweep #5371-#5375 regression passed");

--- a/scripts/regressions/issue-sweep-5371-5375.regression.ts
+++ b/scripts/regressions/issue-sweep-5371-5375.regression.ts
@@ -5,7 +5,9 @@ const chatSetupWizardSource = readFileSync(
   new URL("../../packages/client/src/components/chat/ChatSetupWizard.tsx", import.meta.url),
   "utf8",
 );
-const agentHeaderStart = chatSetupWizardSource.indexOf('className="sticky top-0 z-10 flex items-center justify-between');
+const agentHeaderStart = chatSetupWizardSource.indexOf(
+  'className="sticky top-0 z-10 flex items-center justify-between',
+);
 assert.ok(agentHeaderStart >= 0, "The agent category header must remain sticky");
 const agentHeaderSource = chatSetupWizardSource.slice(agentHeaderStart, agentHeaderStart + 220);
 assert.match(
@@ -21,7 +23,7 @@ const professorMariHomeSource = readFileSync(
 );
 assert.match(
   professorMariHomeSource,
-  /const showConnectionFirstHint = !messages\.some\(\(message\) => message\.role === "user"\);/u,
+  /const showConnectionFirstHint = !sending && !messages\.some\(\(message\) => message\.role === "user"\);/u,
   "Professor Mari's connection guidance must remain visible until the first user message",
 );
 assert.equal(
@@ -38,10 +40,7 @@ assert.equal(
   "Select a connection first by clicking the chainlink icon in the input box below!",
 );
 
-const chatsHookSource = readFileSync(
-  new URL("../../packages/client/src/hooks/use-chats.ts", import.meta.url),
-  "utf8",
-);
+const chatsHookSource = readFileSync(new URL("../../packages/client/src/hooks/use-chats.ts", import.meta.url), "utf8");
 assert.match(
   chatsHookSource,
   /copyLocalSpriteVisualSettings\(chatId, newChat\.id\)/u,
@@ -60,9 +59,8 @@ Object.defineProperty(globalThis, "window", {
 });
 
 try {
-  const spriteSettingsModule = await import(
-    "../../packages/client/src/components/chat/local-sprite-visual-settings.js"
-  );
+  const spriteSettingsModule =
+    await import("../../packages/client/src/components/chat/local-sprite-visual-settings.js");
   const copyLocalSpriteVisualSettings = Reflect.get(spriteSettingsModule, "copyLocalSpriteVisualSettings") as unknown;
   assert.ok(
     typeof copyLocalSpriteVisualSettings === "function",

--- a/scripts/regressions/issue-sweep-5371-5375.regression.ts
+++ b/scripts/regressions/issue-sweep-5371-5375.regression.ts
@@ -23,8 +23,13 @@ const professorMariHomeSource = readFileSync(
 );
 assert.match(
   professorMariHomeSource,
-  /const showConnectionFirstHint = !sending && !messages\.some\(\(message\) => message\.role === "user"\);/u,
-  "Professor Mari's connection guidance must remain visible until the first user message",
+  /const showConnectionFirstHint =\s*chatId !== null &&\s*loadedMessagesChatId === chatId &&\s*!sending &&\s*!messages\.some\(\(message\) => message\.role === "user"\);/u,
+  "Professor Mari's connection guidance must wait for the active chat history and remain visible until the first user message",
+);
+assert.match(
+  professorMariHomeSource,
+  /setMessages\(\[\]\);\s*setLoadedMessagesChatId\(chat\.id\);/u,
+  "Restarting Professor Mari must mark the new empty chat history as loaded",
 );
 assert.equal(
   professorMariHomeSource.match(/showConnectionFirstHint &&/gu)?.length,


### PR DESCRIPTION
## Linked issues

Closes #5371
Closes #5374
Closes #5375

## Why this change

- Agent category labels can become unreadable when scrolled content shows through their translucent sticky background.
- Branching a chat currently leaves its chat-scoped local sprite layout behind, making the new branch look reset.
- A fresh Professor Mari Home chat does not tell the user that a connection must be selected before the first message.

## What changed

- Make the agent category header opaque while it is sticky.
- Copy local sprite visual settings when a chat branch is created.
- Show localized connection guidance in fresh Professor Mari chats until the first user message.
- Add a focused regression for all three behaviors and update the changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Focused regression passes locally
- [ ] `pnpm localization:check` passes locally
- [ ] `pnpm smoke:ui` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Automated evidence

- `pnpm check` — passed.
- `pnpm build:shared && node ./scripts/run-regressions.mjs --filter scripts/regressions/issue-sweep-5371-5375.regression.ts` — passed.
- `pnpm localization:check` — passed.
- `pnpm smoke:ui` — 254 passed and 107 skipped; one unrelated Secret Plot interval case failed once, then passed immediately when rerun alone.
- `pnpm exec playwright test -c playwright.config.ts e2e/core-flows.e2e.ts --project=desktop-chromium --grep "Secret Plot run interval stays editable across repeated commits"` — passed.

### Manual verification notes

- Manually verify the Enable Agents list at a narrow viewport while scrolling across category boundaries.
- Manually branch a sprite-configured Roleplay chat and confirm its local placement/display preferences carry over.
- Manually verify the Professor Mari guidance appears in both docked and floating layouts, then disappears after the first sent message.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `CHANGELOG.md`
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- The focused regression covers the opaque sticky header, both Professor Mari transcript layouts, immediate first-send dismissal, and branch-time sprite-setting inheritance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guidance in Professor Mari chats to select a connection before sending the first message.
  * Preserved local sprite display preferences when creating chat branches.

* **Bug Fixes**
  * Improved agent-category header visibility in the setup wizard.
  * Ensured connection guidance appears consistently in floating and embedded chats, including after restarting a chat.

* **Documentation**
  * Added changelog information covering these updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->