### PR TITLE
fix(ui): stop setup agent headers covering rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Bot-browser character author notes now render their HTML and CSS through the same sanitizer and style containment as chat messages, with scripts, event handlers, links, and global page styling blocked (#5377).
 - Manual Roleplay background generation from Gallery now pauses for media prompt review when that setting is enabled and sends the reviewed prompt exactly once (#5379).
 - Chat branches now retain their locally configured sprite layout and display preferences (#5374).
-- Agent category headers in the setup wizard now fully cover scrolling agent details, keeping both readable (#5371).
+- Agent category headers in the setup wizard now scroll with their agent rows instead of pinning over and obscuring them (#5371, #5386).
 - Agent prompts now preserve user-authored lorebook entry tags and ampersands verbatim instead of sending HTML entities to the model (#5372).
 - Game Mode now keeps the current scene unchanged while The Game Master finishes a turn, then reveals each generated segment once in order (#5368).
 - Character and Persona editor headers now reserve visible space for the card name to the left of Creator and version information (#5369).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -13197,6 +13197,105 @@ test("Roleplay setup points empty agent libraries to the Agents tab", async ({ p
   }
 });
 
+test("Roleplay setup agent category headers never cover agent rows while scrolling", async ({ page, request }) => {
+  const beforeResponse = await request.get("/api/chats");
+  const beforeChats = (await beforeResponse.json()) as Array<{ id: string }>;
+  const existingChatIds = new Set(beforeChats.map((chat) => chat.id));
+  const connectionResponse = await request.post("/api/connections", {
+    data: { name: `Roleplay Agent Scroll Smoke ${Date.now()}`, provider: "custom" },
+  });
+  expect(connectionResponse.ok()).toBeTruthy();
+  const connection = (await connectionResponse.json()) as { id: string };
+  const agentManifests = [
+    ["writer-one", "Writer One", "writer"],
+    ["writer-two", "Writer Two", "writer"],
+    ["tracker-one", "Tracker One", "tracker"],
+    ["tracker-two", "Tracker Two", "tracker"],
+    ["misc-one", "Misc One", "misc"],
+    ["misc-two", "Misc Two", "misc"],
+  ].map(([id, name, category]) => ({
+    id,
+    name,
+    category,
+    description: `${name} has enough setup guidance to make this agent row wrap across multiple lines on narrow screens.`,
+    author: "Pasta Devs",
+    phase: "post_processing",
+    enabledByDefault: false,
+    modeAllowlist: ["roleplay"],
+    defaultPromptTemplate: "Test prompt.",
+  }));
+
+  await page.route("**/api/capability-packages/agents", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(agentManifests) });
+  });
+  await page.route("**/api/capability-packages/installed", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.route("**/api/agents", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.route("**/api/backgrounds/file/Black.jpg**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "image/gif",
+      body: Buffer.from(TRANSPARENT_GIF_BASE64, "base64"),
+    });
+  });
+
+  try {
+    await page.goto("/");
+    await page.locator('[data-tour="sidebar-toggle"]').click();
+    await page.locator('[data-tour="chat-mode-roleplay"]').click();
+    await page.getByLabel("New Roleplay", { exact: true }).click();
+    const connectionGate = page.getByRole("heading", { name: "Set Up Roleplay", exact: true });
+    const wizardHeading = page.getByRole("heading", { name: "New Roleplay", exact: true });
+    await expect(connectionGate.or(wizardHeading)).toBeVisible();
+    if (await connectionGate.isVisible()) {
+      await page.getByRole("button", { name: "Create Chat", exact: true }).click();
+    }
+    await expect(wizardHeading).toBeVisible();
+    const nextButton = page.getByRole("button", { name: "Next", exact: true });
+    await nextButton.click();
+    await expect(page.getByRole("heading", { name: "Pick a Preset", exact: true })).toBeVisible();
+    await nextButton.click();
+    const participantsHeading = page.getByRole("heading", { name: "Persona & Characters", exact: true });
+    const choiceDialog = page.getByRole("dialog", { name: "Configure Preset Variables" });
+    await expect(choiceDialog.or(participantsHeading).first()).toBeVisible();
+    if (await choiceDialog.isVisible()) {
+      await choiceDialog.getByRole("button", { name: "Skip", exact: true }).click();
+    }
+    await expect(participantsHeading).toBeVisible();
+    await nextButton.click();
+    await expect(page.getByRole("heading", { name: "Attach Lorebooks", exact: true })).toBeVisible();
+    await nextButton.click();
+    await expect(page.getByRole("heading", { name: "Enable Agents", exact: true })).toBeVisible();
+
+    const searchInput = page.getByPlaceholder("Search agents", { exact: true });
+    const agentList = searchInput.locator("xpath=../following-sibling::div[1]");
+    const writerHeader = agentList.getByText("Writer Agents", { exact: true }).locator("..");
+    const firstWriterRow = agentList.getByRole("button", { name: /^Writer One\b/u });
+    await expect(firstWriterRow).toBeVisible();
+    await agentList.evaluate(
+      (element, scrollTop) => {
+        element.scrollTop = scrollTop;
+      },
+      ((await writerHeader.boundingBox())?.height ?? 0) / 2,
+    );
+
+    const [headerBox, rowBox] = await Promise.all([writerHeader.boundingBox(), firstWriterRow.boundingBox()]);
+    expect(headerBox).not.toBeNull();
+    expect(rowBox).not.toBeNull();
+    expect(headerBox!.y + headerBox!.height).toBeLessThanOrEqual(rowBox!.y + 0.5);
+  } finally {
+    const afterResponse = await request.get("/api/chats");
+    const afterChats = (await afterResponse.json()) as Array<{ id: string }>;
+    await Promise.all(
+      afterChats.filter((chat) => !existingChatIds.has(chat.id)).map((chat) => request.delete(`/api/chats/${chat.id}`)),
+    );
+    await request.delete(`/api/connections/${connection.id}`, { timeout: 10_000 });
+  }
+});
+
 test("desktop resource editors open beside their source sidebars", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name.includes("mobile"), "Desktop side-by-side editor behavior.");
   await page.setViewportSize({ width: 1360, height: 900 });

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -3027,7 +3027,7 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
                   const activeCount = section.agents.filter((agent) => activeAgentIds.includes(agent.id)).length;
                   return (
                     <div key={section.category} className="border-b border-[var(--border)]/70 last:border-b-0">
-                      <div className="sticky top-0 z-10 flex items-center justify-between bg-[var(--secondary)] px-3 py-1.5">
+                      <div className="flex items-center justify-between bg-[var(--secondary)] px-3 py-1.5">
                         <span className="text-[0.625rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
                           {section.title}
                         </span>

--- a/scripts/regressions/issue-sweep-5371-5375.regression.ts
+++ b/scripts/regressions/issue-sweep-5371-5375.regression.ts
@@ -6,14 +6,14 @@ const chatSetupWizardSource = readFileSync(
   "utf8",
 );
 const agentHeaderStart = chatSetupWizardSource.indexOf(
-  'className="sticky top-0 z-10 flex items-center justify-between',
+  'className="flex items-center justify-between bg-[var(--secondary)] px-3 py-1.5"',
 );
-assert.ok(agentHeaderStart >= 0, "The agent category header must remain sticky");
+assert.ok(agentHeaderStart >= 0, "The setup wizard must render an agent category header");
 const agentHeaderSource = chatSetupWizardSource.slice(agentHeaderStart, agentHeaderStart + 220);
-assert.match(
+assert.doesNotMatch(
   agentHeaderSource,
-  /bg-\[var\(--secondary\)\](?:\s|")/u,
-  "Sticky agent category headers must be opaque so list text cannot show through them",
+  /\bsticky\b|\btop-0\b/u,
+  "Agent category headers must scroll with their rows instead of covering agent text",
 );
 assert.doesNotMatch(agentHeaderSource, /backdrop-blur/u);
 


### PR DESCRIPTION
## Linked issue

Fixes #5386

## Why this change

The Roleplay setup agent categories used sticky positioning, so scrolling the bounded installed-Agent list pinned a category header directly over the previous agent row. Making the header opaque in #5376 hid show-through but did not remove the overlap.

## What changed

- Let agent category headers scroll normally with their rows.
- Correct the prior static regression so it rejects sticky category headers.
- Add a real desktop/mobile scroll geometry regression.
- Update the changelog.

## Validation

- [ ] pnpm check passes locally
- [ ] Focused regression passes locally
- [ ] pnpm localization:check passes locally
- [ ] pnpm smoke:ui passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed CONTRIBUTING.md

### Automated evidence

- pnpm check — passed.
- pnpm build:shared && node ./scripts/run-regressions.mjs --filter scripts/regressions/issue-sweep-5371-5375.regression.ts — passed.
- pnpm exec playwright test e2e/core-flows.e2e.ts --grep "Roleplay setup agent category headers never cover agent rows while scrolling" — 2 passed (desktop and mobile).

### Manual verification notes

- Manually verify a long installed-Agent list in fresh Roleplay setup on Android APK and Firefox.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated CHANGELOG.md
- [ ] Translated docs on the docs-i18n branch updated to match, or a docs-i18n follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent category headers in the Roleplay setup wizard so they scroll normally with the agent list instead of overlapping agent rows.

* **Tests**
  * Added end-to-end coverage to verify correct scrolling behavior.
  * Updated regression checks to prevent sticky or overlapping category headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->