### PR TITLE
Fix/summary pop over closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Added `nai-diffusion-5-full` and `nai-diffusion-5-curated` to `IMAGE_GEN_MODELS` in `model-lists.ts` with display names "NAI Diffusion 5 Full" and "NAI Diffusion 5 Curated" (#5343).
 
 ### Fixed
-
+- Chat Summaries PopOver now doesn't close when clicking anywhere on the Summary Deletion Confirmation Pop Up, including Cancel, Delete, or just the popup itself (#5401).
 - Settings and Chat Settings switches now share one track and thumb design, keeping every toggle the same size, shape, travel distance, and vertical alignment on desktop and mobile.
 - Game widget edit icons and Game log deletion actions now follow Chat Chrome Text Color instead of the app accent.
 - The Conversation Start Call button now matches the adjacent participant control height on desktop and mobile.

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -53,6 +53,7 @@ import {
 import { toast } from "sonner";
 import { cn, generateClientId } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui.store";
+import { useDialogStore } from "../../stores/dialog.store";
 import { useConnections } from "../../hooks/use-connections";
 import {
   NEUTRAL_PANEL_CLOSE_BUTTON,
@@ -428,6 +429,7 @@ export function SummaryPopover({
     const path = typeof event.composedPath === "function" ? event.composedPath() : [];
     if (path.includes(panel)) return true;
     if (event.target instanceof Element && event.target.closest("[data-macro-modal]")) return true;
+    if (event.target instanceof Element && event.target.closest("[data-chat-floating-panel]")) return true;
     return event.target instanceof Node && panel.contains(event.target);
   }, []);
 
@@ -1150,6 +1152,7 @@ export function SummaryPopover({
 
   const handleClose = useCallback(async () => {
     if (document.querySelector("[data-macro-modal]")) return;
+    if (useDialogStore.getState().dialog) return;  // a confirm/alert/prompt/choice dialog is open
     if (await commitCombinePromptDraft()) onClose();
   }, [commitCombinePromptDraft, onClose]);
 

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -1152,7 +1152,7 @@ export function SummaryPopover({
 
   const handleClose = useCallback(async () => {
     if (document.querySelector("[data-macro-modal]")) return;
-    if (useDialogStore.getState().dialog) return;  // a confirm/alert/prompt/choice dialog is open
+    if (useDialogStore.getState().dialog) return; // a confirm/alert/prompt/choice dialog is open
     if (await commitCombinePromptDraft()) onClose();
   }, [commitCombinePromptDraft, onClose]);
 


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #5401

## Why this change

- The previous behaviour had the Chat Summaries Window always close when tapping anywhere on the Confirmation Pop Up, that appeared when trying to delete a summary. This happened even when pressing 'Cancel', tapping the pop-up itself, or hitting delete. This was annoying whether you wanted to continue editing your summaries, or just accidentally fat-fingered the 'trash icon/delete summary button'.


## What changed

- Added safeguards that protect the confirmation popup from the 'tap outside' functionality of the SummaryPopover, including hitting ESC, tapping the popup, or even tapping outside of it.

- Now, if you simply tap the popup, the Chat Summaries Window stays open behind it, and nothing happens.
- If you press ESC, tap cancel/delete, or tap OUTSIDE the Confirmation Popup, the Popup closes, but the Chat Summaries Window stays open.

## Validations

- [ ] `pnpm check` passes locally. (My pnpm check still always fails on prettier, but it fails in the same spot as on staging. I think it's something with CRLF and LF, since i'm on windows, but that's beside the point. I think it should be fine.)
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Tested it out on my browser on windows 11, as seen in the attached mp4, as well as on my android phone using Samsung Browser.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

https://github.com/user-attachments/assets/68c29484-4644-49e4-8548-622cc80a38d0

https://github.com/user-attachments/assets/66956159-f650-4294-8e86-04d1feafeaad




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat Summaries popovers now remain open when interacting with the summary deletion confirmation dialog.
  * Selecting **Cancel**, **Delete**, or interacting with the confirmation dialog no longer unintentionally closes the popover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->