### PR TITLE
fix: unify remaining chat and mobile UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Chat Settings now reuses shared action controls without dimming unrelated Connected Chats options during saves; Storyboard controls align evenly; mobile Home tabs collapse inactive labels; Inventory and branch tags use compact rounded-square styling with usable delete controls; and Tracker Panel, empty Inventory, World State, and Beholder launchers follow cycling accent colors (#5490, Pasta-Devs/Marinara-Agents#555).
 - Roleplay tracker controls now keep World State compact until it has content; Persona Stats, Inventory, Quests, and Custom popovers share the established header order, styling, accent treatment, and count-free titles (#5488, Pasta-Devs/Marinara-Agents#549).
 - Adding Memory Nag to a Roleplay chat now explains how to create its initial memories, then opens and scrolls to its Agent Settings menu after confirmation (#5484).
 - Download Agents now styles its trusted-code permission notice with the configured accent instead of a hard-coded amber warning box.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
-- Chat Settings now reuses shared action controls without dimming unrelated Connected Chats options during saves; Storyboard controls align evenly; mobile Home tabs collapse inactive labels; Inventory and branch tags use compact rounded-square styling with usable delete controls; and Tracker Panel, empty Inventory, World State, and Beholder launchers follow cycling accent colors (#5490, Pasta-Devs/Marinara-Agents#555).
+- Chat Settings now reuses shared action controls without dimming unrelated Connected Chats options during saves; Storyboard controls align evenly; mobile Home tabs collapse inactive labels; the centered mobile Agents menu and combined Trackers panel use consistent count-free sections; the mobile Help overlay keeps uniform toolbar highlights; Inventory and branch tags use compact rounded-square styling with usable delete controls; and Tracker Panel, empty Inventory, World State, and Beholder launchers follow cycling accent colors (#5490, Pasta-Devs/Marinara-Agents#555, Pasta-Devs/Marinara-Agents#557).
 - Roleplay tracker controls now keep World State compact until it has content; Persona Stats, Inventory, Quests, and Custom popovers share the established header order, styling, accent treatment, and count-free titles (#5488, Pasta-Devs/Marinara-Agents#549).
 - Adding Memory Nag to a Roleplay chat now explains how to create its initial memories, then opens and scrolls to its Agent Settings menu after confirmation (#5484).
 - Download Agents now styles its trusted-code permission notice with the configured accent instead of a hard-coded amber warning box.

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -7219,7 +7219,7 @@ test("chat Help overlay labels visible controls in every mode", async ({ page, r
           optionalCall.type = "button";
           optionalCall.dataset.chatHelp = "call";
           optionalCall.setAttribute("aria-label", "Optional voice call fixture");
-          optionalCall.style.cssText = "position:absolute;top:3.5rem;right:1rem;width:2rem;height:2rem";
+          optionalCall.style.cssText = "position:absolute;top:3.5rem;left:1rem;width:2rem;height:2rem";
           root.append(optionalCall);
         });
       }
@@ -7266,6 +7266,21 @@ test("chat Help overlay labels visible controls in every mode", async ({ page, r
       await expect(overlay.locator('[data-chat-help-highlight="branches"]')).toBeVisible();
       await expect(overlay.locator('[data-chat-help-highlight="settings"]')).toBeVisible();
       await expect(overlay.locator('[data-chat-help-highlight="help"]')).toBeVisible();
+
+      if (mobile) {
+        const firstToolbarTargets = await page
+          .locator("[data-chat-toolbar-overflow-menu] [data-chat-help]")
+          .filter({ visible: true })
+          .evaluateAll((elements) =>
+            [...new Set(elements.map((element) => element.getAttribute("data-chat-help")).filter(Boolean))].slice(0, 3),
+          );
+        for (const target of firstToolbarTargets) {
+          const box = await overlay.locator(`[data-chat-help-highlight="${target}"]`).boundingBox();
+          expect(box).not.toBeNull();
+          expect(box!.width, `${target} highlight width`).toBe(32);
+          expect(box!.height, `${target} highlight height`).toBe(32);
+        }
+      }
 
       if (chat.mode === "conversation") {
         await expect(overlay.locator('[data-chat-help-highlight="call"]')).toBeVisible();

--- a/packages/client/src/components/chat/ChatBranchSelector.tsx
+++ b/packages/client/src/components/chat/ChatBranchSelector.tsx
@@ -286,7 +286,7 @@ export function ChatBranchSelector({
         <GitBranch size="0.8125rem" className="shrink-0" />
         <span
           className={cn(
-            "absolute -right-1 -top-1 flex min-w-4 justify-center rounded-[0.25rem] px-1 text-[0.5625rem] font-semibold leading-4",
+            "mari-chrome-tag absolute -right-1 -top-1 flex min-w-4 justify-center px-1 text-[0.5625rem] font-semibold leading-4",
             badgeClassName,
           )}
         >

--- a/packages/client/src/components/chat/ChatHelpOverlay.tsx
+++ b/packages/client/src/components/chat/ChatHelpOverlay.tsx
@@ -273,6 +273,7 @@ const TARGETS_BY_MODE: Record<ChatMode, HelpTargetDefinition[]> = {
 
 const TARGET_PADDING = 5;
 const HIGHLIGHT_GAP = 5;
+const MOBILE_TOOLBAR_HIGHLIGHT_SIZE = 32;
 
 const ACTIONS_BY_MODE: Record<ChatMode, HelpActionDefinition[]> = {
   conversation: [
@@ -347,6 +348,24 @@ function readVisibleRect(element: Element, preferInteractive = false): Rect | nu
   return null;
 }
 
+function normalizeMobileToolbarRect(element: Element, rect: Rect): Rect {
+  if (window.innerWidth >= 768) return rect;
+  const interactive = element.matches("button, [role='button']")
+    ? (element as HTMLElement)
+    : Array.from(element.querySelectorAll<HTMLElement>("button, [role='button']")).find(
+        (candidate) => candidate.getBoundingClientRect().width > 1,
+      );
+  if (!interactive?.closest("[data-chat-toolbar-overflow-menu]")) return rect;
+
+  const interactiveRect = rectFromDomRect(interactive.getBoundingClientRect());
+  return {
+    top: interactiveRect.top + (interactiveRect.height - MOBILE_TOOLBAR_HIGHLIGHT_SIZE) / 2,
+    left: interactiveRect.left + (interactiveRect.width - MOBILE_TOOLBAR_HIGHLIGHT_SIZE) / 2,
+    width: MOBILE_TOOLBAR_HIGHLIGHT_SIZE,
+    height: MOBILE_TOOLBAR_HIGHLIGHT_SIZE,
+  };
+}
+
 function clipRect(rect: Rect, viewportWidth: number, viewportHeight: number): Rect | null {
   const left = Math.max(0, rect.left);
   const top = Math.max(0, rect.top);
@@ -395,7 +414,10 @@ function findTargetRect(definition: HelpTargetDefinition, root: HTMLElement, mod
   if (!definition.selector) return null;
   const preferInteractive = definition.selector.startsWith("[data-chat-help=");
   const rects = Array.from(document.querySelectorAll(definition.selector))
-    .map((element) => readVisibleRect(element, preferInteractive))
+    .map((element) => {
+      const rect = readVisibleRect(element, preferInteractive);
+      return rect ? normalizeMobileToolbarRect(element, rect) : null;
+    })
     .filter((rect): rect is Rect => rect !== null);
   return definition.mergeMatches ? unionRects(rects) : (rects[0] ?? null);
 }
@@ -472,11 +494,29 @@ function measureTargets(mode: ChatMode) {
   const viewportWidth = window.innerWidth;
   const viewportHeight = window.innerHeight;
   const rootRect = clipRect(rectFromDomRect(root.getBoundingClientRect()), viewportWidth, viewportHeight);
-  const targets = TARGETS_BY_MODE[mode].flatMap((definition) => {
+  let targets = TARGETS_BY_MODE[mode].flatMap((definition) => {
     const measured = findTargetRect(definition, root, mode);
     const rect = measured ? clipRect(measured, viewportWidth, viewportHeight) : null;
     return rect ? [{ ...definition, rect }] : [];
   });
+  const mobileOverflowRect =
+    window.innerWidth < 768
+      ? Array.from(document.querySelectorAll<HTMLElement>("[data-chat-toolbar-overflow-menu]"))
+          .map((element) => readVisibleRect(element))
+          .find((rect): rect is Rect => rect !== null)
+      : null;
+  if (mobileOverflowRect) {
+    const railLeft = mobileOverflowRect.left - TARGET_PADDING;
+    targets = targets.map((target) => {
+      const targetBottom = target.rect.top + target.rect.height;
+      const railBottom = mobileOverflowRect.top + mobileOverflowRect.height;
+      const overlapsRailVertically = target.rect.top < railBottom && targetBottom > mobileOverflowRect.top;
+      const reachesBehindRail = target.rect.left < railLeft && target.rect.left + target.rect.width > railLeft;
+      return overlapsRailVertically && reachesBehindRail
+        ? { ...target, rect: { ...target.rect, width: railLeft - target.rect.left } }
+        : target;
+    });
+  }
   const highlightPadding = window.innerWidth < 768 ? 0 : TARGET_PADDING;
   return { rootRect, targets: rootRect ? separateHighlightRects(targets, rootRect, highlightPadding) : targets };
 }

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -942,7 +942,6 @@ export function ChatSettingsDrawer({
       description={localizeUi("ui.chat.chatsettingsdrawer.timelineRefreshesMayIncludeRecentMessagesFromThisChat")}
       checked={noodleTimelineContextEnabled}
       onChange={(checked) => updateMeta.mutate({ id: chat.id, noodleTimelineContextEnabled: checked })}
-      disabled={updateMeta.isPending}
       labelPosition="start"
       className={cn(
         "justify-between rounded-md px-3 py-2.5 text-left",
@@ -4270,14 +4269,10 @@ export function ChatSettingsDrawer({
           )}
           labelClassName="text-[0.6875rem] font-medium"
         />
-        <button
-          type="button"
-          onClick={() => setShowMemoriesModal(true)}
-          className="flex w-full items-center justify-center gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2 text-[0.6875rem] font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--accent)]"
-        >
+        <AgentSettingsActionButton type="button" onClick={() => setShowMemoriesModal(true)} className="w-full">
           <Brain size="0.75rem" />
           {localizeUi("ui.chat.chatsettingsdrawer.accessMemoriesForThisChat")}
-        </button>
+        </AgentSettingsActionButton>
       </div>
     );
   };

--- a/packages/client/src/components/chat/HomeBrowserHub.tsx
+++ b/packages/client/src/components/chat/HomeBrowserHub.tsx
@@ -2202,37 +2202,46 @@ export function HomeBrowserHub({
                 type="button"
                 role="tab"
                 aria-controls={HOME_BROWSER_PANEL_ID}
+                aria-label={t("home.browser.homeTab")}
                 aria-selected={activeTab === "home"}
                 onClick={() => selectTab("home")}
                 className={cn(
-                  "flex min-h-9 min-w-0 flex-[0.8] items-center justify-center gap-1 rounded-t-lg border border-b-0 px-1 text-[0.65rem] font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[oklch(0.79_0.16_205)] sm:min-w-[6.5rem] sm:flex-none sm:gap-1.5 sm:px-3 sm:text-xs",
+                  "flex min-h-9 min-w-0 items-center justify-center rounded-t-lg border border-b-0 text-[0.65rem] font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[oklch(0.79_0.16_205)] sm:min-w-[6.5rem] sm:w-auto sm:flex-none sm:gap-1.5 sm:px-3 sm:text-xs",
+                  activeTab === "home" ? "flex-1 gap-1 px-2" : "w-9 flex-none gap-0 px-0",
                   activeTab === "home"
                     ? "border-[var(--border)] bg-[var(--card)] text-[var(--foreground)]"
                     : "border-transparent text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
                 )}
               >
                 <img src="/home/tab-icons/home.png" alt="" className="h-[1.125rem] w-[1.125rem] object-contain" />
-                <span className="min-w-0 truncate">{t("home.browser.homeTab")}</span>
+                <span className={cn("min-w-0 truncate", activeTab === "home" ? "block" : "hidden sm:block")}>
+                  {t("home.browser.homeTab")}
+                </span>
               </button>
               <button
                 id={homeBrowserTabId("professor")}
                 type="button"
                 role="tab"
                 aria-controls={HOME_BROWSER_PANEL_ID}
+                aria-label={t("home.browser.professorTab")}
                 aria-selected={activeTab === "professor"}
                 onClick={openProfessor}
                 className={cn(
-                  "flex min-h-9 min-w-0 flex-[1.1] items-center justify-center gap-1 rounded-t-lg border border-b-0 px-1 text-[0.65rem] font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)] sm:min-w-[6.5rem] sm:flex-none sm:gap-1.5 sm:px-3 sm:text-xs",
+                  "flex min-h-9 min-w-0 items-center justify-center rounded-t-lg border border-b-0 text-[0.65rem] font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)] sm:min-w-[6.5rem] sm:w-auto sm:flex-none sm:gap-1.5 sm:px-3 sm:text-xs",
+                  activeTab === "professor" ? "flex-1 gap-1 px-2" : "w-9 flex-none gap-0 px-0",
                   activeTab === "professor"
                     ? "border-[var(--border)] bg-[var(--card)] text-[var(--foreground)]"
                     : "border-transparent text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
                 )}
               >
                 <img src="/sprites/mari/Mari_profile.png" alt="" className="h-4 w-4 rounded-sm object-cover" />
-                <span className="min-w-0 truncate">{t("home.browser.professorTab")}</span>
+                <span className={cn("min-w-0 truncate", activeTab === "professor" ? "block" : "hidden sm:block")}>
+                  {t("home.browser.professorTab")}
+                </span>
               </button>
               {localizedBrowserPackages.map(({ item, display }) => {
                 const tab = display.homeBrowserTab;
+                const tabActive = activeTab === item.id;
                 const hasUnreadRefresh = item.id === "noodle" && noodleRefreshUnread;
                 const activityDescriptionId = `${homeBrowserTabId(item.id)}-activity`;
                 return (
@@ -2242,19 +2251,22 @@ export function HomeBrowserHub({
                     type="button"
                     role="tab"
                     aria-controls={HOME_BROWSER_PANEL_ID}
-                    aria-label={tab?.ariaLabel ?? tab?.label}
+                    aria-label={tab?.ariaLabel ?? tab?.label ?? display.name}
                     aria-describedby={hasUnreadRefresh ? activityDescriptionId : undefined}
-                    aria-selected={activeTab === item.id}
+                    aria-selected={tabActive}
                     onClick={() => selectTab(item.id)}
                     className={cn(
-                      "relative flex min-h-9 min-w-0 flex-1 items-center justify-center gap-1 rounded-t-lg border border-b-0 px-1 text-[0.65rem] font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)] sm:min-w-[6.5rem] sm:flex-none sm:gap-1.5 sm:px-3 sm:text-xs",
-                      activeTab === item.id
+                      "relative flex min-h-9 min-w-0 items-center justify-center rounded-t-lg border border-b-0 text-[0.65rem] font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)] sm:min-w-[6.5rem] sm:w-auto sm:flex-none sm:gap-1.5 sm:px-3 sm:text-xs",
+                      tabActive ? "flex-1 gap-1 px-2" : "w-9 flex-none gap-0 px-0",
+                      tabActive
                         ? "border-[var(--border)] bg-[var(--card)] text-[var(--foreground)]"
                         : "border-transparent text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
                     )}
                   >
                     <BrowserPackageTabIcon packageId={item.id} version={item.version} iconPaths={tab?.iconPaths} />
-                    <span className="min-w-0 truncate">{tab?.label ?? display.name}</span>
+                    <span className={cn("min-w-0 truncate", tabActive ? "block" : "hidden sm:block")}>
+                      {tab?.label ?? display.name}
+                    </span>
                     {hasUnreadRefresh ? (
                       <span
                         id={activityDescriptionId}

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -601,7 +601,10 @@ function TrackerPanelToggleButton({ onToggle }: { onToggle: () => void }) {
       title={localizeUi("ui.chat.trackerpaneltogglebutton.showTrackerPanel")}
       aria-label={localizeUi("ui.chat.trackerpaneltogglebutton.showTrackerPanel")}
     >
-      <TrackerPanelIcon size="1.05rem" className="shrink-0 text-[var(--marinara-app-accent-static)]" />
+      <TrackerPanelIcon
+        size="1.05rem"
+        className="mari-accent-animated shrink-0 text-[var(--marinara-app-accent-solid)]"
+      />
       <span className="sr-only">{localizeUi("ui.panels.trackerpanelappearancedrawer.trackerPanel")}</span>
     </button>
   );
@@ -1266,7 +1269,10 @@ function InventoryTrackerWidget({
         className={WIDGET}
         title={localizeUi("ui.chat.inventoryTracker.title")}
       >
-        <Backpack size="0.875rem" className="text-[var(--marinara-app-accent-static)] max-md:h-3 max-md:w-3" />
+        <Backpack
+          size="0.875rem"
+          className="mari-accent-animated text-[var(--marinara-app-accent-solid)] max-md:h-3 max-md:w-3"
+        />
         {total > 0 && <span className="text-[0.5rem] font-semibold tabular-nums">{total}</span>}
       </button>
       <WidgetPopover
@@ -1440,7 +1446,7 @@ function CombinedWorldWidget({
         {!hasWorldState ? (
           <MapPin
             size="0.875rem"
-            className="shrink-0 text-[var(--marinara-app-accent-static)] max-md:h-3.5 max-md:w-3.5"
+            className="mari-accent-animated shrink-0 text-[var(--marinara-app-accent-solid)] max-md:h-3.5 max-md:w-3.5"
           />
         ) : (
           <>

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -666,7 +666,8 @@ function ActionsGroup({
     const aboveTop = rect.top - dropdownHeight - 4;
     const preferredTop = belowTop + dropdownHeight > window.innerHeight - 8 ? aboveTop : belowTop;
     const top = Math.max(8, Math.min(preferredTop, window.innerHeight - dropdownHeight - 8));
-    const left = Math.max(8, Math.min(rect.left, window.innerWidth - dropdownWidth - 8));
+    const preferredLeft = window.innerWidth < 768 ? Math.round((window.innerWidth - dropdownWidth) / 2) : rect.left;
+    const left = Math.max(8, Math.min(preferredLeft, window.innerWidth - dropdownWidth - 8));
     return { top, left };
   }, []);
 

--- a/packages/client/src/components/chat/RoleplayHUDPanels.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDPanels.tsx
@@ -117,10 +117,11 @@ export function RoleplayInventoryTrackerPanel({
       onUpdateInventory={onUpdateInventory}
       deleteMode
       addMode
+      plain
       header={
-        <div className={cn(NEUTRAL_PANEL_HEADER, "flex items-center justify-between")}>
-          <span className={NEUTRAL_PANEL_TITLE}>
-            <Backpack size="0.625rem" className="text-[var(--marinara-app-accent-static)]" />
+        <div className="flex items-center justify-between px-3 pb-1 pt-2">
+          <span className={TRACKER_SECTION_TITLE}>
+            <Backpack size="0.5625rem" className="text-[var(--marinara-chat-chrome-accent)]" />
             {localizeUi("ui.chat.inventoryTracker.title")}
           </span>
           {action}
@@ -439,7 +440,8 @@ export function CombinedPlayerPanel({
     <>
       <div className={cn(NEUTRAL_PANEL_HEADER, "flex items-center justify-between")}>
         <span className={NEUTRAL_PANEL_TITLE}>
-          <Swords size="0.625rem" className="text-orange-400/80" /> {localizeUi("ui.chat.combinedplayerpanel.trackers")}
+          <Swords size="0.625rem" className="text-[var(--marinara-chat-chrome-accent)]" />{" "}
+          {localizeUi("ui.chat.combinedplayerpanel.trackers")}
         </span>
         <span className="flex items-center gap-1">
           <HudLockModeToggle />
@@ -454,12 +456,6 @@ export function CombinedPlayerPanel({
       <div className="overflow-y-auto max-h-[min(calc(75vh-2rem),30rem)] divide-y divide-[var(--border)]">
         {showPersona && (
           <div className="p-2">
-            <PersonaStatusField
-              value={personaStatus}
-              onSave={onUpdatePersonaStatus}
-              locked={personaStatusLock.locked}
-              onToggleLock={personaStatusLock.onToggle}
-            />
             <div className="flex items-center justify-between px-1 pb-1">
               <span className="flex items-center gap-1 text-[0.625rem] font-semibold text-[var(--muted-foreground)] uppercase tracking-wider">
                 <BarChart3 size="0.5625rem" className="text-[var(--marinara-chat-chrome-accent)]" />
@@ -472,6 +468,12 @@ export function CombinedPlayerPanel({
                 title={localizeUi("ui.chat.combinedplayerpanel.reRunPersonaTrackerStatsInventory")}
               />
             </div>
+            <PersonaStatusField
+              value={personaStatus}
+              onSave={onUpdatePersonaStatus}
+              locked={personaStatusLock.locked}
+              onToggleLock={personaStatusLock.onToggle}
+            />
             <div className="space-y-2">
               {personaStats.length === 0 && (
                 <div className={EMPTY_STATE}>{localizeUi("ui.chat.combinedplayerpanel.noStatsTracked")}</div>
@@ -504,9 +506,8 @@ export function CombinedPlayerPanel({
           <div className="p-2">
             <div className="flex items-center justify-between px-1 pb-1">
               <span className={TRACKER_SECTION_TITLE}>
-                <Users size="0.5625rem" className="text-sky-400/80" />{" "}
+                <Users size="0.5625rem" className="text-[var(--marinara-chat-chrome-accent)]" />{" "}
                 {localizeUi("ui.panels.characterspanel.characters")}
-                {characters.length})
               </span>
               <span className="flex items-center gap-1">
                 <TrackerSectionRefresh
@@ -673,8 +674,7 @@ export function CombinedPlayerPanel({
             <div className="flex items-center justify-between px-1 pb-1">
               <span className={TRACKER_SECTION_TITLE}>
                 <Scroll size="0.5625rem" className="text-[var(--marinara-chat-chrome-accent)]" />{" "}
-                {localizeUi("ui.chat.combinedplayerpanel.quests")}
-                {quests.length})
+                {localizeUi("ui.chat.questspanel.quests")}
               </span>
               <span className="flex items-center gap-1">
                 <TrackerSectionRefresh
@@ -723,7 +723,7 @@ export function CombinedPlayerPanel({
             key={`${packageId}-mobile-combined-tracker`}
             packageId={packageId}
             view="tracker"
-            capabilityProps={{ chatId, chatMode: "roleplay" }}
+            capabilityProps={{ chatId, chatMode: "roleplay", mobileCompact: true }}
             className="block"
           />
         ))}
@@ -733,7 +733,7 @@ export function CombinedPlayerPanel({
             <div className="flex items-center justify-between px-1 pb-1">
               <span className={TRACKER_SECTION_TITLE}>
                 <SlidersHorizontal size="0.5625rem" className="text-[var(--marinara-chat-chrome-accent)]" />{" "}
-                {localizeUi("ui.chat.combinedplayerpanel.customValue1", { value1: customTrackerFields.length })}
+                {localizeUi("ui.trackerPanel.customtrackerpanel.customStats")}
               </span>
               <span className="flex items-center gap-1">
                 <TrackerSectionRefresh

--- a/packages/client/src/components/chat/StoryboardChatSettingsPanel.tsx
+++ b/packages/client/src/components/chat/StoryboardChatSettingsPanel.tsx
@@ -83,8 +83,8 @@ function StoryboardSlider({
   onReset: () => void;
 }) {
   return (
-    <div className="space-y-1">
-      <label className="block space-y-2 rounded-lg bg-[var(--background)]/75 px-3 py-2 ring-1 ring-[var(--border)]">
+    <div className="flex h-full flex-col gap-1">
+      <label className="flex flex-1 flex-col justify-between gap-2 rounded-lg bg-[var(--background)]/75 px-3 py-2 ring-1 ring-[var(--border)]">
         <span className="flex items-center justify-between gap-3">
           <span className="min-w-0">
             <span className="block text-[0.625rem] font-medium text-[var(--foreground)]">{label}</span>
@@ -150,8 +150,8 @@ function StoryboardNumberInput({
   };
 
   return (
-    <div className="space-y-1">
-      <label className="grid gap-2 rounded-lg bg-[var(--background)]/75 px-3 py-2 ring-1 ring-[var(--border)] sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+    <div className="flex h-full flex-col gap-1">
+      <label className="grid flex-1 gap-2 rounded-lg bg-[var(--background)]/75 px-3 py-2 ring-1 ring-[var(--border)] sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
         <span className="min-w-0">
           <span className="block text-[0.625rem] font-medium text-[var(--foreground)]">{label}</span>
           <span className="mt-0.5 block text-[0.5625rem] leading-snug text-[var(--muted-foreground)]">

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -1229,7 +1229,7 @@ export function ChatSidebar() {
 
         {/* Branch count badge */}
         {branchCount > 1 && (
-          <span className="mari-chrome-muted-badge flex shrink-0 items-center gap-0.5 !rounded-[0.25rem] px-1.5 py-0.5 text-[0.625rem]">
+          <span className="mari-chrome-muted-badge mari-chrome-tag flex shrink-0 items-center gap-0.5 px-1.5 py-0.5 text-[0.625rem]">
             <GitBranch size="0.625rem" />
             {branchCount}
           </span>

--- a/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
 import { ChevronDown, Save, Settings2 } from "lucide-react";
 import { HelpTooltip } from "../../../components/ui/HelpTooltip";
+import { AgentSettingsActionButton } from "../../../components/chat/AgentSettingsControls";
 import {
   CHAT_PARAMETER_DEFAULTS,
   GenerationParametersFields,
@@ -307,7 +308,9 @@ export function AdvancedParametersSection({
             )}
           </div>
           {canSaveConnectionDefaults && (
-            <button
+            <AgentSettingsActionButton
+              type="button"
+              variant="primary"
               onClick={() => {
                 saveDefaults.mutate({
                   id: connectionId,
@@ -318,20 +321,17 @@ export function AdvancedParametersSection({
                   },
                 });
               }}
-              className="w-full rounded-lg bg-[var(--primary)]/10 px-3 py-1.5 text-[0.625rem] font-medium text-[var(--primary)] ring-1 ring-[var(--primary)]/20 transition-colors hover:bg-[var(--primary)]/20"
+              className="w-full"
             >
               <Save size="0.625rem" className="inline mr-1 -mt-px" />
               {saveDefaults.isPending
                 ? localizeUi("chat.settings.inlineEditor.saving")
                 : localizeUi("ui.chatSettings.advancedparameterssection.saveAsConnectionDefault")}
-            </button>
+            </AgentSettingsActionButton>
           )}
-          <button
-            onClick={() => onChatParametersChange({})}
-            className="w-full rounded-lg bg-[var(--secondary)] px-3 py-1.5 text-[0.625rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]"
-          >
+          <AgentSettingsActionButton type="button" onClick={() => onChatParametersChange({})} className="w-full">
             {localizeUi("ui.chatSettings.advancedparameterssection.resetToDefaults")}
-          </button>
+          </AgentSettingsActionButton>
         </div>
       )}
     </div>

--- a/packages/client/src/features/tracker-panel/components/TrackerSectionList.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerSectionList.tsx
@@ -310,7 +310,7 @@ export function TrackerSectionList({
             onUpdateCurrencies={(rows) => editInventoryTracker("currencies", rows)}
             onUpdateEquipped={(rows) => editInventoryTracker("equipped", rows)}
             onUpdateInventory={(rows) => editInventoryTracker("inventory", rows)}
-            deleteMode={deleteMode}
+            deleteMode
             addMode={addMode}
             collapsed={isPanelCollapsed("inventory")}
             onToggleCollapsed={() => toggleTrackerPanelSectionCollapsed("inventory")}

--- a/packages/client/src/features/tracker-panel/components/TrackerSidebarHeader.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerSidebarHeader.tsx
@@ -86,7 +86,7 @@ export function TrackerSidebarHeader({
       onClick={onClose}
       title={localizeUi("ui.trackerPanel.trackersidebarheader.closeTrackers")}
       aria-label={localizeUi("ui.trackerPanel.trackersidebarheader.closeTrackerPanel")}
-      className="flex h-6 w-6 shrink-0 items-center justify-center rounded-sm text-[var(--marinara-app-accent-static)] transition-colors hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--marinara-app-accent-static)] active:scale-90"
+      className="mari-accent-animated flex h-6 w-6 shrink-0 items-center justify-center rounded-sm text-[var(--marinara-app-accent-solid)] transition-colors hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--marinara-app-accent-solid)] active:scale-90"
     >
       <TrackerPanelIcon size="1.25rem" />
     </button>

--- a/packages/client/src/features/tracker-panel/components/sections/InventoryTrackerPanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/InventoryTrackerPanel.tsx
@@ -196,6 +196,7 @@ export function InventoryTrackerPanel({
   deleteMode,
   addMode,
   header,
+  plain = false,
   collapsed = false,
   onToggleCollapsed,
 }: {
@@ -209,6 +210,7 @@ export function InventoryTrackerPanel({
   deleteMode: boolean;
   addMode: boolean;
   header?: ReactNode;
+  plain?: boolean;
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
 }) {
@@ -217,8 +219,14 @@ export function InventoryTrackerPanel({
     // Own the query container rather than inheriting one. The docked sidebar provides
     // `@container`, but the HUD popover is portaled to document.body and has none — so
     // the same component used to lay itself out differently in its two hosts.
-    <section className="@container relative z-10 overflow-hidden border-b border-[var(--border)] bg-[var(--tracker-panel-section-background,color-mix(in_srgb,var(--card)_10%,transparent))]">
-      <TrackerReadabilityVeil strength="strong" />
+    <section
+      className={cn(
+        "@container relative z-10 overflow-hidden",
+        !plain &&
+          "border-b border-[var(--border)] bg-[var(--tracker-panel-section-background,color-mix(in_srgb,var(--card)_10%,transparent))]",
+      )}
+    >
+      {!plain && <TrackerReadabilityVeil strength="strong" />}
       <div className="relative z-10">
         {header ?? (
           <SectionHeader

--- a/packages/client/src/features/tracker-panel/components/sections/InventoryTrackerPanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/InventoryTrackerPanel.tsx
@@ -133,7 +133,7 @@ function InventoryGroup({ group, label, rows, onUpdate, deleteMode, addMode }: I
           return (
             <div
               key={`${row.name}-${index}`}
-              className="flex min-h-6 min-w-0 max-w-full items-center gap-1 rounded-md border border-[var(--tracker-profile-slot-rule)] bg-[image:var(--tracker-profile-slot-surface)] px-1.5 shadow-[inset_0_1px_2px_var(--tracker-profile-slot-shadow)] [@media(pointer:coarse)]:min-h-7"
+              className="mari-chrome-tag flex min-h-6 min-w-0 max-w-full items-center gap-1 border border-[var(--tracker-profile-slot-rule)] bg-[image:var(--tracker-profile-slot-surface)] px-1.5 text-[color:var(--tracker-profile-text)] shadow-[inset_0_1px_2px_var(--tracker-profile-slot-shadow)] [@media(pointer:coarse)]:min-h-7"
             >
               {nameLocked && LOCK_GLYPH}
               <InlineEdit
@@ -170,11 +170,11 @@ function InventoryGroup({ group, label, rows, onUpdate, deleteMode, addMode }: I
                 <button
                   type="button"
                   onClick={() => removeRow(index)}
-                  className="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full text-[var(--destructive)] ring-1 ring-[var(--border)]"
+                  className="mari-chrome-tag grid h-4 w-4 shrink-0 place-items-center p-0 leading-none text-current ring-1 ring-[color-mix(in_srgb,var(--tracker-profile-text)_28%,transparent)] transition-colors hover:bg-[color-mix(in_srgb,var(--tracker-profile-text)_8%,transparent)] focus-visible:outline-none focus-visible:ring-[color-mix(in_srgb,var(--tracker-profile-text)_48%,transparent)]"
                   title={localizeUi("ui.trackerPanel.inventoryTracker.removeItem", { item: row.name })}
                   aria-label={localizeUi("ui.trackerPanel.inventoryTracker.removeItem", { item: row.name })}
                 >
-                  <X size="0.5625rem" />
+                  <X size="0.5625rem" className="block" />
                 </button>
               )}
             </div>

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -1529,6 +1529,10 @@
   font-weight: 600;
 }
 
+.mari-chrome-tag {
+  border-radius: 0.25rem;
+}
+
 .mari-chat-option-field {
   border: 1px solid var(--marinara-chat-option-field-border);
   background: var(--marinara-chat-option-field-bg);

--- a/scripts/regressions/mobile-tracker-help-layout.regression.mjs
+++ b/scripts/regressions/mobile-tracker-help-layout.regression.mjs
@@ -40,5 +40,15 @@ assert.match(
   /window\.innerWidth < 768 \? 0 : TARGET_PADDING/u,
   "dense mobile help targets must not be expanded into overlapping frames",
 );
+assert.match(
+  chatHelp,
+  /closest\("\[data-chat-toolbar-overflow-menu\]"\)[\s\S]*MOBILE_TOOLBAR_HIGHLIGHT_SIZE/u,
+  "mobile overflow help targets must share one square highlight size",
+);
+assert.match(
+  chatHelp,
+  /const railLeft = mobileOverflowRect\.left - TARGET_PADDING[\s\S]*reachesBehindRail[\s\S]*width: railLeft - target\.rect\.left/u,
+  "large mobile help regions must reserve the open toolbar rail instead of squeezing button highlights",
+);
 
 process.stdout.write("Mobile tracker and help layout regression passed\n");

--- a/scripts/regressions/tracker-gallery-ui.regression.mjs
+++ b/scripts/regressions/tracker-gallery-ui.regression.mjs
@@ -9,6 +9,7 @@ const trackerSidebar = readSource("packages/client/src/features/tracker-panel/co
 const inventoryTracker = readSource(
   "packages/client/src/features/tracker-panel/components/sections/InventoryTrackerPanel.tsx",
 );
+const trackerSectionList = readSource("packages/client/src/features/tracker-panel/components/TrackerSectionList.tsx");
 const roleplayHud = readSource("packages/client/src/components/chat/RoleplayHUD.tsx");
 const roleplayPanels = readSource("packages/client/src/components/chat/RoleplayHUDPanels.tsx");
 const appShell = readSource("packages/client/src/components/layout/AppShell.tsx");
@@ -18,6 +19,8 @@ const chatGallery = readSource("packages/client/src/components/chat/ChatGallery.
 const chatSettingsDrawer = readSource("packages/client/src/components/chat/ChatSettingsDrawer.tsx");
 const chatSidebar = readSource("packages/client/src/components/layout/ChatSidebar.tsx");
 const chatBranchSelector = readSource("packages/client/src/components/chat/ChatBranchSelector.tsx");
+const homeBrowserHub = readSource("packages/client/src/components/chat/HomeBrowserHub.tsx");
+const storyboardChatSettings = readSource("packages/client/src/components/chat/StoryboardChatSettingsPanel.tsx");
 const conversationView = readSource("packages/client/src/components/chat/ConversationView.tsx");
 const agentSettingsControls = readSource("packages/client/src/components/chat/AgentSettingsControls.tsx");
 const translationSection = readSource("packages/client/src/features/chat-settings/sections/TranslationSection.tsx");
@@ -27,6 +30,10 @@ const gameExtraPromptSection = readSource(
 );
 const gameWidgetEditor = readSource("packages/client/src/components/game/GameWidgetSetupEditor.tsx");
 const gameVolumeMixer = readSource("packages/client/src/components/game/GameVolumeMixer.tsx");
+const advancedParameters = readSource(
+  "packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx",
+);
+const globalStyles = readSource("packages/client/src/styles/globals.css");
 
 assert.doesNotMatch(
   trackerSidebar,
@@ -55,13 +62,13 @@ assert.match(
 );
 assert.match(
   roleplayHud,
-  /TrackerPanelIcon[^\n]*text-\[var\(--marinara-app-accent-static\)\]/u,
-  "the roleplay Tracker Panel launcher must use the configured app accent",
+  /TrackerPanelIcon[\s\S]*?mari-accent-animated[^\n]*marinara-app-accent-solid/u,
+  "the roleplay Tracker Panel launcher must follow the animated app accent",
 );
 assert.match(
   trackerHeader,
-  /text-\[var\(--marinara-app-accent-static\)\]/u,
-  "the Tracker Panel header dice must use the configured app accent",
+  /mari-accent-animated[^\n]*marinara-app-accent-solid/u,
+  "the Tracker Panel header dice must follow the animated app accent",
 );
 assert.doesNotMatch(
   inventoryTracker,
@@ -74,14 +81,29 @@ assert.match(
   "Inventory must retain the shared Tracker Panel section wrapper",
 );
 assert.match(
+  inventoryTracker,
+  /mari-chrome-tag grid h-4 w-4[^\n]*place-items-center[^\n]*text-current/u,
+  "Inventory delete controls must stay centered and inherit the item text color",
+);
+assert.match(
+  trackerSectionList,
+  /case "inventory":[\s\S]*?<InventoryTrackerPanel[\s\S]*?\n\s+deleteMode\n/u,
+  "Inventory items must expose delete controls directly in Tracker Panel",
+);
+assert.match(
   roleplayHud,
   /className: compact \? CHAT_TOOLBAR_MOBILE_OVERFLOW_HEIGHT_CLASS : undefined/u,
   "downloadable tracker controls must receive the built-in mobile toolbar height",
 );
 assert.match(
   roleplayHud,
-  /const hasWorldState =[\s\S]*!hasWorldState \?[\s\S]*marinara-app-accent-static/u,
-  "World State must stay a standard accent icon until it has generated content",
+  /const hasWorldState =[\s\S]*!hasWorldState \?[\s\S]*mari-accent-animated[\s\S]*marinara-app-accent-solid/u,
+  "World State must follow the animated accent until it has generated content",
+);
+assert.match(
+  roleplayHud,
+  /function InventoryTrackerWidget[\s\S]*mari-accent-animated[\s\S]*marinara-app-accent-solid/u,
+  "the Inventory toolbar backpack must follow the animated app accent",
 );
 assert.match(
   roleplayPanels,
@@ -145,6 +167,36 @@ assert.match(
   /<SettingsSwitch\s+label=\{localizeUi\("ui\.chat\.chatsettingsdrawer\.addTurnToPrompt"\)\}/u,
   "Add Turn To Prompt must use the shared Settings toggle",
 );
+assert.match(
+  chatSettingsDrawer,
+  /<AgentSettingsActionButton[\s\S]*accessMemoriesForThisChat/u,
+  "Memory Recall must use the shared Chat Settings action button",
+);
+assert.doesNotMatch(
+  chatSettingsDrawer,
+  /noodleTimelineContextEnabled[\s\S]*disabled=\{updateMeta\.isPending\}/u,
+  "unrelated metadata writes must not visually disable the Noodle timeline switch",
+);
+assert.equal(
+  (storyboardChatSettings.match(/className="flex h-full flex-col gap-1"/gu) ?? []).length,
+  2,
+  "Storyboard slider and number cards must share equal-height wrappers",
+);
+assert.equal(
+  (homeBrowserHub.match(/\? "flex-1 gap-1 px-2" : "w-9 flex-none gap-0 px-0"/gu) ?? []).length,
+  3,
+  "mobile Home tabs must expand only the active tab and collapse inactive tabs to icons",
+);
+assert.equal(
+  (homeBrowserHub.match(/\? "block" : "hidden sm:block"/gu) ?? []).length,
+  3,
+  "inactive mobile Home tabs must hide their labels while retaining desktop labels",
+);
+assert.equal(
+  (advancedParameters.match(/<AgentSettingsActionButton/gu) ?? []).length,
+  2,
+  "Advanced Parameters save and reset actions must reuse the shared action button",
+);
 assert.doesNotMatch(
   chatSettingsDrawer,
   /mari-chat-option-switch[^\n]*groupTurnPromptEnabled/u,
@@ -152,13 +204,18 @@ assert.doesNotMatch(
 );
 assert.match(
   chatSidebar,
-  /mari-chrome-muted-badge flex shrink-0 items-center gap-0\.5 !rounded-\[0\.25rem\]/u,
+  /mari-chrome-muted-badge mari-chrome-tag flex shrink-0 items-center gap-0\.5/u,
   "chat-list branch counts must use compact rounded-corner tags instead of capsules",
 );
 assert.match(
   chatBranchSelector,
-  /absolute -right-1 -top-1[^"\n]*rounded-\[0\.25rem\]/u,
+  /mari-chrome-tag absolute -right-1 -top-1/u,
   "the active-chat branch count must use the same compact rounded-corner tag",
+);
+assert.match(
+  globalStyles,
+  /\.mari-chrome-tag\s*\{\s*border-radius: 0\.25rem;/u,
+  "the shared compact tag class must own rounded-square geometry",
 );
 assert.match(
   conversationView,

--- a/scripts/regressions/tracker-gallery-ui.regression.mjs
+++ b/scripts/regressions/tracker-gallery-ui.regression.mjs
@@ -77,7 +77,7 @@ assert.doesNotMatch(
 );
 assert.match(
   inventoryTracker,
-  /<section className="@container relative z-10 overflow-hidden border-b/u,
+  /"@container relative z-10 overflow-hidden"[\s\S]*border-b border-\[var\(--border\)\]/u,
   "Inventory must retain the shared Tracker Panel section wrapper",
 );
 assert.match(
@@ -97,6 +97,11 @@ assert.match(
 );
 assert.match(
   roleplayHud,
+  /window\.innerWidth < 768 \? Math\.round\(\(window\.innerWidth - dropdownWidth\) \/ 2\) : rect\.left/u,
+  "the mobile Agents menu must center itself horizontally",
+);
+assert.match(
+  roleplayHud,
   /const hasWorldState =[\s\S]*!hasWorldState \?[\s\S]*mari-accent-animated[\s\S]*marinara-app-accent-solid/u,
   "World State must follow the animated accent until it has generated content",
 );
@@ -112,13 +117,28 @@ assert.match(
 );
 assert.match(
   roleplayPanels,
-  /header=\{[\s\S]*NEUTRAL_PANEL_HEADER[\s\S]*Backpack[\s\S]*marinara-app-accent-static/u,
-  "the Inventory HUD popover must reuse the neutral header with an accent backpack",
+  /\{showPersona && \([\s\S]*personastatswidget\.personaStats[\s\S]*<PersonaStatusField/u,
+  "the combined mobile panel must place Persona Stats above Current Status",
 );
-assert.equal(
-  (roleplayPanels.match(/ui\.chat\.combinedplayerpanel\.quests/gu) ?? []).length,
-  1,
-  "only the combined mobile panel may keep the counted Quests title",
+assert.doesNotMatch(
+  roleplayPanels,
+  /\{(?:characters|quests)\.length\}\)/u,
+  "combined mobile Character and Quests headings must not append counts",
+);
+assert.doesNotMatch(
+  roleplayPanels,
+  /combinedplayerpanel\.customValue1/u,
+  "the combined mobile Custom heading must not append a count",
+);
+assert.match(
+  roleplayPanels,
+  /capabilityProps=\{\{ chatId, chatMode: "roleplay", mobileCompact: true \}\}/u,
+  "the combined mobile panel must request Memory Nag's fixed-open compact presentation",
+);
+assert.match(
+  roleplayPanels,
+  /<InventoryTrackerGridPanel[\s\S]*\n\s+plain\n/u,
+  "the mobile Inventory section must use the same plain surface treatment as neighboring trackers",
 );
 assert.doesNotMatch(
   roleplayPanels,


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.

## Linked issue

Closes #5490

Companion downloadable-agent changes: Pasta-Devs/Marinara-Agents#556

## Why this change

- Several Chat Settings actions and tracker surfaces still used one-off geometry or stale presentation.
- The mobile Agents menu and combined Trackers panel did not match their neighboring sections.
- Mobile Help highlights were compressed where large chat regions extended beneath the opened toolbar rail.
- Five Home destinations, Inventory delete controls, branch badges, and cycling accent launchers needed the shared compact UI treatment.

## What changed

- Reused shared Chat Settings actions for Memory Recall and Advanced Parameters, kept unrelated Connected Chats settings stable during saves, and equalized Storyboard controls.
- Collapsed inactive mobile Home tabs to icons while leaving the active label visible.
- Centered the mobile Agents menu and aligned the combined Trackers panel: Persona Status follows Persona Stats, headings are count-free, Inventory uses the shared plain section treatment, and Memory Nag receives its fixed-open mobile presentation.
- Added usable Inventory deletion in Tracker Panel and standardized Inventory and branch tags as compact rounded squares.
- Routed Tracker Panel, Inventory, and empty World State launchers through the live cycling accent token.
- Standardized mobile toolbar Help highlights and reserved the open toolbar rail from large chat-region highlights across Roleplay, Conversation, and Game.

## Automated evidence

- `pnpm check`
- `node scripts/regressions/tracker-gallery-ui.regression.mjs`
- `node scripts/regressions/mobile-tracker-help-layout.regression.mjs`
- `pnpm exec playwright test e2e/core-flows.e2e.ts --grep "chat Help overlay labels visible controls in every mode"` (desktop and mobile)

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify affected drawers in every supported chat mode, all five mobile Home tabs, the mobile combined Trackers panel, and Help overlay targets in each mode.
- Install the companion Beholder and Memory Nag updates from the staging agent catalog before checking package-owned UI.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Manually capture mobile Help and combined Trackers views after installing the companion package updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved visual consistency across chat settings, Storyboard, Home, Agents, Help, Inventory, Tracker, and related panels.
  * Enhanced mobile layouts with compact controls, responsive tabs, centered actions, and consistent 32×32 help highlights.
  * Updated tracker, inventory, branch badges, buttons, and accents with shared styling.
  * Improved accessibility with clearer tab labels and responsive label behavior.

* **Bug Fixes**
  * Chat settings controls remain usable while metadata saves.
  * Improved mobile help overlay positioning and overflow handling.

* **Tests**
  * Added regression coverage for mobile help layouts and broader Tracker and Gallery interface behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->