### PR TITLE
Read the staging catalog preview overlay behind a strict channel gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Staging-channel Engines now merge the Agents catalog preview overlay over the published catalog, so packages marked staging-only in the Agents repository reach testers while stable Engines never resolve the overlay URL at all and the unattended startup migrations never auto-install one (#5492).
 - Implemented {{lorebookSize::lorebookID}} macro, which resolves to the total number of entries inside a lorebook, when given its unique ID (#5464)
 - Game Setup now includes an on-by-default Quick Time Events switch; turning it off removes the timed-reaction command from GM prompts for that campaign (#5467).
 - Custom Agents can now opt into proposing complete character cards, which remain editable and require explicit approval before they are saved to the Characters library (#5456).

--- a/packages/server/src/services/capability-packages/package-manager.service.ts
+++ b/packages/server/src/services/capability-packages/package-manager.service.ts
@@ -14,6 +14,8 @@ import {
   packagedAgentDefinitionsSchema,
   type CapabilityCatalog,
   type CapabilityCatalogPackage,
+  type StampedCapabilityCatalog,
+  type StampedCapabilityCatalogPackage,
   type PackagedAgentDefinition,
   type CapabilityPackageUpdate,
   type InstalledCapabilityPackage,
@@ -763,7 +765,7 @@ export const capabilityPackageManager = {
   async catalog(
     fetchCatalog: typeof safeFetch = safeFetch,
     previewCatalogUrl: string | null = PREVIEW_CATALOG_URL,
-  ): Promise<CapabilityCatalog> {
+  ): Promise<StampedCapabilityCatalog> {
     const response = await fetchCatalogDocument(CATALOG_URL, fetchCatalog);
     if (!response.ok) throw new Error(`Catalog request failed with HTTP ${response.status}`);
     // Per-entry tolerant: a catalog entry built for a NEWER Engine (unknown
@@ -795,9 +797,17 @@ export const capabilityPackageManager = {
       );
       return false;
     });
-    const decorate = (entry: CapabilityCatalogPackage, sourceUrl: string, preview: boolean) => ({
+    const decorate = (
+      entry: CapabilityCatalogPackage,
+      sourceUrl: string,
+      preview: boolean,
+    ): StampedCapabilityCatalogPackage => ({
       ...entry,
-      ...(preview ? { preview: true } : {}),
+      // Assigned here from the source URL and nowhere else. `preview` is absent
+      // from the strict downloaded-entry schema, so a published or custom
+      // catalog cannot ship an entry that claims preview provenance for itself
+      // and then ride through this spread.
+      ...(preview ? { preview: true as const } : {}),
       iconUrl: resolveCapabilityPackageIconUrl(entry, sourceUrl),
       artifact: {
         ...entry.artifact,

--- a/packages/server/src/services/capability-packages/package-manager.service.ts
+++ b/packages/server/src/services/capability-packages/package-manager.service.ts
@@ -128,6 +128,52 @@ export function resolveCapabilityCatalogUrl(
   return match ? `${catalogRoot}/v${Number(match[1])}/catalog.json` : `${catalogRoot}/catalog.json`;
 }
 const CATALOG_URL = resolveCapabilityCatalogUrl();
+
+// Packages the catalog repo marks staging-only are cut from the published lanes
+// and emitted into an overlay under catalog/preview/ instead (Marinara-Agents
+// scripts/catalog-incomplete.mjs). Promotion copies staging to main verbatim, so
+// that overlay EXISTS on main and serves 200 there — nothing on the catalog side
+// hides it. The only thing keeping an unreleased package away from a stable user
+// is this Engine declining to build the URL.
+const PREVIEW_CATALOG_SEGMENT = "preview";
+
+/** Whether this Engine may read the staging preview overlay.
+ *
+ *  Deliberately NOT `resolveOfficialAgentBranch() === "staging"`. That helper is
+ *  deny-list shaped — anything that is not `main`, `hotfix/*`, or a release tag
+ *  resolves to "staging" — so a checkout on a branch named `master` (which the
+ *  launchers themselves treat as a mainline name) would qualify. Being wrong
+ *  there merely hands someone a slightly newer package list; being wrong HERE
+ *  shows unreleased packages to a stable user, so this gate takes an exact
+ *  opt-in. Detached checkouts report no branch and are excluded, which costs a
+ *  detached staging tester their preview — the fail-hidden direction, and the
+ *  same way those checkouts already resolve for the published catalog. */
+export function isPreviewCatalogChannel(engineBranch: string | null = getBuildBranch()): boolean {
+  return engineBranch === "staging";
+}
+
+/** URL of the staging preview overlay, or null when this Engine must not read one.
+ *
+ *  Returns null rather than a URL for callers to filter later, so a stable Engine
+ *  never holds a preview URL at all and no later code path can fetch one by
+ *  mistake. Mirrors resolveCapabilityCatalogUrl's lane derivation, including its
+ *  fallback to the legacy alias for a non-release version string. */
+export function resolvePreviewCatalogUrl(
+  engineVersion: string = APP_VERSION,
+  configuredUrl: string | undefined = process.env.MARINARA_AGENT_CATALOG_URL,
+  previewChannel: boolean = isPreviewCatalogChannel(),
+): string | null {
+  // An explicit override IS the whole catalog. Synthesising a preview sibling for
+  // someone's local or forked catalog would fetch a URL they never pointed us at.
+  if (configuredUrl?.trim()) return null;
+  if (!previewChannel) return null;
+  // Only ever the staging branch: isPreviewCatalogChannel already required it.
+  const previewRoot = `${officialCatalogRoot("staging")}/${PREVIEW_CATALOG_SEGMENT}`;
+  const match = ENGINE_RELEASE_VERSION_PATTERN.exec(engineVersion.trim());
+  return match ? `${previewRoot}/v${Number(match[1])}/catalog.json` : `${previewRoot}/catalog.json`;
+}
+
+const PREVIEW_CATALOG_URL = resolvePreviewCatalogUrl();
 const MAX_ARTIFACT_BYTES = 100 * 1024 * 1024;
 const MAX_EXPANDED_BYTES = 250 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRIES = 8_192;
@@ -645,23 +691,80 @@ async function installCatalogPackage(entry: CapabilityCatalogPackage, activateDu
   }
 }
 
-export const capabilityPackageManager = {
-  async catalog(fetchCatalog: typeof safeFetch = safeFetch): Promise<CapabilityCatalog> {
-    const response = await fetchCatalog(CATALOG_URL, {
-      policy: { allowedProtocols: ["https:"] },
-      maxResponseBytes: 2 * 1024 * 1024,
-      allowedContentTypes: ["application/json", "text/plain"],
-      // The fixed catalog remains size-capped and must pass its Zod schema even
-      // when a network intermediary strips the Content-Type header.
-      allowMissingContentType: true,
-      decodeCompressedResponse: true,
-      headers: {
-        Accept: "application/json, text/plain;q=0.9",
-        "User-Agent": `MarinaraEngine/${APP_VERSION}`,
-      },
-      signal: AbortSignal.timeout(15_000),
-      agentOptions: { bodyTimeout: 15_000, headersTimeout: 15_000 },
+function fetchCatalogDocument(url: string, fetchCatalog: typeof safeFetch) {
+  return fetchCatalog(url, {
+    policy: { allowedProtocols: ["https:"] },
+    maxResponseBytes: 2 * 1024 * 1024,
+    allowedContentTypes: ["application/json", "text/plain"],
+    // The fixed catalog remains size-capped and must pass its Zod schema even
+    // when a network intermediary strips the Content-Type header. text/plain is
+    // also what raw.githubusercontent.com answers a missing overlay with, so the
+    // absent-overlay case reaches the status check instead of being rejected as
+    // a disallowed content type.
+    allowMissingContentType: true,
+    decodeCompressedResponse: true,
+    headers: {
+      Accept: "application/json, text/plain;q=0.9",
+      "User-Agent": `MarinaraEngine/${APP_VERSION}`,
+    },
+    signal: AbortSignal.timeout(15_000),
+    agentOptions: { bodyTimeout: 15_000, headersTimeout: 15_000 },
+  });
+}
+
+/** Sort the merged catalog deterministically regardless of the server's locale. */
+const CATALOG_SORT_COLLATOR = new Intl.Collator("en");
+
+/** Staging-only entries from the preview overlay, or [] — never throws.
+ *
+ *  The overlay is absent whenever no package is marked staging-only, which is its
+ *  normal steady state, and raw.githubusercontent.com answers that with a 404.
+ *  catalog() has no cache and no stale fallback, so letting anything here
+ *  propagate would blank the Agents browser and the update prompter for every
+ *  package at once — an unreleased package is never worth that. */
+async function fetchPreviewCatalogPackages(
+  previewCatalogUrl: string | null,
+  fetchCatalog: typeof safeFetch,
+): Promise<CapabilityCatalogPackage[]> {
+  if (!previewCatalogUrl) return [];
+  try {
+    const response = await fetchCatalogDocument(previewCatalogUrl, fetchCatalog);
+    if (response.status === 404) {
+      logger.debug("No Agent preview overlay is published at %s", previewCatalogUrl);
+      return [];
+    }
+    if (!response.ok) {
+      logger.warn("Agent preview overlay request failed with HTTP %d", response.status);
+      return [];
+    }
+    const { catalog, droppedEntries, droppedIds } = parseCapabilityCatalogWithCompat(await response.json());
+    if (droppedEntries > 0) {
+      logger.warn(
+        "Skipped %d Agent preview overlay entr%s this Engine version cannot parse: %s",
+        droppedEntries,
+        droppedEntries === 1 ? "y" : "ies",
+        droppedIds.join(", "),
+      );
+    }
+    return catalog.packages.filter((entry) => {
+      // Dropped rather than fatal, unlike the published path: a tampered stable
+      // catalog must stop everything, but one bad preview entry must not.
+      const sourceIssue = getCapabilityPackageArtifactSourceIssue(entry, previewCatalogUrl);
+      if (sourceIssue) logger.warn("Ignoring an Agent preview overlay entry: %s", sourceIssue);
+      return !sourceIssue;
     });
+  } catch (error) {
+    logger.warn(error, "Could not read the Agent preview overlay; continuing with the published catalog");
+    return [];
+  }
+}
+
+export const capabilityPackageManager = {
+  async catalog(
+    fetchCatalog: typeof safeFetch = safeFetch,
+    previewCatalogUrl: string | null = PREVIEW_CATALOG_URL,
+  ): Promise<CapabilityCatalog> {
+    const response = await fetchCatalogDocument(CATALOG_URL, fetchCatalog);
     if (!response.ok) throw new Error(`Catalog request failed with HTTP ${response.status}`);
     // Per-entry tolerant: a catalog entry built for a NEWER Engine (unknown
     // manifest keys under this Engine's strict schemas) is dropped with a log
@@ -680,19 +783,43 @@ export const capabilityPackageManager = {
       const sourceIssue = getCapabilityPackageArtifactSourceIssue(entry, CATALOG_URL);
       if (sourceIssue) throw new Error(sourceIssue);
     }
+    const publishedIds = new Set(catalog.packages.map((entry) => entry.manifest.id));
+    const previewPackages = (await fetchPreviewCatalogPackages(previewCatalogUrl, fetchCatalog)).filter((entry) => {
+      // The overlay only ever holds packages the published lanes do NOT carry, so
+      // an id in both means the catalog build is inconsistent. Keep what stable
+      // users already receive and carry on rather than failing the catalog.
+      if (!publishedIds.has(entry.manifest.id)) return true;
+      logger.warn(
+        "Agent preview overlay also lists published package %s; keeping the published entry",
+        entry.manifest.id,
+      );
+      return false;
+    });
+    const decorate = (entry: CapabilityCatalogPackage, sourceUrl: string, preview: boolean) => ({
+      ...entry,
+      ...(preview ? { preview: true } : {}),
+      iconUrl: resolveCapabilityPackageIconUrl(entry, sourceUrl),
+      artifact: {
+        ...entry.artifact,
+        url: resolveCapabilityPackageArtifactUrl(entry, sourceUrl),
+      },
+    });
+
     return {
       ...catalog,
       provenance: { kind: isOfficialCatalogUrl(CATALOG_URL) ? "official" : "custom", url: CATALOG_URL },
-      packages: catalog.packages
+      // Re-sorted because the two documents are each sorted only within
+      // themselves and the client renders catalog order as-is.
+      packages: [
+        ...catalog.packages.map((entry) => decorate(entry, CATALOG_URL, false)),
+        ...(previewCatalogUrl ? previewPackages.map((entry) => decorate(entry, previewCatalogUrl, true)) : []),
+      ]
         .filter((entry) => !NON_DOWNLOADABLE_CORE_PACKAGE_IDS.has(entry.manifest.id))
-        .map((entry) => ({
-          ...entry,
-          iconUrl: resolveCapabilityPackageIconUrl(entry, CATALOG_URL),
-          artifact: {
-            ...entry.artifact,
-            url: resolveCapabilityPackageArtifactUrl(entry, CATALOG_URL),
-          },
-        })),
+        .sort(
+          (left, right) =>
+            CATALOG_SORT_COLLATOR.compare(left.manifest.name, right.manifest.name) ||
+            CATALOG_SORT_COLLATOR.compare(left.manifest.id, right.manifest.id),
+        ),
     };
   },
 
@@ -916,7 +1043,11 @@ export const capabilityPackageManager = {
       return { migrated: false, legacy: false, complete: true };
     }
 
-    const catalog = await this.catalog();
+    // Published lanes only (preview overlay explicitly not fetched): this loop
+    // installs and activates EVERY entry it is handed, unattended, at startup.
+    // Merging staging-only packages in here would silently install every
+    // unfinished package on a tester's machine the first time they upgrade.
+    const catalog = await this.catalog(safeFetch, null);
     const installedById = new Map((await this.installed()).map((item) => [item.id, item]));
     for (const entry of catalog.packages) {
       if (installedById.get(entry.manifest.id)?.version === entry.manifest.version) continue;
@@ -942,7 +1073,9 @@ export const capabilityPackageManager = {
 
     const alreadyInstalled = (await this.installed()).some((item) => item.id === "noodle");
     if (!alreadyInstalled) {
-      const catalog = await this.catalog();
+      // Published lanes only, for the same reason as migrateLegacyAvailability:
+      // this path auto-installs what it finds without asking.
+      const catalog = await this.catalog(safeFetch, null);
       const entry = catalog.packages.find((candidate) => candidate.manifest.id === "noodle");
       if (!entry) {
         // Engine and Agents are published independently. Do not turn the short

--- a/packages/shared/src/schemas/capability-package.schema.ts
+++ b/packages/shared/src/schemas/capability-package.schema.ts
@@ -304,11 +304,6 @@ export const capabilityCatalogPackageSchema = z
       .strict(),
     iconUrl: z.string().url().optional(),
     documentationUrl: z.string().url().optional(),
-    /** Stamped by the Engine when this entry came from the staging preview
-     *  overlay instead of the published lanes. A published catalog document
-     *  never carries it — it is declared here only so the strict entry schema
-     *  accepts the stamped value on the way back out. */
-    preview: z.boolean().optional(),
   })
   .strict();
 
@@ -446,6 +441,20 @@ export const packagedAgentDefinitionsSchema = z.array(packagedAgentDefinitionSch
 export type CapabilityPackageManifest = z.infer<typeof capabilityPackageManifestSchema>;
 export type CapabilityCatalogPackage = z.infer<typeof capabilityCatalogPackageSchema>;
 export type CapabilityCatalog = z.infer<typeof capabilityCatalogSchema>;
+
+/** A catalog entry after the Engine has stamped where it came from.
+ *
+ *  `preview` marks an entry the Engine itself read from the staging preview
+ *  overlay. It is deliberately NOT part of the downloaded-entry schema above:
+ *  that schema is the contract for bytes we fetched, and accepting `preview`
+ *  there would let any published or custom catalog claim preview provenance for
+ *  its own entries. The Engine assigns it from the source URL and nowhere else,
+ *  so a value arriving on the wire is rejected by the strict entry schema and
+ *  can never reach a consumer. */
+export type StampedCapabilityCatalogPackage = CapabilityCatalogPackage & { preview?: true };
+export type StampedCapabilityCatalog = Omit<CapabilityCatalog, "packages"> & {
+  packages: StampedCapabilityCatalogPackage[];
+};
 export type InstalledCapabilityPackage = z.infer<typeof installedCapabilityPackageSchema>;
 export type PackagedAgentDefinition = z.infer<typeof packagedAgentDefinitionSchema>;
 

--- a/packages/shared/src/schemas/capability-package.schema.ts
+++ b/packages/shared/src/schemas/capability-package.schema.ts
@@ -304,6 +304,11 @@ export const capabilityCatalogPackageSchema = z
       .strict(),
     iconUrl: z.string().url().optional(),
     documentationUrl: z.string().url().optional(),
+    /** Stamped by the Engine when this entry came from the staging preview
+     *  overlay instead of the published lanes. A published catalog document
+     *  never carries it — it is declared here only so the strict entry schema
+     *  accepts the stamped value on the way back out. */
+    preview: z.boolean().optional(),
   })
   .strict();
 

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -551,6 +551,10 @@ try {
   const stagingCatalogUrl = resolveCapabilityCatalogUrl("development", "", "staging");
   const activeCatalogUrl = resolveCapabilityCatalogUrl();
   let requestedCatalogUrl: string | URL | undefined;
+  // The explicit null preview URL keeps this block pinning the PUBLISHED catalog
+  // selection: run from a `staging` checkout the preview overlay fetch would
+  // otherwise land second and overwrite requestedCatalogUrl. Overlay behaviour
+  // has its own coverage in capability-preview-overlay.regression.ts.
   const normalizedCatalog = await capabilityPackageManager.catalog(async (url) => {
     requestedCatalogUrl = url;
     return new Response(
@@ -561,7 +565,7 @@ try {
       }),
       { status: 200, headers: { "content-type": "application/json" } },
     );
-  });
+  }, null);
   assert.equal(
     requestedCatalogUrl,
     activeCatalogUrl,

--- a/scripts/regressions/capability-preview-overlay.regression.ts
+++ b/scripts/regressions/capability-preview-overlay.regression.ts
@@ -1,0 +1,217 @@
+// ──────────────────────────────────────────────
+// Regression: staging preview-overlay catalog gate (#5492)
+// ──────────────────────────────────────────────
+// Packages the Agents repo marks staging-only are cut from the published lanes
+// and written to an overlay under catalog/preview/. Promotion copies staging to
+// main verbatim, so that overlay EXISTS on main and serves 200 there — the only
+// thing keeping an unreleased package away from a stable user is this Engine
+// refusing to build the URL. These assertions pin that containment:
+//   * the preview gate is an ALLOW-list (exact "staging"), deliberately unlike
+//     the deny-list shaped resolveOfficialAgentBranch, so a checkout on a branch
+//     named `master` gets the staging catalog but never the overlay;
+//   * a stable Engine resolves no overlay URL at all, so nothing can fetch one;
+//   * an absent overlay (its normal steady state, answered 404 + text/plain) and
+//     a failing one both degrade to the published catalog instead of throwing —
+//     catalog() has no cache, so a throw would blank the whole Agents browser;
+//   * overlay entries are stamped `preview` and lose to the published lanes on
+//     an id collision;
+//   * the unattended startup migrations never request the overlay at all.
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dataDir = mkdtempSync(join(tmpdir(), "marinara-preview-overlay-"));
+process.env.DATA_DIR = dataDir;
+process.env.MARINARA_GIT_BRANCH = "staging";
+
+const AGENTS_ROOT = "https://raw.githubusercontent.com/Pasta-Devs/Marinara-Agents";
+
+function catalogEntry(id: string, artifactBranch: "main" | "staging") {
+  return {
+    manifest: {
+      schemaVersion: 1,
+      id,
+      name: id,
+      version: "1.0.0",
+      description: "Preview overlay regression fixture.",
+      engine: { min: "2.3.0", maxExclusive: "3.0.0" },
+      kind: ["agent"],
+      entrypoints: { server: "server.mjs", client: "client.js" },
+      files: [
+        { path: "server.mjs", sha256: "0".repeat(64), bytes: 1 },
+        { path: "client.js", sha256: "0".repeat(64), bytes: 1 },
+      ],
+      permissions: ["ui"],
+      restartRequired: true,
+    },
+    category: "misc" as const,
+    artifact: {
+      url: `${AGENTS_ROOT}/${artifactBranch}/artifacts/${id}-1.0.0.zip`,
+      sha256: "1".repeat(64),
+      bytes: 1,
+    },
+  };
+}
+
+function catalogDocument(entries: ReturnType<typeof catalogEntry>[]) {
+  return { schemaVersion: 1, generatedAt: "2026-08-01T00:00:00.000Z", packages: entries };
+}
+
+/** raw.githubusercontent.com answers a missing file with a text/plain 404, not
+ *  JSON — reproduced exactly, because a content type the fetch policy rejects
+ *  would throw before the caller ever sees the status. */
+function notFound() {
+  return new Response("404: Not Found", { status: 404, headers: { "content-type": "text/plain; charset=utf-8" } });
+}
+
+function ok(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+}
+
+try {
+  const { capabilityPackageManager, isPreviewCatalogChannel, resolvePreviewCatalogUrl, resolveOfficialAgentBranch } =
+    await import("../../packages/server/src/services/capability-packages/package-manager.service.js");
+
+  // ── The gate is an allow-list ───────────────────────────────────────────────
+  assert.equal(isPreviewCatalogChannel("staging"), true, "The staging channel is the one channel that may preview");
+
+  // Each of these resolves to the STAGING catalog under the existing deny-list
+  // helper. None of them may reach the overlay. `master` is the load-bearing
+  // case: the launchers treat it as a mainline branch name.
+  for (const branch of [
+    "main",
+    "master",
+    "release/v2.4.0",
+    "feature/preview-overlay",
+    "hotfix/urgent",
+    "v2.4.2",
+    "refs/tags/v2.4.2",
+    "Staging",
+    "staging-test",
+    "my-staging",
+    "",
+  ]) {
+    assert.equal(isPreviewCatalogChannel(branch), false, `Branch "${branch}" must not qualify for the preview overlay`);
+    assert.equal(
+      resolvePreviewCatalogUrl("2.4.3", "", isPreviewCatalogChannel(branch)),
+      null,
+      `Branch "${branch}" must not resolve a preview overlay URL at all`,
+    );
+  }
+  assert.equal(
+    isPreviewCatalogChannel(null),
+    false,
+    "A detached or non-git checkout reports no branch and must not preview",
+  );
+
+  // The divergence from resolveOfficialAgentBranch is deliberate, not an
+  // oversight: pinned here so nobody "simplifies" the gate back into it.
+  assert.equal(resolveOfficialAgentBranch("master"), "staging");
+  assert.equal(
+    isPreviewCatalogChannel("master"),
+    false,
+    "The preview gate must stay stricter than the catalog-branch helper it sits beside",
+  );
+
+  // ── URL derivation mirrors the published lanes ──────────────────────────────
+  assert.equal(resolvePreviewCatalogUrl("2.4.3", "", true), `${AGENTS_ROOT}/staging/catalog/preview/v2/catalog.json`);
+  assert.equal(resolvePreviewCatalogUrl("3.0.1", "", true), `${AGENTS_ROOT}/staging/catalog/preview/v3/catalog.json`);
+  assert.equal(
+    resolvePreviewCatalogUrl("development", "", true),
+    `${AGENTS_ROOT}/staging/catalog/preview/catalog.json`,
+    "A non-release version must fall back to the legacy preview alias, exactly as the published lane does",
+  );
+  assert.equal(
+    resolvePreviewCatalogUrl("2.4.3", "https://example.test/catalog.json", true),
+    null,
+    "An explicit catalog override is the whole catalog; no preview sibling may be synthesised for it",
+  );
+
+  // ── catalog() merge behaviour ───────────────────────────────────────────────
+  const previewUrl = resolvePreviewCatalogUrl("2.4.3", "", true);
+  assert.ok(previewUrl, "The staging preview URL fixture must resolve");
+  const published = catalogEntry("published-pkg", "main");
+  const previewOnly = catalogEntry("preview-pkg", "staging");
+
+  function trackingFetch(previewResponse: () => Response) {
+    const requested: string[] = [];
+    const fetchImpl = async (url: string | URL) => {
+      const href = String(url);
+      requested.push(href);
+      return href === previewUrl ? previewResponse() : ok(catalogDocument([published]));
+    };
+    return { requested, fetchImpl: fetchImpl as never };
+  }
+
+  // Absent overlay: the steady state whenever no package is marked staging-only.
+  const absent = trackingFetch(notFound);
+  const withoutOverlay = await capabilityPackageManager.catalog(absent.fetchImpl, previewUrl);
+  assert.deepEqual(
+    withoutOverlay.packages.map((entry) => entry.manifest.id),
+    ["published-pkg"],
+    "A missing overlay must leave the published catalog intact",
+  );
+  assert.equal(withoutOverlay.packages[0]?.preview, undefined, "Published entries must not be stamped as preview");
+  assert.ok(absent.requested.includes(previewUrl), "A staging Engine must actually request the overlay");
+
+  // Overlay present: merged, stamped, and artifact URLs resolved against staging.
+  const present = trackingFetch(() => ok(catalogDocument([previewOnly])));
+  const merged = await capabilityPackageManager.catalog(present.fetchImpl, previewUrl);
+  assert.deepEqual(
+    merged.packages.map((entry) => entry.manifest.id).sort(),
+    ["preview-pkg", "published-pkg"],
+    "Overlay entries must be merged over the published catalog",
+  );
+  const mergedPreview = merged.packages.find((entry) => entry.manifest.id === "preview-pkg");
+  assert.equal(mergedPreview?.preview, true, "Overlay entries must be stamped so later consumers can tell them apart");
+  assert.equal(
+    mergedPreview?.artifact.url,
+    `${AGENTS_ROOT}/staging/artifacts/preview-pkg-1.0.0.zip`,
+    "An overlay entry's artifact must resolve through the staging branch",
+  );
+
+  // Id in both documents: the published copy is what stable users already have.
+  const collision = trackingFetch(() => ok(catalogDocument([catalogEntry("published-pkg", "staging")])));
+  const resolved = await capabilityPackageManager.catalog(collision.fetchImpl, previewUrl);
+  assert.deepEqual(
+    resolved.packages.map((entry) => entry.manifest.id),
+    ["published-pkg"],
+    "An id present in both documents must appear exactly once",
+  );
+  assert.equal(resolved.packages[0]?.preview, undefined, "On a collision the published entry must win");
+
+  // A broken overlay must never take the catalog down with it.
+  const failing = trackingFetch(() => {
+    throw new Error("overlay exploded");
+  });
+  const degraded = await capabilityPackageManager.catalog(failing.fetchImpl, previewUrl);
+  assert.deepEqual(
+    degraded.packages.map((entry) => entry.manifest.id),
+    ["published-pkg"],
+    "A failing overlay must degrade to the published catalog instead of throwing",
+  );
+
+  const malformed = trackingFetch(() => ok({ schemaVersion: 1, packages: "not-an-array" }));
+  const survived = await capabilityPackageManager.catalog(malformed.fetchImpl, previewUrl);
+  assert.deepEqual(
+    survived.packages.map((entry) => entry.manifest.id),
+    ["published-pkg"],
+    "A malformed overlay must degrade to the published catalog instead of throwing",
+  );
+
+  // A stable Engine holds no overlay URL, so the overlay is never requested.
+  const stable = trackingFetch(notFound);
+  const stableCatalog = await capabilityPackageManager.catalog(stable.fetchImpl, null);
+  assert.deepEqual(
+    stableCatalog.packages.map((entry) => entry.manifest.id),
+    ["published-pkg"],
+    "A null preview URL must yield the published catalog",
+  );
+  assert.equal(stable.requested.length, 1, "A stable Engine must make exactly one catalog request");
+  assert.ok(!stable.requested.includes(previewUrl), "A stable Engine must never request the preview overlay");
+
+  console.info("Capability preview-overlay regressions passed.");
+} finally {
+  rmSync(dataDir, { recursive: true, force: true });
+}

--- a/scripts/regressions/capability-preview-overlay.regression.ts
+++ b/scripts/regressions/capability-preview-overlay.regression.ts
@@ -158,10 +158,13 @@ try {
   // Overlay present: merged, stamped, and artifact URLs resolved against staging.
   const present = trackingFetch(() => ok(catalogDocument([previewOnly])));
   const merged = await capabilityPackageManager.catalog(present.fetchImpl, previewUrl);
+  // Compared in the order catalog() returned, NOT sorted here: the collator sort
+  // is part of the contract, and sorting in the test would let append order pass
+  // just as happily.
   assert.deepEqual(
-    merged.packages.map((entry) => entry.manifest.id).sort(),
+    merged.packages.map((entry) => entry.manifest.id),
     ["preview-pkg", "published-pkg"],
-    "Overlay entries must be merged over the published catalog",
+    "The merged catalog must come back in collated name order, overlay entries included",
   );
   const mergedPreview = merged.packages.find((entry) => entry.manifest.id === "preview-pkg");
   assert.equal(mergedPreview?.preview, true, "Overlay entries must be stamped so later consumers can tell them apart");
@@ -180,6 +183,32 @@ try {
     "An id present in both documents must appear exactly once",
   );
   assert.equal(resolved.packages[0]?.preview, undefined, "On a collision the published entry must win");
+
+  // Provenance cannot be claimed by the catalog itself. `preview` is absent from
+  // the strict downloaded-entry schema, so a published (or custom) document that
+  // ships `preview: true` cannot ride it through the decoration spread. Only the
+  // source URL decides.
+  // The clean entry rides along so this cannot pass vacuously on an empty list:
+  // the spoofing entry must be the ONLY casualty.
+  const spoofingFetch = (async (url: string | URL) => {
+    if (String(url) === previewUrl) return notFound();
+    return ok({
+      schemaVersion: 1,
+      generatedAt: "2026-08-01T00:00:00.000Z",
+      packages: [{ ...catalogEntry("spoofer-pkg", "main"), preview: true }, catalogEntry("published-pkg", "main")],
+    });
+  }) as never;
+  const unspoofable = await capabilityPackageManager.catalog(spoofingFetch, previewUrl);
+  assert.deepEqual(
+    unspoofable.packages.map((entry) => entry.manifest.id),
+    ["published-pkg"],
+    "An entry claiming preview provenance must be rejected by the strict schema, leaving its neighbours intact",
+  );
+  assert.equal(
+    unspoofable.packages[0]?.preview,
+    undefined,
+    "A downloaded catalog must never be able to stamp an entry as preview-sourced",
+  );
 
   // A broken overlay must never take the catalog down with it.
   const failing = trackingFetch(() => {


### PR DESCRIPTION
## Linked issue

Closes #5492

## Why this change

The Agents repository ships two tiers for holding a package back (Pasta-Devs/Marinara-Agents#410 / Pasta-Devs/Marinara-Agents#411). `INCOMPLETE_PACKAGE_IDS` works — those entries are dropped from every catalog at generation time. `STAGING_ONLY_PACKAGE_IDS` was meant to mean "testers can install it, stable users cannot": those entries are cut from the published lanes and written to an overlay under `catalog/preview/` instead.

Nothing in the Engine had ever heard of that path, so a staging-only package was hidden from staging users too. The tier was inert, and a package author who wanted testers but not stable had no working option — they could expose a package to everyone or to nobody.

This cannot be fixed on the catalog side. Promotion is a wholesale `staging` → `main` byte-copy merge, so `catalog/preview/` **exists on `main`** and serves 200 there, with matching artifacts under `main/artifacts/`. The containment guarantee has to live in the Engine: it must decline to construct that URL.

## What changed

**A strict channel gate.** `isPreviewCatalogChannel()` is an exact match on the `staging` branch. It deliberately does **not** reuse `resolveOfficialAgentBranch()`, which is deny-list shaped — anything that is not `main`, `hotfix/*`, or a release tag resolves to `"staging"`, so a checkout on a branch named `master` (which `start.bat` itself treats as a mainline name) would have qualified. Being wrong there only hands someone a slightly newer package list; being wrong here shows unreleased packages to a stable user.

**A URL that does not exist off-channel.** `resolvePreviewCatalogUrl()` returns `null` unless the gate passes, so a stable Engine never holds an overlay URL that any later code path could fetch — rather than building one and filtering it downstream. It mirrors the published lane derivation exactly, including the fallback to the legacy alias for a non-release version string. An explicit `MARINARA_AGENT_CATALOG_URL` override also returns `null`: that override is the whole catalog, and synthesising a preview sibling for someone's fork would fetch a URL they never pointed us at.

**Merge semantics.** Overlay entries are stamped `preview: true` and merged into `catalog()`. The published lanes win on an id collision (the overlay copy is dropped with a warning rather than failing the catalog), and the combined list is re-sorted with a fixed `en` collator because the two documents are each sorted only within themselves and the client renders catalog order as-is.

**The migrations no longer see the overlay.** This is the part that matters most. `migrateLegacyAvailability` loops the entire catalog and calls `installCatalogPackage(entry, true)` on every entry — unattended, at startup, with activation on. Merging staging-only packages into it would have silently installed and activated every unfinished package on a tester's machine the first time they upgraded. It and `migrateExtractedNoodleAvailability` now pass `null` explicitly, so they never even request the overlay. `install()`, `pendingUpdates()`, and `declineUpdate()` keep the default and do see preview entries, which is what lets a tester install one and then receive its updates.

**Failure is silent and non-fatal.** A missing overlay is the *normal* steady state (`STAGING_ONLY_PACKAGE_IDS` currently ships empty), and raw.githubusercontent.com answers it with a `404` carrying `Content-Type: text/plain`. That, a non-404 error, a malformed document, and a thrown request all degrade to the published catalog. `catalog()` has no cache and no stale fallback, so anything propagating from here would blank the Agents browser and the update prompter for every package at once.

### Deliberately not included

`isOfficialCatalogUrl` accepts a `.../main/catalog/preview/...` path (issue item 8). Nothing constructs that URL, and tightening it would change behaviour on the `MARINARA_AGENT_CATALOG_URL` override path for no live benefit, so it is left alone here. The real containment is that the URL is never built.

## Validation

<!-- These are human tasks. Never tick a box for a check that was not actually performed. -->

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated results from this branch, for whoever picks up the checklist:

- `pnpm lint` passes (TypeScript `--noEmit` on shared and server, ESLint on client).
- `pnpm build` passes.
- `pnpm impeccable:check` and `pnpm localization:check` pass.
- `node ./scripts/run-regressions.mjs --filter capability-preview-overlay` passes (new).
- `node ./scripts/run-regressions.mjs --filter capability-package-lifecycle` passes.
- `git diff --check` is clean.
- **`pnpm format:check` does NOT pass, and did not before this branch either.** This Windows checkout has `core.autocrlf=true` while Prettier defaults to `endOfLine: "lf"`, so it reports all 1303 `packages/**/*.{ts,tsx}` files, including files this branch never touches. Checked with `--end-of-line auto`, both files this PR edits under `packages/` are clean. Please confirm on a LF checkout.

Still needs a human at a real Engine:

- Manually verify in a **staging** Engine that **Agents → Download Agents** lists a staging-only package once the Agents repo marks one, and that installing it works end to end.
- Manually verify in a **stable** Engine that the same package does **not** appear, and that no request to `catalog/preview/` is made (server logs or a proxy).
- Manually verify the empty-overlay path is quiet: with no package marked staging-only, browsing Agents must work normally and must not log a warning (the 404 is logged at `debug`).
- Manually verify a first-upgrade profile (triggering `migrateLegacyAvailability`) does not auto-install a staging-only package on a staging Engine.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

A CHANGELOG entry is included under `[Unreleased] → Added`. No user-facing doc under `docs/` describes catalog channels today, so nothing there needed a matching edit and no `docs-i18n` mirror is implied. No version-bearing file is touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Staging-channel Engines can preview eligible capability packages from an additional catalog overlay.
  - Preview packages are clearly identified and merged with the published catalog, with published packages taking precedence when IDs overlap.
  - Preview package assets are resolved through the appropriate preview catalog locations.

- **Bug Fixes**
  - Missing, unavailable, or invalid preview catalogs no longer prevent the published catalog from loading.
  - Stable-channel Engines and unattended startup migrations continue using only published packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->