### PR TITLE
Unify Roleplay tracker HUD popovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Roleplay tracker controls now keep World State compact until it has content; Persona Stats, Inventory, Quests, and Custom popovers share the established header order, styling, accent treatment, and count-free titles (#5488, Pasta-Devs/Marinara-Agents#549).
 - Adding Memory Nag to a Roleplay chat now explains how to create its initial memories, then opens and scrolls to its Agent Settings menu after confirmation (#5484).
 - Download Agents now styles its trusted-code permission notice with the configured accent instead of a hard-coded amber warning box.
 - Fixed the dev server and Playwright webServer failing to start on Windows with standalone pnpm installs: the pnpm runner now detects that `npm_execpath` points at a native `pnpm.exe` binary — which Node cannot execute — and falls back to invoking pnpm through `ComSpec` instead of crashing with `SyntaxError: Invalid or unexpected token` on the PE header.

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -1266,7 +1266,7 @@ function InventoryTrackerWidget({
         className={WIDGET}
         title={localizeUi("ui.chat.inventoryTracker.title")}
       >
-        <Backpack size="0.875rem" className="max-md:h-3 max-md:w-3" />
+        <Backpack size="0.875rem" className="text-[var(--marinara-app-accent-static)] max-md:h-3 max-md:w-3" />
         {total > 0 && <span className="text-[0.5rem] font-semibold tabular-nums">{total}</span>}
       </button>
       <WidgetPopover
@@ -1417,6 +1417,9 @@ function CombinedWorldWidget({
     weatherFamily === "atmosphere" && !weather ? "text-[var(--muted-foreground)]/70" : weatherStyle.color;
   const temperatureDisplay = getTemperatureGaugeDisplay(temperature, trackerTemperatureUnit);
   const tempColor = temperatureDisplay.color;
+  const hasWorldState =
+    [location, date, time, weather, temperature].some((value) => value.trim().length > 0) ||
+    worldCustomFields.some((field) => field.name.trim().length > 0 || field.value.trim().length > 0);
 
   return (
     <div className="relative">
@@ -1430,43 +1433,56 @@ function CombinedWorldWidget({
             className: CHAT_TOOLBAR_MOBILE_OVERFLOW_HEIGHT_CLASS,
           }),
           "cursor-pointer select-none",
-          "w-auto min-w-8 gap-1 px-2",
+          hasWorldState ? "w-auto min-w-8 gap-1 px-2" : "group flex-col gap-0 overflow-hidden",
         )}
         title={localizeUi("ui.panels.appearancesettings.worldState")}
       >
-        {/* Location pin */}
-        <MapPin size="0.9375rem" className={cn("shrink-0 drop-shadow-sm", pinColor)} />
+        {!hasWorldState ? (
+          <MapPin
+            size="0.875rem"
+            className="shrink-0 text-[var(--marinara-app-accent-static)] max-md:h-3.5 max-md:w-3.5"
+          />
+        ) : (
+          <>
+            {/* Location pin */}
+            <MapPin size="0.9375rem" className={cn("shrink-0 drop-shadow-sm", pinColor)} />
 
-        {/* Mini calendar with day number */}
-        <WorldCalendarIcon
-          day={dateDisplay.day}
-          className={cn("h-4 w-4 shrink-0 drop-shadow-sm", dateDisplay.iconColor)}
-        />
+            {/* Mini calendar with day number */}
+            <WorldCalendarIcon
+              day={dateDisplay.day}
+              className={cn("h-4 w-4 shrink-0 drop-shadow-sm", dateDisplay.iconColor)}
+            />
 
-        <WorldClockIcon
-          display={timeDisplay}
-          variant="monochrome"
-          className={cn("h-4 w-4 shrink-0 drop-shadow-sm", timeColor)}
-        />
+            <WorldClockIcon
+              display={timeDisplay}
+              variant="monochrome"
+              className={cn("h-4 w-4 shrink-0 drop-shadow-sm", timeColor)}
+            />
 
-        {/* Weather emoji */}
-        <span
-          className={cn(
-            "text-sm leading-none shrink-0 drop-shadow-sm [text-shadow:0_0_8px_currentColor]",
-            weatherColor,
-          )}
-        >
-          {weatherEmoji}
-        </span>
+            {/* Weather emoji */}
+            <span
+              className={cn(
+                "text-sm leading-none shrink-0 drop-shadow-sm [text-shadow:0_0_8px_currentColor]",
+                weatherColor,
+              )}
+            >
+              {weatherEmoji}
+            </span>
 
-        <WorldThermometerIcon display={temperatureDisplay} variant="solid-bulb" className="h-4 w-[0.625rem] shrink-0" />
-        {temperatureDisplay.isPure && (
-          <span
-            className="shrink-0 text-[0.5rem] font-bold leading-none md:text-[0.5625rem]"
-            style={{ color: tempColor }}
-          >
-            {temperatureDisplay.label}
-          </span>
+            <WorldThermometerIcon
+              display={temperatureDisplay}
+              variant="solid-bulb"
+              className="h-4 w-[0.625rem] shrink-0"
+            />
+            {temperatureDisplay.isPure && (
+              <span
+                className="shrink-0 text-[0.5rem] font-bold leading-none md:text-[0.5625rem]"
+                style={{ color: tempColor }}
+              >
+                {temperatureDisplay.label}
+              </span>
+            )}
+          </>
         )}
       </button>
 

--- a/packages/client/src/components/chat/RoleplayHUDPanels.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDPanels.tsx
@@ -11,6 +11,7 @@ import {
 import { createPortal } from "react-dom";
 import {
   CalendarDays,
+  Backpack,
   BarChart3,
   CheckCircle2,
   Circle,
@@ -95,6 +96,17 @@ export function RoleplayInventoryTrackerPanel({
   isTrackerRetryBusy?: boolean;
 }) {
   const { t: localizeUi } = useUiTranslation();
+  const action = (
+    <span className="flex items-center gap-0.5">
+      <TrackerSectionRefresh
+        agentType="inventory-tracker"
+        onRerunSingleTracker={onRerunSingleTracker}
+        busy={isTrackerRetryBusy}
+        title={localizeUi("ui.chat.inventoryTracker.reRun")}
+      />
+      <HudLockModeToggle />
+    </span>
+  );
   return (
     <InventoryTrackerGridPanel
       currencies={currencies}
@@ -105,16 +117,14 @@ export function RoleplayInventoryTrackerPanel({
       onUpdateInventory={onUpdateInventory}
       deleteMode
       addMode
-      action={
-        <span className="flex items-center gap-0.5">
-          <TrackerSectionRefresh
-            agentType="inventory-tracker"
-            onRerunSingleTracker={onRerunSingleTracker}
-            busy={isTrackerRetryBusy}
-            title={localizeUi("ui.chat.inventoryTracker.reRun")}
-          />
-          <HudLockModeToggle />
-        </span>
+      header={
+        <div className={cn(NEUTRAL_PANEL_HEADER, "flex items-center justify-between")}>
+          <span className={NEUTRAL_PANEL_TITLE}>
+            <Backpack size="0.625rem" className="text-[var(--marinara-app-accent-static)]" />
+            {localizeUi("ui.chat.inventoryTracker.title")}
+          </span>
+          {action}
+        </div>
       }
     />
   );
@@ -843,14 +853,6 @@ export function PersonaStatsPanel({
 
   return (
     <>
-      <div className="border-b border-[var(--border)] p-2">
-        <PersonaStatusField
-          value={status}
-          onSave={onUpdateStatus}
-          locked={statusLock.locked}
-          onToggleLock={statusLock.onToggle}
-        />
-      </div>
       <div className={cn(NEUTRAL_PANEL_HEADER, "flex items-center justify-between")}>
         <span className={NEUTRAL_PANEL_TITLE}>
           <BarChart3 size="0.625rem" className="text-[var(--marinara-chat-chrome-accent)]" />
@@ -865,6 +867,14 @@ export function PersonaStatsPanel({
           />
           <HudLockModeToggle />
         </span>
+      </div>
+      <div className="border-b border-[var(--border)] p-2">
+        <PersonaStatusField
+          value={status}
+          onSave={onUpdateStatus}
+          locked={statusLock.locked}
+          onToggleLock={statusLock.onToggle}
+        />
       </div>
       <div className="p-2 space-y-2">
         {bars.map((bar, idx) => {
@@ -1277,8 +1287,7 @@ export function QuestsPanel({ quests, onUpdate, onRerunSingleTracker, isTrackerR
       <div className={cn(NEUTRAL_PANEL_HEADER, "flex items-center justify-between")}>
         <span className={NEUTRAL_PANEL_TITLE}>
           <Scroll size="0.625rem" className="text-[var(--marinara-chat-chrome-accent)]" />{" "}
-          {localizeUi("ui.chat.combinedplayerpanel.quests")}
-          {quests.length})
+          {localizeUi("ui.chat.questspanel.quests")}
         </span>
         <span className="flex items-center gap-1">
           <TrackerSectionRefresh
@@ -1359,7 +1368,7 @@ export function CustomTrackerPanel({
       <div className={cn(NEUTRAL_PANEL_HEADER, "flex items-center justify-between")}>
         <span className={NEUTRAL_PANEL_TITLE}>
           <SlidersHorizontal size="0.625rem" className="text-[var(--marinara-chat-chrome-accent)]" />{" "}
-          {localizeUi("ui.chat.customtrackerpanel.customTrackerValue1", { value1: fields.length })}
+          {localizeUi("ui.chat.customtrackerwidget.customTracker")}
         </span>
         <span className="flex items-center gap-1">
           <TrackerSectionRefresh

--- a/packages/client/src/features/tracker-panel/components/sections/InventoryTrackerPanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/InventoryTrackerPanel.tsx
@@ -195,6 +195,7 @@ export function InventoryTrackerPanel({
   onUpdateInventory,
   deleteMode,
   addMode,
+  header,
   collapsed = false,
   onToggleCollapsed,
 }: {
@@ -207,6 +208,7 @@ export function InventoryTrackerPanel({
   onUpdateInventory: (rows: InventoryTrackerRow[]) => void;
   deleteMode: boolean;
   addMode: boolean;
+  header?: ReactNode;
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
 }) {
@@ -218,14 +220,16 @@ export function InventoryTrackerPanel({
     <section className="@container relative z-10 overflow-hidden border-b border-[var(--border)] bg-[var(--tracker-panel-section-background,color-mix(in_srgb,var(--card)_10%,transparent))]">
       <TrackerReadabilityVeil strength="strong" />
       <div className="relative z-10">
-        <SectionHeader
-          icon={<Backpack size="0.6875rem" />}
-          title={localizeUi("ui.trackerPanel.inventoryTracker.title")}
-          badge={currencies.length + equipped.length + inventory.length}
-          action={action}
-          collapsed={collapsed}
-          onToggle={onToggleCollapsed}
-        />
+        {header ?? (
+          <SectionHeader
+            icon={<Backpack size="0.6875rem" />}
+            title={localizeUi("ui.trackerPanel.inventoryTracker.title")}
+            badge={currencies.length + equipped.length + inventory.length}
+            action={action}
+            collapsed={collapsed}
+            onToggle={onToggleCollapsed}
+          />
+        )}
         {!collapsed && (
           // Groups stack full-width. Splitting the panel into three columns gave the
           // longest group a third of the width and truncated its names, while a group

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -3960,6 +3960,7 @@
   "ui.chat.questcardeditable.questName": "Quest name",
   "ui.chat.questcardeditable.removeQuest": "Remove quest",
   "ui.chat.questcardeditable.value1Completion": "{{value1}} completion",
+  "ui.chat.questspanel.quests": "Quests",
   "ui.chat.questswidget.activeQuests": "Active Quests",
   "ui.chat.questswidget.loadingQuests": "Loading quests…",
   "ui.chat.quickconnectionswitcher.clickToAddToRandomPool": "Click to add to random pool",

--- a/scripts/regressions/tracker-gallery-ui.regression.mjs
+++ b/scripts/regressions/tracker-gallery-ui.regression.mjs
@@ -10,6 +10,7 @@ const inventoryTracker = readSource(
   "packages/client/src/features/tracker-panel/components/sections/InventoryTrackerPanel.tsx",
 );
 const roleplayHud = readSource("packages/client/src/components/chat/RoleplayHUD.tsx");
+const roleplayPanels = readSource("packages/client/src/components/chat/RoleplayHUDPanels.tsx");
 const appShell = readSource("packages/client/src/components/layout/AppShell.tsx");
 const trackerHeader = readSource("packages/client/src/features/tracker-panel/components/TrackerSidebarHeader.tsx");
 const uiStore = readSource("packages/client/src/stores/ui.store.ts");
@@ -20,9 +21,7 @@ const chatBranchSelector = readSource("packages/client/src/components/chat/ChatB
 const conversationView = readSource("packages/client/src/components/chat/ConversationView.tsx");
 const agentSettingsControls = readSource("packages/client/src/components/chat/AgentSettingsControls.tsx");
 const translationSection = readSource("packages/client/src/features/chat-settings/sections/TranslationSection.tsx");
-const discordMirrorSection = readSource(
-  "packages/client/src/features/chat-settings/sections/DiscordMirrorSection.tsx",
-);
+const discordMirrorSection = readSource("packages/client/src/features/chat-settings/sections/DiscordMirrorSection.tsx");
 const gameExtraPromptSection = readSource(
   "packages/client/src/features/chat-settings/sections/GameExtraPromptSection.tsx",
 );
@@ -78,6 +77,31 @@ assert.match(
   roleplayHud,
   /className: compact \? CHAT_TOOLBAR_MOBILE_OVERFLOW_HEIGHT_CLASS : undefined/u,
   "downloadable tracker controls must receive the built-in mobile toolbar height",
+);
+assert.match(
+  roleplayHud,
+  /const hasWorldState =[\s\S]*!hasWorldState \?[\s\S]*marinara-app-accent-static/u,
+  "World State must stay a standard accent icon until it has generated content",
+);
+assert.match(
+  roleplayPanels,
+  /export function PersonaStatsPanel[\s\S]*NEUTRAL_PANEL_HEADER[\s\S]*PersonaStatusField/u,
+  "Persona Stats must place Current Status below its panel header",
+);
+assert.match(
+  roleplayPanels,
+  /header=\{[\s\S]*NEUTRAL_PANEL_HEADER[\s\S]*Backpack[\s\S]*marinara-app-accent-static/u,
+  "the Inventory HUD popover must reuse the neutral header with an accent backpack",
+);
+assert.equal(
+  (roleplayPanels.match(/ui\.chat\.combinedplayerpanel\.quests/gu) ?? []).length,
+  1,
+  "only the combined mobile panel may keep the counted Quests title",
+);
+assert.doesNotMatch(
+  roleplayPanels,
+  /ui\.chat\.customtrackerpanel\.customTrackerValue1/u,
+  "the Custom HUD popover must not append a count to its title",
 );
 assert.match(
   chatGallery,


### PR DESCRIPTION
## Linked issue

Closes #5488

Package counterpart: Pasta-Devs/Marinara-Agents#549

## Why this change

- Several Roleplay tracker HUD controls still used inconsistent header order, icon treatment, title counts, and empty-state sizing.

## What changed

- Moved Current Status below the Persona Stats popover header.
- Reused the neutral popover header for Inventory and applied the configured accent to its backpack control.
- Removed count suffixes from the Quests and Custom HUD popover titles.
- Kept World State as a standard-sized accent icon until it has generated content, then retained the existing expanded preview.
- Added a focused UI regression and an Unreleased changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Additional automated proof run locally: `pnpm check`, `pnpm localization:check`, `node scripts/regressions/tracker-gallery-ui.regression.mjs`, and `git diff --check`.

### Manual verification notes

- Manually verify the five affected Roleplay HUD controls on desktop and mobile.
- Manually verify World State before and after its first generated value.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- No screenshot attached; focused regression proof is included and browser verification remains listed above.