### PR TITLE
Return the raw stored text when an experience-state row fails to parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Game-surface Experience packages now receive the raw stored text when a saved world state fails to parse, so a damaged save can be quarantined for recovery or a bug report before the repairing write replaces it (#5407).
 - Professor Mari can now create nested lorebook folders through her existing lorebook commands, and lorebook-capable custom agents can opt into sequential, configurable history-backfill chunks with explicit target selection (#5391).
 - The Roleplay Summariser can now select every entry and delete the current multi-selection in one confirmed action while safely restoring message visibility (#5394).
 - Roleplay Appearance settings can now place model thinking in a collapsible field above each response, stream it live, optionally keep it expanded, and style its stable disclosure header with Chat Chrome Text Color (#5381).

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -10116,16 +10116,51 @@ export async function gameRoutes(app: FastifyInstance) {
       return { exists: false, state: null, schemaVersion: null, anchor: null, committed: false, createdAt: null };
 
     let state: unknown = null;
-    try {
-      state = JSON.parse(row.state);
-    } catch {
-      // The PUT below always stores JSON.stringify output, so this indicates
-      // on-disk corruption; surface an empty save rather than a 500.
-      logger.warn("Unparseable experience state for chat %s (%s)", req.params.chatId, gameType);
+    // Set ONLY when the stored value is unreadable — `stateUnparseable: true` is the
+    // corruption signal (always truthy, unlike `rawState`, which can legitimately be
+    // an empty string). It keeps a corrupt row distinguishable from a legitimately
+    // stored null: the PUT always stores JSON.stringify output, so a stored null is
+    // the four-character string "null", never a missing or non-string column.
+    let corrupt: { stateUnparseable: true; rawState: string; rawStateTruncated: boolean } | null = null;
+    // The catch below exists because the stored value may not be what its type says —
+    // so nothing in this block may re-assume it is a string. A missing key reads back
+    // as null through the store's default path, and a hand-repaired shard can hold a
+    // real object; both are corruption, and both must yield a 200 with a STRING
+    // rawState rather than a 500 or a shape surprise.
+    const storedIsString = typeof row.state === "string";
+    const quarantineFrom = (
+      value: unknown,
+    ): { stateUnparseable: true; rawState: string; rawStateTruncated: boolean } => {
+      const raw = typeof value === "string" ? value : (JSON.stringify(value) ?? "undefined");
+      // Bounded at the same character ceiling the PUT enforces. (JSON escaping can
+      // still expand these characters on the wire; the bound is on the source text.)
+      const rawStateTruncated = raw.length > MAX_EXPERIENCE_STATE_CHARS;
+      return {
+        stateUnparseable: true,
+        rawState: rawStateTruncated ? raw.slice(0, MAX_EXPERIENCE_STATE_CHARS) : raw,
+        rawStateTruncated,
+      };
+    };
+    if (!storedIsString) {
+      logger.warn("Non-string experience state on disk for chat %s (%s)", req.params.chatId, gameType);
+      corrupt = quarantineFrom(row.state);
+    } else {
+      try {
+        state = JSON.parse(row.state);
+      } catch (err) {
+        // On-disk corruption; surface an empty save rather than a 500. Hand the
+        // unparseable text back (#5407): the package's own repair is a replacing PUT,
+        // so without this the damaged bytes are destroyed unseen; with it a package
+        // can preserve a bounded excerpt (a few KB in metadata, or a bug-report copy)
+        // before repairing — the full blob does not belong in hot chat metadata.
+        logger.warn(err, "Unparseable experience state for chat %s (%s)", req.params.chatId, gameType);
+        corrupt = quarantineFrom(row.state);
+      }
     }
     return {
       exists: true,
       state,
+      ...(corrupt ?? {}),
       schemaVersion: row.schemaVersion,
       anchor: { messageId: row.messageId, swipeIndex: row.swipeIndex },
       // False when the returned row is a fallback rather than the visible anchor's own

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -10142,7 +10142,7 @@ export async function gameRoutes(app: FastifyInstance) {
       };
     };
     if (!storedIsString) {
-      logger.warn("Non-string experience state on disk for chat %s (%s)", req.params.chatId, gameType);
+      logger.error("Non-string experience state on disk for chat %s (%s)", req.params.chatId, gameType);
       corrupt = quarantineFrom(row.state);
     } else {
       try {
@@ -10153,7 +10153,7 @@ export async function gameRoutes(app: FastifyInstance) {
         // so without this the damaged bytes are destroyed unseen; with it a package
         // can preserve a bounded excerpt (a few KB in metadata, or a bug-report copy)
         // before repairing — the full blob does not belong in hot chat metadata.
-        logger.warn(err, "Unparseable experience state for chat %s (%s)", req.params.chatId, gameType);
+        logger.error(err, "Unparseable experience state for chat %s (%s)", req.params.chatId, gameType);
         corrupt = quarantineFrom(row.state);
       }
     }

--- a/scripts/regressions/experience-state.regression.ts
+++ b/scripts/regressions/experience-state.regression.ts
@@ -26,6 +26,9 @@
 //  11. Turn-game resign wipes turn-game rows but never experience rows.
 //  12. Checkpoint restore recovers the capture-time world even after the same anchor is
 //      rewritten post-checkpoint (the ordering that invalidated the createdAt re-lookup).
+//  13. A row whose stored value is unreadable (unparseable text, or a non-string column)
+//      returns exists:true / state:null / stateUnparseable:true PLUS the raw text (capped,
+//      flagged when truncated); healthy rows carry none of the three keys.
 import assert from "node:assert/strict";
 import Fastify from "../../packages/server/node_modules/fastify/fastify.js";
 // Shared must come from the built dist so the echo engine registers into the SAME module
@@ -38,7 +41,10 @@ import { createCheckpointService } from "../../packages/server/src/services/game
 import { createChatsStorage } from "../../packages/server/src/services/storage/chats.storage.js";
 import { createGameEngineStateStorage } from "../../packages/server/src/services/storage/game-engine-state.storage.js";
 import { createGameStateStorage } from "../../packages/server/src/services/storage/game-state.storage.js";
-import { getTurnGameView, resignTurnGame } from "../../packages/server/src/services/turn-games/turn-game-runner.service.js";
+import {
+  getTurnGameView,
+  resignTurnGame,
+} from "../../packages/server/src/services/turn-games/turn-game-runner.service.js";
 
 const { getDB, closeDB } = await import("../../packages/server/src/db/connection.js");
 const db = await getDB();
@@ -366,6 +372,132 @@ try {
       { world: "W1-at-checkpoint" },
       "restore recovers the checkpoint-time world even after a same-anchor rewrite",
     );
+  }
+
+  // ── 13. A row whose stored text will not parse hands the raw bytes back (#5407) ──
+  // The client's repair for a corrupt row is a replacing PUT, which destroys the evidence,
+  // and `state: null` on its own is indistinguishable from a legitimately stored null — so
+  // the unparseable text rides along on the failure path only, letting a package quarantine
+  // it first. Corruption is written straight through the storage layer here because the PUT
+  // can only ever store JSON.stringify output.
+  {
+    const chat = await createExperienceChat("experience corrupt row");
+    const m1 = await addAssistantMessage(chat.id, "turn 1");
+    const CORRUPT = '{"zone":"village","x":5';
+    await engineStore.create({
+      chatId: chat.id,
+      messageId: m1.id,
+      swipeIndex: 0,
+      gameType: GAME_TYPE,
+      schemaVersion: 1,
+      state: CORRUPT,
+      committed: true,
+    });
+
+    const get = await getState(chat.id);
+    assert.equal(get.statusCode, 200, "a corrupt row is still a 200, not a 500");
+    const body = get.json();
+    assert.equal(body.exists, true, "a corrupt row still reports exists:true");
+    assert.equal(body.state, null, "unparseable state still reads as null");
+    assert.equal(body.stateUnparseable, true, "the corruption signal is an always-truthy boolean");
+    assert.equal(body.rawState, CORRUPT, "a corrupt row hands back its raw stored text verbatim");
+    assert.equal(body.rawStateTruncated, false, "stored text within the ceiling is returned whole");
+
+    // Healthy rows must not carry the keys at all — their presence IS the corruption signal.
+    const healthy = await createExperienceChat("experience healthy row");
+    await addAssistantMessage(healthy.id, "turn 1");
+    await putState(healthy.id, { state: { fine: true } });
+    const healthyBody = (await getState(healthy.id)).json();
+    assert.deepEqual(healthyBody.state, { fine: true });
+    assert.ok(!("rawState" in healthyBody), "a healthy row carries no rawState key");
+    assert.ok(!("rawStateTruncated" in healthyBody), "a healthy row carries no rawStateTruncated key");
+    assert.ok(!("stateUnparseable" in healthyBody), "a healthy row carries no stateUnparseable key");
+
+    // The catch must never re-assume the type it exists to distrust: a NON-STRING state
+    // column (a hand-repaired shard holding a real object, or a missing key reading back
+    // as null through the store's default path) is corruption too — a 200 with a STRING
+    // rawState, never a 500 and never a silent state:null that masquerades as legitimate.
+    const objectRow = await createExperienceChat("experience object-state row");
+    const m3 = await addAssistantMessage(objectRow.id, "turn 1");
+    await engineStore.create({
+      chatId: objectRow.id,
+      messageId: m3.id,
+      swipeIndex: 0,
+      gameType: GAME_TYPE,
+      schemaVersion: 1,
+      state: { zone: "village", x: 5 } as unknown as string,
+      committed: true,
+    });
+    const objectGet = await getState(objectRow.id);
+    assert.equal(objectGet.statusCode, 200, "a non-string state column is a 200, not a 500");
+    const objectBody = objectGet.json();
+    assert.equal(objectBody.stateUnparseable, true, "a non-string state column reports corruption");
+    assert.equal(typeof objectBody.rawState, "string", "rawState is a string under every on-disk shape");
+    assert.deepEqual(
+      JSON.parse(objectBody.rawState),
+      { zone: "village", x: 5 },
+      "the object round-trips as its JSON text",
+    );
+
+    const nullRow = await createExperienceChat("experience null-state row");
+    const m4 = await addAssistantMessage(nullRow.id, "turn 1");
+    await engineStore.create({
+      chatId: nullRow.id,
+      messageId: m4.id,
+      swipeIndex: 0,
+      gameType: GAME_TYPE,
+      schemaVersion: 1,
+      state: null as unknown as string,
+      committed: true,
+    });
+    const nullColBody = (await getState(nullRow.id)).json();
+    assert.equal(nullColBody.stateUnparseable, true, "a null state COLUMN is corruption, not a stored null");
+    assert.equal(nullColBody.rawState, "null", "and its rawState is the stringified column");
+
+    // An empty-string stored state is unparseable and its rawState is falsy — which is
+    // exactly why the discriminator is stateUnparseable, not truthiness of rawState.
+    const emptyRow = await createExperienceChat("experience empty-state row");
+    const m5 = await addAssistantMessage(emptyRow.id, "turn 1");
+    await engineStore.create({
+      chatId: emptyRow.id,
+      messageId: m5.id,
+      swipeIndex: 0,
+      gameType: GAME_TYPE,
+      schemaVersion: 1,
+      state: "",
+      committed: true,
+    });
+    const emptyBody = (await getState(emptyRow.id)).json();
+    assert.equal(emptyBody.stateUnparseable, true, "an empty-string row reports corruption");
+    assert.equal(emptyBody.rawState, "", "with its (falsy) raw text intact");
+
+    // ...which is what makes a legitimately stored null distinguishable from corruption.
+    const storedNull = await createExperienceChat("experience stored null");
+    await addAssistantMessage(storedNull.id, "turn 1");
+    await putState(storedNull.id, { state: null });
+    const storedNullBody = (await getState(storedNull.id)).json();
+    assert.equal(storedNullBody.state, null);
+    assert.ok(!("rawState" in storedNullBody), "a legitimately stored null is not reported as corrupt");
+
+    // On-disk damage is not bounded by the PUT's ceiling, so the response is: the raw text
+    // is capped at MAX_EXPERIENCE_STATE_CHARS (262_144) and flagged rather than inflating it.
+    const oversize = await createExperienceChat("experience corrupt oversize");
+    const m2 = await addAssistantMessage(oversize.id, "turn 1");
+    const HUGE = `{"blob":"${"x".repeat(300_000)}`; // unterminated → unparseable
+    await engineStore.create({
+      chatId: oversize.id,
+      messageId: m2.id,
+      swipeIndex: 0,
+      gameType: GAME_TYPE,
+      schemaVersion: 1,
+      state: HUGE,
+      committed: true,
+    });
+    const oversizeBody = (await getState(oversize.id)).json();
+    assert.equal(oversizeBody.state, null);
+    assert.equal(oversizeBody.rawStateTruncated, true, "an oversize corrupt row is flagged as truncated");
+    assert.equal(oversizeBody.rawState.length, 262_144, "the raw text is capped at MAX_EXPERIENCE_STATE_CHARS");
+    assert.ok(HUGE.startsWith(oversizeBody.rawState), "the truncated text is a prefix of the stored text");
   }
 
   console.log("experience-state regression passed");


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5407

## Why this change

- When a stored experience-state row fails to parse, the GET currently returns `{ exists: true, state: null }` and drops the raw text — so a package's correct repair (a replacing PUT) destroys the damaged bytes with no way to preserve them first, and a corrupt row is indistinguishable from a legitimately stored `null`.
- Filed from the Pixelforge S5 (player state) planning work, where the save block makes corrupt-row recovery worth having.

## What changed

- `GET /api/game/:chatId/experience-state`: when the stored value is unreadable, the response now carries `stateUnparseable: true` (always-truthy corruption discriminator), `rawState` (the stored text, capped at `MAX_EXPERIENCE_STATE_CHARS`), and `rawStateTruncated`. Healthy rows are byte-identical to before — none of the three keys appear.
- A **non-string** `state` column (a missing key reading back as null, or a hand-repaired shard holding a real object) is treated as corruption too — a 200 with a *string* `rawState` (its JSON text), never a 500 and never a silent `state: null` masquerading as legitimate. The catch path no longer re-assumes the type it exists to distrust.
- The parse-failure warn log is now error-object-first per repo convention (note: the SyntaxError message can carry a snippet of the stored text into the log).
- Regression case 13 extended: verbatim raw text, truncation cap + prefix, healthy/stored-null rows carry no corruption keys, object-column, null-column, and empty-string-column shapes (the last is why the discriminator is a boolean — `rawState` can legitimately be falsy). Fail-first proven.
- CHANGELOG entry under Unreleased.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Agent-run (not manual): `experience-state` regression lane green (fail-first proven before the change); `pnpm lint` (typecheck, all 3 packages) green; prettier clean on touched files. `format:check` on the whole tree false-fails in CRLF worktrees (pre-existing, environmental); CI on LF is authoritative.
- No UI surface — this is a package-facing HTTP response change; there is nothing to click through in a browser.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Experience state requests now remain successful when stored data is malformed, empty, non-string, or oversized.
  - Invalid state data returns clear corruption details, including bounded raw text and truncation status.
  - Valid states and legitimately stored `null` values continue to be handled distinctly.

- **Documentation**
  - Added changelog documentation for providing recoverable raw saved-world text when parsing fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->