### PR TITLE
feat(agents): give Memory Nag standalone settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
-- Active Memory Nag packages now get a standalone Roleplay Agents settings section, while remaining available in Tracker Agents for initial setup and tracker scheduling (#5440, Pasta-Devs/Marinara-Agents#518).
+- Active Memory Nag packages now get a standalone Roleplay Agents settings section; inactive Memory Nag remains in Tracker Agents for initial setup and tracker scheduling (#5440, Pasta-Devs/Marinara-Agents#518).
 - Pull requests and scheduled security audits now run the focused import, sandbox, host-authentication, and runtime-integrity regression lane, while the new security policy provides private vulnerability reporting without changing Marinara's local-first capabilities (#5436).
 - Game setup's Review Starting Widgets step can now add, rename, re-icon, retype, duplicate, and fully edit proposed widgets before the first turn (#5426).
 - Roleplay and Conversation message deletion can now keep the selected swipe and delete every alternate in one action (#5380).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Active Memory Nag packages now get a standalone Roleplay Agents settings section, while remaining available in Tracker Agents for initial setup and tracker scheduling (#5440, Pasta-Devs/Marinara-Agents#518).
 - Pull requests and scheduled security audits now run the focused import, sandbox, host-authentication, and runtime-integrity regression lane, while the new security policy provides private vulnerability reporting without changing Marinara's local-first capabilities (#5436).
 - Game setup's Review Starting Widgets step can now add, rename, re-icon, retype, duplicate, and fully edit proposed widgets before the first turn (#5426).
 - Roleplay and Conversation message deletion can now keep the selected swipe and delete every alternate in one action (#5380).

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -164,7 +164,7 @@ import {
   stepCadenceValue,
 } from "../../lib/agent-cadence";
 import { characterMatchesSearch, getCharacterTitle, parseCharacterDisplayData } from "../../lib/character-display";
-import { buildRoleplayAgentSettingsOrder } from "../../lib/agent-settings-order";
+import { buildRoleplayAgentSettingsOrder, hasStandaloneRoleplayAgentSettings } from "../../lib/agent-settings-order";
 import { extractCreatorNotesCss } from "../../lib/creator-notes-css";
 import { isLorebookScopeActiveForChat } from "../../lib/lorebook-scope";
 import { addSilentGreetingSwipes } from "../../lib/message-swipes";
@@ -441,6 +441,8 @@ function renderRoleplayAgentMenuIcon(agentId: string, variant: "card" | "chip" =
     case "haptic":
       return <Vibrate size={size} className={className} />;
     case "long-term-memory":
+      return <Brain size={size} className={className} />;
+    case "memory-nag":
       return <Brain size={size} className={className} />;
     case "hierarchical-maps":
       return <MapIcon size={size} className={className} />;
@@ -1280,7 +1282,10 @@ export function ChatSettingsDrawer({
     }
     return packages;
   }, [installedCapabilities]);
-  const renderDownloadedAgentChatSettings = (agent: { id: string; name: string; description: string }) => {
+  const renderDownloadedAgentChatSettings = (
+    agent: { id: string; name: string; description: string },
+    className = "mt-2 block overflow-hidden rounded-lg",
+  ) => {
     if (agent.id === "hierarchical-maps" || agent.id === "long-term-memory") return null;
     const capabilityPackage = chatSettingsPackageByAgentId.get(agent.id);
     if (!capabilityPackage) return null;
@@ -1297,7 +1302,7 @@ export function ChatSettingsDrawer({
           onDirtyChange: setEditorDirty,
           confirmAction: showConfirmDialog,
         }}
-        className="mt-2 block overflow-hidden rounded-lg"
+        className={className}
       />
     );
   };
@@ -2101,6 +2106,14 @@ export function ChatSettingsDrawer({
   const ltmAgent = availableAgents.find((agent) => agent.id === ltmPackage?.id);
   const storyboardAgent = availableAgents.find((agent) => agent.id === STORYBOARD_AGENT_ID);
   const beholderAgent = availableAgents.find((agent) => agent.id === "beholder");
+  const memoryNagAgent = availableAgents.find((agent) => agent.id === "memory-nag");
+  const memoryNagStandaloneActive = Boolean(
+    metadata.enableAgents === true &&
+    isRoleplayMode &&
+    memoryNagAgent &&
+    activeAgentIds.includes(memoryNagAgent.id) &&
+    chatSettingsPackageByAgentId.has(memoryNagAgent.id),
+  );
   const [pendingAgentMenuTargetId, setPendingAgentMenuTargetId] = useState<string | null>(null);
   const roleplayAgentMenuLinks = useMemo(() => {
     if (!metadata.enableAgents || !isRoleplayMode || isGame) return [];
@@ -7730,6 +7743,19 @@ export function ChatSettingsDrawer({
                         />
                       )}
 
+                      {memoryNagStandaloneActive && memoryNagAgent && (
+                        <AgentSettingsCard
+                          id={getAgentSettingsMenuId(chat.id, memoryNagAgent.id)}
+                          icon={renderRoleplayAgentMenuIcon(memoryNagAgent.id)}
+                          title={memoryNagAgent.name}
+                          description={memoryNagAgent.description}
+                          order={getRoleplayAgentSettingsOrder(memoryNagAgent.id)}
+                          onRemove={getRoleplayAgentMenuRemoveHandler(memoryNagAgent.id, memoryNagAgent.name)}
+                        >
+                          {renderDownloadedAgentChatSettings(memoryNagAgent, "block overflow-hidden rounded-lg")}
+                        </AgentSettingsCard>
+                      )}
+
                       {metadata.enableAgents && !isGame && expressionActive && (
                         <AgentSettingsCard
                           id={getAgentSettingsMenuId(chat.id, "expression")}
@@ -8721,7 +8747,11 @@ export function ChatSettingsDrawer({
                           ).map((cat) => {
                             const catAgents = availableAgents.filter((a) => a.category === cat.key);
                             const activeInCat = catAgents
-                              .filter((a) => activeAgentIds.includes(a.id))
+                              .filter(
+                                (a) =>
+                                  activeAgentIds.includes(a.id) &&
+                                  !(hasStandaloneRoleplayAgentSettings(a.id) && memoryNagStandaloneActive),
+                              )
                               .sort(
                                 (a, b) => getRoleplayAgentSettingsOrder(a.id) - getRoleplayAgentSettingsOrder(b.id),
                               );
@@ -8735,7 +8765,9 @@ export function ChatSettingsDrawer({
                                 description={cat.description}
                                 count={activeInCat.length}
                                 openRequest={catAgents.some(
-                                  (agent) => getAgentSettingsMenuId(chat.id, agent.id) === pendingAgentMenuTargetId,
+                                  (agent) =>
+                                    !(hasStandaloneRoleplayAgentSettings(agent.id) && memoryNagStandaloneActive) &&
+                                    getAgentSettingsMenuId(chat.id, agent.id) === pendingAgentMenuTargetId,
                                 )}
                               >
                                 {/* Active agents in this category */}

--- a/packages/client/src/lib/agent-settings-order.ts
+++ b/packages/client/src/lib/agent-settings-order.ts
@@ -6,6 +6,12 @@ const AGENT_CATEGORY_ORDER: Record<string, number> = {
   misc: 2,
 };
 
+const STANDALONE_ROLEPLAY_AGENT_SETTINGS = new Set(["memory-nag"]);
+
+export function hasStandaloneRoleplayAgentSettings(agentId: string): boolean {
+  return STANDALONE_ROLEPLAY_AGENT_SETTINGS.has(agentId);
+}
+
 export function buildRoleplayAgentSettingsOrder(agents: readonly BuiltInAgentManifest[]): Map<string, number> {
   const order = new Map<string, number>(
     agents

--- a/scripts/regressions/agent-registry-hydration.regression.ts
+++ b/scripts/regressions/agent-registry-hydration.regression.ts
@@ -5,7 +5,10 @@ import {
   type BuiltInAgentManifest,
   type InstalledCapabilityPackage,
 } from "../../packages/shared/dist/index.js";
-import { buildRoleplayAgentSettingsOrder } from "../../packages/client/src/lib/agent-settings-order.js";
+import {
+  buildRoleplayAgentSettingsOrder,
+  hasStandaloneRoleplayAgentSettings,
+} from "../../packages/client/src/lib/agent-settings-order.js";
 import {
   isCapabilityPackageAvailableUntilRestart,
   selectHomeBrowserPackages,
@@ -120,6 +123,8 @@ const activeSettingsOrder = ["writer", "tracker", "misc"].flatMap((category) =>
     .map((agent) => agent.id),
 );
 assert.deepEqual(activeSettingsOrder, menuOrder, "Roleplay quick links and active settings must share one order");
+assert.equal(hasStandaloneRoleplayAgentSettings("memory-nag"), true);
+assert.equal(hasStandaloneRoleplayAgentSettings("late-tracker"), false);
 
 // Connections can mount before this query resolves. It must use the React Query
 // result, rather than reading the mutable shared registry that is already hydrated.


### PR DESCRIPTION
## Why

Memory Nag has its own vault, scan workflow, connection routing, and per-chat controls, but active installs were embedded inside the generic Tracker Agents list. That makes a substantial agent harder to find and unlike peer menus such as Echo Chamber and Expression Engine.

Closes #5440
Package update: Pasta-Devs/Marinara-Agents#519

## What changed

- render active Memory Nag package settings in a standalone Roleplay `AgentSettingsCard`
- keep Memory Nag in Tracker Agents while inactive so it can still be added normally
- remove the active duplicate from the Tracker Agents category
- keep tracker scheduling and execution behavior unchanged
- give Memory Nag the same brain icon in Agent menu links and cards

## Validation

- [ ] Run `pnpm check`
- [ ] Run `pnpm localization:check`
- [ ] Run `scripts/regressions/agent-registry-hydration.regression.ts`
- [ ] Install/update Memory Nag 1.0.3 and restart Engine
- [ ] Manually verify the Memory Nag card and quick link in Roleplay Chat Settings
- [ ] Manually verify inactive Memory Nag remains addable from Tracker Agents
- [ ] Manually verify desktop and mobile drawer layouts

## Notes

The Engine only owns placement and host props. The downloadable UI, prompt, generation defaults, translations, and package artifact remain in Marinara-Agents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone settings section for Active Memory Nag roleplay agents.
  * Active Memory Nag remains available in Tracker Agents for initial setup and scheduling.
  * Added dedicated activation and configuration controls in chat settings.
  * Standalone settings now display the agent’s icon and relevant configuration options.

* **Bug Fixes**
  * Prevented standalone agents from appearing redundantly in general roleplay agent settings.
  * Improved detection of agents that provide dedicated standalone settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->