### PR TITLE
fix: make agent catalog organization visible on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Download Agents now shows each package's supported chat modes directly in the mobile catalog list, while mobile shell panels cap malformed browser safe-area values so Android Firefox cannot hide the bottom of the list behind a large empty inset (#5507).
 - Roleplay group chats now retain their response controls and generation behavior when only one character is enabled, while Sequential generation skips every disabled character (#5501, #5502).
 - Game narration now restores choices after rewinding or switching swipes, scopes saved narration progress to the active swipe, and restarts safely when a saved cursor exceeds the available segments (#5474).
 - The Roleplay active-summary and branch counters now share one themed badge treatment with the configured accent color (#5499).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -11664,13 +11664,17 @@ test("downloadable agent catalog is usable on desktop and mobile", async ({ page
   await expect(trackerSection.getByText("Hierarchical Maps", { exact: true })).toBeVisible();
   await expect(catalogView.getByText("About Me Keeper")).toHaveCount(0);
   await expect(catalogView.getByText("Play UNO with Conversation characters.").first()).toBeVisible();
+  const unoListButton = catalogView.locator("aside button").filter({
+    hasText: "Play UNO with Conversation characters.",
+  });
+  await expect(unoListButton.getByText("Conversation", { exact: true })).toBeVisible();
   const allAgentsButton = catalogView.locator("button", { hasText: "All agents" });
   if (testInfo.project.name.includes("mobile")) {
-    await catalogView.getByRole("button", { name: "UNO Play UNO with Conversation characters.", exact: true }).click();
+    await unoListButton.click();
     await expect(allAgentsButton).toBeVisible();
     await allAgentsButton.click();
     await expect(allAgentsButton).toBeHidden();
-    await catalogView.getByRole("button", { name: "UNO Play UNO with Conversation characters.", exact: true }).click();
+    await unoListButton.click();
   } else {
     await expect(allAgentsButton).toBeHidden();
   }

--- a/packages/client/src/components/agents/AgentCatalogView.tsx
+++ b/packages/client/src/components/agents/AgentCatalogView.tsx
@@ -44,6 +44,7 @@ type CatalogMode = "conversation" | "roleplay" | "game";
 type CatalogModeFilter = "all" | CatalogMode;
 
 const OFFICIAL_PACKAGE_MODES: Readonly<Record<string, readonly CatalogMode[]>> = Object.freeze({
+  beholder: ["roleplay"],
   "card-evolution-auditor": ["roleplay"],
   continuity: ["roleplay"],
   "knowledge-retrieval": ["roleplay"],
@@ -57,6 +58,7 @@ const OFFICIAL_PACKAGE_MODES: Readonly<Record<string, readonly CatalogMode[]>> =
   "memory-nag": ["roleplay"],
   "long-term-memory": ["conversation", "roleplay", "game"],
   expression: ["roleplay"],
+  "gacha-forge": ["conversation", "roleplay", "game"],
   "hierarchical-maps": ["roleplay", "game"],
   "persona-stats": ["roleplay"],
   quest: ["roleplay"],
@@ -73,6 +75,7 @@ const OFFICIAL_PACKAGE_MODES: Readonly<Record<string, readonly CatalogMode[]>> =
   html: ["roleplay"],
   "lorebook-keeper": ["roleplay", "game"],
   noodle: ["conversation", "roleplay", "game"],
+  slurp: ["conversation", "roleplay", "game"],
   spotify: ["conversation", "roleplay", "game"],
   poker: ["conversation"],
   "rock-paper-scissors": ["conversation"],
@@ -620,6 +623,19 @@ export function AgentCatalogView() {
                                         </span>
                                         <span className="mt-0.5 line-clamp-2 text-xs text-[var(--muted-foreground)]">
                                           {entry.manifest.description}
+                                        </span>
+                                        <span data-agent-catalog-mode-badges className="mt-1 flex flex-wrap gap-1">
+                                          {packageModes(entry.manifest.id).map((mode) => (
+                                            <span
+                                              key={mode}
+                                              className={cn(
+                                                "rounded-md border px-1.5 py-0.5 text-[0.5625rem] font-semibold text-[var(--foreground)]",
+                                                MODE_BADGES[mode].className,
+                                              )}
+                                            >
+                                              {MODE_BADGES[mode].label}
+                                            </span>
+                                          ))}
                                         </span>
                                       </span>
                                     </button>

--- a/packages/client/src/components/agents/AgentCatalogView.tsx
+++ b/packages/client/src/components/agents/AgentCatalogView.tsx
@@ -83,19 +83,19 @@ const OFFICIAL_PACKAGE_MODES: Readonly<Record<string, readonly CatalogMode[]>> =
   uno: ["conversation"],
 });
 
-const MODE_BADGES: Record<CatalogMode, { label: string; className: string }> = {
+const MODE_BADGES: Record<CatalogMode, { labelKey: string; className: string }> = {
   conversation: {
-    label: "Conversation",
+    labelKey: "ui.agents.agentcatalogview.conversationMode",
     className:
       "border-[color-mix(in_srgb,var(--mari-logo-cyan)_55%,var(--border))] bg-[color-mix(in_srgb,var(--mari-logo-cyan)_18%,transparent)]",
   },
   roleplay: {
-    label: "Roleplay",
+    labelKey: "ui.agents.agentcatalogview.roleplayMode",
     className:
       "border-[color-mix(in_srgb,var(--mari-logo-orange)_55%,var(--border))] bg-[color-mix(in_srgb,var(--mari-logo-orange)_18%,transparent)]",
   },
   game: {
-    label: "Game",
+    labelKey: "ui.agents.agentcatalogview.gameMode",
     className:
       "border-[color-mix(in_srgb,var(--mari-logo-pink)_55%,var(--border))] bg-[color-mix(in_srgb,var(--mari-logo-pink)_18%,transparent)]",
   },
@@ -166,13 +166,13 @@ export function AgentCatalogView() {
             manifest.id,
             category,
             ...manifest.kind.map(kindLabel),
-            ...packageModes(manifest.id).map((mode) => MODE_BADGES[mode].label),
+            ...packageModes(manifest.id).map((mode) => localizeUi(MODE_BADGES[mode].labelKey)),
           ]
             .join(" ")
             .toLowerCase()
             .includes(needle)),
     );
-  }, [catalog.data, modeFilter, query]);
+  }, [catalog.data, localizeUi, modeFilter, query]);
   const packageGroups = useMemo(
     () => [
       {
@@ -589,6 +589,7 @@ export function AgentCatalogView() {
                               <div className="space-y-1">
                                 {entries.map((entry) => {
                                   const active = entry.manifest.id === selected?.manifest.id;
+                                  const modes = packageModes(entry.manifest.id);
                                   return (
                                     <button
                                       key={entry.manifest.id}
@@ -624,19 +625,21 @@ export function AgentCatalogView() {
                                         <span className="mt-0.5 line-clamp-2 text-xs text-[var(--muted-foreground)]">
                                           {entry.manifest.description}
                                         </span>
-                                        <span data-agent-catalog-mode-badges className="mt-1 flex flex-wrap gap-1">
-                                          {packageModes(entry.manifest.id).map((mode) => (
-                                            <span
-                                              key={mode}
-                                              className={cn(
-                                                "rounded-md border px-1.5 py-0.5 text-[0.5625rem] font-semibold text-[var(--foreground)]",
-                                                MODE_BADGES[mode].className,
-                                              )}
-                                            >
-                                              {MODE_BADGES[mode].label}
-                                            </span>
-                                          ))}
-                                        </span>
+                                        {modes.length > 0 && (
+                                          <span data-agent-catalog-mode-badges className="mt-1 flex flex-wrap gap-1">
+                                            {modes.map((mode) => (
+                                              <span
+                                                key={mode}
+                                                className={cn(
+                                                  "rounded-md border px-1.5 py-0.5 text-[0.5625rem] font-semibold text-[var(--foreground)]",
+                                                  MODE_BADGES[mode].className,
+                                                )}
+                                              >
+                                                {localizeUi(MODE_BADGES[mode].labelKey)}
+                                              </span>
+                                            ))}
+                                          </span>
+                                        )}
                                       </span>
                                     </button>
                                   );
@@ -699,7 +702,7 @@ export function AgentCatalogView() {
                           MODE_BADGES[mode].className,
                         )}
                       >
-                        {MODE_BADGES[mode].label}
+                        {localizeUi(MODE_BADGES[mode].labelKey)}
                       </span>
                     ))}
                   </div>

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -125,6 +125,7 @@ const TRACKER_PANEL_ANCHOR_SELECTOR = '[data-tracker-panel-anchor="roleplay-hud"
 const ROLEPLAY_CHAT_COLUMN_SELECTOR = '[data-roleplay-chat-column="true"]';
 const TOP_BAR_SELECTOR = '[data-component="TopBar"]';
 const MOBILE_SHELL_PANEL_TOP_CLASS = "top-[calc(env(safe-area-inset-top)_+_3rem)]";
+const MOBILE_SHELL_PANEL_BOTTOM_PADDING_CLASS = "pb-[min(max(env(safe-area-inset-bottom),0.5rem),3rem)]";
 const CENTER_COMPACT_WIDTH = 768;
 const CENTER_COMPACT_HYSTERESIS = 80;
 const CENTER_COMPACT_SCAN_DEPTH = 6;
@@ -1363,8 +1364,9 @@ export function AppShell() {
                   "mari-app-background-paint flex min-h-0 flex-1 flex-col overflow-hidden",
                   shellOverlayMode &&
                     cn(
-                      "mari-mobile-detail-sheet !fixed bottom-0 right-0 z-50 !w-full bg-[var(--background)]/95 pb-[max(env(safe-area-inset-bottom),0.5rem)] shadow-2xl backdrop-blur-xl",
+                      "mari-mobile-detail-sheet !fixed bottom-0 right-0 z-50 !w-full bg-[var(--background)]/95 shadow-2xl backdrop-blur-xl",
                       MOBILE_SHELL_PANEL_TOP_CLASS,
+                      MOBILE_SHELL_PANEL_BOTTOM_PADDING_CLASS,
                     ),
                 )}
               >
@@ -1414,8 +1416,9 @@ export function AppShell() {
               data-component="TrackerDataSidebarMobile"
               aria-label={localizeUi("ui.layout.appshell.trackerDataPanel")}
               className={cn(
-                "mari-tracker-panel !fixed bottom-0 z-50 w-screen max-w-none overflow-hidden bg-zinc-950/95 pb-[max(env(safe-area-inset-bottom),0.5rem)] shadow-2xl ring-1 ring-[var(--marinara-app-accent-static)] backdrop-blur-xl",
+                "mari-tracker-panel !fixed bottom-0 z-50 w-screen max-w-none overflow-hidden bg-zinc-950/95 shadow-2xl ring-1 ring-[var(--marinara-app-accent-static)] backdrop-blur-xl",
                 MOBILE_SHELL_PANEL_TOP_CLASS,
+                MOBILE_SHELL_PANEL_BOTTOM_PADDING_CLASS,
                 trackerPanelSide === "left" ? "left-0" : "right-0",
               )}
               style={trackerPanelBackgroundStyle}
@@ -1446,8 +1449,9 @@ export function AppShell() {
                   : "ui.layout.appshell.settingsAndToolsPanel",
               )}
               className={cn(
-                "!fixed right-0 bottom-0 z-50 !w-full overflow-hidden pb-[max(env(safe-area-inset-bottom),0.5rem)] shadow-2xl backdrop-blur-xl",
+                "!fixed right-0 bottom-0 z-50 !w-full overflow-hidden shadow-2xl backdrop-blur-xl",
                 MOBILE_SHELL_PANEL_TOP_CLASS,
+                MOBILE_SHELL_PANEL_BOTTOM_PADDING_CLASS,
                 mobileNavigationPanel === "chats"
                   ? "mari-sidebar bg-[var(--background)]/95"
                   : "mari-right-panel bg-[var(--background)]/80",

--- a/scripts/regressions/agent-catalog-kind-badges.regression.ts
+++ b/scripts/regressions/agent-catalog-kind-badges.regression.ts
@@ -21,12 +21,12 @@ assert.match(
   /storyboard:\s*\["roleplay",\s*"game"\]/u,
   "Storyboard must advertise its Roleplay and Game catalog badges",
 );
-for (const packageId of ["beholder", "gacha-forge", "slurp"]) {
-  assert.match(catalogViewSource, new RegExp(`(?:"${packageId}"|${packageId}):\\s*\\[`, "u"));
-}
+assert.match(catalogViewSource, /(?:"beholder"|beholder):\s*\[\s*"roleplay"\s*\]/u);
+assert.match(catalogViewSource, /(?:"gacha-forge"|gacha-forge):\s*\[\s*"conversation",\s*"roleplay",\s*"game"\s*\]/u);
+assert.match(catalogViewSource, /(?:"slurp"|slurp):\s*\[\s*"conversation",\s*"roleplay",\s*"game"\s*\]/u);
 assert.match(
   catalogViewSource,
-  /data-agent-catalog-mode-badges[\s\S]*?packageModes\(entry\.manifest\.id\)\.map/u,
+  /const modes = packageModes\(entry\.manifest\.id\);[\s\S]*?data-agent-catalog-mode-badges[\s\S]*?modes\.map/u,
   "Catalog rows must show their supported chat modes without opening the detail view",
 );
 assert.match(

--- a/scripts/regressions/agent-catalog-kind-badges.regression.ts
+++ b/scripts/regressions/agent-catalog-kind-badges.regression.ts
@@ -15,10 +15,24 @@ const catalogViewSource = readFileSync(
   join(repositoryRoot, "packages/client/src/components/agents/AgentCatalogView.tsx"),
   "utf8",
 );
+const appShellSource = readFileSync(join(repositoryRoot, "packages/client/src/components/layout/AppShell.tsx"), "utf8");
 assert.match(
   catalogViewSource,
   /storyboard:\s*\["roleplay",\s*"game"\]/u,
   "Storyboard must advertise its Roleplay and Game catalog badges",
+);
+for (const packageId of ["beholder", "gacha-forge", "slurp"]) {
+  assert.match(catalogViewSource, new RegExp(`(?:"${packageId}"|${packageId}):\\s*\\[`, "u"));
+}
+assert.match(
+  catalogViewSource,
+  /data-agent-catalog-mode-badges[\s\S]*?packageModes\(entry\.manifest\.id\)\.map/u,
+  "Catalog rows must show their supported chat modes without opening the detail view",
+);
+assert.match(
+  appShellSource,
+  /MOBILE_SHELL_PANEL_BOTTOM_PADDING_CLASS\s*=\s*\n?\s*"pb-\[min\(max\(env\(safe-area-inset-bottom\),0\.5rem\),3rem\)\]"/u,
+  "Mobile shell panels must cap broken browser safe-area insets",
 );
 
 console.info("Agent catalog kind badge regressions passed.");


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.

## Linked issue

Closes #5507

## Why this change

- Chat-mode organization existed as filters and detail badges, but mobile users could not see a package's supported modes in the catalog list. Firefox Android could also report an excessive bottom safe-area inset, leaving unusable space below the list.

## What changed

- Show the existing Conversation, Roleplay, and Game badges on each catalog row.
- Complete the host's current package-mode map for Beholder, Gacha Forge, and Slurp.
- Reuse one capped bottom-safe-area class for mobile shell panels so malformed browser values cannot consume the panel.
- Extend the existing catalog regression and desktop/mobile browser scenario.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Validation notes

- `pnpm check`: formatting, localization, lint, shared/server builds passed; the client build was then run successfully with the matching ARM `esbuild` binary after the local dependency cache supplied an x64 binary.
- `pnpm localization:check`: passed.
- `agent-catalog-kind-badges.regression.ts`: passed.
- Targeted Playwright catalog scenario: passed on desktop Chromium and mobile Chromium (2 tests).
- The broader UI smoke run was stopped after unrelated pre-existing scenarios failed; this PR's targeted scenario passes independently.
- Manual Android Firefox verification remains for the reporter/maintainer.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

The Unreleased changelog includes the user-facing fix. No user documentation or release metadata changed.

## UI evidence (if applicable)

- Automated desktop/mobile catalog coverage is included. Manual Android Firefox confirmation is still requested for the device-specific inset report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added localized chat-mode badges to catalog entries, including Beholder, Gacha Forge, and Slurp.
  - Added clearer mode labels and colored badge rows to catalog listings and detail views.

- **Bug Fixes**
  - Improved mobile spacing around detail sheets, trackers, and navigation panels on devices with screen cutouts.
  - Capped Android Firefox safe-area spacing to prevent excessive padding.
  - Improved the mobile UNO catalog flow for reliably opening the Conversation entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->