### PR TITLE
fix: recover stale storage locks after Docker container replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Recreated Docker and Podman containers can now recover a storage lock left after an interrupted shutdown even when the replacement reuses the same internal PID (#5389).
 - The in-field Macro reference and `/macro` help now show the supported `!=`, `is not`, `not contains`, and `not includes` conditional operators (#5383).
 - Bot-browser character author notes now render their HTML and CSS through the same sanitizer and style containment as chat messages, with scripts, event handlers, links, and global page styling blocked (#5377).
 - Manual Roleplay background generation from Gallery now pauses for media prompt review when that setting is enabled and sends the reviewed prompt exactly once (#5379).

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -1227,7 +1227,7 @@ async function stopWriterLeaseLiveness(liveness: WriterLeaseLiveness | null) {
   for (const socket of liveness.sockets) socket.destroy();
   await new Promise<void>((resolveClose, rejectClose) => {
     liveness.server.close((error) => {
-      if (error) rejectClose(error);
+      if (error && (error as NodeJS.ErrnoException).code !== "ERR_SERVER_NOT_RUNNING") rejectClose(error);
       else resolveClose();
     });
   });

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -1697,7 +1697,7 @@ class FileTableStore {
           return;
         } catch (err) {
           try {
-            await stopWriterLeaseLiveness(liveness);
+            await stopWriterLeaseLiveness(liveness).catch(() => undefined);
           } finally {
             rmSync(path, { recursive: true, force: true });
           }

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -22,6 +22,7 @@ import {
 import { chmod, copyFile, open, rename, unlink, writeFile } from "node:fs/promises";
 import { execFileSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
+import { createConnection, createServer, type Server, type Socket } from "node:net";
 import { dirname, join, resolve, sep } from "node:path";
 import { hostname, networkInterfaces } from "node:os";
 import { AsyncLocalStorage } from "node:async_hooks";
@@ -93,15 +94,17 @@ type TableSnapshotManifest = {
 };
 
 type StorageWriterLeaseRecord = {
-  version: 1 | 2;
+  version: 1 | 2 | 3;
   pid: number;
   hostId: string | null;
+  scopeId?: string;
   hostname: string;
   token: string;
   acquiredAt: string;
 };
 
-type ActiveStorageWriterLease = { path: string; token: string };
+type WriterLeaseLiveness = { server: Server; sockets: Set<Socket>; scopeId: string };
+type ActiveStorageWriterLease = { path: string; token: string; liveness: WriterLeaseLiveness | null };
 
 type FileTransactionContext = {
   snapshots: Map<string, Row[]>;
@@ -144,8 +147,9 @@ function hardenPrivateStorageTree(rootDir: string) {
     for (const entry of entries) {
       const path = join(current, entry.name);
       if (entry.isDirectory()) pending.push(path);
-      else if (entry.isFile()) applyPrivateMode(path, PRIVATE_FILE_MODE);
-      else failures.push(new Error(`Storage contains an unsupported filesystem entry: ${path}`));
+      else if (entry.isFile() || (entry.isSocket() && path === writerLeaseLivenessPath(writerLeasePath(rootDir)))) {
+        applyPrivateMode(path, PRIVATE_FILE_MODE);
+      } else failures.push(new Error(`Storage contains an unsupported filesystem entry: ${path}`));
     }
   }
   if (failures.length > 0) {
@@ -190,6 +194,7 @@ export type FileNativeDB = {
 
 export type FileNativeStoreTestHooks = {
   beforeTableWrite?: (table: string, serializedRows: string) => Promise<void> | void;
+  writerLeaseScopeId?: string;
 };
 
 type SelectFromBuilder<TProjection extends Projection | undefined> = {
@@ -239,6 +244,7 @@ type InsertValuesBuilder = Executable<void> & {
 export const STORAGE_VERSION = 5;
 export const STORAGE_WRITER_LEASE_FILENAME = ".writer-lease";
 export const STORAGE_WRITER_OWNER_FILENAME = "owner.json";
+export const STORAGE_WRITER_LIVENESS_FILENAME = "live.sock";
 const SAVE_DEBOUNCE_MS = 750;
 const SAFETY_SAVE_MS = 10_000;
 
@@ -1067,6 +1073,10 @@ function writerLeaseOwnerPath(path: string) {
   return join(path, STORAGE_WRITER_OWNER_FILENAME);
 }
 
+function writerLeaseLivenessPath(path: string) {
+  return join(path, STORAGE_WRITER_LIVENESS_FILENAME);
+}
+
 const CURRENT_HOSTNAME = hostname();
 const CURRENT_LEGACY_HOST_ID = (() => {
   const machineId = ["/etc/machine-id", "/var/lib/dbus/machine-id"].flatMap((path) => {
@@ -1140,6 +1150,19 @@ const CURRENT_HOST_ID = (() => {
     .digest("hex");
 })();
 
+const CURRENT_CONTAINER_WRITER_SCOPE_ID = (() => {
+  if (process.platform !== "linux" || process.env.MARINARA_DOCKER !== "true") return null;
+  try {
+    const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
+    if (bootId) {
+      return createHash("sha256").update(`marinara-writer-lease-boot\n${bootId}`).digest("hex");
+    }
+  } catch {
+    return null;
+  }
+  return null;
+})();
+
 function writerLeaseBelongsToCurrentHost(record: StorageWriterLeaseRecord) {
   if (record.version === 2) {
     return Boolean(CURRENT_HOST_ID && record.hostId === CURRENT_HOST_ID);
@@ -1151,6 +1174,94 @@ function writerLeaseBelongsToCurrentHost(record: StorageWriterLeaseRecord) {
   // hostname fallback is intentionally limited to legacy macOS leases; v2
   // leases always require the stable platform UUID above.
   return process.platform === "darwin" && record.hostname === CURRENT_HOSTNAME;
+}
+
+async function startWriterLeaseLiveness(
+  path: string,
+  token: string,
+  scopeId: string | null,
+): Promise<WriterLeaseLiveness | null> {
+  if (process.platform === "win32" || !scopeId) return null;
+
+  const socketPath = writerLeaseLivenessPath(path);
+  // sockaddr_un is shortest on macOS (103 usable bytes). Stay below every
+  // supported POSIX limit instead of letting a platform silently truncate it.
+  if (Buffer.byteLength(socketPath) > 100) return null;
+
+  // Container PID namespaces can reuse the same internal PID after a recreation.
+  // A socket on the shared data mount remains reachable while its writer lives,
+  // and the kernel drops the listener even when that container is force-killed.
+  const sockets = new Set<Socket>();
+  const server = createServer((socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+    socket.end(token);
+  });
+  try {
+    await new Promise<void>((resolveListen, rejectListen) => {
+      const onError = (error: Error) => rejectListen(error);
+      server.once("error", onError);
+      server.listen(socketPath, () => {
+        server.off("error", onError);
+        resolveListen();
+      });
+    });
+  } catch (error) {
+    rmSync(socketPath, { force: true });
+    logger.debug(
+      { err: error, path: socketPath },
+      "[file-storage] Writer lease socket is unavailable; a stale container lease may require manual recovery.",
+    );
+    return null;
+  }
+
+  server.on("error", (error) => {
+    logger.error(error, "[file-storage] Writer lease socket failed");
+  });
+  server.unref();
+  return { server, sockets, scopeId };
+}
+
+async function stopWriterLeaseLiveness(liveness: WriterLeaseLiveness | null) {
+  if (!liveness) return;
+  for (const socket of liveness.sockets) socket.destroy();
+  await new Promise<void>((resolveClose, rejectClose) => {
+    liveness.server.close((error) => {
+      if (error) rejectClose(error);
+      else resolveClose();
+    });
+  });
+}
+
+async function probeWriterLeaseLiveness(path: string, token: string): Promise<"active" | "stale" | "uncertain"> {
+  if (process.platform === "win32") return "uncertain";
+
+  return new Promise((resolveProbe) => {
+    let response = "";
+    let settled = false;
+    let timeout: NodeJS.Timeout | null = null;
+    const socket = createConnection(writerLeaseLivenessPath(path));
+    const finish = (result: "active" | "stale" | "uncertain") => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      socket.destroy();
+      resolveProbe(result);
+    };
+    timeout = setTimeout(() => finish("uncertain"), 1_000);
+    timeout.unref();
+
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => {
+      response += chunk;
+      if (response.length > 128) finish("uncertain");
+    });
+    socket.on("end", () => finish(response === token ? "active" : "uncertain"));
+    socket.on("error", (error) => {
+      const code = (error as NodeJS.ErrnoException).code;
+      finish(code === "ECONNREFUSED" ? "stale" : "uncertain");
+    });
+  });
 }
 
 class WriterLeasePendingError extends Error {}
@@ -1177,10 +1288,11 @@ function parseWriterLease(path: string): { raw: string; record: StorageWriterLea
   try {
     const record = JSON.parse(raw) as StorageWriterLeaseRecord;
     if (
-      (record.version !== 1 && record.version !== 2) ||
+      (record.version !== 1 && record.version !== 2 && record.version !== 3) ||
       !Number.isSafeInteger(record.pid) ||
       record.pid <= 0 ||
       (record.hostId !== null && typeof record.hostId !== "string") ||
+      (record.version === 3 && (typeof record.scopeId !== "string" || record.scopeId.length === 0)) ||
       typeof record.hostname !== "string" ||
       typeof record.token !== "string" ||
       typeof record.acquiredAt !== "string"
@@ -1549,30 +1661,46 @@ class FileTableStore {
 
   private async acquireWriterLease() {
     const path = writerLeasePath(this.rootDir);
+    const writerScopeId = this.testHooks?.writerLeaseScopeId ?? CURRENT_CONTAINER_WRITER_SCOPE_ID;
     for (let attempt = 0; attempt < 10; attempt++) {
       const token = randomUUID();
       let created = false;
       try {
         mkdirSync(path, { mode: PRIVATE_DIRECTORY_MODE });
         created = true;
-        const record: StorageWriterLeaseRecord = {
-          version: 2,
-          pid: process.pid,
-          hostId: CURRENT_HOST_ID,
-          hostname: CURRENT_HOSTNAME,
-          token,
-          acquiredAt: new Date().toISOString(),
-        };
-        writeFileSync(writerLeaseOwnerPath(path), JSON.stringify(record, null, 2), {
-          encoding: "utf8",
-          flag: "wx",
-          mode: PRIVATE_FILE_MODE,
-        });
-        this.writerLease = { path, token };
-        return;
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
-          if (created) rmSync(path, { recursive: true, force: true });
+          throw new StorageWriterLeaseError(`Could not acquire the storage writer lease at ${path}.`, {
+            cause: err,
+          });
+        }
+      }
+
+      if (created) {
+        const liveness = await startWriterLeaseLiveness(path, token, writerScopeId);
+        try {
+          const record: StorageWriterLeaseRecord = {
+            version: liveness ? 3 : 2,
+            pid: process.pid,
+            hostId: CURRENT_HOST_ID,
+            ...(liveness ? { scopeId: liveness.scopeId } : {}),
+            hostname: CURRENT_HOSTNAME,
+            token,
+            acquiredAt: new Date().toISOString(),
+          };
+          writeFileSync(writerLeaseOwnerPath(path), JSON.stringify(record, null, 2), {
+            encoding: "utf8",
+            flag: "wx",
+            mode: PRIVATE_FILE_MODE,
+          });
+          this.writerLease = { path, token, liveness };
+          return;
+        } catch (err) {
+          try {
+            await stopWriterLeaseLiveness(liveness);
+          } finally {
+            rmSync(path, { recursive: true, force: true });
+          }
           throw new StorageWriterLeaseError(`Could not acquire the storage writer lease at ${path}.`, {
             cause: err,
           });
@@ -1592,8 +1720,23 @@ class FileTableStore {
         }
         throw err;
       }
-      const sameHost = writerLeaseBelongsToCurrentHost(existing.record) || isTermuxPrivateHomeStorage(this.rootDir);
-      if (!sameHost || !pidDefinitelyExited(existing.record.pid)) {
+
+      let staleReason: "liveness" | "pid" | null = null;
+      if (existing.record.version === 3) {
+        // A socket refusal is proof only within the same host kernel. Shared
+        // network storage may expose the socket path to a different machine.
+        if (
+          writerScopeId &&
+          existing.record.scopeId === writerScopeId &&
+          (await probeWriterLeaseLiveness(path, existing.record.token)) === "stale"
+        ) {
+          staleReason = "liveness";
+        }
+      } else {
+        const sameHost = writerLeaseBelongsToCurrentHost(existing.record) || isTermuxPrivateHomeStorage(this.rootDir);
+        if (sameHost && pidDefinitelyExited(existing.record.pid)) staleReason = "pid";
+      }
+      if (!staleReason) {
         throw new StorageWriterLeaseError(
           `Another Marinara Engine process (PID ${existing.record.pid}, host ${existing.record.hostname}) may be using ${this.rootDir}. ` +
             `Close it before retrying. If it no longer exists, verify every process is stopped and remove only ${path}.`,
@@ -1622,16 +1765,19 @@ class FileTableStore {
       }
       rmSync(stalePath, { recursive: true });
       logger.warn(
-        { previousPid: existing.record.pid, path },
-        "[file-storage] Reclaimed the writer lease after confirming its same-host PID exited.",
+        { previousPid: existing.record.pid, path, staleReason },
+        staleReason === "liveness"
+          ? "[file-storage] Reclaimed the writer lease after confirming the previous owner was no longer listening."
+          : "[file-storage] Reclaimed the writer lease after confirming its same-host PID exited.",
       );
     }
     throw new StorageWriterLeaseError(`The storage writer lease at ${path} changed repeatedly; retry startup.`);
   }
 
-  private releaseWriterLease() {
+  private async releaseWriterLease() {
     const active = this.writerLease;
     if (!active) return;
+    await stopWriterLeaseLiveness(active.liveness);
     if (!existsSync(active.path)) {
       logger.warn({ path: active.path }, "[file-storage] The writer lease was already removed.");
       this.writerLease = null;
@@ -1701,7 +1847,7 @@ class FileTableStore {
       logger.info(`[file-storage] Using file-native storage at ${this.rootDir}`);
     } catch (err) {
       try {
-        this.releaseWriterLease();
+        await this.releaseWriterLease();
       } catch (releaseError) {
         throw new AggregateError([err, releaseError], "Storage initialization and writer-lease cleanup failed");
       }
@@ -2336,13 +2482,13 @@ class FileTableStore {
       }
     } catch (err) {
       try {
-        this.releaseWriterLease();
+        await this.releaseWriterLease();
       } catch (releaseError) {
         throw new AggregateError([err, releaseError], "Storage shutdown and writer-lease release both failed");
       }
       throw err;
     }
-    this.releaseWriterLease();
+    await this.releaseWriterLease();
   }
 
   getQuarantinedTables() {

--- a/scripts/regressions/storage-writer-lock.regression.ts
+++ b/scripts/regressions/storage-writer-lock.regression.ts
@@ -123,8 +123,9 @@ try {
     const db = await createFileNativeDB(containerLeaseHooks);
     const leaseTemplate = readJson<LeaseRecord>(ownerPath(dir));
     const socketPathIsSupported = process.platform !== "win32" && Buffer.byteLength(livenessPath(dir)) <= 100;
-    assert.ok(
-      leaseTemplate.version === 2 || (socketPathIsSupported && leaseTemplate.version === 3),
+    assert.equal(
+      leaseTemplate.version,
+      socketPathIsSupported ? 3 : 2,
       "new leases use an owner socket only when the platform, host identity, and path support it",
     );
     assert.equal(existsSync(livenessPath(dir)), leaseTemplate.version === 3);

--- a/scripts/regressions/storage-writer-lock.regression.ts
+++ b/scripts/regressions/storage-writer-lock.regression.ts
@@ -75,6 +75,9 @@ async function leaveStaleSocket(path: string) {
   );
   await new Promise<void>((resolveReady, rejectReady) => {
     child.once("error", rejectReady);
+    child.once("exit", (code, signal) => {
+      rejectReady(new Error(`Stale-socket helper exited before listening (code=${code}, signal=${signal})`));
+    });
     child.stdout!.once("data", () => resolveReady());
   });
   child.kill("SIGKILL");

--- a/scripts/regressions/storage-writer-lock.regression.ts
+++ b/scripts/regressions/storage-writer-lock.regression.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { closeDB, getDB } from "../../packages/server/src/db/connection.js";
 import {
   createFileNativeDB,
+  STORAGE_WRITER_LIVENESS_FILENAME,
   STORAGE_WRITER_LEASE_FILENAME,
   STORAGE_WRITER_OWNER_FILENAME,
   StorageWriterLeaseError,
@@ -16,9 +17,10 @@ import { getMariDbService } from "../../packages/server/src/services/mari-db/mar
 import { resolvePnpmRunner } from "../pnpm-runner.mjs";
 
 type LeaseRecord = {
-  version: 1 | 2;
+  version: 1 | 2 | 3;
   pid: number;
   hostId: string | null;
+  scopeId?: string;
   hostname: string;
   token: string;
   acquiredAt: string;
@@ -43,6 +45,10 @@ function ownerPath(dir: string) {
   return join(leasePath(dir), STORAGE_WRITER_OWNER_FILENAME);
 }
 
+function livenessPath(dir: string) {
+  return join(leasePath(dir), STORAGE_WRITER_LIVENESS_FILENAME);
+}
+
 function readJson<T>(path: string): T {
   return JSON.parse(readFileSync(path, "utf8")) as T;
 }
@@ -55,6 +61,24 @@ async function exitedPid() {
     child.once("exit", () => resolve());
   });
   return child.pid!;
+}
+
+async function leaveStaleSocket(path: string) {
+  const child = spawn(
+    process.execPath,
+    [
+      "-e",
+      'const net = require("node:net"); const server = net.createServer(); server.listen(process.argv[1], () => process.stdout.write("ready\\n"));',
+      path,
+    ],
+    { stdio: ["ignore", "pipe", "inherit"] },
+  );
+  await new Promise<void>((resolveReady, rejectReady) => {
+    child.once("error", rejectReady);
+    child.stdout!.once("data", () => resolveReady());
+  });
+  child.kill("SIGKILL");
+  await waitForExit(child);
 }
 
 async function waitForExit(child: ReturnType<typeof spawn>, timeoutMs = 15_000) {
@@ -92,17 +116,29 @@ try {
   // for the exact same root fails before loading or mutating any data.
   {
     const dir = useTempStorage("writer-lock");
-    const db = await createFileNativeDB();
+    const containerLeaseHooks = { writerLeaseScopeId: "writer-lock-container-host" };
+    const db = await createFileNativeDB(containerLeaseHooks);
     const leaseTemplate = readJson<LeaseRecord>(ownerPath(dir));
-    assert.equal(leaseTemplate.version, 2, "new leases use the stable host-identity format");
+    const socketPathIsSupported = process.platform !== "win32" && Buffer.byteLength(livenessPath(dir)) <= 100;
+    assert.ok(
+      leaseTemplate.version === 2 || (socketPathIsSupported && leaseTemplate.version === 3),
+      "new leases use an owner socket only when the platform, host identity, and path support it",
+    );
+    assert.equal(existsSync(livenessPath(dir)), leaseTemplate.version === 3);
+    if (leaseTemplate.version === 3) {
+      writeFileSync(ownerPath(dir), JSON.stringify({ ...leaseTemplate, hostname: "another-container" }, null, 2));
+    }
     await assert.rejects(
-      createFileNativeDB(),
+      createFileNativeDB(containerLeaseHooks),
       (error: unknown) =>
         error instanceof StorageWriterLeaseError &&
         error.message.includes(String(process.pid)) &&
         error.message.includes(dir),
       "a second live writer is rejected with owner and data-directory details",
     );
+    if (leaseTemplate.version === 3) {
+      writeFileSync(ownerPath(dir), JSON.stringify(leaseTemplate, null, 2));
+    }
 
     const pnpmRunner = resolvePnpmRunner();
     const watcher = spawn(
@@ -155,9 +191,61 @@ try {
     await db._fileStore.close();
     assert.equal(existsSync(leasePath(dir)), false, "a clean close removes its verified lease");
 
-    const externallyReleased = await createFileNativeDB();
+    const externallyReleased = await createFileNativeDB(containerLeaseHooks);
     rmSync(leasePath(dir), { recursive: true });
     await externallyReleased._fileStore.close();
+
+    if (leaseTemplate.version === 3) {
+      mkdirSync(leasePath(dir));
+      await leaveStaleSocket(livenessPath(dir));
+      writeFileSync(
+        ownerPath(dir),
+        JSON.stringify({
+          ...leaseTemplate,
+          version: 3,
+          pid: process.pid,
+          scopeId: "another-host-scope",
+          hostname: "replaced-container",
+          token: "stale-container-token",
+          acquiredAt: "2026-08-13T00:00:00.000Z",
+        }),
+      );
+      await assert.rejects(
+        createFileNativeDB(containerLeaseHooks),
+        StorageWriterLeaseError,
+        "a stale-looking socket from another host scope remains locked",
+      );
+      writeFileSync(
+        ownerPath(dir),
+        JSON.stringify({
+          ...leaseTemplate,
+          version: 3,
+          pid: process.pid,
+          hostname: "replaced-container",
+          token: "stale-container-token",
+          acquiredAt: "2026-08-13T00:00:00.000Z",
+        }),
+      );
+      const afterContainerReplacement = await createFileNativeDB(containerLeaseHooks);
+      assert.notEqual(readJson<LeaseRecord>(ownerPath(dir)).token, "stale-container-token");
+      await afterContainerReplacement._fileStore.close();
+
+      mkdirSync(leasePath(dir));
+      writeFileSync(
+        ownerPath(dir),
+        JSON.stringify({
+          ...leaseTemplate,
+          hostname: "missing-owner-socket",
+          token: "missing-owner-socket-token",
+        }),
+      );
+      await assert.rejects(
+        createFileNativeDB(containerLeaseHooks),
+        StorageWriterLeaseError,
+        "a missing owner socket remains locked because it does not prove the previous writer exited",
+      );
+      rmSync(leasePath(dir), { recursive: true });
+    }
 
     // A same-host stale lock is reclaimed only after its PID is definitely
     // absent. Restricted hosts without a stable host ID deliberately require
@@ -168,6 +256,7 @@ try {
         ownerPath(dir),
         JSON.stringify({
           ...leaseTemplate,
+          version: 2,
           pid: await exitedPid(),
           token: "stale-owner-token",
           acquiredAt: "2026-08-13T00:00:00.000Z",
@@ -219,6 +308,7 @@ try {
           ownerPath(dir),
           JSON.stringify({
             ...leaseTemplate,
+            version: 2,
             pid: await exitedPid(),
             hostId: "stable-id-from-another-machine",
             token: "foreign-v2-token",
@@ -248,6 +338,7 @@ try {
         ownerPath(termuxStorage),
         JSON.stringify({
           ...leaseTemplate,
+          version: 2,
           pid: await exitedPid(),
           hostId: null,
           token: "stale-termux-token",
@@ -268,6 +359,7 @@ try {
           ownerPath(outsideHome),
           JSON.stringify({
             ...leaseTemplate,
+            version: 2,
             pid: await exitedPid(),
             hostId: null,
             token: "outside-termux-home-token",


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5389

## Why this change

If a container exits before shutdown cleanup finishes, it can leave Marinara's storage lock (`.writer-lease`) in the mounted data folder. Outside containers, the machine identity normally stays the same between starts, so Marinara can check whether the recorded process is still running. A replacement container has a new hostname and may reuse the same internal PID, so the current checks cannot confirm that the old container is gone and block the replacement on every startup.

## What changed

- In Docker and Podman, the storage lock now includes a small local socket that responds while its owner is running. If the owner exits without removing the lock, a replacement on the same host can confirm that the socket is no longer active and recover the lock.
- Automatic recovery applies only when the replacement is on the same host and the host has not rebooted. Other cases keep the existing manual recovery path.
- Existing lock formats and non-container installs are unchanged.
- Extended the existing writer-lock regression to cover a live writer under a different container hostname, a stopped container that reuses the same PID, and the fallback when Marinara cannot verify that the old writer is gone.
- Added the fix to the Unreleased changelog.

This adds one local socket while Marinara is running, with no polling or storage scan.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passed.
- The focused storage writer-lock regression passed, including live-owner rejection, same-PID recovery, different-host rejection, uncertain-state rejection, existing lock formats, and clean lock removal.
- Full `pnpm test` passed all 143 regressions.
- Confirmed current `staging` at `57e29c8b6` still fails after a force-killed container is replaced on the same volume: the replacement had a different hostname, reused PID 13, exited with code 1, and left the old lock unchanged.
- Built the fixed Docker image and tested it with a disposable persistent volume. After force-killing a container whose lock recorded PID 13, a replacement with a different hostname and the same PID 13 recovered the lock and served `/api/health`. A second live container using that volume was rejected with `StorageWriterLeaseError` while the replacement stayed healthy. Clean shutdown removed the lock.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

`CHANGELOG.md` is updated. The existing troubleshooting steps remain valid for older locks and cases where Marinara cannot confirm that the previous process stopped.

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of storage locks after interrupted shutdowns in recreated Docker and Podman containers.
  * Prevented replacement containers from being blocked when reusing the same internal process ID.
  * Improved detection, cleanup, and reclamation of stale storage leases, including support for legacy leases.
  * Ensured storage lease resources are cleaned up reliably during startup and shutdown.

* **Documentation**
  * Added a v2.4.3 changelog entry describing these storage lock recovery improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->