### PR TITLE
Show Memory Nag Roleplay availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Memory Nag now shows its Roleplay badge in Download Agents, while capability-package regression coverage tracks the API version required by its runtime (#5438).
 - Professor Mari now shows a one-click Accept action for proposed writes, accepts exact confirmations in any language within the pending operation's scope, resumes authorized work after output limits without exact phrasing, goes directly to supplied character or Persona IDs, and prevents hidden reasoning from consuming local JSON responses (#5431, #5434).
 - Character and Persona card macros now resolve in request-scoped text and appearance context before generation and image agents consume them, without changing the saved card (#5432).
 - OpenAI-compatible custom connections now preserve Anthropic-style `tool_use` content blocks, restoring visible LinkAPI Opus tool calls (#5430).

--- a/packages/client/src/components/agents/AgentCatalogView.tsx
+++ b/packages/client/src/components/agents/AgentCatalogView.tsx
@@ -53,6 +53,7 @@ const OFFICIAL_PACKAGE_MODES: Readonly<Record<string, readonly CatalogMode[]>> =
   "character-tracker": ["roleplay"],
   "custom-tracker": ["roleplay"],
   "inventory-tracker": ["roleplay"],
+  "memory-nag": ["roleplay"],
   expression: ["roleplay"],
   "hierarchical-maps": ["roleplay", "game"],
   "persona-stats": ["roleplay"],

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -104,7 +104,7 @@ try {
   const legacyManifest = capabilityPackageManifestSchema.parse(installedPackage("legacy", ["agent"]).manifest);
   assert.equal(legacyManifest.schemaVersion, 1, "Existing manifest v1 packages must remain readable");
   assert.equal(getCapabilityApiCompatibilityIssue(legacyManifest), null);
-  assert.deepEqual(supportedCapabilityApi, { major: 1, minor: 13 });
+  assert.deepEqual(supportedCapabilityApi, { major: 1, minor: 14 });
 
   const manifestV2 = capabilityPackageManifestSchema.parse({
     ...legacyManifest,
@@ -140,20 +140,20 @@ try {
   });
   assert.match(
     getCapabilityApiCompatibilityIssue(unsupportedMajorManifest) ?? "",
-    /requires capability API 2\.0; this Engine supports 1\.13/,
+    /requires capability API 2\.0; this Engine supports 1\.14/,
   );
   const currentMinorManifest = capabilityPackageManifestSchema.parse({
     ...manifestV2,
-    capabilityApi: { major: 1, minor: 13 },
+    capabilityApi: { major: 1, minor: 14 },
   });
   assert.equal(getCapabilityApiCompatibilityIssue(currentMinorManifest), null);
   const unsupportedMinorManifest = capabilityPackageManifestSchema.parse({
     ...manifestV2,
-    capabilityApi: { major: 1, minor: 14 },
+    capabilityApi: { major: 1, minor: 15 },
   });
   assert.match(
     getCapabilityApiCompatibilityIssue(unsupportedMinorManifest) ?? "",
-    /requires capability API 1\.14; this Engine supports 1\.13/,
+    /requires capability API 1\.15; this Engine supports 1\.14/,
   );
 
   const forwardCompatibleCatalog = capabilityCatalogSchema.parse({


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5438

## Why this change

Download Agents omitted Memory Nag's Roleplay badge even though the package is Roleplay-only. The catalog view maintains the official mode badges in an Engine-side mapping, and Memory Nag was missing from it.

## What changed

- Add Memory Nag to the existing Roleplay package-mode mapping.
- Bring the capability-package lifecycle regression in sync with Engine's current capability API 1.14 contract used by Memory Nag.
- Add a user-facing changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Run `packages/server/node_modules/.bin/tsx scripts/regressions/capability-package-lifecycle.regression.ts`.
- Run `pnpm check` and `pnpm localization:check`.
- Open Download Agents and verify Memory Nag displays the Roleplay badge.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No layout or styling changed; this restores the existing Roleplay badge on Memory Nag's catalog card.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Memory Nag to the official agent catalog for roleplay experiences.
  - Memory Nag’s Roleplay badge is now displayed in the Download Agents view.

- **Bug Fixes**
  - Updated capability compatibility checks to support runtime API version 1.14.
  - Versions beyond the supported range now show the correct compatibility error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->