### PR TITLE
fix(ui): unify Chat Settings agent controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Chat Settings now reuses one compact action, toggle, and segmented-control design across agent menus; World Maps, Beholder, Storyboards, Long-Term Memory, and Memory Nag have standalone active-agent cards, while Impersonate prompts use the standard expandable macro field (#5443, Pasta-Devs/Marinara-Agents#521).
 - Memory Nag now shows its Roleplay badge in Download Agents, while capability-package regression coverage tracks the API version required by its runtime (#5438).
 - Professor Mari now shows a one-click Accept action for proposed writes, accepts exact confirmations in any language within the pending operation's scope, resumes authorized work after output limits without exact phrasing, goes directly to supplied character or Persona IDs, and prevents hidden reasoning from consuming local JSON responses (#5431, #5434).
 - Character and Persona card macros now resolve in request-scoped text and appearance context before generation and image agents consume them, without changing the saved card (#5432).

--- a/packages/client/src/components/chat/AgentSettingsControls.tsx
+++ b/packages/client/src/components/chat/AgentSettingsControls.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState, type ReactNode } from "react";
+import { useEffect, useId, useState, type ButtonHTMLAttributes, type ReactNode } from "react";
 import { ChevronDown, ChevronRight, Settings2, Trash2 } from "lucide-react";
 import { useTranslation as useUiTranslation } from "react-i18next";
 import type { AgentPromptTemplateOption } from "@marinara-engine/shared";
@@ -7,6 +7,31 @@ import { useUIStore } from "../../stores/ui.store";
 import { SettingsSwitch } from "../panels/settings/SettingControls";
 
 export const AGENT_SETTINGS_SURFACE_CLASS = "border border-[var(--border)] bg-[var(--secondary)]/70";
+
+export function AgentSettingsActionButton({
+  variant = "default",
+  iconOnly = false,
+  className,
+  type = "button",
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: "default" | "primary" | "danger";
+  iconOnly?: boolean;
+}) {
+  return (
+    <button
+      {...props}
+      type={type}
+      className={cn(
+        "mari-agent-settings-action",
+        variant === "primary" && "mari-agent-settings-action--primary",
+        variant === "danger" && "mari-agent-settings-action--danger",
+        iconOnly && "mari-agent-settings-action--icon",
+        className,
+      )}
+    />
+  );
+}
 
 export function AgentCategorySection({
   label,

--- a/packages/client/src/components/chat/BeholderChatSettingsPanel.tsx
+++ b/packages/client/src/components/chat/BeholderChatSettingsPanel.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Eye, Loader2, Settings2 } from "lucide-react";
 import { useTranslation as useUiTranslation } from "react-i18next";
 import { api } from "../../lib/api-client";
+import { AgentSettingsActionButton } from "./AgentSettingsControls";
 
 type Damage = "pristine" | "damaged" | "cracked" | "broken";
 type WoundSeverity = "minor" | "serious" | "critical";
@@ -65,10 +66,9 @@ export default function BeholderChatSettingsPanel({
         </p>
       </div>
 
-      <button
-        type="button"
+      <AgentSettingsActionButton
         onClick={onOpenAgentSettings}
-        className="flex w-full items-center gap-2 rounded-lg bg-[var(--secondary)]/70 px-2.5 py-2 text-left transition-colors hover:bg-[var(--accent)]"
+        className="h-auto w-full justify-start px-2.5 py-2 text-left"
       >
         <Settings2 size="0.75rem" className="shrink-0 text-[var(--primary)]" />
         <span className="min-w-0 flex-1">
@@ -79,7 +79,7 @@ export default function BeholderChatSettingsPanel({
             {localizeUi("ui.chat.beholder.configureAgentDescription")}
           </span>
         </span>
-      </button>
+      </AgentSettingsActionButton>
 
       <section className="rounded-lg bg-[var(--background)]/65 p-2.5 ring-1 ring-[var(--border)]">
         <div className="mb-2 flex items-center gap-1.5">

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -22,6 +22,7 @@ import {
   AlertTriangle,
   GripVertical,
   MessageCircle,
+  MessageSquareQuote,
   Bot,
   CalendarClock,
   Camera,
@@ -95,7 +96,9 @@ import {
   AGENT_SETTINGS_SURFACE_CLASS,
   AgentCategorySection,
   AgentDefaultStatus,
+  AgentSettingsActionButton,
   AgentSettingsCard,
+  AgentSettingsSegmentedControl,
   AgentSettingsSubsection,
   AgentSettingsTextarea,
   AgentSettingsToggle,
@@ -443,7 +446,7 @@ function renderRoleplayAgentMenuIcon(agentId: string, variant: "card" | "chip" =
     case "long-term-memory":
       return <Brain size={size} className={className} />;
     case "memory-nag":
-      return <Brain size={size} className={className} />;
+      return <MessageSquareQuote size={size} className={className} />;
     case "hierarchical-maps":
       return <MapIcon size={size} className={className} />;
     case "custom-agents":
@@ -1319,6 +1322,20 @@ export function ChatSettingsDrawer({
     const ids = latestChat ? getChatActiveAgentIds(latestChat) : [...activeAgentIds];
     return ids.filter((id) => !deletedBuiltInAgentTypes.has(id));
   }, [activeAgentIds, chat.id, deletedBuiltInAgentTypes, qc]);
+  const setMapsEnabledForChat = useCallback(
+    async (enabled: boolean) => {
+      if (!mapsPackage) return;
+      const current = readLatestActiveAgentIds();
+      await updateMeta.mutateAsync({
+        id: chat.id,
+        ...(enabled ? { enableAgents: true } : {}),
+        activeAgentIds: enabled
+          ? Array.from(new Set([...current, mapsPackage.id]))
+          : current.filter((id) => id !== mapsPackage.id),
+      });
+    },
+    [chat.id, mapsPackage, readLatestActiveAgentIds, updateMeta],
+  );
   const setLtmEnabledForChat = useCallback(
     async (enabled: boolean) => {
       if (!ltmPackageId) return;
@@ -2106,13 +2123,30 @@ export function ChatSettingsDrawer({
   const ltmAgent = availableAgents.find((agent) => agent.id === ltmPackage?.id);
   const storyboardAgent = availableAgents.find((agent) => agent.id === STORYBOARD_AGENT_ID);
   const beholderAgent = availableAgents.find((agent) => agent.id === "beholder");
-  const memoryNagAgent = availableAgents.find((agent) => agent.id === "memory-nag");
-  const memoryNagStandaloneActive = Boolean(
-    metadata.enableAgents === true &&
-    isRoleplayMode &&
-    memoryNagAgent &&
-    activeAgentIds.includes(memoryNagAgent.id) &&
-    chatSettingsPackageByAgentId.has(memoryNagAgent.id),
+  const standaloneRoleplayAgents = useMemo(
+    () =>
+      metadata.enableAgents === true && isRoleplayMode
+        ? availableAgents.filter((agent) => {
+            if (!activeAgentIds.includes(agent.id) || !hasStandaloneRoleplayAgentSettings(agent.id)) return false;
+            if (agent.id === "hierarchical-maps") return Boolean(mapsPackage);
+            if (agent.id === "long-term-memory") return Boolean(ltmPackage);
+            if (agent.id === STORYBOARD_AGENT_ID || agent.id === "beholder") return true;
+            return chatSettingsPackageByAgentId.has(agent.id);
+          })
+        : [],
+    [
+      activeAgentIds,
+      availableAgents,
+      chatSettingsPackageByAgentId,
+      isRoleplayMode,
+      ltmPackage,
+      mapsPackage,
+      metadata.enableAgents,
+    ],
+  );
+  const standaloneRoleplayAgentIds = useMemo(
+    () => new Set(standaloneRoleplayAgents.map((agent) => agent.id)),
+    [standaloneRoleplayAgents],
   );
   const [pendingAgentMenuTargetId, setPendingAgentMenuTargetId] = useState<string | null>(null);
   const roleplayAgentMenuLinks = useMemo(() => {
@@ -2990,6 +3024,100 @@ export function ChatSettingsDrawer({
     };
   };
 
+  const renderStandaloneRoleplayAgentSettingsCard = (agent: (typeof availableAgents)[number]) => {
+    let settings: React.ReactNode = null;
+
+    if (agent.id === "hierarchical-maps" && mapsPackage) {
+      settings = (
+        <CapabilityElement
+          packageId={mapsPackage.id}
+          view="settings"
+          capabilityProps={{
+            chatId: chat.id,
+            chatName: chat.name,
+            chatMode,
+            debugMode,
+            enabledForChat: mapsPackageEnabledForChat,
+            onEnabledForChatChange: setMapsEnabledForChat,
+            confirmAction: showConfirmDialog,
+            onDirtyChange: setEditorDirty,
+            onOpenLorebook: openLorebookFromSettings,
+            onLorebooksChanged: refreshLorebooks,
+          }}
+          className="block overflow-hidden"
+        />
+      );
+    } else if (agent.id === "long-term-memory" && ltmPackage) {
+      settings = (
+        <CapabilityElement
+          packageId={ltmPackage.id}
+          view="settings"
+          capabilityProps={{
+            chatId: chat.id,
+            enabledForChat: metadata.enableAgents === true && activeAgentIds.includes(ltmPackage.id),
+            chatSettings: {
+              longTermMemoryRecallStyle: metadata.longTermMemoryRecallStyle,
+              longTermMemoryBudgetTokens: metadata.longTermMemoryBudgetTokens,
+              longTermMemoryMaxChunks: metadata.longTermMemoryMaxChunks,
+            },
+            onEnabledForChatChange: setLtmEnabledForChat,
+            onChatSettingsChange: async (patch: Record<string, unknown>) => {
+              await updateMeta.mutateAsync({ id: chat.id, ...patch });
+            },
+            onOpenAgentSettings: () => {
+              void requestClose().then((closed) => {
+                if (closed) useUIStore.getState().openAgentDetail("long-term-memory");
+              });
+            },
+            onDirtyChange: setEditorDirty,
+          }}
+          className="block overflow-hidden"
+        />
+      );
+    } else if (agent.id === STORYBOARD_AGENT_ID) {
+      settings = (
+        <Suspense fallback={null}>
+          <StoryboardChatSettingsPanel
+            chatId={chat.id}
+            metadata={metadata as Record<string, unknown>}
+            onClose={onClose}
+            ownerMode="roleplay"
+          />
+        </Suspense>
+      );
+    } else if (agent.id === "beholder") {
+      settings = (
+        <Suspense fallback={null}>
+          <BeholderChatSettingsPanel
+            chatId={chat.id}
+            onOpenAgentSettings={() => {
+              void requestClose().then((closed) => {
+                if (closed) useUIStore.getState().openAgentDetail("beholder");
+              });
+            }}
+          />
+        </Suspense>
+      );
+    } else {
+      settings = renderDownloadedAgentChatSettings(agent, "block overflow-hidden");
+    }
+
+    if (!settings) return null;
+    return (
+      <AgentSettingsCard
+        key={agent.id}
+        id={getAgentSettingsMenuId(chat.id, agent.id)}
+        icon={renderRoleplayAgentMenuIcon(agent.id)}
+        title={agent.name}
+        description={agent.id === "hierarchical-maps" ? worldMapsSettingsDescription : agent.description}
+        order={getRoleplayAgentSettingsOrder(agent.id)}
+        onRemove={getRoleplayAgentMenuRemoveHandler(agent.id, agent.name)}
+      >
+        {settings}
+      </AgentSettingsCard>
+    );
+  };
+
   const updateAgentPromptTemplateSelection = useCallback(
     (agentId: string, promptTemplateId: string) => {
       const next = { ...readLatestAgentPromptTemplateSelections() };
@@ -3427,7 +3555,6 @@ export function ChatSettingsDrawer({
           agent.id !== "spotify" &&
           agent.id !== "youtube" &&
           agent.id !== "lorebook-keeper" &&
-          agent.id !== "storyboard" &&
           agent.category !== "custom",
       ),
     [availableAgents],
@@ -4413,52 +4540,27 @@ export function ChatSettingsDrawer({
                 <span className="text-[0.6875rem] font-semibold text-[var(--foreground)]">
                   {localizeUi("ui.chat.chatsettingsdrawer.touchSensitivity")}
                 </span>
-                <div className="grid grid-cols-3 gap-1 rounded-lg bg-[var(--background)]/35 p-1">
-                  {HAPTIC_SENSITIVITY_OPTIONS.map((option) => (
-                    <button
-                      key={option.id}
-                      type="button"
-                      onClick={() => updateMeta.mutate({ id: chat.id, hapticSensitivity: option.id })}
-                      className={cn(
-                        "rounded-md px-2 py-1.5 text-[0.625rem] font-semibold transition-colors",
-                        hapticSensitivity === option.id
-                          ? "bg-[var(--accent)] text-[var(--foreground)] ring-1 ring-[var(--border)]"
-                          : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
-                      )}
-                      title={localizeUi(option.descriptionKey)}
-                    >
-                      {localizeUi(option.labelKey)}
-                    </button>
-                  ))}
-                </div>
+                <AgentSettingsSegmentedControl<HapticFeedbackSensitivity>
+                  value={hapticSensitivity}
+                  columns={3}
+                  options={HAPTIC_SENSITIVITY_OPTIONS.map((option) => ({
+                    id: option.id,
+                    label: localizeUi(option.labelKey),
+                  }))}
+                  onChange={(hapticSensitivity) => updateMeta.mutate({ id: chat.id, hapticSensitivity })}
+                />
               </div>
-              <button
-                type="button"
-                onClick={() =>
+              <AgentSettingsToggle
+                label={localizeUi("ui.chat.chatsettingsdrawer.incidentalContact")}
+                description={localizeUi("ui.chat.hapticsetupfields.tinyTapsForAccidentalBrushesAndBumps")}
+                enabled={metadata.hapticIncidentalContact === true}
+                onToggle={() =>
                   updateMeta.mutate({
                     id: chat.id,
                     hapticIncidentalContact: metadata.hapticIncidentalContact !== true,
                   })
                 }
-                className="flex w-full items-center justify-between gap-3 rounded-md px-2 py-1.5 text-left text-[0.6875rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-                aria-pressed={metadata.hapticIncidentalContact === true}
-              >
-                <span className="min-w-0">
-                  <span className="block font-medium text-[var(--foreground)]">
-                    {localizeUi("ui.chat.chatsettingsdrawer.incidentalContact")}
-                  </span>
-                  <span className="block text-[0.5625rem] leading-snug text-[var(--muted-foreground)]">
-                    {localizeUi("ui.chat.hapticsetupfields.tinyTapsForAccidentalBrushesAndBumps")}
-                  </span>
-                </span>
-                <SettingsSwitchTrack
-                  checked={metadata.hapticIncidentalContact === true}
-                  className={cn(
-                    "mari-chat-option-switch",
-                    metadata.hapticIncidentalContact === true && "mari-chat-option-switch--active",
-                  )}
-                />
-              </button>
+              />
             </div>
             <HapticConnectionPanel
               intifaceUrl={typeof metadata.hapticIntifaceUrl === "string" ? metadata.hapticIntifaceUrl : undefined}
@@ -7243,27 +7345,15 @@ export function ChatSettingsDrawer({
                         onToggle={() => void toggleGameMusicDj()}
                       />
 
-                      <div className="grid grid-cols-3 gap-1 rounded-xl border border-[var(--border)] bg-[var(--background)]/65 p-1">
-                        {(["spotify", "youtube", "custom"] as const).map((provider) => {
-                          const active = musicPlayerSource === provider;
-                          return (
-                            <button
-                              key={provider}
-                              type="button"
-                              onClick={() => void changeMusicDjProvider(provider)}
-                              aria-pressed={active}
-                              className={cn(
-                                "rounded-md px-2 py-1.5 text-[0.625rem] font-semibold transition-colors",
-                                active
-                                  ? "bg-[var(--primary)]/18 text-[var(--foreground)] shadow-sm"
-                                  : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
-                              )}
-                            >
-                              {getMusicProviderLabel(provider)}
-                            </button>
-                          );
-                        })}
-                      </div>
+                      <AgentSettingsSegmentedControl<MusicProvider>
+                        value={musicPlayerSource}
+                        columns={3}
+                        options={(["spotify", "youtube", "custom"] as const).map((provider) => ({
+                          id: provider,
+                          label: getMusicProviderLabel(provider),
+                        }))}
+                        onChange={(provider) => void changeMusicDjProvider(provider)}
+                      />
 
                       {gameMusicDjEnabled && musicPlayerSource === "spotify" && (
                         <div className="space-y-2">
@@ -7405,30 +7495,25 @@ export function ChatSettingsDrawer({
                               )}
                             </p>
                             <div className="flex w-full min-w-0 flex-col items-stretch gap-1.5 sm:w-auto sm:shrink-0 sm:flex-row sm:items-center">
-                              <button
-                                type="button"
+                              <AgentSettingsActionButton
                                 onClick={() => {
                                   onClose();
                                   useUIStore.getState().openAgentDetail("lorebook-keeper");
                                 }}
-                                className="inline-flex w-full items-center justify-center gap-1.5 rounded-lg bg-[var(--background)]/80 px-3 py-1.5 text-[0.6875rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] sm:w-auto"
+                                className="w-full sm:w-auto"
                               >
                                 <Settings2 size="0.75rem" />
                                 <span>{localizeUi("ui.chat.chatsettingsdrawer.openSetup")}</span>
-                              </button>
-                              <button
+                              </AgentSettingsActionButton>
+                              <AgentSettingsActionButton
                                 onClick={handleLorebookKeeperBackfill}
                                 disabled={agentProcessing}
-                                className={cn(
-                                  "inline-flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 text-[0.6875rem] font-medium transition-colors sm:w-auto",
-                                  agentProcessing
-                                    ? "cursor-not-allowed bg-[var(--muted)] text-[var(--muted-foreground)]"
-                                    : "bg-[var(--primary)]/10 text-[var(--primary)] hover:bg-[var(--primary)]/15",
-                                )}
+                                className="w-full sm:w-auto"
+                                variant="primary"
                               >
                                 <RefreshCw size="0.75rem" className={cn(agentProcessing && "animate-spin")} />
                                 <span>{localizeUi("ui.chat.chatsettingsdrawer.backfillUnprocessed")}</span>
-                              </button>
+                              </AgentSettingsActionButton>
                             </div>
                           </div>
                           <div className="grid gap-2 sm:grid-cols-2">
@@ -7503,17 +7588,16 @@ export function ChatSettingsDrawer({
                             <p className="text-[0.625rem] leading-snug text-[var(--muted-foreground)]">
                               {localizeUi("ui.chat.chatsettingsdrawer.thisAgentNeverEditsCardsDirectlyItProposesExact")}
                             </p>
-                            <button
-                              type="button"
+                            <AgentSettingsActionButton
                               onClick={() => {
                                 onClose();
                                 useUIStore.getState().openAgentDetail("card-evolution-auditor");
                               }}
-                              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--primary)]/10 px-3 py-1.5 text-[0.6875rem] font-medium text-[var(--primary)] transition-colors hover:bg-[var(--primary)]/15"
+                              variant="primary"
                             >
                               <Settings2 size="0.75rem" />
                               <span>{localizeUi("ui.chat.chatsettingsdrawer.openAuditorSetup")}</span>
-                            </button>
+                            </AgentSettingsActionButton>
                           </div>
                         </AgentSettingsCard>
                       )}
@@ -7743,18 +7827,7 @@ export function ChatSettingsDrawer({
                         />
                       )}
 
-                      {memoryNagStandaloneActive && memoryNagAgent && (
-                        <AgentSettingsCard
-                          id={getAgentSettingsMenuId(chat.id, memoryNagAgent.id)}
-                          icon={renderRoleplayAgentMenuIcon(memoryNagAgent.id)}
-                          title={memoryNagAgent.name}
-                          description={memoryNagAgent.description}
-                          order={getRoleplayAgentSettingsOrder(memoryNagAgent.id)}
-                          onRemove={getRoleplayAgentMenuRemoveHandler(memoryNagAgent.id, memoryNagAgent.name)}
-                        >
-                          {renderDownloadedAgentChatSettings(memoryNagAgent, "block overflow-hidden rounded-lg")}
-                        </AgentSettingsCard>
-                      )}
+                      {standaloneRoleplayAgents.map(renderStandaloneRoleplayAgentSettingsCard)}
 
                       {metadata.enableAgents && !isGame && expressionActive && (
                         <AgentSettingsCard
@@ -7861,17 +7934,16 @@ export function ChatSettingsDrawer({
                                 "ui.chat.chatsettingsdrawer.promptModeControlsTheFictionalAudienceStyleUsedFor",
                               )}
                             </p>
-                            <button
-                              type="button"
+                            <AgentSettingsActionButton
                               onClick={() => {
                                 onClose();
                                 useUIStore.getState().openAgentDetail("echo-chamber");
                               }}
-                              className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg bg-[var(--background)]/80 px-3 py-1.5 text-[0.6875rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                              className="shrink-0"
                             >
                               <Settings2 size="0.75rem" />
                               <span>{localizeUi("ui.chat.chatsettingsdrawer.openSetup")}</span>
-                            </button>
+                            </AgentSettingsActionButton>
                           </div>
                         </AgentSettingsCard>
                       )}
@@ -7942,17 +8014,16 @@ export function ChatSettingsDrawer({
                                 "ui.chat.chatsettingsdrawer.promptModeControlsHowIllustratorWritesImagePromptsFor",
                               )}
                             </p>
-                            <button
-                              type="button"
+                            <AgentSettingsActionButton
                               onClick={() => {
                                 onClose();
                                 useUIStore.getState().openAgentDetail("illustrator");
                               }}
-                              className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg bg-[var(--background)]/80 px-3 py-1.5 text-[0.6875rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                              className="shrink-0"
                             >
                               <Settings2 size="0.75rem" />
                               <span>{localizeUi("ui.chat.chatsettingsdrawer.openSetup")}</span>
-                            </button>
+                            </AgentSettingsActionButton>
                           </div>
                           {illustratorInstalled && (
                             <AgentSettingsSubsection
@@ -8019,27 +8090,15 @@ export function ChatSettingsDrawer({
                             {getMusicProviderLabel(musicPlayerSource)}.
                           </p>
 
-                          <div className="grid grid-cols-3 gap-1 rounded-xl border border-[var(--border)] bg-[var(--background)]/65 p-1">
-                            {(["spotify", "youtube", "custom"] as const).map((provider) => {
-                              const active = musicPlayerSource === provider;
-                              return (
-                                <button
-                                  key={provider}
-                                  type="button"
-                                  onClick={() => void changeMusicDjProvider(provider)}
-                                  aria-pressed={active}
-                                  className={cn(
-                                    "rounded-md px-2 py-1.5 text-[0.625rem] font-semibold transition-colors",
-                                    active
-                                      ? "bg-[var(--primary)]/18 text-[var(--foreground)] shadow-sm"
-                                      : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
-                                  )}
-                                >
-                                  {getMusicProviderLabel(provider)}
-                                </button>
-                              );
-                            })}
-                          </div>
+                          <AgentSettingsSegmentedControl<MusicProvider>
+                            value={musicPlayerSource}
+                            columns={3}
+                            options={(["spotify", "youtube", "custom"] as const).map((provider) => ({
+                              id: provider,
+                              label: getMusicProviderLabel(provider),
+                            }))}
+                            onChange={(provider) => void changeMusicDjProvider(provider)}
+                          />
 
                           {musicPlayerSource === "spotify" && (
                             <>
@@ -8466,14 +8525,6 @@ export function ChatSettingsDrawer({
                           </p>
                         </AgentSettingsSubsection>
                       )}
-                      <Suspense fallback={null}>
-                        <StoryboardChatSettingsPanel
-                          chatId={chat.id}
-                          metadata={metadata as Record<string, unknown>}
-                          onClose={onClose}
-                          ownerMode="game"
-                        />
-                      </Suspense>
                     </AgentSettingsCard>
                   )}
 
@@ -8487,7 +8538,7 @@ export function ChatSettingsDrawer({
                               {gameAgentPool.map((agent) => {
                                 const active = activeAgentIds.includes(agent.id);
                                 const knowledgeAgentType = isKnowledgeAgentType(agent.id) ? agent.id : null;
-                                if (agent.id === "hierarchical-maps" && mapsPackage) {
+                                if (active && agent.id === "hierarchical-maps" && mapsPackage) {
                                   return (
                                     <div key={agent.id} data-chat-agent-entry={agent.id} className="space-y-1.5">
                                       <AgentSettingsCard
@@ -8504,17 +8555,7 @@ export function ChatSettingsDrawer({
                                             chatMode,
                                             debugMode,
                                             enabledForChat: mapsPackageEnabledForChat,
-                                            onEnabledForChatChange: async (enabled: boolean) => {
-                                              const current = readLatestActiveAgentIds();
-                                              const nextActiveAgentIds = enabled
-                                                ? Array.from(new Set([...current, mapsPackage.id]))
-                                                : current.filter((id) => id !== mapsPackage.id);
-                                              await updateMeta.mutateAsync({
-                                                id: chat.id,
-                                                ...(enabled ? { enableAgents: true } : {}),
-                                                activeAgentIds: nextActiveAgentIds,
-                                              });
-                                            },
+                                            onEnabledForChatChange: setMapsEnabledForChat,
                                             confirmAction: showConfirmDialog,
                                             onDirtyChange: setEditorDirty,
                                             onOpenLorebook: openLorebookFromSettings,
@@ -8526,7 +8567,7 @@ export function ChatSettingsDrawer({
                                     </div>
                                   );
                                 }
-                                if (agent.id === "long-term-memory" && ltmPackage) {
+                                if (active && agent.id === "long-term-memory" && ltmPackage) {
                                   return (
                                     <div key={agent.id} data-chat-agent-entry={agent.id} className="space-y-1.5">
                                       <AgentSettingsCard
@@ -8561,6 +8602,26 @@ export function ChatSettingsDrawer({
                                           }}
                                           className="block overflow-hidden rounded-lg"
                                         />
+                                      </AgentSettingsCard>
+                                    </div>
+                                  );
+                                }
+                                if (active && agent.id === STORYBOARD_AGENT_ID) {
+                                  return (
+                                    <div key={agent.id} data-chat-agent-entry={agent.id} className="space-y-1.5">
+                                      <AgentSettingsCard
+                                        icon={renderRoleplayAgentMenuIcon(agent.id)}
+                                        title={agent.name}
+                                        description={agent.description}
+                                      >
+                                        <Suspense fallback={null}>
+                                          <StoryboardChatSettingsPanel
+                                            chatId={chat.id}
+                                            metadata={metadata as Record<string, unknown>}
+                                            onClose={onClose}
+                                            ownerMode="game"
+                                          />
+                                        </Suspense>
                                       </AgentSettingsCard>
                                     </div>
                                   );
@@ -8689,8 +8750,8 @@ export function ChatSettingsDrawer({
                             className={cn(
                               "flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-[0.6875rem] ring-1",
                               agentLoadCost.cost.level === "high"
-                                ? "bg-amber-400/10 text-amber-400/90 ring-amber-400/30"
-                                : "bg-[var(--secondary)]/60 text-[var(--muted-foreground)] ring-[var(--border)]",
+                                ? "bg-[var(--primary)]/10 text-[var(--primary)] ring-[var(--primary)]/30"
+                                : "bg-[var(--secondary)]/60 text-[var(--primary)] ring-[var(--border)]",
                             )}
                             title={localizeUi(
                               "ui.chat.chatsettingsdrawer.approximateEachCallAlsoCarriesChatContextRecentMessages",
@@ -8748,9 +8809,8 @@ export function ChatSettingsDrawer({
                             const catAgents = availableAgents.filter((a) => a.category === cat.key);
                             const activeInCat = catAgents
                               .filter(
-                                (a) =>
-                                  activeAgentIds.includes(a.id) &&
-                                  !(hasStandaloneRoleplayAgentSettings(a.id) && memoryNagStandaloneActive),
+                                (agent) =>
+                                  activeAgentIds.includes(agent.id) && !standaloneRoleplayAgentIds.has(agent.id),
                               )
                               .sort(
                                 (a, b) => getRoleplayAgentSettingsOrder(a.id) - getRoleplayAgentSettingsOrder(b.id),
@@ -8766,7 +8826,7 @@ export function ChatSettingsDrawer({
                                 count={activeInCat.length}
                                 openRequest={catAgents.some(
                                   (agent) =>
-                                    !(hasStandaloneRoleplayAgentSettings(agent.id) && memoryNagStandaloneActive) &&
+                                    !standaloneRoleplayAgentIds.has(agent.id) &&
                                     getAgentSettingsMenuId(chat.id, agent.id) === pendingAgentMenuTargetId,
                                 )}
                               >
@@ -8775,12 +8835,7 @@ export function ChatSettingsDrawer({
                                   <div className="flex flex-col gap-1 mb-1.5">
                                     {activeInCat.map((agent) => {
                                       const tokenEst = agentLoadCost.tokensByType.get(agent.id);
-                                      const hasSettingsTarget =
-                                        agent.id === "hierarchical-maps" ||
-                                        agent.id === "long-term-memory" ||
-                                        agent.id === "beholder" ||
-                                        agent.id === STORYBOARD_AGENT_ID ||
-                                        chatSettingsPackageByAgentId.has(agent.id);
+                                      const hasSettingsTarget = chatSettingsPackageByAgentId.has(agent.id);
                                       return (
                                         <div
                                           key={agent.id}
@@ -8838,87 +8893,7 @@ export function ChatSettingsDrawer({
                                               }
                                             />
                                           )}
-                                          {agent.id === "hierarchical-maps" && mapsPackage && (
-                                            <CapabilityElement
-                                              packageId={mapsPackage.id}
-                                              view="settings"
-                                              capabilityProps={{
-                                                chatId: chat.id,
-                                                chatName: chat.name,
-                                                chatMode,
-                                                debugMode,
-                                                enabledForChat: mapsPackageEnabledForChat,
-                                                onEnabledForChatChange: async (enabled: boolean) => {
-                                                  const current = readLatestActiveAgentIds();
-                                                  const nextActiveAgentIds = enabled
-                                                    ? Array.from(new Set([...current, mapsPackage.id]))
-                                                    : current.filter((id) => id !== mapsPackage.id);
-                                                  await updateMeta.mutateAsync({
-                                                    id: chat.id,
-                                                    ...(enabled ? { enableAgents: true } : {}),
-                                                    activeAgentIds: nextActiveAgentIds,
-                                                  });
-                                                },
-                                                confirmAction: showConfirmDialog,
-                                                onDirtyChange: setEditorDirty,
-                                                onOpenLorebook: openLorebookFromSettings,
-                                                onLorebooksChanged: refreshLorebooks,
-                                              }}
-                                              className="mt-2 block overflow-hidden rounded-lg"
-                                            />
-                                          )}
-                                          {agent.id === "long-term-memory" && ltmPackage && (
-                                            <CapabilityElement
-                                              packageId={ltmPackage.id}
-                                              view="settings"
-                                              capabilityProps={{
-                                                chatId: chat.id,
-                                                enabledForChat:
-                                                  metadata.enableAgents === true &&
-                                                  activeAgentIds.includes(ltmPackage.id),
-                                                chatSettings: {
-                                                  longTermMemoryRecallStyle: metadata.longTermMemoryRecallStyle,
-                                                  longTermMemoryBudgetTokens: metadata.longTermMemoryBudgetTokens,
-                                                  longTermMemoryMaxChunks: metadata.longTermMemoryMaxChunks,
-                                                },
-                                                onEnabledForChatChange: setLtmEnabledForChat,
-                                                onChatSettingsChange: async (patch: Record<string, unknown>) => {
-                                                  await updateMeta.mutateAsync({ id: chat.id, ...patch });
-                                                },
-                                                onOpenAgentSettings: () => {
-                                                  void requestClose().then((closed) => {
-                                                    if (closed)
-                                                      useUIStore.getState().openAgentDetail("long-term-memory");
-                                                  });
-                                                },
-                                                onDirtyChange: setEditorDirty,
-                                              }}
-                                              className="mt-2 block overflow-hidden rounded-lg"
-                                            />
-                                          )}
                                           {renderDownloadedAgentChatSettings(agent)}
-                                          {agent.id === STORYBOARD_AGENT_ID && (
-                                            <Suspense fallback={null}>
-                                              <StoryboardChatSettingsPanel
-                                                chatId={chat.id}
-                                                metadata={metadata as Record<string, unknown>}
-                                                onClose={onClose}
-                                                ownerMode="roleplay"
-                                              />
-                                            </Suspense>
-                                          )}
-                                          {agent.id === "beholder" && (
-                                            <Suspense fallback={null}>
-                                              <BeholderChatSettingsPanel
-                                                chatId={chat.id}
-                                                onOpenAgentSettings={() => {
-                                                  void requestClose().then((closed) => {
-                                                    if (closed) useUIStore.getState().openAgentDetail("beholder");
-                                                  });
-                                                }}
-                                              />
-                                            </Suspense>
-                                          )}
                                         </div>
                                       );
                                     })}

--- a/packages/client/src/components/chat/ExpressionSpriteSettings.tsx
+++ b/packages/client/src/components/chat/ExpressionSpriteSettings.tsx
@@ -2,7 +2,12 @@ import { Image } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { AvatarCrop } from "@marinara-engine/shared";
 import { cn, getAvatarCropStyle } from "../../lib/utils";
-import { SpriteRangeSlider } from "./AgentSettingsControls";
+import {
+  AgentSettingsActionButton,
+  AgentSettingsSegmentedControl,
+  AgentSettingsToggle,
+  SpriteRangeSlider,
+} from "./AgentSettingsControls";
 import {
   SPRITE_DISPLAY_OPACITY_PERCENT_MAX,
   SPRITE_DISPLAY_OPACITY_PERCENT_MIN,
@@ -102,38 +107,12 @@ export function ExpressionSpriteSettings({
     <>
       <SpriteDisplayModeToggle modes={displayModes} onToggle={onToggleDisplayMode} />
 
-      <button
-        type="button"
-        onClick={onToggleExpressionAvatars}
-        className={cn(
-          "flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2.5 text-left transition-all",
-          expressionAvatarsEnabled
-            ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-            : "bg-[var(--background)]/75 ring-1 ring-[var(--border)] hover:bg-[var(--accent)]",
-        )}
-      >
-        <div className="min-w-0 flex-1">
-          <span className="text-[0.6875rem] font-medium">
-            {localizeUi("ui.chat.expressionsetupfields.expressionAvatars")}
-          </span>
-          <p className="mt-0.5 text-[0.625rem] text-[var(--muted-foreground)]">
-            {localizeUi("ui.chat.expressionsetupfields.replaceMessageAvatarsWithTheSelectedExpressionSprite")}
-          </p>
-        </div>
-        <div
-          className={cn(
-            "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-            expressionAvatarsEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
-          )}
-        >
-          <div
-            className={cn(
-              "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-              expressionAvatarsEnabled && "translate-x-3.5",
-            )}
-          />
-        </div>
-      </button>
+      <AgentSettingsToggle
+        label={localizeUi("ui.chat.expressionsetupfields.expressionAvatars")}
+        description={localizeUi("ui.chat.expressionsetupfields.replaceMessageAvatarsWithTheSelectedExpressionSprite")}
+        enabled={expressionAvatarsEnabled}
+        onToggle={onToggleExpressionAvatars}
+      />
 
       {ownerCount === 0 ? (
         <p className="text-[0.625rem] text-[var(--muted-foreground)]">
@@ -222,35 +201,18 @@ export function ExpressionSpriteSettings({
             <span className="flex-1 text-[0.6875rem] text-[var(--muted-foreground)]">
               {localizeUi("ui.chat.expressionsetupfields.spriteLayout")}
             </span>
-            <button
-              type="button"
+            <AgentSettingsActionButton
               onClick={onToggleSpriteArrange}
               disabled={!onToggleSpriteArrange}
-              className={cn(
-                "rounded-md px-2.5 py-1 text-[0.625rem] font-medium transition-colors ring-1 ring-[var(--border)]",
-                spriteArrangeMode
-                  ? "bg-[var(--primary)] text-white"
-                  : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
-                !onToggleSpriteArrange && "cursor-not-allowed opacity-40",
-              )}
+              variant={spriteArrangeMode ? "primary" : "default"}
             >
               {spriteArrangeMode
                 ? localizeUi("lorebook.editor.batch.done")
                 : localizeUi("ui.chat.chatsettingsdrawer.arrange")}
-            </button>
-            <button
-              type="button"
-              onClick={onResetSpritePlacements}
-              disabled={!hasCustomSpritePlacements}
-              className={cn(
-                "rounded-md px-2.5 py-1 text-[0.625rem] font-medium transition-colors ring-1 ring-[var(--border)]",
-                hasCustomSpritePlacements
-                  ? "text-[var(--muted-foreground)] hover:bg-[var(--accent)]"
-                  : "cursor-not-allowed opacity-40 text-[var(--muted-foreground)]",
-              )}
-            >
+            </AgentSettingsActionButton>
+            <AgentSettingsActionButton onClick={onResetSpritePlacements} disabled={!hasCustomSpritePlacements}>
               {localizeUi("ui.characters.charactercliptrimmodal.reset")}
-            </button>
+            </AgentSettingsActionButton>
           </div>
 
           <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -274,14 +236,12 @@ export function ExpressionSpriteSettings({
               ))}
             </select>
             {selectedLayoutSubjectId && (
-              <button
-                type="button"
+              <AgentSettingsActionButton
                 onClick={onResetSelectedLayoutSubject}
                 disabled={!selectedLayoutSubjectHasOverride}
-                className="rounded-md px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {localizeUi("ui.chat.chatsettingsdrawer.useAllSpriteLayoutSettings")}
-              </button>
+              </AgentSettingsActionButton>
             )}
           </div>
 
@@ -291,31 +251,15 @@ export function ExpressionSpriteSettings({
                 ? localizeUi("ui.chat.chatsettingsdrawer.characterSide")
                 : localizeUi("ui.chat.chatsettingsdrawer.defaultSide")}
             </span>
-            <div className="flex rounded-md ring-1 ring-[var(--border)]">
-              <button
-                type="button"
-                onClick={() => onSpritePositionChange("left")}
-                className={cn(
-                  "rounded-l-md px-2.5 py-1 text-[0.625rem] font-medium transition-colors",
-                  spritePosition === "left"
-                    ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
-                    : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
-                )}
-              >
-                {localizeUi("ui.chat.chatsettingsdrawer.left")}
-              </button>
-              <button
-                type="button"
-                onClick={() => onSpritePositionChange("right")}
-                className={cn(
-                  "rounded-r-md px-2.5 py-1 text-[0.625rem] font-medium transition-colors",
-                  spritePosition === "right"
-                    ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
-                    : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
-                )}
-              >
-                {localizeUi("ui.chat.chatsettingsdrawer.right")}
-              </button>
+            <div className="min-w-32 flex-1">
+              <AgentSettingsSegmentedControl
+                value={spritePosition}
+                options={[
+                  { id: "left", label: localizeUi("ui.chat.chatsettingsdrawer.left") },
+                  { id: "right", label: localizeUi("ui.chat.chatsettingsdrawer.right") },
+                ]}
+                onChange={onSpritePositionChange}
+              />
             </div>
           </div>
 

--- a/packages/client/src/components/chat/HapticConnectionPanel.tsx
+++ b/packages/client/src/components/chat/HapticConnectionPanel.tsx
@@ -8,7 +8,7 @@ import {
   useHapticStartScan,
   useHapticStatus,
 } from "../../hooks/use-haptic";
-import { cn } from "../../lib/utils";
+import { AgentSettingsActionButton } from "./AgentSettingsControls";
 
 interface HapticConnectionPanelProps {
   intifaceUrl?: string;
@@ -77,7 +77,7 @@ export function HapticConnectionPanel({
           onChange={(event) => setIntifaceUrl(event.target.value)}
           onBlur={saveIntifaceUrl}
           placeholder={defaultServerUrl}
-          className="rounded-md bg-[var(--background)] px-2.5 py-1.5 text-[0.6875rem] text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)]/55 focus:ring-[var(--primary)]/60"
+          className="mari-chrome-field rounded-md px-2.5 py-1.5 text-[0.6875rem] placeholder:text-[var(--muted-foreground)]/55"
         />
         <span className="text-[0.5625rem] leading-relaxed text-[var(--muted-foreground)]">
           {localizeUi("ui.chat.hapticconnectionpanel.blankUsesTheServerDefaultDockerOrRemoteBrowser")}
@@ -86,8 +86,8 @@ export function HapticConnectionPanel({
 
       <div className="flex items-center justify-between rounded-lg bg-[var(--secondary)] px-3 py-2">
         <div className="min-w-0 flex items-center gap-1.5">
-          <div className={cn("h-1.5 w-1.5 rounded-full", connected ? "bg-green-400" : "bg-red-400")} />
-          <span className="min-w-0 truncate text-[0.625rem] text-[var(--muted-foreground)]">
+          <div className="h-1.5 w-1.5 rounded-full bg-[var(--primary)]" />
+          <span className="min-w-0 truncate text-[0.625rem] text-[var(--primary)]">
             {connect.isPending
               ? localizeUi("ui.chat.hapticconnectionpanel.connectingToValue1", {
                   value1: intifaceUrl.trim() || defaultServerUrl,
@@ -97,8 +97,7 @@ export function HapticConnectionPanel({
                 : localizeUi("ui.chat.hapticconnectionpanel.notConnected")}
           </span>
         </div>
-        <button
-          type="button"
+        <AgentSettingsActionButton
           onClick={() => {
             if (connected) {
               disconnect.mutate();
@@ -107,16 +106,16 @@ export function HapticConnectionPanel({
             }
           }}
           disabled={connect.isPending || disconnect.isPending}
-          className="text-[0.625rem] font-medium text-[var(--primary)] hover:underline disabled:opacity-50"
+          variant="primary"
         >
           {connected
             ? localizeUi("ui.agents.agenteditor.disconnect")
             : localizeUi("ui.chat.hapticconnectionpanel.connect")}
-        </button>
+        </AgentSettingsActionButton>
       </div>
 
       {connect.isError && !connected && (
-        <p className="text-[0.625rem] text-red-400 px-1">
+        <p className="px-1 text-[0.625rem] text-[var(--primary)]">
           {localizeUi("ui.chat.hapticconnectionpanel.couldNotConnectMakeSure")}{" "}
           <a href="https://intiface.com/central/" target="_blank" rel="noopener noreferrer" className="underline">
             {localizeUi("ui.chat.hapticconnectionpanel.intifaceCentral")}
@@ -136,16 +135,15 @@ export function HapticConnectionPanel({
                     value2: devices.length !== 1 ? localizeUi("ui.noodle.stageprofileview.s") : "",
                   })}
             </span>
-            <button
-              type="button"
+            <AgentSettingsActionButton
               onClick={() => startScan.mutate()}
               disabled={scanning || startScan.isPending}
-              className="text-[0.625rem] font-medium text-[var(--primary)] hover:underline disabled:opacity-50"
+              variant="primary"
             >
               {scanning
                 ? localizeUi("ui.chat.hapticconnectionpanel.scanning")
                 : localizeUi("ui.chat.hapticconnectionpanel.scanForDevices")}
-            </button>
+            </AgentSettingsActionButton>
           </div>
           {devices.map((device) => (
             <div

--- a/packages/client/src/components/chat/HapticConnectionPanel.tsx
+++ b/packages/client/src/components/chat/HapticConnectionPanel.tsx
@@ -86,8 +86,20 @@ export function HapticConnectionPanel({
 
       <div className="flex items-center justify-between rounded-lg bg-[var(--secondary)] px-3 py-2">
         <div className="min-w-0 flex items-center gap-1.5">
-          <div className="h-1.5 w-1.5 rounded-full bg-[var(--primary)]" />
-          <span className="min-w-0 truncate text-[0.625rem] text-[var(--primary)]">
+          <div
+            className={
+              connected || connect.isPending || connect.isError
+                ? "h-1.5 w-1.5 rounded-full bg-[var(--primary)]"
+                : "h-1.5 w-1.5 rounded-full bg-[var(--muted-foreground)]/40"
+            }
+          />
+          <span
+            className={
+              connected || connect.isPending || connect.isError
+                ? "min-w-0 truncate text-[0.625rem] text-[var(--primary)]"
+                : "min-w-0 truncate text-[0.625rem] text-[var(--muted-foreground)]"
+            }
+          >
             {connect.isPending
               ? localizeUi("ui.chat.hapticconnectionpanel.connectingToValue1", {
                   value1: intifaceUrl.trim() || defaultServerUrl,

--- a/packages/client/src/components/chat/StoryboardChatSettingsPanel.tsx
+++ b/packages/client/src/components/chat/StoryboardChatSettingsPanel.tsx
@@ -19,6 +19,7 @@ import { useUpdateChatMetadata } from "../../hooks/use-chats";
 import { useConnections } from "../../hooks/use-connections";
 import { useUIStore } from "../../stores/ui.store";
 import {
+  AgentSettingsActionButton,
   AgentDefaultStatus,
   AgentSettingsSegmentedControl,
   AgentSettingsSubsection,
@@ -576,14 +577,10 @@ export function StoryboardChatSettingsPanel({
             <p className="min-w-0 flex-1 text-[0.625rem] leading-snug text-[var(--muted-foreground)]">
               {localizeUi("ui.agents.storyboard.promptChainDescription")}
             </p>
-            <button
-              type="button"
-              onClick={onOpenAgentSettings}
-              className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg bg-[var(--background)]/80 px-3 py-1.5 text-[0.6875rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-            >
+            <AgentSettingsActionButton onClick={onOpenAgentSettings} className="shrink-0">
               <Settings2 size="0.75rem" />
               <span>{localizeUi("ui.chat.chatsettingsdrawer.openSetup")}</span>
-            </button>
+            </AgentSettingsActionButton>
           </div>
         </AgentSettingsSubsection>
       ) : null}
@@ -943,14 +940,10 @@ function RoleplayStoryboardChatSettingsPanel({
             <p className="min-w-0 flex-1 text-[0.625rem] leading-snug text-[var(--muted-foreground)]">
               {localizeUi("ui.agents.storyboard.roleplayPromptChainDescription")}
             </p>
-            <button
-              type="button"
-              onClick={onOpenAgentSettings}
-              className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg bg-[var(--background)]/80 px-3 py-1.5 text-[0.6875rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-            >
+            <AgentSettingsActionButton onClick={onOpenAgentSettings} className="shrink-0">
               <Settings2 size="0.75rem" />
               <span>{localizeUi("ui.chat.chatsettingsdrawer.openSetup")}</span>
-            </button>
+            </AgentSettingsActionButton>
           </div>
         </AgentSettingsSubsection>
       ) : null}

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -66,6 +66,7 @@ interface ExpandedMacroEditorProps {
   onChange: (value: string) => void;
   onClose: () => void;
   placeholder?: string;
+  readOnly?: boolean;
   formatOnChange?: (textarea: HTMLTextAreaElement, inputEvent: InputEvent) => string;
 }
 
@@ -76,6 +77,7 @@ function ExpandedMacroEditor({
   onChange,
   onClose,
   placeholder,
+  readOnly = false,
   formatOnChange,
 }: ExpandedMacroEditorProps) {
   const { t: localizeUi } = useUiTranslation();
@@ -101,14 +103,14 @@ function ExpandedMacroEditor({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        onChange(localValue);
+        if (!readOnly) onChange(localValue);
         onClose();
       }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [localValue, onChange, onClose, open]);
+  }, [localValue, onChange, onClose, open, readOnly]);
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
@@ -147,7 +149,7 @@ function ExpandedMacroEditor({
             <button
               type="button"
               onClick={() => {
-                onChange(localValue);
+                if (!readOnly) onChange(localValue);
                 onClose();
               }}
               className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--secondary)] text-[var(--muted-foreground)] transition hover:border-[var(--primary)] hover:bg-[var(--accent)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
@@ -163,6 +165,7 @@ function ExpandedMacroEditor({
             onChange={handleChange}
             onKeyDown={handleTextareaTab}
             placeholder={placeholder}
+            readOnly={readOnly}
             className="min-h-0 flex-1 resize-none bg-[var(--secondary)] p-4 font-mono text-sm leading-6 text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]"
             spellCheck={false}
           />
@@ -313,6 +316,7 @@ export interface MacroTextareaProps {
   /** Character the edited field belongs to — resolves card://self refs in the preview only. */
   selfCharacterId?: string | null;
   spellCheck?: boolean;
+  readOnly?: boolean;
   /** Optional ref to the underlying textarea (e.g. to insert emoji at the caret). */
   textareaRef?: Ref<HTMLTextAreaElement>;
 }
@@ -340,6 +344,7 @@ export function MacroTextarea({
   showMarkdownPreview = false,
   selfCharacterId,
   spellCheck = true,
+  readOnly = false,
   textareaRef,
 }: MacroTextareaProps) {
   const { t: localizeUi } = useUiTranslation();
@@ -412,6 +417,7 @@ export function MacroTextarea({
             aria-label={ariaLabel}
             placeholder={placeholder}
             spellCheck={spellCheck}
+            readOnly={readOnly}
             className={cn(
               "w-full resize-y rounded-lg bg-[var(--secondary)] p-2.5 text-sm leading-6 text-[var(--foreground)] ring-1 ring-[var(--border)] transition placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]",
               className,
@@ -470,6 +476,7 @@ export function MacroTextarea({
         onChange={onChange}
         onClose={handleExpandedClose}
         placeholder={placeholder}
+        readOnly={readOnly}
         formatOnChange={formatOnChange}
       />
       <MacrosReferenceModal open={showMacroRef} onClose={() => setShowMacroRef(false)} />

--- a/packages/client/src/features/chat-settings/sections/ImpersonatePromptTemplateField.tsx
+++ b/packages/client/src/features/chat-settings/sections/ImpersonatePromptTemplateField.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from "react";
-import { Copy, Maximize2, RotateCcw, Save, Trash2, X } from "lucide-react";
+import { Copy, RotateCcw, Save, Trash2, X } from "lucide-react";
 import {
   DEFAULT_IMPERSONATE_PROMPT,
   EMPTY_IMPERSONATE_PROMPT_TEMPLATE_CATALOG,
   IMPERSONATE_PROMPT_TEMPLATE_MAX_NAME_LENGTH,
 } from "@marinara-engine/shared";
 import { useTranslation as useUiTranslation } from "react-i18next";
-import { ExpandedTextarea } from "../../../components/ui/ExpandedTextarea";
+import { AgentSettingsActionButton } from "../../../components/chat/AgentSettingsControls";
 import { HelpTooltip } from "../../../components/ui/HelpTooltip";
+import { MacroTextarea } from "../../../components/ui/MacroTextarea";
 import {
   showImpersonatePromptTemplateValidationError,
   useIsSavingImpersonatePromptTemplates,
@@ -16,7 +17,7 @@ import {
   validateImpersonatePromptTemplates,
 } from "../../../hooks/use-impersonate-prompt-templates";
 import { showConfirmDialog } from "../../../lib/app-dialogs";
-import { cn, generateClientId } from "../../../lib/utils";
+import { generateClientId } from "../../../lib/utils";
 import { useUIStore } from "../../../stores/ui.store";
 
 export function ImpersonatePromptTemplateField() {
@@ -40,7 +41,6 @@ export function ImpersonatePromptTemplateField() {
   const hasStandaloneDraft = !activePromptTemplate && hasPromptTemplate;
   const usingBuiltInDefault = !activePromptTemplate && !hasStandaloneDraft;
   const displayedPromptTemplate = usingBuiltInDefault ? DEFAULT_IMPERSONATE_PROMPT : promptTemplate;
-  const [promptEditorExpanded, setPromptEditorExpanded] = useState(false);
   const [templateNameDraft, setTemplateNameDraft] = useState<string | null>(null);
   const saveAsPending = savePromptTemplates.isPending && templateNameDraft !== null;
 
@@ -200,100 +200,68 @@ export function ImpersonatePromptTemplateField() {
           ))}
         </select>
       </div>
-      <div className="relative">
-        <textarea
+      <div className="mari-quick-preset-editor">
+        <MacroTextarea
           value={displayedPromptTemplate}
-          onChange={(event) => setPromptTemplate(event.target.value)}
+          onChange={setPromptTemplate}
           readOnly={usingBuiltInDefault || saveAsPending}
           placeholder={localizeUi("ui.chatSettings.impersonatesection.emptyUseChatBuiltInDefault")}
           rows={4}
-          className={cn(
-            "min-h-20 w-full resize-y rounded-lg bg-[var(--secondary)] px-3 py-1.5 pr-8 font-mono text-xs leading-relaxed outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40",
-            usingBuiltInDefault && "cursor-text text-[var(--muted-foreground)]",
-          )}
+          title={localizeUi("ui.chatSettings.impersonatesection.promptTemplate")}
+          ariaLabel={localizeUi("ui.chatSettings.impersonatesection.promptTemplate")}
+          className="mari-editor-field min-h-20 w-full px-3 py-1.5 font-mono text-xs leading-relaxed"
+          spellCheck={false}
         />
-        <button
-          type="button"
-          aria-label={localizeUi("ui.chatSettings.impersonatesection.expandPromptTemplateEditor")}
-          onClick={() => setPromptEditorExpanded(true)}
-          className="absolute right-1.5 top-1.5 rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-          title={localizeUi("ui.chatSettings.impersonatesection.expandEditor")}
-        >
-          <Maximize2 size="0.75rem" />
-        </button>
       </div>
-      <ExpandedTextarea
-        open={promptEditorExpanded}
-        onClose={() => setPromptEditorExpanded(false)}
-        title={localizeUi("ui.chatSettings.impersonatesection.promptTemplate")}
-        value={displayedPromptTemplate}
-        onChange={setPromptTemplate}
-        readOnly={usingBuiltInDefault || saveAsPending}
-        placeholder={localizeUi("ui.chatSettings.impersonatesection.emptyUseChatBuiltInDefault")}
-        closeLabel={localizeUi("ui.chatSettings.impersonatesection.collapsePromptTemplateEditor")}
-        surface="chat"
-      />
       <div className="flex flex-wrap items-center justify-end gap-1">
         {usingBuiltInDefault && (
-          <button
-            type="button"
-            onClick={handleStartStandalonePrompt}
-            disabled={saveAsPending}
-            className="flex items-center gap-1 rounded-md bg-[var(--secondary)] px-2 py-1 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-          >
+          <AgentSettingsActionButton onClick={handleStartStandalonePrompt} disabled={saveAsPending}>
             <Copy size="0.625rem" />
             {localizeUi("ui.chatSettings.impersonatesection.copyBuiltInDefaultToEdit")}
-          </button>
+          </AgentSettingsActionButton>
         )}
         {displayedPromptTemplate.trim() && (
-          <button
-            type="button"
-            onClick={handleStartSaveAs}
-            disabled={promptTemplateCatalogBusy}
-            className="flex items-center gap-1 rounded-md bg-[var(--secondary)] px-2 py-1 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-40"
-          >
+          <AgentSettingsActionButton onClick={handleStartSaveAs} disabled={promptTemplateCatalogBusy}>
             <Copy size="0.625rem" />
             {localizeUi("ui.chatSettings.impersonatesection.saveAs")}
-          </button>
+          </AgentSettingsActionButton>
         )}
         {activePromptTemplate && (
-          <button
-            type="button"
+          <AgentSettingsActionButton
             onClick={() => {
               void handleSavePromptTemplate();
             }}
             disabled={!hasPromptTemplate || !promptIsDirty || promptTemplateCatalogBusy}
-            className="flex items-center gap-1 rounded-md bg-[var(--secondary)] px-2 py-1 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-40"
+            variant="primary"
           >
             <Save size="0.625rem" />
             {localizeUi("ui.chatSettings.impersonatesection.save")}
-          </button>
+          </AgentSettingsActionButton>
         )}
         {promptIsDirty && (
-          <button
-            type="button"
+          <AgentSettingsActionButton
             onClick={handleResetPromptDraft}
             disabled={promptTemplateCatalogMutationPending}
-            className="flex h-6 w-6 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
+            iconOnly
             title={localizeUi("ui.chatSettings.impersonatesection.resetUnsavedChanges")}
             aria-label={localizeUi("ui.chatSettings.impersonatesection.resetUnsavedChanges")}
           >
             <RotateCcw size="0.6875rem" />
-          </button>
+          </AgentSettingsActionButton>
         )}
         {activePromptTemplate && (
-          <button
-            type="button"
+          <AgentSettingsActionButton
             onClick={() => {
               void handleDeletePromptTemplate();
             }}
             disabled={promptTemplateCatalogBusy}
-            className="flex h-6 w-6 items-center justify-center rounded-md text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10 disabled:cursor-not-allowed disabled:opacity-40"
+            iconOnly
+            variant="danger"
             title={localizeUi("ui.chatSettings.impersonatesection.deleteTemplate")}
             aria-label={localizeUi("ui.chatSettings.impersonatesection.deleteTemplate")}
           >
             <Trash2 size="0.6875rem" />
-          </button>
+          </AgentSettingsActionButton>
         )}
       </div>
       {templateNameDraft !== null && (
@@ -311,40 +279,34 @@ export function ImpersonatePromptTemplateField() {
             placeholder={localizeUi("ui.chatSettings.impersonatesection.templateName")}
             className="min-w-40 flex-1 rounded-md bg-[var(--card)] px-2 py-1 text-xs text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] focus:ring-2 focus:ring-[var(--ring)]"
           />
-          <button
-            type="button"
+          <AgentSettingsActionButton
             onClick={() => {
               if (!saveAsPending) setTemplateNameDraft(null);
             }}
             disabled={saveAsPending}
-            className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+            iconOnly
             aria-label={localizeUi("ui.chatSettings.impersonatesection.cancel")}
           >
             <X size="0.75rem" />
-          </button>
-          <button
-            type="button"
+          </AgentSettingsActionButton>
+          <AgentSettingsActionButton
             onClick={() => {
               void handleSaveAsPromptTemplate();
             }}
             disabled={!templateNameDraft.trim() || !displayedPromptTemplate.trim() || promptTemplateCatalogBusy}
-            className="flex items-center gap-1 rounded-md bg-[var(--secondary)] px-2.5 py-1.5 text-[0.6875rem] font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-40"
+            variant="primary"
           >
             <Save size="0.6875rem" />
             {localizeUi("ui.chatSettings.impersonatesection.saveAs")}
-          </button>
+          </AgentSettingsActionButton>
         </div>
       )}
       {promptTemplatesQuery.isError && (
         <div className="flex items-center justify-between gap-2 rounded-lg bg-[var(--destructive)]/10 px-2.5 py-2 text-[0.6875rem] text-[var(--destructive)]">
           <span>{localizeUi("ui.chatSettings.impersonatesection.loadFailed")}</span>
-          <button
-            type="button"
-            onClick={() => void promptTemplatesQuery.refetch()}
-            className="shrink-0 rounded-md bg-[var(--secondary)] px-2 py-1 font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)]"
-          >
+          <AgentSettingsActionButton onClick={() => void promptTemplatesQuery.refetch()} className="shrink-0">
             {localizeUi("ui.chatSettings.impersonatesection.retry")}
-          </button>
+          </AgentSettingsActionButton>
         </div>
       )}
     </div>

--- a/packages/client/src/lib/agent-settings-order.ts
+++ b/packages/client/src/lib/agent-settings-order.ts
@@ -6,7 +6,13 @@ const AGENT_CATEGORY_ORDER: Record<string, number> = {
   misc: 2,
 };
 
-const STANDALONE_ROLEPLAY_AGENT_SETTINGS = new Set(["memory-nag"]);
+const STANDALONE_ROLEPLAY_AGENT_SETTINGS = new Set([
+  "memory-nag",
+  "hierarchical-maps",
+  "beholder",
+  STORYBOARD_AGENT_ID,
+  "long-term-memory",
+]);
 
 export function hasStandaloneRoleplayAgentSettings(agentId: string): boolean {
   return STANDALONE_ROLEPLAY_AGENT_SETTINGS.has(agentId);

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -772,6 +772,73 @@
   color: var(--destructive);
 }
 
+/* Compact actions inside Chat Settings and downloadable Agent settings. */
+.mari-agent-settings-action {
+  display: inline-flex;
+  min-height: 1.75rem;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  border: 1px solid var(--marinara-chat-chrome-button-border, var(--border));
+  border-radius: 0.5rem;
+  background: var(--marinara-chat-chrome-button-bg, var(--secondary));
+  padding: 0.375rem 0.625rem;
+  color: var(--marinara-chat-chrome-panel-text, var(--foreground));
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease,
+    box-shadow 150ms ease,
+    transform 120ms ease;
+}
+
+.mari-agent-settings-action:hover {
+  border-color: var(--marinara-chat-chrome-button-border-hover, var(--border));
+  background: var(--marinara-chat-chrome-button-bg-hover, var(--accent));
+  color: var(--marinara-chat-chrome-button-text-hover, var(--foreground));
+}
+
+.mari-agent-settings-action:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 0.125rem var(--marinara-chat-chrome-focus-ring, var(--ring));
+}
+
+.mari-agent-settings-action:active {
+  transform: scale(0.98);
+}
+
+.mari-agent-settings-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.mari-agent-settings-action--primary {
+  border-color: var(--marinara-chat-chrome-button-border-active, color-mix(in srgb, var(--primary) 30%, transparent));
+  background: var(--marinara-chat-chrome-button-bg-active, color-mix(in srgb, var(--primary) 12%, transparent));
+  color: var(--marinara-chat-chrome-button-text-active, var(--primary));
+}
+
+.mari-agent-settings-action--danger {
+  border-color: color-mix(in srgb, var(--destructive) 30%, transparent);
+  background: color-mix(in srgb, var(--destructive) 10%, transparent);
+  color: var(--destructive);
+}
+
+.mari-agent-settings-action--danger:hover {
+  border-color: color-mix(in srgb, var(--destructive) 42%, transparent);
+  background: color-mix(in srgb, var(--destructive) 16%, transparent);
+  color: var(--destructive);
+}
+
+.mari-agent-settings-action--icon {
+  width: 1.75rem;
+  padding: 0;
+}
+
 .mari-chat-logo-mode--conversation {
   --mari-chat-logo-mode-color: var(--mari-logo-cyan);
   --mari-chat-logo-mode-color-deep: var(--mari-logo-cyan-deep);

--- a/scripts/regressions/agent-registry-hydration.regression.ts
+++ b/scripts/regressions/agent-registry-hydration.regression.ts
@@ -124,6 +124,10 @@ const activeSettingsOrder = ["writer", "tracker", "misc"].flatMap((category) =>
 );
 assert.deepEqual(activeSettingsOrder, menuOrder, "Roleplay quick links and active settings must share one order");
 assert.equal(hasStandaloneRoleplayAgentSettings("memory-nag"), true);
+assert.equal(hasStandaloneRoleplayAgentSettings("hierarchical-maps"), true);
+assert.equal(hasStandaloneRoleplayAgentSettings("beholder"), true);
+assert.equal(hasStandaloneRoleplayAgentSettings("storyboard"), true);
+assert.equal(hasStandaloneRoleplayAgentSettings("long-term-memory"), true);
 assert.equal(hasStandaloneRoleplayAgentSettings("late-tracker"), false);
 
 // Connections can mount before this query resolves. It must use the React Query


### PR DESCRIPTION
Fixes #5443

Why

Chat Settings accumulated one-off button, toggle, segmented-control, and prompt-field styles. This made agent menus visually inconsistent and left several active agents nested inside add-agent categories instead of giving them the same standalone settings treatment.

What changed

- Add one shared compact action primitive and reuse the existing shared toggle and segmented controls across the requested agent menus.
- Give active Memory Nag, World Maps, Beholder, Storyboards, and Long-Term Memory standalone collapsible Roleplay cards above the add-agent categories.
- Move Game Storyboards into its own collapsible card when active.
- Replace the Memory Nag brain with a speaking-thought icon.
- Normalize Card Evolution Auditor, Expression Engine, Music DJ, Illustrator, Lorebook Keeper, Storyboards, Beholder, and Haptic Feedback actions.
- Make Haptic incidental contact use the established toggle and use the configured color for both connection outcomes.
- Make Impersonate use the standard expandable Macro field and shared compact actions.
- Replace amber agent-cost information styling with the configured color.

Validation

- pnpm check
- node ./scripts/run-regressions.mjs --filter scripts/regressions/agent-registry-hydration.regression.ts

Manual verification

- [ ] Verify each requested active agent card expands, collapses, and removes correctly in Roleplay Chat Settings.
- [ ] Verify Storyboards has a standalone active card in Game Chat Settings.
- [ ] Verify Impersonate Expand and Macros controls and all template actions on desktop and mobile.
- [ ] Verify Haptic status, sensitivity, and incidental-contact controls with the configured theme colors.
- [ ] Verify Memory Nag 1.0.5 actions with Pasta-Devs/Marinara-Agents#522.

Cross-repository package PR: Pasta-Devs/Marinara-Agents#522.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified Chat Settings controls with consistent buttons, segmented controls, and styling.
  * Added standalone settings cards for maps, memory, storyboard, Beholder, and downloaded capabilities.
  * Standardized expandable macro prompts, including read-only editing support.
  * Improved expression, sprite, haptic connection, and storyboard settings controls.
* **Bug Fixes**
  * Improved agent settings organization and visibility across roleplay and game agents.
  * Corrected high-cost agent indicators and memory-related settings behavior.
* **Tests**
  * Added regression coverage for standalone agent settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->