### PR TITLE
fix: group mobile roleplay trackers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Roleplay now places Beholder directly beside Tracker Panel before Agents, groups Inventory and Memory Nag into the combined mobile tracker control, and preserves full mobile touch-target bounds in the chat Help overlay (#5457, Pasta-Devs/Marinara-Agents#533).
 - Downloadable Roleplay tracker buttons now keep the built-in mobile size; Memory Nag and Inventory headers inherit the neutral Tracker Panel icon treatment; Gallery and Translation language fields reuse the standard chat field; active agent drawers omit redundant installation instructions; Storyboards toggles and Lorebook Keeper actions align evenly; Long-Term Memory uses its archive icon in every mode; and Narrative Director and Expression Engine have distinct clapperboard and theatre-mask icons (#5452, Pasta-Devs/Marinara-Agents#528, Pasta-Devs/Marinara-Agents#530, Pasta-Devs/Marinara-Agents#531).
 - Roleplay tracker controls and Chat Settings now share canonical ordering, icons, labels, toggles, fields, badges, and compact actions; Memory Nag and Beholder integrate with the Tracker Panel, while Persona Stats no longer duplicates Inventory Tracker ownership and dedicated inventory changes continue filling the journal (#5450, Pasta-Devs/Marinara-Agents#525).
 - Image Connection model controls now stay inside narrow Android viewports, and long message editors expand to their content on desktop while retaining the mobile height cap (#5447, #5448).

--- a/packages/client/src/components/chat/ChatHelpOverlay.tsx
+++ b/packages/client/src/components/chat/ChatHelpOverlay.tsx
@@ -330,13 +330,21 @@ function unionRects(rects: Rect[]): Rect | null {
   return { top, left, width: right - left, height: bottom - top };
 }
 
-function readVisibleRect(element: Element): Rect | null {
+function readVisibleRect(element: Element, preferInteractive = false): Rect | null {
   const ownRect = rectFromDomRect((element as HTMLElement).getBoundingClientRect());
-  if (ownRect.width > 1 && ownRect.height > 1) return ownRect;
-  const childRects = Array.from(element.querySelectorAll<HTMLElement>("button, [role='button'], input, textarea"))
+  if (!preferInteractive && ownRect.width > 1 && ownRect.height > 1) return ownRect;
+
+  const interactive = element.matches("button, [role='button'], input, textarea")
+    ? [element as HTMLElement]
+    : Array.from(element.querySelectorAll<HTMLElement>("button, [role='button'], input, textarea"));
+  const interactiveRects = interactive
     .map((child) => rectFromDomRect(child.getBoundingClientRect()))
     .filter((rect) => rect.width > 1 && rect.height > 1);
-  return unionRects(childRects);
+  const interactiveRect = unionRects(interactiveRects);
+  if (interactiveRect) return interactiveRect;
+
+  if (ownRect.width > 1 && ownRect.height > 1) return ownRect;
+  return null;
 }
 
 function clipRect(rect: Rect, viewportWidth: number, viewportHeight: number): Rect | null {
@@ -367,7 +375,7 @@ function findTargetRect(definition: HelpTargetDefinition, root: HTMLElement, mod
         '[data-chat-help="identity"], [data-roleplay-top-controls="right"], [data-chat-help="agents"]',
       ),
     )
-      .map(readVisibleRect)
+      .map((element) => readVisibleRect(element, true))
       .filter((rect): rect is Rect => rect !== null);
     const top = Math.max(scrollRect.top + 8, ...topControls.map((rect) => rect.top + rect.height + 8));
     const bottom = Math.min(scrollRect.top + scrollRect.height - 8, (composerRect?.top ?? Infinity) - 8);
@@ -385,22 +393,23 @@ function findTargetRect(definition: HelpTargetDefinition, root: HTMLElement, mod
   }
 
   if (!definition.selector) return null;
+  const preferInteractive = definition.selector.startsWith("[data-chat-help=");
   const rects = Array.from(document.querySelectorAll(definition.selector))
-    .map(readVisibleRect)
+    .map((element) => readVisibleRect(element, preferInteractive))
     .filter((rect): rect is Rect => rect !== null);
   return definition.mergeMatches ? unionRects(rects) : (rects[0] ?? null);
 }
 
-function expandRectWithin(rect: Rect, bounds: Rect): Rect {
-  const left = Math.max(bounds.left, rect.left - TARGET_PADDING);
-  const top = Math.max(bounds.top, rect.top - TARGET_PADDING);
-  const right = Math.min(bounds.left + bounds.width, rect.left + rect.width + TARGET_PADDING);
-  const bottom = Math.min(bounds.top + bounds.height, rect.top + rect.height + TARGET_PADDING);
+function expandRectWithin(rect: Rect, bounds: Rect, padding: number): Rect {
+  const left = Math.max(bounds.left, rect.left - padding);
+  const top = Math.max(bounds.top, rect.top - padding);
+  const right = Math.min(bounds.left + bounds.width, rect.left + rect.width + padding);
+  const bottom = Math.min(bounds.top + bounds.height, rect.top + rect.height + padding);
   return { top, left, width: right - left, height: bottom - top };
 }
 
-function separateHighlightRects(targets: MeasuredTarget[], bounds: Rect): MeasuredTarget[] {
-  const separated = targets.map((target) => ({ ...target, rect: expandRectWithin(target.rect, bounds) }));
+function separateHighlightRects(targets: MeasuredTarget[], bounds: Rect, padding = TARGET_PADDING): MeasuredTarget[] {
+  const separated = targets.map((target) => ({ ...target, rect: expandRectWithin(target.rect, bounds, padding) }));
   for (let firstIndex = 0; firstIndex < separated.length; firstIndex += 1) {
     for (let secondIndex = firstIndex + 1; secondIndex < separated.length; secondIndex += 1) {
       const first = separated[firstIndex]!;
@@ -468,7 +477,8 @@ function measureTargets(mode: ChatMode) {
     const rect = measured ? clipRect(measured, viewportWidth, viewportHeight) : null;
     return rect ? [{ ...definition, rect }] : [];
   });
-  return { rootRect, targets: rootRect ? separateHighlightRects(targets, rootRect) : targets };
+  const highlightPadding = window.innerWidth < 768 ? 0 : TARGET_PADDING;
+  return { rootRect, targets: rootRect ? separateHighlightRects(targets, rootRect, highlightPadding) : targets };
 }
 
 function getLegendStyle(rootRect: Rect): CSSProperties {

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -290,6 +290,8 @@ export function RoleplayHUD({
     enabledAgentTypes.has("quest") ||
     enabledAgentTypes.has("custom-tracker");
   const hasInventoryTracker = enabledAgentTypes.has("inventory-tracker");
+  const hasMobilePlayerTrackerSections =
+    hasPlayerTrackerSections || hasInventoryTracker || memoryNagTrackerPackages.length > 0;
 
   // If mobileCompact, widgets are even narrower and action buttons are not cut off
 
@@ -307,6 +309,15 @@ export function RoleplayHUD({
         {trackerPanelEnabled && !trackerPanelOpen && (
           <TrackerPanelToggleButton onToggle={() => toggleTrackerPanel(chatId)} />
         )}
+
+        {beholderTrackerPackages.map((item) => (
+          <RoleplayTrackerCapability
+            key={`${item.id}-beholder-launcher`}
+            packageId={item.id}
+            chatId={chatId}
+            compact={mobileCompact}
+          />
+        ))}
 
         {/* Actions (Agents + Clear) */}
         <ActionsGroup
@@ -359,11 +370,14 @@ export function RoleplayHUD({
               />
             )}
 
-            {hasPlayerTrackerSections && (
+            {hasMobilePlayerTrackerSections && (
               <CombinedPlayerWidget
                 showPersona={hasPersonaStatsTracker}
                 showCharacters={enabledAgentTypes.has("character-tracker")}
                 showQuests={enabledAgentTypes.has("quest")}
+                showInventory={hasInventoryTracker}
+                memoryNagPackageIds={memoryNagTrackerPackages.map((item) => item.id)}
+                chatId={chatId}
                 showCustomTracker={enabledAgentTypes.has("custom-tracker")}
                 personaStats={personaStatBars}
                 onUpdatePersonaStats={(bars) => patchField("personaStats", bars)}
@@ -373,6 +387,12 @@ export function RoleplayHUD({
                 onUpdateCharacters={(chars) => patchField("presentCharacters", chars)}
                 quests={activeQuests}
                 onUpdateQuests={(q) => patchPlayerStats("activeQuests", q)}
+                inventoryCurrencies={inventoryTrackerCurrencies}
+                inventoryEquipped={inventoryTrackerEquipped}
+                inventory={inventoryTrackerInventory}
+                onUpdateInventoryCurrencies={(rows) => editInventoryTracker("currencies", rows)}
+                onUpdateInventoryEquipped={(rows) => editInventoryTracker("equipped", rows)}
+                onUpdateInventory={(rows) => editInventoryTracker("inventory", rows)}
                 customTrackerFields={customTrackerFields}
                 onUpdateCustomTracker={(fields) => patchPlayerStats("customTrackerFields", fields)}
                 onRerunSingleTracker={onRerunSingleTracker}
@@ -380,20 +400,7 @@ export function RoleplayHUD({
               />
             )}
 
-            {hasInventoryTracker && (
-              <InventoryTrackerWidget
-                currencies={inventoryTrackerCurrencies}
-                equipped={inventoryTrackerEquipped}
-                inventory={inventoryTrackerInventory}
-                onUpdateCurrencies={(rows) => editInventoryTracker("currencies", rows)}
-                onUpdateEquipped={(rows) => editInventoryTracker("equipped", rows)}
-                onUpdateInventory={(rows) => editInventoryTracker("inventory", rows)}
-                onRerunSingleTracker={onRerunSingleTracker}
-                isTrackerRetryBusy={isTrackerBusy}
-              />
-            )}
-
-            {[...memoryNagTrackerPackages, ...otherRoleplayTrackerPackages, ...beholderTrackerPackages].map((item) => (
+            {otherRoleplayTrackerPackages.map((item) => (
               <RoleplayTrackerCapability
                 key={`${item.id}-roleplay-tracker-mobile`}
                 packageId={item.id}
@@ -502,10 +509,6 @@ export function RoleplayHUD({
             )}
 
             {otherRoleplayTrackerPackages.map((item) => (
-              <RoleplayTrackerCapability key={`${item.id}-roleplay-tracker`} packageId={item.id} chatId={chatId} />
-            ))}
-
-            {beholderTrackerPackages.map((item) => (
               <RoleplayTrackerCapability key={`${item.id}-roleplay-tracker`} packageId={item.id} chatId={chatId} />
             ))}
 
@@ -810,6 +813,9 @@ function CombinedPlayerWidget({
   showPersona,
   showCharacters,
   showQuests,
+  showInventory,
+  memoryNagPackageIds,
+  chatId,
   showCustomTracker,
   personaStats,
   onUpdatePersonaStats,
@@ -819,6 +825,12 @@ function CombinedPlayerWidget({
   onUpdateCharacters,
   quests,
   onUpdateQuests,
+  inventoryCurrencies,
+  inventoryEquipped,
+  inventory,
+  onUpdateInventoryCurrencies,
+  onUpdateInventoryEquipped,
+  onUpdateInventory,
   customTrackerFields,
   onUpdateCustomTracker,
   onRerunSingleTracker,
@@ -827,6 +839,9 @@ function CombinedPlayerWidget({
   showPersona: boolean;
   showCharacters: boolean;
   showQuests: boolean;
+  showInventory: boolean;
+  memoryNagPackageIds: string[];
+  chatId: string;
   showCustomTracker: boolean;
   personaStats: CharacterStat[];
   onUpdatePersonaStats: (bars: CharacterStat[]) => void;
@@ -836,6 +851,12 @@ function CombinedPlayerWidget({
   onUpdateCharacters: (chars: PresentCharacter[]) => void;
   quests: QuestProgress[];
   onUpdateQuests: (quests: QuestProgress[]) => void;
+  inventoryCurrencies: InventoryTrackerRow[];
+  inventoryEquipped: InventoryTrackerRow[];
+  inventory: InventoryTrackerRow[];
+  onUpdateInventoryCurrencies: (rows: InventoryTrackerRow[]) => void;
+  onUpdateInventoryEquipped: (rows: InventoryTrackerRow[]) => void;
+  onUpdateInventory: (rows: InventoryTrackerRow[]) => void;
   customTrackerFields: CustomTrackerField[];
   onUpdateCustomTracker: (fields: CustomTrackerField[]) => void;
   onRerunSingleTracker?: (agentType: string) => void;
@@ -872,6 +893,9 @@ function CombinedPlayerWidget({
             showPersona={showPersona}
             showCharacters={showCharacters}
             showQuests={showQuests}
+            showInventory={showInventory}
+            memoryNagPackageIds={memoryNagPackageIds}
+            chatId={chatId}
             showCustomTracker={showCustomTracker}
             personaStats={personaStats}
             onUpdatePersonaStats={onUpdatePersonaStats}
@@ -881,6 +905,12 @@ function CombinedPlayerWidget({
             onUpdateCharacters={onUpdateCharacters}
             quests={quests}
             onUpdateQuests={onUpdateQuests}
+            inventoryCurrencies={inventoryCurrencies}
+            inventoryEquipped={inventoryEquipped}
+            inventory={inventory}
+            onUpdateInventoryCurrencies={onUpdateInventoryCurrencies}
+            onUpdateInventoryEquipped={onUpdateInventoryEquipped}
+            onUpdateInventory={onUpdateInventory}
             customTrackerFields={customTrackerFields}
             onUpdateCustomTracker={onUpdateCustomTracker}
             onClose={() => setOpen(false)}

--- a/packages/client/src/components/chat/RoleplayHUDPanels.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDPanels.tsx
@@ -73,6 +73,7 @@ import { WorldCustomFieldIcon } from "../../features/tracker-panel/lib/world-cus
 import { trackerEditableText } from "../../features/tracker-panel/lib/tracker-display";
 import { useTranslation as useUiTranslation } from "react-i18next";
 import { InventoryTrackerPanel as InventoryTrackerGridPanel } from "../../features/tracker-panel/components/sections/InventoryTrackerPanel";
+import { CapabilityElement } from "../capabilities/CapabilityElement";
 
 export function RoleplayInventoryTrackerPanel({
   currencies,
@@ -123,6 +124,9 @@ interface CombinedPlayerPanelProps {
   showPersona: boolean;
   showCharacters: boolean;
   showQuests: boolean;
+  showInventory: boolean;
+  memoryNagPackageIds: string[];
+  chatId: string;
   showCustomTracker: boolean;
   personaStats: CharacterStat[];
   onUpdatePersonaStats: (bars: CharacterStat[]) => void;
@@ -132,6 +136,12 @@ interface CombinedPlayerPanelProps {
   onUpdateCharacters: (chars: PresentCharacter[]) => void;
   quests: QuestProgress[];
   onUpdateQuests: (quests: QuestProgress[]) => void;
+  inventoryCurrencies: InventoryTrackerRow[];
+  inventoryEquipped: InventoryTrackerRow[];
+  inventory: InventoryTrackerRow[];
+  onUpdateInventoryCurrencies: (rows: InventoryTrackerRow[]) => void;
+  onUpdateInventoryEquipped: (rows: InventoryTrackerRow[]) => void;
+  onUpdateInventory: (rows: InventoryTrackerRow[]) => void;
   customTrackerFields: CustomTrackerField[];
   onUpdateCustomTracker: (fields: CustomTrackerField[]) => void;
   onClose: () => void;
@@ -275,6 +285,9 @@ export function CombinedPlayerPanel({
   showPersona,
   showCharacters,
   showQuests,
+  showInventory,
+  memoryNagPackageIds,
+  chatId,
   showCustomTracker,
   personaStats,
   onUpdatePersonaStats,
@@ -284,6 +297,12 @@ export function CombinedPlayerPanel({
   onUpdateCharacters,
   quests,
   onUpdateQuests,
+  inventoryCurrencies,
+  inventoryEquipped,
+  inventory,
+  onUpdateInventoryCurrencies,
+  onUpdateInventoryEquipped,
+  onUpdateInventory,
   customTrackerFields,
   onUpdateCustomTracker,
   onClose,
@@ -675,6 +694,29 @@ export function CombinedPlayerPanel({
             </div>
           </div>
         )}
+
+        {showInventory && (
+          <RoleplayInventoryTrackerPanel
+            currencies={inventoryCurrencies}
+            equipped={inventoryEquipped}
+            inventory={inventory}
+            onUpdateCurrencies={onUpdateInventoryCurrencies}
+            onUpdateEquipped={onUpdateInventoryEquipped}
+            onUpdateInventory={onUpdateInventory}
+            onRerunSingleTracker={onRerunSingleTracker}
+            isTrackerRetryBusy={isTrackerRetryBusy}
+          />
+        )}
+
+        {memoryNagPackageIds.map((packageId) => (
+          <CapabilityElement
+            key={`${packageId}-mobile-combined-tracker`}
+            packageId={packageId}
+            view="tracker"
+            capabilityProps={{ chatId, chatMode: "roleplay" }}
+            className="block"
+          />
+        ))}
 
         {showCustomTracker && (
           <div className="p-2">

--- a/scripts/regressions/mobile-tracker-help-layout.regression.mjs
+++ b/scripts/regressions/mobile-tracker-help-layout.regression.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function readSource(relativePath) {
+  return readFileSync(new URL(`../../${relativePath}`, import.meta.url), "utf8");
+}
+
+const roleplayHud = readSource("packages/client/src/components/chat/RoleplayHUD.tsx");
+const roleplayPanels = readSource("packages/client/src/components/chat/RoleplayHUDPanels.tsx");
+const chatHelp = readSource("packages/client/src/components/chat/ChatHelpOverlay.tsx");
+
+const beholderLauncher = roleplayHud.indexOf("item.id}-beholder-launcher");
+const agentsGroup = roleplayHud.indexOf("<ActionsGroup");
+assert.ok(
+  beholderLauncher >= 0 && beholderLauncher < agentsGroup,
+  "Beholder must launch between Tracker Panel and Agents",
+);
+assert.doesNotMatch(
+  roleplayHud,
+  /\[\.\.\.memoryNagTrackerPackages, \.\.\.otherRoleplayTrackerPackages, \.\.\.beholderTrackerPackages\]/u,
+  "mobile must not mount standalone Memory Nag or Beholder controls in the tracker row",
+);
+assert.match(
+  roleplayPanels,
+  /showQuests[\s\S]*showInventory[\s\S]*memoryNagPackageIds\.map[\s\S]*showCustomTracker/u,
+  "the combined mobile tracker panel must order Inventory and Memory Nag after Quests and before Custom",
+);
+assert.match(
+  chatHelp,
+  /element\.matches\("button, \[role='button'\], input, textarea"\)[\s\S]*interactiveRect/u,
+  "help targets must be able to use the full interactive control bounds",
+);
+assert.match(
+  chatHelp,
+  /definition\.selector\.startsWith\("\[data-chat-help="\)[\s\S]*readVisibleRect\(element, preferInteractive\)/u,
+  "only chat toolbar targets should shrink to their interactive controls",
+);
+assert.match(
+  chatHelp,
+  /window\.innerWidth < 768 \? 0 : TARGET_PADDING/u,
+  "dense mobile help targets must not be expanded into overlapping frames",
+);
+
+process.stdout.write("Mobile tracker and help layout regression passed\n");


### PR DESCRIPTION
## Why

Roleplay mobile spent scarce toolbar space on standalone Inventory and Memory Nag controls, placed Beholder away from the related Tracker Panel control, and shrank dense Help-overlay frames until they no longer outlined their touch targets.

## What changed

- places Beholder immediately after Tracker Panel and before Agents on desktop and mobile
- moves Inventory and Memory Nag into the combined mobile tracker panel after Quests and before Custom
- keeps desktop Inventory and Memory Nag controls unchanged
- measures the interactive control bounds for toolbar Help targets while preserving full frames for content sections
- removes expansion padding for dense mobile Help targets so adjacent frames do not overlap
- adds a focused source-contract regression and an Unreleased changelog entry

Closes #5457

## Validation

- `pnpm check`
- `node scripts/regressions/mobile-tracker-help-layout.regression.mjs`
- `pnpm exec playwright test -c playwright.config.ts e2e/core-flows.e2e.ts --project=mobile-chromium --grep "chat Help overlay labels visible controls in every mode"`
- `git diff --check`

The full UI smoke run reached 273 passing and 108 skipped tests. Its original mobile Help failure was corrected and the focused rerun above passes; two unrelated package-fixture cases for Illustrator and World Maps remained failing.

## Manual verification

- [ ] Manually verify toolbar order with Tracker Panel, Beholder, and Agents enabled on desktop.
- [ ] Manually verify Inventory and Memory Nag appear inside the combined mobile Trackers panel in the requested order.
- [ ] Manually verify the mobile Help overlay frames every right-side toolbar button at its full touch-target size.
- [ ] Manually verify either Beholder launcher reopens the package window after it is closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Repositioned Roleplay chat controls for clearer access.
  - Grouped mobile tracker controls into a combined panel.
  - Displayed relevant inventory and capability information together on mobile.

- **Bug Fixes**
  - Improved chat-help highlighting for interactive controls.
  - Preserved accurate touch-target boundaries on mobile, including Help overlays.

- **Tests**
  - Added regression coverage for mobile tracker ordering and help-overlay layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->