### PR TITLE
Fix safe bot-browser notes and background prompt review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Bot-browser character author notes now render their HTML and CSS through the same sanitizer and style containment as chat messages, with scripts, event handlers, links, and global page styling blocked (#5377).
+- Manual Roleplay background generation from Gallery now pauses for media prompt review when that setting is enabled and sends the reviewed prompt exactly once (#5379).
 - Chat branches now retain their locally configured sprite layout and display preferences (#5374).
 - Agent category headers in the setup wizard now fully cover scrolling agent details, keeping both readable (#5371).
 - Agent prompts now preserve user-authored lorebook entry tags and ampersands verbatim instead of sending HTML entities to the model (#5372).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -10172,6 +10172,16 @@ test("Downloaded cards use Marinara destination and lorebook choices", async ({ 
         personality: "Curious and precise.",
         scenario: "Inside the Marinara test kitchen.",
         creator: "Marinara Tester",
+        creator_notes: [
+          "<style>",
+          "body { --unsafe-note-leak: yes; }",
+          ".formatted-note { color: rgb(12, 200, 140); position: fixed; inset: 0; }",
+          "</style>",
+          '<div class="formatted-note" onclick="document.body.dataset.noteScript = \'clicked\'">',
+          'Readable <strong>author note</strong> <a href="https://example.com" target="_blank">external link</a>',
+          "<script>document.body.dataset.noteScript = 'executed'</script>",
+          "</div>",
+        ].join(""),
         character_book: {
           name: `${cardName} Lore`,
           entries: [
@@ -10206,6 +10216,31 @@ test("Downloaded cards use Marinara destination and lorebook choices", async ({ 
   await library.getByRole("button", { name: /ChubAI/u }).click();
   await page.getByRole("button", { name: /Wyvern/u }).click();
   await library.getByRole("button", { name: new RegExp(cardName, "u") }).click();
+
+  const authorNotes = library.locator("[data-bot-browser-rich-text]");
+  await expect(authorNotes.getByText(/Readable author note external link/u)).toBeVisible();
+  await expect(authorNotes.locator("strong")).toHaveText("author note");
+  await expect(authorNotes.locator("script")).toHaveCount(0);
+  await expect(authorNotes.locator(".formatted-note")).not.toHaveAttribute("onclick");
+  const inertExternalLink = authorNotes.locator("a", { hasText: "external link" });
+  await expect(inertExternalLink).not.toHaveAttribute("href");
+  await expect(inertExternalLink).not.toHaveAttribute("target");
+  const noteSecurity = await page.evaluate(() => {
+    const note = document.querySelector<HTMLElement>("[data-bot-browser-rich-text] .formatted-note");
+    return {
+      color: note ? getComputedStyle(note).color : "",
+      position: note ? getComputedStyle(note).position : "",
+      scriptMarker: document.body.dataset.noteScript ?? "",
+      leakedProperty: getComputedStyle(document.body).getPropertyValue("--unsafe-note-leak").trim(),
+    };
+  });
+  expect(noteSecurity).toEqual({
+    color: "rgb(12, 200, 140)",
+    position: "absolute",
+    scriptMarker: "",
+    leakedProperty: "",
+  });
+
   await library.getByRole("button", { name: "Import", exact: true }).click();
 
   const importDialog = page.locator('[data-component="BotBrowserImportDialog"]');
@@ -17877,7 +17912,7 @@ test("persona editor preserves unsaved fields across responsive layout changes",
   }
 });
 
-test("image prompt review preserves edits through rerenders and submits the edited prompt", async ({
+test("background prompt review preserves edits through rerenders and resumes the background target", async ({
   page,
   request,
 }) => {
@@ -17890,16 +17925,21 @@ test("image prompt review preserves edits through rerenders and submits the edit
   });
   expect(chatResponse.ok()).toBeTruthy();
   const chat = (await chatResponse.json()) as { id: string };
-  const originalPrompt = "Original illustration prompt";
-  const editedPrompt = "Edited illustration prompt with deliberate composition";
+  const originalPrompt = "Original background prompt";
+  const editedPrompt = "Edited background prompt with deliberate composition";
   const releaseRetry = createDeferred();
   let submittedPrompt = "";
+  let submittedTargets: unknown = null;
+  let submittedResultData: unknown = null;
 
   await page.route("**/api/generate/retry-agents", async (route) => {
     const body = route.request().postDataJSON() as {
-      illustratorPromptReviewOverride?: { prompt?: string };
+      illustratorPromptReviewOverride?: { prompt?: string; resultData?: unknown };
+      illustratorRetryTargets?: unknown;
     };
     submittedPrompt = body.illustratorPromptReviewOverride?.prompt ?? "";
+    submittedTargets = body.illustratorRetryTargets;
+    submittedResultData = body.illustratorPromptReviewOverride?.resultData;
     await releaseRetry.promise;
     await route.fulfill({
       status: 200,
@@ -17919,12 +17959,20 @@ test("image prompt review preserves edits through rerenders and submits the edit
             detail: {
               chatId,
               item: {
-                id: "illustration",
-                kind: "illustration",
-                title: "Scene illustration",
+                id: "roleplay-scene-background",
+                kind: "background",
+                title: "Scene background",
                 prompt,
               },
-              resultData: { shouldGenerate: true },
+              resultData: {
+                generateBackground: true,
+                backgroundPlan: {
+                  locationName: "Marinara test kitchen",
+                  prompt,
+                  tags: ["kitchen"],
+                  reason: "Manual Gallery background request",
+                },
+              },
             },
           }),
         );
@@ -17951,6 +17999,11 @@ test("image prompt review preserves edits through rerenders and submits the edit
 
     await dialog.getByRole("button", { name: "Generate", exact: true }).click();
     await expect.poll(() => submittedPrompt).toBe(editedPrompt);
+    expect(submittedTargets).toEqual(["background"]);
+    expect(submittedResultData).toMatchObject({
+      generateBackground: true,
+      backgroundPlan: { locationName: "Marinara test kitchen" },
+    });
     await expect(promptEditor).toHaveValue(editedPrompt);
     await expect(dialog.getByRole("button", { name: "Generate", exact: true })).toBeDisabled();
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -10240,6 +10240,26 @@ test("Downloaded cards use Marinara destination and lorebook choices", async ({ 
     scriptMarker: "",
     leakedProperty: "",
   });
+  const normalizedLink = await page.evaluate(async () => {
+    const { sanitizeChatHtml } = (await import("/src/lib/chat-html.ts")) as {
+      sanitizeChatHtml: (html: string) => string;
+    };
+    const host = document.createElement("div");
+    host.innerHTML = sanitizeChatHtml(
+      '<a href="https://example.com" target="_blank" rel="opener">external link</a>',
+    );
+    const link = host.querySelector("a");
+    return {
+      href: link?.getAttribute("href"),
+      target: link?.getAttribute("target"),
+      rel: link?.getAttribute("rel"),
+    };
+  });
+  expect(normalizedLink).toEqual({
+    href: "https://example.com",
+    target: "_blank",
+    rel: "noopener noreferrer",
+  });
 
   await library.getByRole("button", { name: "Import", exact: true }).click();
 

--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -3,7 +3,7 @@
 // Multi-provider: ChubAI, JannyAI, CharacterTavern, Pygmalion, Wyvern, DataCat
 // With login modals for Pygmalion & CharacterTavern NSFW, PNG download for all providers
 // ──────────────────────────────────────────────
-import { useState, useCallback, useEffect, useLayoutEffect, useRef, useMemo } from "react";
+import { useState, useCallback, useEffect, useId, useLayoutEffect, useRef, useMemo } from "react";
 import { createPortal } from "react-dom";
 import {
   Search,
@@ -39,6 +39,13 @@ import { parsePngCharacterCard } from "../../lib/png-parser";
 import { useUIStore } from "../../stores/ui.store";
 import { toast } from "sonner";
 import { cn } from "../../lib/utils";
+import { scopeChatMessageCss } from "../../lib/chat-message-css";
+import {
+  containsChatHtml,
+  decodeEncodedChatHtmlTags,
+  extractChatStyleBlocks,
+  sanitizeChatHtml,
+} from "../../lib/chat-html";
 import {
   countLorebookEntries,
   hasLorebookEntries,
@@ -3570,6 +3577,7 @@ function DetailView({
                   <DefSection
                     title={localizeUi("ui.botBrowser.detailview.creatorSNotes")}
                     content={displayDetail.creatorNotes}
+                    allowHtml
                   />
                 )}
                 {displayDetail.description && (
@@ -3777,13 +3785,35 @@ crc32.table = null as Uint32Array | null;
 // Definition Section
 // ════════════════════════════════════════════════
 
-function DefSection({ title, content }: { title: string; content: string }) {
+function DefSection({ title, content, allowHtml = false }: { title: string; content: string; allowHtml?: boolean }) {
+  const sectionId = useId();
+  const htmlScopeClass = `mari-bot-notes-${sectionId.replace(/[^a-zA-Z0-9_-]/g, "") || "content"}`;
+  const renderedHtml = useMemo(() => {
+    if (!allowHtml || !containsChatHtml(content)) return null;
+    const decoded = decodeEncodedChatHtmlTags(content);
+    const { html, css } = extractChatStyleBlocks(decoded);
+    const clean = sanitizeChatHtml(html, { allowStyle: true, allowLinks: false });
+    const scopedCss = scopeChatMessageCss(css, `.${htmlScopeClass}`);
+    return scopedCss ? `<style>${scopedCss}</style>${clean}` : clean;
+  }, [allowHtml, content, htmlScopeClass]);
+
   return (
     <div>
       <h4 className="mb-1 text-xs font-semibold text-[var(--foreground)]">{title}</h4>
-      <div className="max-h-40 overflow-y-auto whitespace-pre-wrap rounded-lg bg-[var(--secondary)] p-2.5 text-xs leading-relaxed text-[var(--muted-foreground)]">
-        {content}
-      </div>
+      {renderedHtml !== null ? (
+        <div
+          data-bot-browser-rich-text
+          className={cn(
+            "relative max-h-40 !overflow-x-hidden overflow-y-auto whitespace-pre-wrap !contain-paint rounded-lg bg-[var(--secondary)] p-2.5 text-xs leading-relaxed text-[var(--muted-foreground)]",
+            htmlScopeClass,
+          )}
+          dangerouslySetInnerHTML={{ __html: renderedHtml }}
+        />
+      ) : (
+        <div className="max-h-40 overflow-y-auto whitespace-pre-wrap rounded-lg bg-[var(--secondary)] p-2.5 text-xs leading-relaxed text-[var(--muted-foreground)]">
+          {content}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -758,6 +758,7 @@ export const ChatArea = memo(function ChatArea() {
           prompt: override.prompt,
           ...(override.negativePrompt ? { negativePrompt: override.negativePrompt } : {}),
         },
+        illustratorRetryTargets: [illustratorPromptReview.item.kind === "background" ? "background" : "illustration"],
       });
       setIllustratorPromptReviewSubmitting(false);
       if (success) setIllustratorPromptReview(null);

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -74,9 +74,15 @@ import { buildTTSVoiceRequests, normalizeTTSCharacterName, withTTSVoiceRequestCa
 import { DIALOGUE_QUOTE_PATTERN_SOURCE, HTML_SAFE_DIALOGUE_QUOTE_PATTERN_SOURCE } from "../../lib/dialogue-quotes";
 import { resolveMessageRewriteVersions } from "../../lib/message-rewrite-versions";
 import { convertChatHtmlNewlines } from "../../lib/chat-html-newlines";
-import { sanitizeChatMessageCss, scopeChatMessageCss } from "../../lib/chat-message-css";
+import { scopeChatMessageCss } from "../../lib/chat-message-css";
+import {
+  HTML_TAG_RE,
+  containsChatHtml,
+  decodeEncodedChatHtmlTags,
+  extractChatStyleBlocks,
+  sanitizeChatHtml,
+} from "../../lib/chat-html";
 import { resolveMessageReasoningDisplay } from "../../lib/message-reasoning";
-import DOMPurify from "dompurify";
 import type { CharacterMap, ExpressionAvatarResolver, MessageSelectionToggle, PersonaInfo } from "./chat-area.types";
 import {
   MESSAGE_SELECTION_CHECKBOX_CLASS,
@@ -1061,159 +1067,12 @@ function highlightDialogue(text: string, dialogueColor?: string, boldDialogue = 
   return result;
 }
 
-const HTML_TAG_NAME_SOURCE =
-  "div|span|style|table|p|br|img|a|ul|ol|li|h[1-6]|em|strong|b|i|pre|code|section|article|header|footer|nav|button|input|form|label|select|option|textarea|canvas|svg|video|audio|source|iframe|hr|blockquote|details|summary|figure|figcaption|main|aside|mark|small|sub|sup|del|ins|abbr|time|progress|meter|output|dialog|template|slot|ruby|rt|rp|bdi|bdo|wbr|area|map|track|embed|object|param|picture|portal|datalist|fieldset|legend|optgroup|caption|col|colgroup|thead|tbody|tfoot|th|td|dl|dt|dd|kbd|samp|var|cite|dfn|q|s|u|font|center";
-
-/** Check whether text contains meaningful HTML tags. */
-const HTML_TAG_RE = new RegExp(`<(?:${HTML_TAG_NAME_SOURCE})\\b[^>]*>`, "i");
-const ENCODED_HTML_TAG_RE = new RegExp(
-  `&(?:lt|#0*60|#x0*3c);(\\/?\\s*(?:${HTML_TAG_NAME_SOURCE})\\b[^<>]*?)&(?:gt|#0*62|#x0*3e);`,
-  "gi",
-);
-
-function decodeHtmlTagAttributeEntities(value: string): string {
-  return value.replace(/&quot;|&#0*34;|&#x0*22;/gi, '"').replace(/&apos;|&#0*39;|&#x0*27;/gi, "'");
-}
-
-function decodeEncodedChatHtmlTags(value: string): string {
-  return value.replace(
-    ENCODED_HTML_TAG_RE,
-    (_match, tagBody: string) => `<${decodeHtmlTagAttributeEntities(tagBody)}>`,
-  );
-}
-
-function containsChatHtml(value: string): boolean {
-  return HTML_TAG_RE.test(decodeEncodedChatHtmlTags(value));
-}
-
-const CHAT_HTML_ALLOWED_TAGS = [
-  "a",
-  "abbr",
-  "aside",
-  "b",
-  "bdi",
-  "bdo",
-  "blockquote",
-  "br",
-  "caption",
-  "center",
-  "cite",
-  "code",
-  "col",
-  "colgroup",
-  "dd",
-  "del",
-  "details",
-  "dfn",
-  "div",
-  "dl",
-  "dt",
-  "em",
-  "figcaption",
-  "figure",
-  "font",
-  "footer",
-  "h1",
-  "h2",
-  "h3",
-  "h4",
-  "h5",
-  "h6",
-  "header",
-  "hr",
-  "i",
-  "img",
-  "ins",
-  "kbd",
-  "li",
-  "main",
-  "mark",
-  "nav",
-  "ol",
-  "p",
-  "pre",
-  "q",
-  "s",
-  "samp",
-  "section",
-  "small",
-  "span",
-  "strong",
-  "sub",
-  "summary",
-  "sup",
-  "table",
-  "tbody",
-  "td",
-  "tfoot",
-  "th",
-  "thead",
-  "time",
-  "tr",
-  "u",
-  "ul",
-  "var",
-] as const;
-
-const CHAT_HTML_ALLOWED_ATTR = [
-  "alt",
-  "class",
-  "color",
-  "colspan",
-  "data-spk",
-  "decoding",
-  "href",
-  "id",
-  "loading",
-  "rel",
-  "rowspan",
-  "src",
-  "style",
-  "target",
-  "title",
-] as const;
-
-const CHAT_STYLE_BLOCK_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
 const MD_IMAGE_HTML_RE = /!\[([^\]]*)\]\(((?:https?:\/\/[^)\s]+|card:\/\/[^)\s]+|\/api\/[^)\s]+))\)/g;
 
 function escapeHtmlAttr(value: string): string {
   return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-function sanitizeChatHtml(html: string, options: { allowStyle?: boolean } = {}) {
-  const allowedAttr = options.allowStyle
-    ? [...CHAT_HTML_ALLOWED_ATTR]
-    : CHAT_HTML_ALLOWED_ATTR.filter((attr) => attr !== "style");
-  const clean = DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: [...CHAT_HTML_ALLOWED_TAGS],
-    ALLOWED_ATTR: allowedAttr,
-    ALLOW_DATA_ATTR: false,
-    ALLOW_UNKNOWN_PROTOCOLS: false,
-    FORBID_TAGS: ["animate", "embed", "foreignObject", "iframe", "math", "object", "script", "svg", "style"],
-    FORBID_ATTR: ["onerror", "onload", "onclick", "srcdoc"],
-  });
-  if (!options.allowStyle || typeof document === "undefined") return clean;
-  const template = document.createElement("template");
-  template.innerHTML = clean;
-  for (const element of template.content.querySelectorAll<HTMLElement>("[style]")) {
-    const style = sanitizeChatMessageCss(element.getAttribute("style") ?? "");
-    if (style) element.setAttribute("style", style);
-    else element.removeAttribute("style");
-  }
-  for (const media of template.content.querySelectorAll("img, audio, video")) {
-    media.setAttribute("referrerpolicy", "no-referrer");
-  }
-  return template.innerHTML;
-}
-
-function extractChatStyleBlocks(html: string): { html: string; css: string } {
-  const cssBlocks: string[] = [];
-  const withoutStyles = html.replace(CHAT_STYLE_BLOCK_RE, (_match, css: string) => {
-    cssBlocks.push(css);
-    return "";
-  });
-  return { html: withoutStyles, css: cssBlocks.join("\n") };
-}
 /**
  * Extract the brightest solid color from a gradient string.
  * Handles formats like: gradient(linear-gradient(90deg, #ff6b6b, #4ecdc4))

--- a/packages/client/src/lib/chat-html.ts
+++ b/packages/client/src/lib/chat-html.ts
@@ -113,8 +113,6 @@ const CHAT_HTML_ALLOWED_ATTR = [
   "title",
 ] as const;
 
-const CHAT_STYLE_BLOCK_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
-
 export function sanitizeChatHtml(html: string, options: { allowStyle?: boolean; allowLinks?: boolean } = {}): string {
   const allowedAttr = CHAT_HTML_ALLOWED_ATTR.filter(
     (attr) =>
@@ -144,10 +142,17 @@ export function sanitizeChatHtml(html: string, options: { allowStyle?: boolean; 
 }
 
 export function extractChatStyleBlocks(html: string): { html: string; css: string } {
-  const cssBlocks: string[] = [];
-  const withoutStyles = html.replace(CHAT_STYLE_BLOCK_RE, (_match, css: string) => {
-    cssBlocks.push(css);
-    return "";
-  });
-  return { html: withoutStyles, css: cssBlocks.join("\n") };
+  const stylesOnly = DOMPurify.sanitize(`<div>${html}</div>`, {
+    ALLOWED_TAGS: ["div", "style"],
+    ALLOWED_ATTR: [],
+    FORBID_CONTENTS: [],
+    RETURN_DOM_FRAGMENT: true,
+  }) as DocumentFragment;
+  const cssBlocks = [...stylesOnly.querySelectorAll("style")].map((style) => style.textContent ?? "");
+  return {
+    // The normal sanitizer removes the original style elements after their
+    // sanitized, browser-parsed contents have been collected above.
+    html,
+    css: cssBlocks.join("\n"),
+  };
 }

--- a/packages/client/src/lib/chat-html.ts
+++ b/packages/client/src/lib/chat-html.ts
@@ -126,19 +126,24 @@ export function sanitizeChatHtml(html: string, options: { allowStyle?: boolean; 
     ALLOW_UNKNOWN_PROTOCOLS: false,
     FORBID_TAGS: ["animate", "embed", "foreignObject", "iframe", "math", "object", "script", "svg", "style"],
     FORBID_ATTR: ["onerror", "onload", "onclick", "srcdoc"],
-  });
-  if (!options.allowStyle || typeof document === "undefined") return clean;
-  const template = document.createElement("template");
-  template.innerHTML = clean;
-  for (const element of template.content.querySelectorAll<HTMLElement>("[style]")) {
-    const style = sanitizeChatMessageCss(element.getAttribute("style") ?? "");
-    if (style) element.setAttribute("style", style);
-    else element.removeAttribute("style");
+    RETURN_DOM_FRAGMENT: true,
+  }) as DocumentFragment;
+  for (const anchor of clean.querySelectorAll<HTMLAnchorElement>("a[href]")) {
+    anchor.setAttribute("rel", "noopener noreferrer");
   }
-  for (const media of template.content.querySelectorAll("img, audio, video")) {
-    media.setAttribute("referrerpolicy", "no-referrer");
+  if (options.allowStyle) {
+    for (const element of clean.querySelectorAll<HTMLElement>("[style]")) {
+      const style = sanitizeChatMessageCss(element.getAttribute("style") ?? "");
+      if (style) element.setAttribute("style", style);
+      else element.removeAttribute("style");
+    }
+    for (const media of clean.querySelectorAll("img, audio, video")) {
+      media.setAttribute("referrerpolicy", "no-referrer");
+    }
   }
-  return template.innerHTML;
+  const container = clean.ownerDocument.createElement("div");
+  container.append(clean);
+  return container.innerHTML;
 }
 
 export function extractChatStyleBlocks(html: string): { html: string; css: string } {

--- a/packages/client/src/lib/chat-html.ts
+++ b/packages/client/src/lib/chat-html.ts
@@ -1,0 +1,153 @@
+import DOMPurify from "dompurify";
+import { sanitizeChatMessageCss } from "./chat-message-css";
+
+const HTML_TAG_NAME_SOURCE =
+  "div|span|style|table|p|br|img|a|ul|ol|li|h[1-6]|em|strong|b|i|pre|code|section|article|header|footer|nav|button|input|form|label|select|option|textarea|canvas|svg|video|audio|source|iframe|hr|blockquote|details|summary|figure|figcaption|main|aside|mark|small|sub|sup|del|ins|abbr|time|progress|meter|output|dialog|template|slot|ruby|rt|rp|bdi|bdo|wbr|area|map|track|embed|object|param|picture|portal|datalist|fieldset|legend|optgroup|caption|col|colgroup|thead|tbody|tfoot|th|td|dl|dt|dd|kbd|samp|var|cite|dfn|q|s|u|font|center";
+
+/** Check whether text contains meaningful HTML tags. */
+export const HTML_TAG_RE = new RegExp(`<(?:${HTML_TAG_NAME_SOURCE})\\b[^>]*>`, "i");
+const ENCODED_HTML_TAG_RE = new RegExp(
+  `&(?:lt|#0*60|#x0*3c);(\\/?\\s*(?:${HTML_TAG_NAME_SOURCE})\\b[^<>]*?)&(?:gt|#0*62|#x0*3e);`,
+  "gi",
+);
+
+function decodeHtmlTagAttributeEntities(value: string): string {
+  return value.replace(/&quot;|&#0*34;|&#x0*22;/gi, '"').replace(/&apos;|&#0*39;|&#x0*27;/gi, "'");
+}
+
+export function decodeEncodedChatHtmlTags(value: string): string {
+  return value.replace(
+    ENCODED_HTML_TAG_RE,
+    (_match, tagBody: string) => `<${decodeHtmlTagAttributeEntities(tagBody)}>`,
+  );
+}
+
+export function containsChatHtml(value: string): boolean {
+  return HTML_TAG_RE.test(decodeEncodedChatHtmlTags(value));
+}
+
+const CHAT_HTML_ALLOWED_TAGS = [
+  "a",
+  "abbr",
+  "aside",
+  "b",
+  "bdi",
+  "bdo",
+  "blockquote",
+  "br",
+  "caption",
+  "center",
+  "cite",
+  "code",
+  "col",
+  "colgroup",
+  "dd",
+  "del",
+  "details",
+  "dfn",
+  "div",
+  "dl",
+  "dt",
+  "em",
+  "figcaption",
+  "figure",
+  "font",
+  "footer",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "header",
+  "hr",
+  "i",
+  "img",
+  "ins",
+  "kbd",
+  "li",
+  "main",
+  "mark",
+  "nav",
+  "ol",
+  "p",
+  "pre",
+  "q",
+  "s",
+  "samp",
+  "section",
+  "small",
+  "span",
+  "strong",
+  "sub",
+  "summary",
+  "sup",
+  "table",
+  "tbody",
+  "td",
+  "tfoot",
+  "th",
+  "thead",
+  "time",
+  "tr",
+  "u",
+  "ul",
+  "var",
+] as const;
+
+const CHAT_HTML_ALLOWED_ATTR = [
+  "alt",
+  "class",
+  "color",
+  "colspan",
+  "data-spk",
+  "decoding",
+  "href",
+  "id",
+  "loading",
+  "rel",
+  "rowspan",
+  "src",
+  "style",
+  "target",
+  "title",
+] as const;
+
+const CHAT_STYLE_BLOCK_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+
+export function sanitizeChatHtml(html: string, options: { allowStyle?: boolean; allowLinks?: boolean } = {}): string {
+  const allowedAttr = CHAT_HTML_ALLOWED_ATTR.filter(
+    (attr) =>
+      (options.allowStyle || attr !== "style") &&
+      (options.allowLinks !== false || (attr !== "href" && attr !== "target")),
+  );
+  const clean = DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: [...CHAT_HTML_ALLOWED_TAGS],
+    ALLOWED_ATTR: allowedAttr,
+    ALLOW_DATA_ATTR: false,
+    ALLOW_UNKNOWN_PROTOCOLS: false,
+    FORBID_TAGS: ["animate", "embed", "foreignObject", "iframe", "math", "object", "script", "svg", "style"],
+    FORBID_ATTR: ["onerror", "onload", "onclick", "srcdoc"],
+  });
+  if (!options.allowStyle || typeof document === "undefined") return clean;
+  const template = document.createElement("template");
+  template.innerHTML = clean;
+  for (const element of template.content.querySelectorAll<HTMLElement>("[style]")) {
+    const style = sanitizeChatMessageCss(element.getAttribute("style") ?? "");
+    if (style) element.setAttribute("style", style);
+    else element.removeAttribute("style");
+  }
+  for (const media of template.content.querySelectorAll("img, audio, video")) {
+    media.setAttribute("referrerpolicy", "no-referrer");
+  }
+  return template.innerHTML;
+}
+
+export function extractChatStyleBlocks(html: string): { html: string; css: string } {
+  const cssBlocks: string[] = [];
+  const withoutStyles = html.replace(CHAT_STYLE_BLOCK_RE, (_match, css: string) => {
+    cssBlocks.push(css);
+    return "";
+  });
+  return { html: withoutStyles, css: cssBlocks.join("\n") };
+}

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -199,6 +199,8 @@ import {
   illustratorBackgroundGenerationEnabled,
   illustratorRequestedBackground,
   illustratorTrackerLocationChanged,
+  parseIllustratorBackgroundPlan,
+  previewIllustratorSceneBackground,
   resolveIllustratorImageConnectionId,
   resolveIllustratorPromptStyle,
 } from "../../services/generation/illustrator-background-generation.js";
@@ -3710,7 +3712,6 @@ async function applyRetryResultEffects(args: {
   if (
     illustratorResult &&
     illustratorEntry &&
-    !illustratorPromptReviewOverride &&
     shouldRetryIllustratorTarget(illustratorRetryTargets, "background") &&
     (isManualIllustratorBackgroundRequest ||
       illustratorBackgroundGenerationEnabled((chat as { mode?: unknown }).mode, chatMeta))
@@ -3757,11 +3758,11 @@ async function applyRetryResultEffects(args: {
           latestGameState?.location,
         );
       }
-      const generated = await generateIllustratorSceneBackground({
+      const backgroundArgs = {
         db: app.db,
         chatId,
         chatName: chat.name,
-        chatMode: (chat as { mode?: unknown }).mode === "game" ? "game" : "roleplay",
+        chatMode: ((chat as { mode?: unknown }).mode === "game" ? "game" : "roleplay") as "game" | "roleplay",
         chatMetadata: freshMeta,
         currentBackground:
           backgroundBeforeGeneration ??
@@ -3773,7 +3774,38 @@ async function applyRetryResultEffects(args: {
         recentMessages: agentContext.recentMessages,
         force: isManualIllustratorBackgroundRequest,
         signal: agentContext.signal,
-        debugLog: (message, ...values) => logDebugOverride(debugMode || isDebugAgentsEnabled(), message, ...values),
+        debugLog: (message: string, ...values: unknown[]) =>
+          logDebugOverride(debugMode || isDebugAgentsEnabled(), message, ...values),
+      };
+      if (isManualIllustratorBackgroundRequest && reviewImagePromptsBeforeSend && !illustratorPromptReviewOverride) {
+        const preview = await previewIllustratorSceneBackground(backgroundArgs);
+        assertRetryActive();
+        sendSseEvent(reply, {
+          type: "image_prompt_review",
+          data: {
+            chatId,
+            item: {
+              id: "roleplay-scene-background",
+              kind: "background",
+              title: "Scene background",
+              prompt: preview.prompt,
+              ...(preview.negativePrompt ? { negativePrompt: preview.negativePrompt } : {}),
+              width: preview.width,
+              height: preview.height,
+            },
+            resultData: { ...illData, generateBackground: true, backgroundPlan: preview.plan },
+          },
+        });
+        return;
+      }
+
+      const generated = await generateIllustratorSceneBackground({
+        ...backgroundArgs,
+        planOverride: illustratorPromptReviewOverride
+          ? (parseIllustratorBackgroundPlan(illData.backgroundPlan) ?? undefined)
+          : undefined,
+        promptOverride: illustratorPromptReviewOverride?.prompt,
+        negativePromptOverride: illustratorPromptReviewOverride?.negativePrompt,
       });
       assertRetryActive();
 

--- a/packages/server/src/services/generation/illustrator-background-generation.ts
+++ b/packages/server/src/services/generation/illustrator-background-generation.ts
@@ -8,9 +8,14 @@ import type { DB } from "../../db/connection.js";
 import { logger } from "../../lib/logger.js";
 import type { ResolvedAgent } from "../agents/agent-pipeline.js";
 import { normalizeAgentContextSize } from "../agents/agent-executor.js";
-import { generateChatBackground } from "../game/game-asset-generation.js";
+import {
+  buildBackgroundProviderPrompt,
+  generateChatBackground,
+  type ChatBackgroundGenRequest,
+} from "../game/game-asset-generation.js";
 import { resolveConnectionImageDefaults, resolveConnectionImageQuality } from "../image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../image/image-generation-settings.js";
+import { resolveImagePromptReviewSize } from "../image/image-prompt-review.js";
 import { createConnectionsStorage } from "../storage/connections.storage.js";
 import { createPromptOverridesStorage } from "../storage/prompt-overrides.storage.js";
 import { resolveImageConnectionFallback } from "./media-connection-fallback.js";
@@ -40,6 +45,22 @@ export type IllustratorBackgroundPlan = {
 export type GeneratedIllustratorBackground = IllustratorBackgroundPlan & {
   filename: string;
   url: string;
+};
+
+type IllustratorSceneBackgroundArgs = {
+  db: DB;
+  chatId: string;
+  chatName?: string | null;
+  chatMode: "roleplay" | "game";
+  chatMetadata: Record<string, unknown>;
+  currentBackground: string | null;
+  illustratorAgent: ResolvedAgent;
+  assistantResponse: string;
+  decisionReason?: string;
+  gameState: GameState | null;
+  recentMessages: Array<{ role: string; content: string; gameState?: GameState | null }>;
+  signal?: AbortSignal;
+  debugLog?: (message: string, ...args: unknown[]) => void;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -322,23 +343,10 @@ async function resolveIllustratorImageConnection(
   return connection;
 }
 
-export async function generateIllustratorSceneBackground(args: {
-  db: DB;
-  chatId: string;
-  chatName?: string | null;
-  chatMode: "roleplay" | "game";
-  chatMetadata: Record<string, unknown>;
-  currentBackground: string | null;
-  illustratorAgent: ResolvedAgent;
-  assistantResponse: string;
-  decisionReason?: string;
-  gameState: GameState | null;
-  recentMessages: Array<{ role: string; content: string; gameState?: GameState | null }>;
-  /** Manual Gallery requests always render again, even when this location slug already exists. */
-  force?: boolean;
-  signal?: AbortSignal;
-  debugLog?: (message: string, ...args: unknown[]) => void;
-}): Promise<GeneratedIllustratorBackground> {
+async function prepareIllustratorSceneBackground(
+  args: IllustratorSceneBackgroundArgs,
+  planOverride?: IllustratorBackgroundPlan,
+) {
   const connections = createConnectionsStorage(args.db);
   const imageConnection = await resolveIllustratorImageConnection(
     connections,
@@ -349,7 +357,6 @@ export async function generateIllustratorSceneBackground(args: {
   const imageSettings = await loadImageGenerationUserSettings(args.db);
   const imageFallback = await resolveImageConnectionFallback(connections, imageConnection.id);
   const imageDefaults = resolveConnectionImageDefaults(imageConnection);
-  const imageQuality = resolveConnectionImageQuality(imageConnection);
   const setupConfig = isRecord(args.chatMetadata.gameSetupConfig) ? args.chatMetadata.gameSetupConfig : {};
   const { styleProfileId, styleInstruction } = resolveIllustratorStyleProfile(
     setupConfig,
@@ -357,8 +364,8 @@ export async function generateIllustratorSceneBackground(args: {
     imageDefaults?.styleProfileId,
     imageSettings.styleProfiles,
   );
-  const plan = await writeIllustratorBackgroundPlan({ ...args, styleInstruction });
-  const filename = await generateChatBackground({
+  const plan = planOverride ?? (await writeIllustratorBackgroundPlan({ ...args, styleInstruction }));
+  const request: ChatBackgroundGenRequest = {
     chatId: args.chatId,
     locationSlug: plan.locationName,
     sceneDescription: plan.prompt,
@@ -380,7 +387,7 @@ export async function generateIllustratorSceneBackground(args: {
     imgEndpointId: imageConnection.imageEndpointId || undefined,
     imgComfyWorkflow: imageConnection.comfyuiWorkflow || undefined,
     imgDefaults: imageDefaults,
-    imgQuality: imageQuality,
+    imgQuality: resolveConnectionImageQuality(imageConnection),
     imgFallback: imageFallback,
     styleProfiles: imageSettings.styleProfiles,
     styleProfileId,
@@ -391,8 +398,39 @@ export async function generateIllustratorSceneBackground(args: {
     omitProfileStyleText: true,
     omitProfileSubjectTags: true,
     debugLog: args.debugLog,
-    force: args.force === true,
     signal: args.signal,
+  };
+  return { imageConnection, imageDefaults, imageSettings, plan, request };
+}
+
+export async function previewIllustratorSceneBackground(args: IllustratorSceneBackgroundArgs) {
+  const prepared = await prepareIllustratorSceneBackground(args);
+  const compiled = await buildBackgroundProviderPrompt(prepared.request);
+  const size = resolveImagePromptReviewSize({
+    connection: prepared.imageConnection,
+    prompt: compiled.prompt,
+    width: prepared.imageSettings.background.width,
+    height: prepared.imageSettings.background.height,
+    imageDefaults: prepared.imageDefaults,
+  });
+  return { plan: prepared.plan, ...compiled, ...size };
+}
+
+export async function generateIllustratorSceneBackground(
+  args: IllustratorSceneBackgroundArgs & {
+    /** Manual Gallery requests always render again, even when this location slug already exists. */
+    force?: boolean;
+    planOverride?: IllustratorBackgroundPlan;
+    promptOverride?: string;
+    negativePromptOverride?: string;
+  },
+): Promise<GeneratedIllustratorBackground> {
+  const { plan, request } = await prepareIllustratorSceneBackground(args, args.planOverride);
+  const filename = await generateChatBackground({
+    ...request,
+    promptOverride: args.promptOverride,
+    negativePromptOverride: args.negativePromptOverride,
+    force: args.force === true,
   });
   if (!filename) throw new Error("Background image generation failed. Check the Illustrator image connection.");
   return {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -5794,6 +5794,21 @@ const cases: RegressionCase[] = [
       assert.match(compiledAutoBackground.prompt, /hastily cleaned floorboards/u);
       assert.doesNotMatch(compiledAutoBackground.prompt, /Infer a consistent visual style from/u);
 
+      const reviewedBackground = await buildBackgroundProviderPrompt({
+        chatId: "manual-gallery-background-reviewed",
+        locationSlug: "fontaine-quarantine-berth",
+        sceneDescription: quarantinePrompt,
+        imgModel: "gpt-image-2",
+        imgBaseUrl: "https://example.invalid",
+        imgApiKey: "",
+        promptOverride: "Reviewer-approved background prompt",
+        negativePromptOverride: "Reviewer-approved negative prompt",
+      });
+      assert.deepEqual(reviewedBackground, {
+        prompt: "Reviewer-approved background prompt",
+        negativePrompt: "Reviewer-approved negative prompt",
+      });
+
       const cinematicProfile = styleProfilesForHandoff.profiles.find((profile) => profile.id === "cinematic")!;
       styleProfilesForHandoff.profiles.push({
         ...cinematicProfile,
@@ -5904,6 +5919,14 @@ const cases: RegressionCase[] = [
       assert.match(retryAgentsRouteSource, /writeManualIllustratorPromptPlan/u);
       assert.match(retryAgentsRouteSource, /_styleProfileInstructionApplied:\s*true/u);
       assert.match(retryAgentsRouteSource, /force:\s*isManualIllustratorBackgroundRequest/u);
+      assert.match(retryAgentsRouteSource, /await previewIllustratorSceneBackground\(backgroundArgs\)/u);
+      assert.match(retryAgentsRouteSource, /kind:\s*"background"/u);
+      assert.match(retryAgentsRouteSource, /backgroundPlan:\s*preview\.plan/u);
+      assert.match(retryAgentsRouteSource, /promptOverride:\s*illustratorPromptReviewOverride\?\.prompt/u);
+      assert.match(
+        chatAreaSource,
+        /illustratorPromptReview\.item\.kind === "background" \? "background" : "illustration"/u,
+      );
       assert.match(retryAgentsRouteSource, /await executeRetryBatches\(\s*agentContext/u);
       assert.ok(
         generationRoutesSource.indexOf("const illustratorPromptAgent") >


### PR DESCRIPTION
## Why

Bot-browser author notes currently expose raw HTML/CSS text, and manual Roleplay gallery backgrounds bypass the enabled media-prompt review gate. This sweep makes author notes readable without granting remote content access to scripts or surrounding UI, and makes manual background generation pause for the same review flow as illustrations.

Closes #5377
Closes #5379

## Summary

- Render bot-browser author-note HTML through the existing chat allowlist.
- Scope sanitized CSS to one contained notes panel; remove scripts, event handlers, link destinations, and global selectors.
- Route manual Roleplay Gallery background prompts through the existing media review modal.
- Resume with the saved background plan and the reviewed prompt, without rerunning the planner.
- Add focused regression coverage and changelog entries.

## Automated validation

- `pnpm localization:check`
- `pnpm check`
- `pnpm regression:prompt`
- `pnpm smoke:ui` — 255 passed, 107 platform-intentional skips
- Focused desktop browser proof — 2 passed
- `git diff --check`

The browser proof verifies safe formatting, script/event removal, inert links, fixed-position containment, and no custom-property leakage to `body`.

## Test plan

- [ ] Run focused regression coverage for HTML/CSS containment and background prompt review.
- [ ] Run `pnpm localization:check`.
- [ ] Run `pnpm check`.
- [ ] Run `pnpm smoke:ui`.
- [ ] Manually verify formatted author notes in the bot browser.
- [ ] Manually verify unsafe scripts, event handlers, navigation, and global CSS cannot escape the author-notes panel.
- [ ] Manually verify Gallery → Background pauses for prompt review when enabled and generates directly when disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added manual review for Roleplay background-generation prompts before image creation.
  - Reviewed prompts and positive/negative prompt edits are submitted exactly as approved.
  - Background generation can resume using the reviewed plan and prompt settings.

- **Bug Fixes**
  - Improved sanitization of Bot-browser creator notes while preserving safe formatting.
  - Blocked scripts, unsafe links, event handlers, and unsafe styles in rich text.
  - Corrected background retry targeting and prompt-review behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->