### PR TITLE
[codex] Theme Download Agents permission notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Download Agents now styles its trusted-code permission notice with the configured accent instead of a hard-coded amber warning box.
 - Fixed the dev server and Playwright webServer failing to start on Windows with standalone pnpm installs: the pnpm runner now detects that `npm_execpath` points at a native `pnpm.exe` binary — which Node cannot execute — and falls back to invoking pnpm through `ComSpec` instead of crashing with `SyntaxError: Invalid or unexpected token` on the PE header.
 - Profile imports now keep only the local canonical Universal Preset protected; imported copies retain their content but remain editable and deletable (#5469).
 - Game creation now reports unreachable, refused, timed-out, and other GM provider failures with actionable messages instead of a bare internal-server error (#5466).

--- a/packages/client/src/components/agents/AgentCatalogView.tsx
+++ b/packages/client/src/components/agents/AgentCatalogView.tsx
@@ -702,7 +702,7 @@ export function AgentCatalogView() {
               <section>
                 <h3 className="text-sm font-semibold">{localizeUi("ui.agents.agentcatalogview.permissions")}</h3>
                 {(selected.manifest.entrypoints.server || selected.manifest.entrypoints.client) && (
-                  <p className="mt-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs leading-relaxed text-[var(--foreground)]">
+                  <p className="mt-2 rounded-lg border border-[var(--primary)]/30 bg-[var(--primary)]/10 px-3 py-2 text-xs leading-relaxed text-[var(--foreground)]">
                     {localizeUi("ui.agents.agentcatalogview.trustedCodeAccessNotice")}
                   </p>
                 )}


### PR DESCRIPTION
## Linked issue

Closes #5480

## Why this change

- The trusted-code notice in Download Agents used fixed amber utilities, so it ignored the user-configured app accent.

## What changed

- Replaced the notice border and background tint with the existing `--primary` theme token.
- Added an Unreleased changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Commands run by Codex:

- `pnpm localization:check`
- `pnpm check`
- `git diff --check`

### Manual verification notes

- Manually verify the trusted-code notice under Agents → Download Agents → Permissions with a downloadable package that includes client or server code.
- Manually verify that changing the configured accent updates the notice border and background tint.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence

- Manual browser verification requested above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the Download Agents trusted-code permission notice to use the configured accent color instead of a fixed amber warning style.
  - Improved visual consistency with the application’s active theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->