### PR TITLE
fix: address game, preset, and Termux issue sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Profile imports now keep only the local canonical Universal Preset protected; imported copies retain their content but remain editable and deletable (#5469).
-- Game creation now reports reachable, refused, and timed-out GM connection failures with actionable messages instead of a bare internal-server error (#5466).
+- Game creation now reports unreachable, refused, and timed-out GM connection failures with actionable messages instead of a bare internal-server error (#5466).
 - Termux now uses a 1 GB automatic Node.js heap ceiling while preserving explicit operator overrides, reducing Android memory pressure that could terminate the entire background session (#5470).
 - Conversation autonomy and Game agent controls now use the shared toggle design; automatic-summary, Discord Mirror, Illustrator, Prompt Preset, and widget controls reuse canonical fields and actions; muted Game audio follows the configured accent; journal entries can be deleted after confirmation; and Stop Agents cancels every attached or detached agent run without flickering or aborting the main response (#5463).
 - Tracker Panel now keeps Inventory above Custom and uses the configured app accent for its frame and dice controls; Group Chat's Add Turn To Prompt setting now uses the shared toggle and muted off-state; branch counts use the compact rounded-corner tag shape instead of capsules; Conversation places Start Call beside the character or group name; and Markdown horizontal rules follow the surrounding message text color instead of the legacy border tint (#5462).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Profile imports now keep only the local canonical Universal Preset protected; imported copies retain their content but remain editable and deletable (#5469).
-- Game creation now reports unreachable, refused, and timed-out GM connection failures with actionable messages instead of a bare internal-server error (#5466).
+- Game creation now reports unreachable, refused, timed-out, and other GM provider failures with actionable messages instead of a bare internal-server error (#5466).
 - Termux now uses a 1 GB automatic Node.js heap ceiling while preserving explicit operator overrides, reducing Android memory pressure that could terminate the entire background session (#5470).
 - Conversation autonomy and Game agent controls now use the shared toggle design; automatic-summary, Discord Mirror, Illustrator, Prompt Preset, and widget controls reuse canonical fields and actions; muted Game audio follows the configured accent; journal entries can be deleted after confirmation; and Stop Agents cancels every attached or detached agent run without flickering or aborting the main response (#5463).
 - Tracker Panel now keeps Inventory above Custom and uses the configured app accent for its frame and dice controls; Group Chat's Add Turn To Prompt setting now uses the shared toggle and muted off-state; branch counts use the compact rounded-corner tag shape instead of capsules; Conversation places Start Call beside the character or group name; and Markdown horizontal rules follow the surrounding message text color instead of the legacy border tint (#5462).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Termux now uses a 1 GB automatic Node.js heap ceiling while preserving explicit operator overrides, reducing Android memory pressure that could terminate the entire background session (#5470).
 - Conversation autonomy and Game agent controls now use the shared toggle design; automatic-summary, Discord Mirror, Illustrator, Prompt Preset, and widget controls reuse canonical fields and actions; muted Game audio follows the configured accent; journal entries can be deleted after confirmation; and Stop Agents cancels every attached or detached agent run without flickering or aborting the main response (#5463).
 - Tracker Panel now keeps Inventory above Custom and uses the configured app accent for its frame and dice controls; Group Chat's Add Turn To Prompt setting now uses the shared toggle and muted off-state; branch counts use the compact rounded-corner tag shape instead of capsules; Conversation places Start Call beside the character or group name; and Markdown horizontal rules follow the surrounding message text color instead of the legacy border tint (#5462).
 - Character and Persona editors now switch to their compact section menu before constrained Windows layouts can crush toolbar buttons together, and the menu trigger matches neighboring action heights on desktop and mobile (#5460).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Added
 
 - Implemented {{lorebookSize::lorebookID}} macro, which resolves to the total number of entries inside a lorebook, when given its unique ID (#5464)
+- Game Setup now includes an on-by-default Quick Time Events switch; turning it off removes the timed-reaction command from GM prompts for that campaign (#5467).
 - Custom Agents can now opt into proposing complete character cards, which remain editable and require explicit approval before they are saved to the Characters library (#5456).
 - Active Memory Nag packages now get a standalone Roleplay Agents settings section; inactive Memory Nag remains in Tracker Agents for initial setup and tracker scheduling (#5440, Pasta-Devs/Marinara-Agents#518).
 - Pull requests and scheduled security audits now run the focused import, sandbox, host-authentication, and runtime-integrity regression lane, while the new security policy provides private vulnerability reporting without changing Marinara's local-first capabilities (#5436).
@@ -37,6 +38,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Profile imports now keep only the local canonical Universal Preset protected; imported copies retain their content but remain editable and deletable (#5469).
+- Game creation now reports reachable, refused, and timed-out GM connection failures with actionable messages instead of a bare internal-server error (#5466).
 - Termux now uses a 1 GB automatic Node.js heap ceiling while preserving explicit operator overrides, reducing Android memory pressure that could terminate the entire background session (#5470).
 - Conversation autonomy and Game agent controls now use the shared toggle design; automatic-summary, Discord Mirror, Illustrator, Prompt Preset, and widget controls reuse canonical fields and actions; muted Game audio follows the configured accent; journal entries can be deleted after confirmation; and Stop Agents cancels every attached or detached agent run without flickering or aborting the main response (#5463).
 - Tracker Panel now keeps Inventory above Custom and uses the configured app accent for its frame and dice controls; Group Chat's Add Turn To Prompt setting now uses the shared toggle and muted off-state; branch counts use the compact rounded-corner tag shape instead of capsules; Conversation places Start Call beside the character or group name; and Markdown horizontal rules follow the surrounding message text color instead of the legacy border tint (#5462).

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -41,6 +41,7 @@ import {
   Download,
   CheckCircle2,
   ChevronDown,
+  Timer,
 } from "lucide-react";
 import {
   ANIME_GAME_PROMPT_TEMPLATE_ID,
@@ -516,6 +517,7 @@ export function GameSetupWizard({
   const [enableSpriteGeneration, setEnableSpriteGeneration] = useState(false);
   const [gameImageDynamicPromptEnabled, setGameImageDynamicPromptEnabled] = useState(false);
   const [enableAgents, setEnableAgents] = useState(false);
+  const [enableQuickTimeEvents, setEnableQuickTimeEvents] = useState(true);
   const [enableSpotifyDj, setEnableSpotifyDj] = useState(false);
   const [gameSpotifySourceType, setGameSpotifySourceType] = useState<GameSpotifySourceType>("liked");
   const [gameSpotifyPlaylistId, setGameSpotifyPlaylistId] = useState("");
@@ -1075,6 +1077,7 @@ export function GameSetupWizard({
           config.gameWorldMapMode === "hierarchical" ||
           Boolean(config.spatialMapInstructions?.trim()),
       );
+      setEnableQuickTimeEvents(config.enableQuickTimeEvents !== false);
       setEnableSpriteGeneration(visualGenerationEnabled);
       setGameImageDynamicPromptEnabled(config.gameImageDynamicPromptEnabled === true);
       setImageConnectionId(config.imageConnectionId ?? null);
@@ -1181,6 +1184,7 @@ export function GameSetupWizard({
       personaId: personaId ?? undefined,
       sceneConnectionId: sceneModelValue && sceneModelValue !== "local" ? sceneModelValue : undefined,
       enableAgents: enableAgents || undefined,
+      enableQuickTimeEvents: enableQuickTimeEvents ? undefined : false,
       enableSpriteGeneration: illustratorEnabled,
       gameImageDynamicPromptEnabled: illustratorEnabled && gameImageDynamicPromptEnabled,
       imageConnectionId: illustratorEnabled && imageConnectionId ? imageConnectionId : undefined,
@@ -2199,6 +2203,49 @@ export function GameSetupWizard({
                         {localizeUi("ui.game.gamesetupwizard.gameFeatures")}
                       </label>
                       <div className="space-y-2">
+                        <button
+                          type="button"
+                          aria-pressed={enableQuickTimeEvents}
+                          onClick={() => setEnableQuickTimeEvents((enabled) => !enabled)}
+                          className={cn(
+                            "flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2.5 text-left transition-all",
+                            enableQuickTimeEvents
+                              ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
+                              : "bg-[var(--secondary)] ring-1 ring-transparent hover:ring-[var(--border)]",
+                          )}
+                        >
+                          <span className="flex min-w-0 flex-1 items-center gap-2.5">
+                            <Timer
+                              size={14}
+                              className={
+                                enableQuickTimeEvents ? "text-[var(--primary)]" : "text-[var(--muted-foreground)]"
+                              }
+                            />
+                            <span className="min-w-0">
+                              <span className="block text-xs font-medium text-[var(--foreground)]">
+                                {localizeUi("ui.game.gamesetupwizard.quickTimeEvents")}
+                              </span>
+                              <span className="block text-[0.575rem] text-[var(--muted-foreground)]">
+                                {localizeUi("ui.game.gamesetupwizard.quickTimeEventsDescription")}
+                              </span>
+                            </span>
+                          </span>
+                          <span
+                            aria-hidden="true"
+                            className={cn(
+                              "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                              enableQuickTimeEvents ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                            )}
+                          >
+                            <span
+                              className={cn(
+                                "block h-4 w-4 rounded-full bg-white transition-transform",
+                                enableQuickTimeEvents && "translate-x-3.5",
+                              )}
+                            />
+                          </span>
+                        </button>
+
                         {installedAgentsLoading ? (
                           <div className="flex items-center justify-center gap-2 rounded-lg border border-dashed border-[var(--border)] px-4 py-4 text-xs text-[var(--muted-foreground)]">
                             <Loader2 size={13} className="animate-spin" />

--- a/packages/client/src/lib/game-setup-share.ts
+++ b/packages/client/src/lib/game-setup-share.ts
@@ -200,6 +200,7 @@ function parseShareConfig(value: unknown): GameSetupConfig {
 
   const optionalBooleans = [
     "enableAgents",
+    "enableQuickTimeEvents",
     "enableSpriteGeneration",
     "gameImageDynamicPromptEnabled",
     "gameStoryboardsEnabled",
@@ -692,6 +693,7 @@ export function buildGameSetupSummarySections(source: GameSetupShareSource): Gam
         { label: "Tone", value: config.tone },
         { label: "Difficulty", value: titleCaseToken(config.difficulty) },
         { label: "Combat style", value: titleCaseToken(config.combatStyle ?? "classic") },
+        { label: "Quick Time Events", value: config.enableQuickTimeEvents === false ? "Off" : "On" },
         { label: "Content rating", value: config.rating.toUpperCase() },
         { label: "Language", value: config.language?.trim() || "Default" },
         { label: "Player goals", value: config.playerGoals.trim() || "None" },

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -5217,6 +5217,8 @@
   "ui.game.gamesetupwizard.powersAutomaticPortraitsBackgroundsAndSceneIllustrations": "Powers automatic portraits, backgrounds, and scene illustrations.",
   "ui.game.gamesetupwizard.powersAutomaticPortraitsBackgroundsSceneIllustrationsAndStoryboardKeyframes": "Powers automatic portraits, backgrounds, scene illustrations, and storyboard keyframes.",
   "ui.game.gamesetupwizard.previewingTheSelectedPromptEditItToOverride": "Previewing the selected prompt; edit it to override",
+  "ui.game.gamesetupwizard.quickTimeEvents": "Quick Time Events",
+  "ui.game.gamesetupwizard.quickTimeEventsDescription": "Let the GM offer timed reactions. Turn this off for screen-reader or untimed play.",
   "ui.game.gamesetupwizard.recommendedUseAStrongStateOfTheArtImage": "Recommended: use a strong state-of-the-art image model for storyboard images, or something equivalent to Google Nano Banana 2 Lite.",
   "ui.game.gamesetupwizard.resetToSelected": "Reset to selected",
   "ui.game.gamesetupwizard.reuseAGameSetup": "Reuse a game setup",

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -764,9 +764,10 @@ export function normalizeProfilePromptPresetRow(
   row: Record<string, unknown>,
   localStockPresetId: string | null,
 ): Record<string, unknown> {
-  if (!localStockPresetId || row.id === localStockPresetId || row.systemKey !== MARINARA_UNIVERSAL_PRESET_SYSTEM_KEY) {
-    return row;
+  if (localStockPresetId && row.id === localStockPresetId) {
+    return { ...row, systemKey: MARINARA_UNIVERSAL_PRESET_SYSTEM_KEY };
   }
+  if (!localStockPresetId || row.systemKey !== MARINARA_UNIVERSAL_PRESET_SYSTEM_KEY) return row;
   return { ...row, systemKey: "" };
 }
 

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -26,6 +26,8 @@ import { createThemesStorage } from "../services/storage/themes.storage.js";
 import { createAppSettingsStorage } from "../services/storage/app-settings.storage.js";
 import {
   canReparentFolder,
+  isStockMarinaraUniversalPreset,
+  MARINARA_UNIVERSAL_PRESET_SYSTEM_KEY,
   normalizePersonalExtensionCapabilities,
   type ExportEnvelope,
 } from "@marinara-engine/shared";
@@ -758,6 +760,16 @@ export function quarantineProfileThemeRow(row: Record<string, unknown>) {
   return { ...row, isActive: "false" };
 }
 
+export function normalizeProfilePromptPresetRow(
+  row: Record<string, unknown>,
+  localStockPresetId: string | null,
+): Record<string, unknown> {
+  if (!localStockPresetId || row.id === localStockPresetId || row.systemKey !== MARINARA_UNIVERSAL_PRESET_SYSTEM_KEY) {
+    return row;
+  }
+  return { ...row, systemKey: "" };
+}
+
 // Secret-bearing columns to omit on the conflict-UPDATE path so an existing row
 // keeps its stored secret (the file store leaves an unmentioned column untouched); only
 // the fresh-insert path carries the export's redacted values. For custom_tools the
@@ -1236,6 +1248,8 @@ async function importProfileStorageSnapshot(
     let rollbackFailed = false;
     try {
       await app.db.transaction(async (tx) => {
+        const localStockPresetId =
+          ((await tx.select().from(schema.promptPresets)).find(isStockMarinaraUniversalPreset)?.id as string) ?? null;
         const plannedSnapshot = await planProfileNoodleImport(
           tx,
           snapshot,
@@ -1270,6 +1284,9 @@ async function importProfileStorageSnapshot(
             if (tableName === "custom_tools") cleanRow = quarantineProfileCustomToolRow(cleanRow);
             if (tableName === "mari_instructions") cleanRow = quarantineProfileMariInstructionRow(cleanRow);
             if (tableName === "custom_themes") cleanRow = quarantineProfileThemeRow(cleanRow);
+            if (tableName === "prompt_presets") {
+              cleanRow = normalizeProfilePromptPresetRow(cleanRow, localStockPresetId);
+            }
             const insert = tx.insert(table as any).values(cleanRow as any) as any;
             const conflictTarget = schemaPrimaryKeyColumn(table);
             if (conflictTarget) {

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -48,6 +48,7 @@ import {
 import { isDiceNotation, rollDice } from "../services/game/dice.service.js";
 import { jsonishLooksTruncated, parseGameJsonish } from "../services/game/jsonish.js";
 import {
+  formatInitialGameGmConnectionError,
   GAME_SETUP_GENERATION_TIMEOUT_MS,
   resolveInitialGameGmConnectionId,
 } from "../services/game/initial-game-setup.js";
@@ -1777,6 +1778,7 @@ const gameSetupConfigSchema = z.object({
     .optional(),
   sceneConnectionId: z.string().optional(),
   enableAgents: z.boolean().optional(),
+  enableQuickTimeEvents: z.boolean().optional(),
   enableSpriteGeneration: z.boolean().optional(),
   gameImageDynamicPromptEnabled: z.boolean().optional(),
   imageConnectionId: z.string().optional(),
@@ -6790,12 +6792,20 @@ export async function gameRoutes(app: FastifyInstance) {
     let setupFinishReason: ChatCompletionResult["finishReason"] | null = null;
 
     for (let attempt = 1; attempt <= 2; attempt++) {
-      const result = await runGameChatComplete(
-        provider,
-        messages,
-        setupOptions,
-        attempt === 1 ? "Game setup" : "Game setup retry",
-      );
+      let result: ChatCompletionResult;
+      try {
+        result = await runGameChatComplete(
+          provider,
+          messages,
+          setupOptions,
+          attempt === 1 ? "Game setup" : "Game setup retry",
+        );
+      } catch (error) {
+        const failure = formatInitialGameGmConnectionError(error);
+        logger.warn(error, "[game/setup] GM connection failed");
+        reply.code(failure.statusCode).send({ error: failure.message });
+        return;
+      }
       setupFinishReason = result.finishReason;
       const setupExtraction = extractLeadingThinkingBlocks(
         result.content ?? "",

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3693,6 +3693,7 @@ export async function generateRoutes(app: FastifyInstance) {
               characterSprites: gmCtx.characterSprites,
               language: gmCtx.language,
               rating: gmCtx.rating,
+              enableQuickTimeEvents: gmCtx.enableQuickTimeEvents,
               gameSpecialInstructions: gmCtx.gameSpecialInstructions,
               canGenerateBackgrounds: gmCtx.canGenerateBackgrounds,
               artStylePrompt: gmCtx.artStylePrompt,

--- a/packages/server/src/services/game/gm-prompts.ts
+++ b/packages/server/src/services/game/gm-prompts.ts
@@ -51,6 +51,8 @@ export interface GmPromptContext {
   hudWidgets?: HudWidget[];
   /** Content rating: sfw or nsfw */
   rating?: "sfw" | "nsfw";
+  /** Whether the GM may emit timed reaction prompts. Defaults to true. */
+  enableQuickTimeEvents?: boolean;
   /** Whether a separate scene model handles bg, music, sfx, ambient, widgets, expressions */
   hasSceneModel?: boolean;
   /** Whether inline GM scene tags may request generated location backgrounds. */
@@ -620,6 +622,7 @@ export function buildGmFormatReminder(
     | "playerInventory"
     | "language"
     | "rating"
+    | "enableQuickTimeEvents"
     | "gameSpecialInstructions"
   > & {
     /** Special non-scene-advancing address mode inferred from the current player turn prefix. */
@@ -765,7 +768,11 @@ export function buildGmFormatReminder(
   }
 
   lines.push(
-    `- [qte: action1|action2|action3, timer: 6s] - only as the final thing in the turn when the player must react to an immediate timed prompt or split-second action. Stop immediately after this tag: choosing an action commits the player's next turn.`,
+    ...(ctx.enableQuickTimeEvents === false
+      ? []
+      : [
+          `- [qte: action1|action2|action3, timer: 6s] - only as the final thing in the turn when the player must react to an immediate timed prompt or split-second action. Stop immediately after this tag: choosing an action commits the player's next turn.`,
+        ]),
     ...(ctx.map?.type === "node"
       ? [
           `- [map_update: new_location="Location Name" connected_to="Previous Location Name" node_emoji="emoji"] - only when the party arrives at an entirely new location on the current node map.`,

--- a/packages/server/src/services/game/initial-game-setup.ts
+++ b/packages/server/src/services/game/initial-game-setup.ts
@@ -6,3 +6,50 @@ export function resolveInitialGameGmConnectionId(
 ): string | null {
   return explicitConnectionId || chatConnectionId || null;
 }
+
+export function formatInitialGameGmConnectionError(error: unknown): {
+  statusCode: 502 | 504;
+  message: string;
+} {
+  const details: string[] = [];
+  const seen = new Set<object>();
+  let current: unknown = error;
+
+  while (current && typeof current === "object" && !seen.has(current) && seen.size < 5) {
+    seen.add(current);
+    const value = current as { name?: unknown; message?: unknown; code?: unknown; cause?: unknown };
+    for (const detail of [value.name, value.message, value.code]) {
+      if (typeof detail === "string") details.push(detail);
+    }
+    current = value.cause;
+  }
+
+  const joined = details.join(" ").toLowerCase();
+  if (/timed? out|timeout|etimedout|und_err_(connect|headers)_timeout/u.test(joined)) {
+    return {
+      statusCode: 504,
+      message: "The GM connection timed out. Check the connection and try again.",
+    };
+  }
+  if (/econnrefused|connection refused/u.test(joined)) {
+    return {
+      statusCode: 502,
+      message:
+        "The GM connection refused the request. Check that the provider is running and the connection URL is correct, then try again.",
+    };
+  }
+  if (
+    /fetch failed|bad port|enotfound|eai_again|enetunreach|ehostunreach|econnreset|err_invalid_url|und_err_connect/u.test(
+      joined,
+    )
+  ) {
+    return {
+      statusCode: 502,
+      message: "The GM connection could not be reached. Check the connection and try again.",
+    };
+  }
+  return {
+    statusCode: 502,
+    message: "The GM connection returned an error. Check the connection settings and try again.",
+  };
+}

--- a/packages/server/src/services/game/initial-game-setup.ts
+++ b/packages/server/src/services/game/initial-game-setup.ts
@@ -59,7 +59,7 @@ export function formatInitialGameGmConnectionError(error: unknown): {
         "The GM provider rejected the configured credentials. Check the API key or account connection and try again.",
     };
   }
-  if (/\b404\b|invalid model|unknown model|model.*(?:not found|does not exist|unavailable)/u.test(joined)) {
+  if (/invalid model|unknown model|model.*(?:not found|does not exist|unavailable)/u.test(joined)) {
     return {
       statusCode: 400,
       message: "The selected GM model is unavailable. Check the connection's model and try again.",

--- a/packages/server/src/services/game/initial-game-setup.ts
+++ b/packages/server/src/services/game/initial-game-setup.ts
@@ -8,7 +8,7 @@ export function resolveInitialGameGmConnectionId(
 }
 
 export function formatInitialGameGmConnectionError(error: unknown): {
-  statusCode: 502 | 504;
+  statusCode: 400 | 401 | 429 | 502 | 504;
   message: string;
 } {
   const details: string[] = [];
@@ -17,9 +17,9 @@ export function formatInitialGameGmConnectionError(error: unknown): {
 
   while (current && typeof current === "object" && !seen.has(current) && seen.size < 5) {
     seen.add(current);
-    const value = current as { name?: unknown; message?: unknown; code?: unknown; cause?: unknown };
-    for (const detail of [value.name, value.message, value.code]) {
-      if (typeof detail === "string") details.push(detail);
+    const value = current as { name?: unknown; message?: unknown; code?: unknown; status?: unknown; cause?: unknown };
+    for (const detail of [value.name, value.message, value.code, value.status]) {
+      if (typeof detail === "string" || typeof detail === "number") details.push(String(detail));
     }
     current = value.cause;
   }
@@ -48,8 +48,31 @@ export function formatInitialGameGmConnectionError(error: unknown): {
       message: "The GM connection could not be reached. Check the connection and try again.",
     };
   }
+  if (
+    /\b(?:401|403)\b|unauthori[sz]ed|forbidden|invalid api key|api key.*expired|expired.*api key|authentication/u.test(
+      joined,
+    )
+  ) {
+    return {
+      statusCode: 401,
+      message:
+        "The GM provider rejected the configured credentials. Check the API key or account connection and try again.",
+    };
+  }
+  if (/\b404\b|invalid model|unknown model|model.*(?:not found|does not exist|unavailable)/u.test(joined)) {
+    return {
+      statusCode: 400,
+      message: "The selected GM model is unavailable. Check the connection's model and try again.",
+    };
+  }
+  if (/\b429\b|rate.?limit|quota/u.test(joined)) {
+    return {
+      statusCode: 429,
+      message: "The GM provider is rate-limited or out of quota. Check the provider account or try again later.",
+    };
+  }
   return {
     statusCode: 502,
-    message: "The GM connection returned an error. Check the connection settings and try again.",
+    message: "The GM provider returned an error. Check the provider and model settings, then try again.",
   };
 }

--- a/packages/server/src/services/generation/game-gm-prompt-runtime.ts
+++ b/packages/server/src/services/generation/game-gm-prompt-runtime.ts
@@ -324,6 +324,7 @@ export async function injectGameGmPromptRuntime(args: {
     setting: (setupConfig?.setting as string) || "original",
     tone: (setupConfig?.tone as string) || "balanced",
     rating: (setupConfig?.rating as "sfw" | "nsfw") || "sfw",
+    enableQuickTimeEvents: setupConfig?.enableQuickTimeEvents !== false,
     campaignPlan: gameBlueprint?.campaignPlan ?? null,
     canGenerateBackgrounds:
       !!args.chatMetadata.enableSpriteGeneration &&

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -232,6 +232,8 @@ export interface GameSetupConfig {
   experienceConfig?: Record<string, unknown>;
   /** Enable installed agents and agent-driven Game Mode features for this game. */
   enableAgents?: boolean;
+  /** Let the GM offer timed reaction prompts. Defaults to true. */
+  enableQuickTimeEvents?: boolean;
   /** Enable automatic sprite generation for characters using image model */
   enableSpriteGeneration?: boolean;
   /** Ask the configured prompt model to rewrite Game Illustrator prompts before image generation. */

--- a/scripts/regressions/assigned-issue-sweep.regression.ts
+++ b/scripts/regressions/assigned-issue-sweep.regression.ts
@@ -92,6 +92,10 @@ assert.deepEqual(formatInitialGameGmConnectionError(Object.assign(new Error("Mod
   statusCode: 400,
   message: "The selected GM model is unavailable. Check the connection's model and try again.",
 });
+assert.deepEqual(formatInitialGameGmConnectionError(Object.assign(new Error("Not found"), { status: 404 })), {
+  statusCode: 502,
+  message: "The GM provider returned an error. Check the provider and model settings, then try again.",
+});
 assert.deepEqual(formatInitialGameGmConnectionError(Object.assign(new Error("Quota exceeded"), { status: 429 })), {
   statusCode: 429,
   message: "The GM provider is rate-limited or out of quota. Check the provider account or try again later.",

--- a/scripts/regressions/assigned-issue-sweep.regression.ts
+++ b/scripts/regressions/assigned-issue-sweep.regression.ts
@@ -79,6 +79,23 @@ assert.deepEqual(formatInitialGameGmConnectionError(new Error("fetch failed", { 
   statusCode: 502,
   message: "The GM connection could not be reached. Check the connection and try again.",
 });
+assert.deepEqual(formatInitialGameGmConnectionError(new Error("provider exploded")), {
+  statusCode: 502,
+  message: "The GM provider returned an error. Check the provider and model settings, then try again.",
+});
+assert.deepEqual(formatInitialGameGmConnectionError(Object.assign(new Error("Unauthorized"), { status: 401 })), {
+  statusCode: 401,
+  message:
+    "The GM provider rejected the configured credentials. Check the API key or account connection and try again.",
+});
+assert.deepEqual(formatInitialGameGmConnectionError(Object.assign(new Error("Model not found"), { status: 404 })), {
+  statusCode: 400,
+  message: "The selected GM model is unavailable. Check the connection's model and try again.",
+});
+assert.deepEqual(formatInitialGameGmConnectionError(Object.assign(new Error("Quota exceeded"), { status: 429 })), {
+  statusCode: 429,
+  message: "The GM provider is rate-limited or out of quota. Check the provider account or try again later.",
+});
 
 const dispatchedAgentEvents: Array<Record<string, unknown>> = [];
 const immutableAgentOwnership = {

--- a/scripts/regressions/assigned-issue-sweep.regression.ts
+++ b/scripts/regressions/assigned-issue-sweep.regression.ts
@@ -19,6 +19,8 @@ import {
 import { useAgentStore } from "../../packages/client/src/stores/agent.store.js";
 import { agentResultMatchesVisibleSwipe } from "../../packages/client/src/lib/agent-result-ownership.js";
 import { createAgentEventDispatcher } from "../../packages/server/src/services/generation/agent-event-dispatcher.js";
+import { buildGmFormatReminder } from "../../packages/server/src/services/game/gm-prompts.js";
+import { formatInitialGameGmConnectionError } from "../../packages/server/src/services/game/initial-game-setup.js";
 import { resolveMacrosForPreview } from "../../packages/server/src/services/prompt/macro-context.js";
 import {
   isStockMarinaraUniversalPreset,
@@ -30,6 +32,53 @@ import {
 } from "../../packages/shared/src/types/game.js";
 
 const repositoryRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+const gameFormatContext = {
+  hasSceneModel: false,
+  canGenerateBackgrounds: false,
+  artStylePrompt: undefined,
+  hudWidgets: [],
+  turnNumber: 1,
+  gameActiveState: "exploration" as const,
+  sessionNumber: 1,
+  gameTime: "Day 1, 09:00",
+  map: null,
+  partyNames: [],
+  playerName: "Mari",
+  characterSprites: [],
+  playerInventory: [],
+  language: "English",
+  rating: "sfw" as const,
+  gameSpecialInstructions: null,
+};
+assert.match(
+  buildGmFormatReminder(gameFormatContext),
+  /\[qte:/u,
+  "legacy and default game setups continue offering Quick Time Events",
+);
+assert.doesNotMatch(
+  buildGmFormatReminder({ ...gameFormatContext, enableQuickTimeEvents: false }),
+  /\[qte:/u,
+  "disabling Quick Time Events removes the command from the provider prompt",
+);
+
+const refusedCause = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:1234"), {
+  code: "ECONNREFUSED",
+});
+const refusedConnectionError = new Error("fetch failed", { cause: refusedCause });
+assert.deepEqual(formatInitialGameGmConnectionError(refusedConnectionError), {
+  statusCode: 502,
+  message:
+    "The GM connection refused the request. Check that the provider is running and the connection URL is correct, then try again.",
+});
+assert.deepEqual(formatInitialGameGmConnectionError(new Error("Game setup timed out after 500 seconds")), {
+  statusCode: 504,
+  message: "The GM connection timed out. Check the connection and try again.",
+});
+assert.deepEqual(formatInitialGameGmConnectionError(new Error("fetch failed", { cause: new Error("bad port") })), {
+  statusCode: 502,
+  message: "The GM connection could not be reached. Check the connection and try again.",
+});
 
 const dispatchedAgentEvents: Array<Record<string, unknown>> = [];
 const immutableAgentOwnership = {

--- a/scripts/regressions/launcher/format-guard.regression.mjs
+++ b/scripts/regressions/launcher/format-guard.regression.mjs
@@ -80,6 +80,16 @@ assert.match(
   /trap release_termux_wake_lock EXIT/u,
   "the Termux launcher must release its wake lock whenever the server exits",
 );
+assert.match(
+  termuxLauncherSource,
+  /--max-old-space-size=1024/u,
+  "the Termux launcher must leave Android enough memory headroom instead of inviting a full-session LMK kill",
+);
+assert.doesNotMatch(
+  termuxLauncherSource,
+  /--max-old-space-size=2048/u,
+  "the Termux launcher must not restore the memory-heavy 2 GB automatic heap default",
+);
 const wakeLockTrapIndex = termuxLauncherSource.search(/^[ \t]*trap release_termux_wake_lock EXIT[ \t]*$/mu);
 const wakeLockAcquireIndex = termuxLauncherSource.search(/^[ \t]*if[ \t]+termux-wake-lock\b[^\n]*;[ \t]*then[ \t]*$/mu);
 const serverStartIndex = termuxLauncherSource.lastIndexOf("node dist/index.js");

--- a/scripts/regressions/launcher/format-guard.regression.mjs
+++ b/scripts/regressions/launcher/format-guard.regression.mjs
@@ -95,6 +95,23 @@ assert.match(
   /if ! has_explicit_node_heap_limit; then[\s\S]*NODE_OPTIONS="\$\{NODE_OPTIONS:\+\$\{NODE_OPTIONS\} \}--max-old-space-size=1024"/u,
   "an explicit NODE_OPTIONS heap limit must override the 1 GB mobile default",
 );
+const heapSetupStart = termuxLauncherSource.indexOf("has_explicit_node_heap_limit() {");
+const heapDefaultStart = termuxLauncherSource.indexOf("if ! has_explicit_node_heap_limit; then", heapSetupStart);
+const heapSetupEnd = termuxLauncherSource.indexOf("\nfi", heapDefaultStart);
+assert.ok(heapSetupStart >= 0 && heapDefaultStart >= 0 && heapSetupEnd >= 0, "the Termux heap setup must be present");
+const heapSetupSource = termuxLauncherSource.slice(heapSetupStart, heapSetupEnd + 3);
+const resolveTermuxNodeOptions = (nodeOptions) => {
+  const marker = "__NODE_OPTIONS__";
+  const probe = spawnSync("bash", ["-c", `${heapSetupSource}\nprintf '\\n${marker}%s' "$NODE_OPTIONS"`], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    env: { ...process.env, NODE_OPTIONS: nodeOptions },
+  });
+  assert.equal(probe.status, 0, probe.stderr);
+  return probe.stdout.slice(probe.stdout.lastIndexOf(marker) + marker.length);
+};
+assert.equal(resolveTermuxNodeOptions("--max-old-space-size=512"), "--max-old-space-size=512");
+assert.equal(resolveTermuxNodeOptions(""), "--max-old-space-size=1024");
 const wakeLockTrapIndex = termuxLauncherSource.search(/^[ \t]*trap release_termux_wake_lock EXIT[ \t]*$/mu);
 const wakeLockAcquireIndex = termuxLauncherSource.search(/^[ \t]*if[ \t]+termux-wake-lock\b[^\n]*;[ \t]*then[ \t]*$/mu);
 const serverStartIndex = termuxLauncherSource.lastIndexOf("node dist/index.js");

--- a/scripts/regressions/launcher/format-guard.regression.mjs
+++ b/scripts/regressions/launcher/format-guard.regression.mjs
@@ -90,12 +90,15 @@ assert.doesNotMatch(
   /--max-old-space-size=2048/u,
   "the Termux launcher must not restore the memory-heavy 2 GB automatic heap default",
 );
+assert.match(
+  termuxLauncherSource,
+  /if ! has_explicit_node_heap_limit; then[\s\S]*NODE_OPTIONS="\$\{NODE_OPTIONS:\+\$\{NODE_OPTIONS\} \}--max-old-space-size=1024"/u,
+  "an explicit NODE_OPTIONS heap limit must override the 1 GB mobile default",
+);
 const wakeLockTrapIndex = termuxLauncherSource.search(/^[ \t]*trap release_termux_wake_lock EXIT[ \t]*$/mu);
 const wakeLockAcquireIndex = termuxLauncherSource.search(/^[ \t]*if[ \t]+termux-wake-lock\b[^\n]*;[ \t]*then[ \t]*$/mu);
 const serverStartIndex = termuxLauncherSource.lastIndexOf("node dist/index.js");
-const persistentLogIndex = termuxLauncherSource.indexOf(
-  'exec > >(tee -a "$MARINARA_TERMUX_LOG_FILE") 2>&1',
-);
+const persistentLogIndex = termuxLauncherSource.indexOf('exec > >(tee -a "$MARINARA_TERMUX_LOG_FILE") 2>&1');
 const dependencySetupIndex = termuxLauncherSource.indexOf("resolve_pnpm_runner || exit 1");
 assert.ok(
   wakeLockTrapIndex >= 0 && wakeLockAcquireIndex >= 0 && wakeLockTrapIndex < wakeLockAcquireIndex,

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -5027,10 +5027,11 @@ const termuxLauncher = readFileSync(new URL("../../start-termux.sh", import.meta
 assert.doesNotMatch(termuxLauncher, /run_pnpm install --force/u);
 assert.match(termuxLauncher, /run_pnpm store prune/u);
 assert.match(termuxLauncher, /TERMUX_REBUILD_REQUIRED/u);
-assert.match(termuxLauncher, /--max-old-space-size=2048/u);
+assert.match(termuxLauncher, /--max-old-space-size=1024/u);
+assert.doesNotMatch(termuxLauncher, /--max-old-space-size=2048/u);
 assert.match(
   termuxLauncher,
-  /has_explicit_node_heap_limit\(\)[\s\S]*NODE_OPTIONS_VALUE[\s\S]*const heapOption = \/\^--max[\s\S]*if ! has_explicit_node_heap_limit; then[\s\S]*NODE_OPTIONS="\$\{NODE_OPTIONS:\+\$\{NODE_OPTIONS\} \}--max-old-space-size=2048"/u,
+  /has_explicit_node_heap_limit\(\)[\s\S]*NODE_OPTIONS_VALUE[\s\S]*const heapOption = \/\^--max[\s\S]*if ! has_explicit_node_heap_limit; then[\s\S]*NODE_OPTIONS="\$\{NODE_OPTIONS:\+\$\{NODE_OPTIONS\} \}--max-old-space-size=1024"/u,
   "Termux must parse complete heap-option tokens before applying its safe default",
 );
 for (const buildEntry of [

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -2249,7 +2249,10 @@ try {
       }),
     ),
   );
-  assert.equal(concurrentEntryFolderResults.every((result) => result.ok), true);
+  assert.equal(
+    concurrentEntryFolderResults.every((result) => result.ok),
+    true,
+  );
   const professorMariFolderList = await mariDb.executeAction({
     action: "lorebook.folder.list",
     lorebookId: professorMariLorebookId,
@@ -2293,7 +2296,10 @@ try {
       }),
     ),
   );
-  assert.equal(concurrentLibraryFolderResults.every((result) => result.ok), true);
+  assert.equal(
+    concurrentLibraryFolderResults.every((result) => result.ok),
+    true,
+  );
   const professorMariLibraryFolders = await mariDb.executeAction({ action: "lorebook.libraryFolder.list" });
   const professorMariLibraryFolderRows = professorMariLibraryFolders.output as Array<{
     id: string;
@@ -7104,6 +7110,7 @@ const sharedGameSetupSource: GameSetupShareSource = {
     useCampaignArtStyle: false,
     imageStyleProfileId: "image-style-profile-local-id",
     enableAgents: true,
+    enableQuickTimeEvents: false,
     enableSpriteGeneration: true,
     imageConnectionId: "image-connection-local-id",
     videoConnectionId: "video-connection-local-id",
@@ -7154,6 +7161,7 @@ assert.match(sharedGameSetup, /gpt-5\.6-sol/iu);
 assert.match(sharedGameSetup, /Use clear progression and frequent loot rewards/u);
 assert.match(sharedGameSetup, /Dungeon Lore/u);
 assert.match(sharedGameSetup, /Combat style: Tactical/u);
+assert.match(sharedGameSetup, /Quick Time Events: Off/u);
 assert.match(sharedGameSetup, /Build a shifting tower with a market ward and flooded catacombs\./u);
 assert.match(sharedGameSetup, /World map size: Medium/u);
 assert.match(sharedGameSetup, /World map place target: 10/u);
@@ -7196,6 +7204,7 @@ assert.equal(exportedGameSetup.format, "marinara-game-setup");
 assert.equal(exportedGameSetup.version, 1);
 assert.equal(exportedGameSetup.exportedAt, "2026-07-16T12:00:00.000Z");
 assert.equal(resolvedGameSetup.config.enableAgents, true);
+assert.equal(resolvedGameSetup.config.enableQuickTimeEvents, false);
 assert.equal(parsedGameSetup.setup.effectiveGenerationParameters?.temperature, 1.1);
 assert.equal(parsedGameSetup.setup.effectiveGenerationParameters?.maxContext, 128000);
 assert.deepEqual(parsedGameSetup.setup.effectiveGenerationParameters?.stopSequences, ["[END]"]);

--- a/scripts/regressions/profile-import-data-security.regression.ts
+++ b/scripts/regressions/profile-import-data-security.regression.ts
@@ -84,6 +84,30 @@ try {
       connectionFixture("changed-embedding", { embeddingBaseUrl: "https://trusted.example/embeddings" }),
     ];
     await db.insert(schema.apiConnections).values(existingFixtures as never);
+    const promptPresetFixture = (id: string, name: string) => ({
+      id,
+      name,
+      description: "",
+      imagePath: null,
+      conversationPrompt: "",
+      gamePrompt: "",
+      sectionOrder: "[]",
+      groupOrder: "[]",
+      variableGroups: "[]",
+      variableValues: "{}",
+      parameters: "{}",
+      wrapFormat: "xml",
+      defaultChoices: "{}",
+      isDefault: "false",
+      author: "Marinara",
+      systemKey: "marinara-universal-preset",
+      embedding: null,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    const localStockPreset = promptPresetFixture("local-stock-preset", "Marinara's Universal Preset");
+    const importedStockCopy = promptPresetFixture("imported-stock-copy", "Marinara's Universal Preset");
+    await db.insert(schema.promptPresets).values(localStockPreset);
     const storedConnections = (await db.select().from(schema.apiConnections)) as Array<Record<string, unknown>>;
     const storedById = new Map(storedConnections.map((row) => [row.id, row]));
     const importedConnection = (id: string, overrides: Record<string, unknown> = {}) => {
@@ -198,6 +222,7 @@ try {
           version: 1,
           tables: {
             api_connections: importedConnections,
+            prompt_presets: [importedStockCopy],
             mari_instructions: [importedInstruction],
             custom_themes: [importedTheme],
             custom_tools: [importedTool],
@@ -216,6 +241,7 @@ try {
     assert.equal(previewResponse.statusCode, 200, previewResponse.body);
     const preview = previewResponse.json();
     assert.equal(preview.imported.connections, 6);
+    assert.equal(preview.imported.presets, 1);
     assert.equal(preview.imported.customTools, 1);
     assert.equal(preview.imported.mariInstructions, 1);
     assert.equal(preview.imported.personalExtensions, 2);
@@ -238,6 +264,17 @@ try {
     const afterImport = (await db.select().from(schema.apiConnections)) as Array<Record<string, unknown>>;
     const afterById = new Map(afterImport.map((row) => [row.id, row]));
     const connections = connectionsModule.createConnectionsStorage(db);
+    const importedPresets = await db.select().from(schema.promptPresets);
+    assert.equal(
+      importedPresets.find((preset) => preset.id === localStockPreset.id)?.systemKey,
+      "marinara-universal-preset",
+      "the local canonical Universal Preset must stay protected",
+    );
+    assert.equal(
+      importedPresets.find((preset) => preset.id === importedStockCopy.id)?.systemKey,
+      "",
+      "a foreign Universal Preset copy must import as an editable, deletable preset",
+    );
     const sameIdentity = afterById.get("same-identity")!;
     assert.equal(
       cryptoModule.decryptApiKey(String(sameIdentity.apiKeyEncrypted)),

--- a/scripts/regressions/profile-import-data-security.regression.ts
+++ b/scripts/regressions/profile-import-data-security.regression.ts
@@ -107,6 +107,7 @@ try {
     });
     const localStockPreset = promptPresetFixture("local-stock-preset", "Marinara's Universal Preset");
     const importedStockCopy = promptPresetFixture("imported-stock-copy", "Marinara's Universal Preset");
+    const importedLocalStockPreset = { ...localStockPreset, systemKey: "" };
     await db.insert(schema.promptPresets).values(localStockPreset);
     const storedConnections = (await db.select().from(schema.apiConnections)) as Array<Record<string, unknown>>;
     const storedById = new Map(storedConnections.map((row) => [row.id, row]));
@@ -222,7 +223,7 @@ try {
           version: 1,
           tables: {
             api_connections: importedConnections,
-            prompt_presets: [importedStockCopy],
+            prompt_presets: [importedLocalStockPreset, importedStockCopy],
             mari_instructions: [importedInstruction],
             custom_themes: [importedTheme],
             custom_tools: [importedTool],
@@ -241,7 +242,7 @@ try {
     assert.equal(previewResponse.statusCode, 200, previewResponse.body);
     const preview = previewResponse.json();
     assert.equal(preview.imported.connections, 6);
-    assert.equal(preview.imported.presets, 1);
+    assert.equal(preview.imported.presets, 2);
     assert.equal(preview.imported.customTools, 1);
     assert.equal(preview.imported.mariInstructions, 1);
     assert.equal(preview.imported.personalExtensions, 2);

--- a/start-termux.sh
+++ b/start-termux.sh
@@ -160,7 +160,7 @@ fi
 
 # Large profiles can exceed Node's conservative mobile heap limit while the
 # file-backed store serializes them. Keep an explicit operator limit, otherwise
-# give Termux enough headroom for installation and normal server operation.
+# use a bounded mobile default that leaves Android room for the Termux process.
 has_explicit_node_heap_limit() {
     local node_options_value="${NODE_OPTIONS:-}"
     NODE_OPTIONS= NODE_OPTIONS_VALUE="$node_options_value" node <<'NODE_OPTIONS_PARSER'
@@ -202,9 +202,9 @@ NODE_OPTIONS_PARSER
 }
 
 if ! has_explicit_node_heap_limit; then
-    NODE_OPTIONS="${NODE_OPTIONS:+${NODE_OPTIONS} }--max-old-space-size=2048"
+    NODE_OPTIONS="${NODE_OPTIONS:+${NODE_OPTIONS} }--max-old-space-size=1024"
     export NODE_OPTIONS
-    echo "  [OK] Node.js heap limit raised for large profiles"
+    echo "  [OK] Node.js heap limit set for large profiles"
 fi
 
 load_launcher_setting() {


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issues

Closes #5466
Closes #5467
Closes #5469
Closes #5470

## Why this change

- Game setup should explain unreachable GM connections instead of leaking a generic server error.
- Players using assistive technology need to disable Quick Time Events without changing their story prompt.
- Imported copies of the protected Universal Preset must not become undeletable duplicates.
- Termux installs need a conservative background runtime that is less likely to be killed under Android memory pressure.

## What changed

- Classify initial GM provider failures as refused, unreachable, timed out, or another connection error and return actionable 502/504 messages.
- Add an on-by-default Quick Time Events switch to Game Setup; an explicit off value removes the QTE command from the GM prompt and survives setup export/import.
- Preserve the local canonical Universal Preset system key while importing foreign copies as ordinary editable presets.
- Lower only Termux's automatic Node heap ceiling from 2 GB to 1 GB while preserving explicit `NODE_OPTIONS` overrides.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Automated evidence

- `pnpm check`
- `scripts/regressions/assigned-issue-sweep.regression.ts`
- `scripts/regressions/profile-import-data-security.regression.ts`
- `scripts/regressions/launcher/format-guard.regression.mjs`

### Manual verification requested

- Create a Game chat with a refused, unreachable, and slow GM endpoint and verify the setup dialog displays the returned guidance.
- Toggle Quick Time Events off in Game Setup, export/import that setup, and verify the choice remains off.
- Import a profile containing the Universal Preset twice and verify imported copies can be deleted while the local stock preset remains protected.
- Run a Termux install in the background on a physical Android device and inspect its durable launcher log if the OS terminates it.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- The Quick Time Events control reuses the existing Game Features toggle card and theme tokens at desktop and mobile widths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Quick Time Events setting during game setup, enabled by default and preserved when sharing or importing setups.
  * Disabled Quick Time Events remove related GM commands and prompts.

* **Bug Fixes**
  * Imported Universal Preset copies can now be edited and deleted independently.
  * Game setup provides actionable messages when GM connections fail.
  * Termux uses a 1 GB default memory limit while respecting explicit overrides.

* **Tests**
  * Added regression coverage for these updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->