### PR TITLE
[codex] harden v2.4.4 release security gates

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -64,10 +64,7 @@ jobs:
           else
             tag="${RELEASE_TAG:-${INPUT_TAG:-$REF_NAME}}"
           fi
-          if [ -n "$tag" ] && [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?(\+[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
-            echo "Release tag must use vX.Y.Z semantic-version format: $tag" >&2
-            exit 1
-          fi
+          if [ -n "$tag" ]; then node scripts/check-release-tag.mjs "$tag"; fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
 
       - name: Decode signing key
@@ -92,8 +89,6 @@ jobs:
       - name: Locate APK
         id: locate
         working-directory: android
-        env:
-          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
         run: |
           APK_PATH=$(find app/build/outputs/apk/release -name "*.apk" | head -n1)
           if [ -z "$APK_PATH" ]; then
@@ -103,10 +98,6 @@ jobs:
           VERSION=$(node -p "require('../package.json').version")
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?(\+[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
             echo "package.json version must use X.Y.Z semantic-version format: $VERSION" >&2
-            exit 1
-          fi
-          if [ -n "$RELEASE_TAG" ] && [ "${RELEASE_TAG#v}" != "$VERSION" ]; then
-            echo "Release tag $RELEASE_TAG must match package.json version $VERSION" >&2
             exit 1
           fi
           OUT_NAME="marinara-engine-${VERSION}-android-termux-bootstrap.apk"

--- a/.github/workflows/build-container-lite.yml
+++ b/.github/workflows/build-container-lite.yml
@@ -45,7 +45,9 @@ jobs:
 
       - name: Verify release tag
         if: startsWith(github.ref, 'refs/tags/v')
-        run: node scripts/check-release-tag.mjs "${{ github.ref_name }}"
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: node scripts/check-release-tag.mjs "$RELEASE_TAG"
 
       - name: Lowercase image name
         id: lower

--- a/.github/workflows/build-container-lite.yml
+++ b/.github/workflows/build-container-lite.yml
@@ -40,6 +40,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify release tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: node scripts/check-release-tag.mjs "${{ github.ref_name }}"
 
       - name: Lowercase image name
         id: lower
@@ -111,6 +117,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Lowercase image name
         id: lower

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -73,7 +73,9 @@ jobs:
 
       - name: Verify release tag
         if: startsWith(github.ref, 'refs/tags/v')
-        run: node scripts/check-release-tag.mjs "${{ github.ref_name }}"
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: node scripts/check-release-tag.mjs "$RELEASE_TAG"
 
       # github.repository can have uppercase (Pasta-Devs/Marinara-Engine)
       # but Docker image refs must be all-lowercase

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -68,6 +68,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify release tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: node scripts/check-release-tag.mjs "${{ github.ref_name }}"
 
       # github.repository can have uppercase (Pasta-Devs/Marinara-Engine)
       # but Docker image refs must be all-lowercase
@@ -144,6 +150,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Lowercase image name
         id: lower

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -35,13 +35,11 @@ jobs:
       - name: Resolve release tag
         id: release_tag
         shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.tag || github.ref_name }}
         run: |
-          release_tag="${{ github.event.release.tag_name || '' }}"
-          input_tag="${{ github.event.inputs.tag || '' }}"
-          ref_name="${{ github.ref_name }}"
-          tag="${release_tag:-${input_tag:-$ref_name}}"
-          node scripts/check-release-tag.mjs "$tag"
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          node scripts/check-release-tag.mjs "$RELEASE_TAG"
+          echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Build installer
         id: build

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.release.tag_name || github.event.inputs.tag || github.ref }}
+          persist-credentials: false
 
       - name: Install NSIS
         run: |
@@ -39,6 +40,7 @@ jobs:
           input_tag="${{ github.event.inputs.tag || '' }}"
           ref_name="${{ github.ref_name }}"
           tag="${release_tag:-${input_tag:-$ref_name}}"
+          node scripts/check-release-tag.mjs "$tag"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
 
       - name: Build installer

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, staging]
   pull_request:
-    branches: [staging]
+    branches: [main, staging]
   schedule:
     - cron: "41 4 * * 2"
   workflow_dispatch:

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -43,11 +43,12 @@ jobs:
       - name: Resolve release tag
         id: resolve_tag
         shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
-          node scripts/check-release-tag.mjs "$TAG"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          node scripts/check-release-tag.mjs "$RELEASE_TAG"
+          echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Check version drift
         run: pnpm version:check

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag || github.ref }}
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -44,6 +45,7 @@ jobs:
         shell: bash
         run: |
           TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          node scripts/check-release-tag.mjs "$TAG"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Run focused security regressions
         run: pnpm regression:security
 
+      - name: Test release tag validation
+        run: pnpm regression:release
+
       - name: Validate pull request gate topology
         run: node scripts/validate-pr-triage.mjs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Official release workflows now reject tags that do not match the canonical app version, avoid retaining checkout write credentials, and run CodeQL for both staging and main-targeted pull requests (#5510).
 - Matched character, persona, and agent tags plus chat branch counts to the shared compact search-tag shape instead of capsule badges.
 - Unified Quest Board, Memory Nag, and Beholder surfaces, separators, and responsive typography with the rest of the Roleplay Tracker Panel.
 - Unified inactive Roleplay tracker toolbar icons at the shared muted chroma strength and removed the stray count punctuation from the mobile Characters heading.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,3 +22,5 @@ Some features intentionally execute code only after explicit opt-in:
 - Official capability-package and local-model runtimes are integrity checked before execution.
 
 Security boundaries include unintended host command execution, sandbox escape, unauthorized remote access, unsafe filesystem access, archive traversal, secret exposure, and active content executing without the documented approval gates. Reports that preserve legitimate local-first workflows while demonstrating one of those boundary crossings are especially helpful.
+
+Official versioned artifact workflows reject malformed or mismatched release tags before building or publishing. CodeQL analyzes pull requests to both `staging` and `main`, while the dependency audit and focused security regressions provide a separate release-candidate check.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "regression:professor-mari-shell-sandbox": "pnpm build:shared && node ./scripts/run-regressions.mjs --filter scripts/regressions/professor-mari/shell-sandbox.regression.ts",
     "regression:runtime-integrity": "pnpm build:shared && node ./scripts/run-regressions.mjs --filter scripts/regressions/runtime-integrity.regression.ts",
     "regression:security": "pnpm build:shared && node ./scripts/run-regressions.mjs --filter security && node ./scripts/run-regressions.mjs --filter runtime-integrity && node ./scripts/run-regressions.mjs --filter shell-sandbox && node ./scripts/run-regressions.mjs --filter extension-ipc && node ./scripts/run-regressions.mjs --filter android-local-auth && node ./scripts/run-regressions.mjs --filter docker-proxy-auth",
+    "regression:release": "node ./scripts/regressions/release-tag-version.regression.mjs",
     "regression:static-cache": "node ./scripts/run-regressions.mjs --filter scripts/regressions/static-cache-headers.regression.ts",
     "regression:launcher-update": "node ./scripts/regressions/pnpm-runner.regression.mjs && node ./scripts/regressions/launcher/env.regression.mjs && node ./scripts/regressions/launcher/existing-server.regression.mjs && node ./scripts/regressions/launcher/update.regression.mjs && node ./scripts/regressions/dev-launcher-process.regression.mjs && node ./scripts/regressions/launcher/format-guard.regression.mjs && node ./scripts/check-windows-installer-layout.mjs",
     "regression:android-local-auth:run": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/android-local-auth.regression.ts",
@@ -53,6 +54,7 @@
     "backgroundremover:install": "node ./scripts/install-backgroundremover.mjs",
     "backgroundremover:reinstall": "node ./scripts/install-backgroundremover.mjs --reinstall",
     "guard:installer-artifacts": "node ./scripts/check-tracked-installers.mjs",
+    "release:check-tag": "node ./scripts/check-release-tag.mjs",
     "release:notes": "node ./scripts/render-release-notes.mjs",
     "clean": "pnpm -r --if-present run clean && node ./scripts/clean-workspace.mjs"
   },

--- a/scripts/check-release-tag.mjs
+++ b/scripts/check-release-tag.mjs
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const RELEASE_TAG_PATTERN =
-  /^v(\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?(?:\+[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?)$/u;
+  /^v((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*)|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:(?:0|[1-9]\d*)|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)$/u;
 
 export function validateReleaseTag(tag, version) {
   const match = RELEASE_TAG_PATTERN.exec(tag);

--- a/scripts/check-release-tag.mjs
+++ b/scripts/check-release-tag.mjs
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const RELEASE_TAG_PATTERN =
+  /^v(\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?(?:\+[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?)$/u;
+
+export function validateReleaseTag(tag, version) {
+  const match = RELEASE_TAG_PATTERN.exec(tag);
+  if (!match) throw new Error(`Release tag must use vX.Y.Z semantic-version format: ${tag || "(empty)"}`);
+  if (match[1] !== version) throw new Error(`Release tag ${tag} must match package.json version ${version}`);
+  return version;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+  validateReleaseTag(process.argv[2] ?? "", packageJson.version);
+  console.info(`Release tag ${process.argv[2]} matches package.json version ${packageJson.version}.`);
+}

--- a/scripts/regressions/android-local-auth.regression.ts
+++ b/scripts/regressions/android-local-auth.regression.ts
@@ -302,6 +302,7 @@ try {
     return apkWorkflowSource.slice(start, next === -1 ? undefined : next);
   };
   const checkoutStepSource = getWorkflowStep("Checkout");
+  const releaseTagStepSource = getWorkflowStep("Resolve release tag");
   const locateStepSource = getWorkflowStep("Locate APK");
   const releaseUploadStepSource = getWorkflowStep("Attach APK to release");
 
@@ -331,9 +332,14 @@ try {
     assert.doesNotMatch(invalidVersion, versionPattern, `the release guard must reject ${invalidVersion}`);
   }
   assert.match(
-    locateStepSource,
-    /RELEASE_TAG: \$\{\{ steps\.release_tag\.outputs\.tag \}\}[\s\S]*\[ -n "\$RELEASE_TAG" \] && \[ "\$\{RELEASE_TAG#v\}" != "\$VERSION" \][\s\S]*exit 1[\s\S]*OUT_NAME=/u,
-    "a release tag must match package.json.version before the APK is named or uploaded",
+    releaseTagStepSource,
+    /if \[ -n "\$tag" \]; then node scripts\/check-release-tag\.mjs "\$tag"; fi/u,
+    "a release tag must pass the shared package.json.version guard",
+  );
+  assert.ok(
+    apkWorkflowSource.indexOf("      - name: Resolve release tag\n") <
+      apkWorkflowSource.indexOf("      - name: Build release APK\n"),
+    "the release tag must be validated before the APK is built",
   );
 
   const wrapperProperties = readFileSync(

--- a/scripts/regressions/release-tag-version.regression.mjs
+++ b/scripts/regressions/release-tag-version.regression.mjs
@@ -4,16 +4,28 @@ import { validateReleaseTag } from "../check-release-tag.mjs";
 
 assert.equal(validateReleaseTag("v2.4.4", "2.4.4"), "2.4.4");
 assert.equal(validateReleaseTag("v2.4.4-beta.1+build.7", "2.4.4-beta.1+build.7"), "2.4.4-beta.1+build.7");
+assert.equal(validateReleaseTag("v2.4.4+build.007", "2.4.4+build.007"), "2.4.4+build.007");
 assert.throws(() => validateReleaseTag("2.4.4", "2.4.4"), /must use vX\.Y\.Z/u);
 assert.throws(() => validateReleaseTag("v2.4", "2.4.4"), /must use vX\.Y\.Z/u);
+assert.throws(() => validateReleaseTag("v01.2.3", "01.2.3"), /must use vX\.Y\.Z/u);
+assert.throws(() => validateReleaseTag("v2.4.4-rc.01", "2.4.4-rc.01"), /must use vX\.Y\.Z/u);
 assert.throws(() => validateReleaseTag("v2.4.5", "2.4.4"), /must match package\.json version/u);
 
 for (const [workflow, invocation] of [
   ["build-apk.yml", /node scripts\/check-release-tag\.mjs "\$tag"/u],
-  ["build-container.yml", /node scripts\/check-release-tag\.mjs "\$\{\{ github\.ref_name \}\}"/u],
-  ["build-container-lite.yml", /node scripts\/check-release-tag\.mjs "\$\{\{ github\.ref_name \}\}"/u],
-  ["build-windows-installer.yml", /node scripts\/check-release-tag\.mjs "\$tag"/u],
-  ["publish-github-release.yml", /node scripts\/check-release-tag\.mjs "\$TAG"/u],
+  ["build-container.yml", /RELEASE_TAG: \$\{\{ github\.ref_name \}\}[\s\S]*check-release-tag\.mjs "\$RELEASE_TAG"/u],
+  [
+    "build-container-lite.yml",
+    /RELEASE_TAG: \$\{\{ github\.ref_name \}\}[\s\S]*check-release-tag\.mjs "\$RELEASE_TAG"/u,
+  ],
+  [
+    "build-windows-installer.yml",
+    /RELEASE_TAG: \$\{\{ github\.event\.release\.tag_name \|\| github\.event\.inputs\.tag \|\| github\.ref_name \}\}[\s\S]*check-release-tag\.mjs "\$RELEASE_TAG"/u,
+  ],
+  [
+    "publish-github-release.yml",
+    /RELEASE_TAG: \$\{\{ github\.event\.inputs\.tag \|\| github\.ref_name \}\}[\s\S]*check-release-tag\.mjs "\$RELEASE_TAG"/u,
+  ],
 ]) {
   const source = readFileSync(new URL(`../../.github/workflows/${workflow}`, import.meta.url), "utf8");
   assert.match(source, invocation, `${workflow} must reject a tag that does not match package.json`);

--- a/scripts/regressions/release-tag-version.regression.mjs
+++ b/scripts/regressions/release-tag-version.regression.mjs
@@ -11,24 +11,57 @@ assert.throws(() => validateReleaseTag("v01.2.3", "01.2.3"), /must use vX\.Y\.Z/
 assert.throws(() => validateReleaseTag("v2.4.4-rc.01", "2.4.4-rc.01"), /must use vX\.Y\.Z/u);
 assert.throws(() => validateReleaseTag("v2.4.5", "2.4.4"), /must match package\.json version/u);
 
-for (const [workflow, invocation] of [
-  ["build-apk.yml", /node scripts\/check-release-tag\.mjs "\$tag"/u],
-  ["build-container.yml", /RELEASE_TAG: \$\{\{ github\.ref_name \}\}[\s\S]*check-release-tag\.mjs "\$RELEASE_TAG"/u],
-  [
-    "build-container-lite.yml",
-    /RELEASE_TAG: \$\{\{ github\.ref_name \}\}[\s\S]*check-release-tag\.mjs "\$RELEASE_TAG"/u,
-  ],
-  [
-    "build-windows-installer.yml",
-    /RELEASE_TAG: \$\{\{ github\.event\.release\.tag_name \|\| github\.event\.inputs\.tag \|\| github\.ref_name \}\}[\s\S]*check-release-tag\.mjs "\$RELEASE_TAG"/u,
-  ],
-  [
-    "publish-github-release.yml",
-    /RELEASE_TAG: \$\{\{ github\.event\.inputs\.tag \|\| github\.ref_name \}\}[\s\S]*check-release-tag\.mjs "\$RELEASE_TAG"/u,
-  ],
+for (const { workflow, validationStep, tagSource, invocation, artifactStep } of [
+  {
+    workflow: "build-apk.yml",
+    validationStep: "Resolve release tag",
+    tagSource:
+      /EVENT_NAME: \$\{\{ github\.event_name \}\}[\s\S]*INPUT_TAG: \$\{\{ github\.event\.inputs\.tag \|\| '' \}\}[\s\S]*RELEASE_TAG: \$\{\{ github\.event\.release\.tag_name \|\| '' \}\}[\s\S]*REF_NAME: \$\{\{ github\.ref_name \}\}/u,
+    invocation: /node scripts\/check-release-tag\.mjs "\$tag"/u,
+    artifactStep: "Build release APK",
+  },
+  {
+    workflow: "build-container.yml",
+    validationStep: "Verify release tag",
+    tagSource: /RELEASE_TAG: \$\{\{ github\.ref_name \}\}/u,
+    invocation: /node scripts\/check-release-tag\.mjs "\$RELEASE_TAG"/u,
+    artifactStep: "Build and push by digest",
+  },
+  {
+    workflow: "build-container-lite.yml",
+    validationStep: "Verify release tag",
+    tagSource: /RELEASE_TAG: \$\{\{ github\.ref_name \}\}/u,
+    invocation: /node scripts\/check-release-tag\.mjs "\$RELEASE_TAG"/u,
+    artifactStep: "Build and push by digest",
+  },
+  {
+    workflow: "build-windows-installer.yml",
+    validationStep: "Resolve release tag",
+    tagSource:
+      /RELEASE_TAG: \$\{\{ github\.event\.release\.tag_name \|\| github\.event\.inputs\.tag \|\| github\.ref_name \}\}/u,
+    invocation: /node scripts\/check-release-tag\.mjs "\$RELEASE_TAG"/u,
+    artifactStep: "Build installer",
+  },
+  {
+    workflow: "publish-github-release.yml",
+    validationStep: "Resolve release tag",
+    tagSource: /RELEASE_TAG: \$\{\{ github\.event\.inputs\.tag \|\| github\.ref_name \}\}/u,
+    invocation: /node scripts\/check-release-tag\.mjs "\$RELEASE_TAG"/u,
+    artifactStep: "Build named source archive",
+  },
 ]) {
   const source = readFileSync(new URL(`../../.github/workflows/${workflow}`, import.meta.url), "utf8");
-  assert.match(source, invocation, `${workflow} must reject a tag that does not match package.json`);
+  const validationMarker = `      - name: ${validationStep}\n`;
+  const validationStart = source.indexOf(validationMarker);
+  assert.notEqual(validationStart, -1, `${workflow} must contain its ${validationStep} step`);
+  const validationEnd = source.indexOf("\n      - name:", validationStart + validationMarker.length);
+  const validationSource = source.slice(validationStart, validationEnd === -1 ? undefined : validationEnd);
+  assert.match(validationSource, tagSource, `${workflow} must pass the tag through the validation step environment`);
+  assert.match(validationSource, invocation, `${workflow} must reject a tag that does not match package.json`);
+  assert.ok(
+    validationStart < source.indexOf(`      - name: ${artifactStep}\n`),
+    `${workflow} must validate the tag before ${artifactStep}`,
+  );
 }
 
 console.info("Release tag/version regressions passed.");

--- a/scripts/regressions/release-tag-version.regression.mjs
+++ b/scripts/regressions/release-tag-version.regression.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { validateReleaseTag } from "../check-release-tag.mjs";
+
+assert.equal(validateReleaseTag("v2.4.4", "2.4.4"), "2.4.4");
+assert.equal(validateReleaseTag("v2.4.4-beta.1+build.7", "2.4.4-beta.1+build.7"), "2.4.4-beta.1+build.7");
+assert.throws(() => validateReleaseTag("2.4.4", "2.4.4"), /must use vX\.Y\.Z/u);
+assert.throws(() => validateReleaseTag("v2.4", "2.4.4"), /must use vX\.Y\.Z/u);
+assert.throws(() => validateReleaseTag("v2.4.5", "2.4.4"), /must match package\.json version/u);
+
+for (const [workflow, invocation] of [
+  ["build-apk.yml", /node scripts\/check-release-tag\.mjs "\$tag"/u],
+  ["build-container.yml", /node scripts\/check-release-tag\.mjs "\$\{\{ github\.ref_name \}\}"/u],
+  ["build-container-lite.yml", /node scripts\/check-release-tag\.mjs "\$\{\{ github\.ref_name \}\}"/u],
+  ["build-windows-installer.yml", /node scripts\/check-release-tag\.mjs "\$tag"/u],
+  ["publish-github-release.yml", /node scripts\/check-release-tag\.mjs "\$TAG"/u],
+]) {
+  const source = readFileSync(new URL(`../../.github/workflows/${workflow}`, import.meta.url), "utf8");
+  assert.match(source, invocation, `${workflow} must reject a tag that does not match package.json`);
+}
+
+console.info("Release tag/version regressions passed.");

--- a/scripts/validate-pr-triage.mjs
+++ b/scripts/validate-pr-triage.mjs
@@ -43,6 +43,7 @@ export function validatePullRequestTriage() {
   ).replace(/\r\n/gu, "\n");
   const approvalEvaluator = readFileSync(new URL("./evaluate-owner-approval.mjs", import.meta.url), "utf8");
   const codeOwners = readFileSync(new URL("../.github/CODEOWNERS", import.meta.url), "utf8");
+  const codeqlWorkflow = readFileSync(new URL("../.github/workflows/codeql.yml", import.meta.url), "utf8");
   const triggersSectionStart = triageWorkflow.indexOf("\non:\n");
   const triggersSectionEnd = triageWorkflow.indexOf("\nconcurrency:\n", triggersSectionStart);
   const jobsSectionStart = triageWorkflow.indexOf("\njobs:\n");
@@ -57,9 +58,7 @@ export function validatePullRequestTriage() {
   );
 
   const jobIds = [
-    ...triageWorkflow
-      .slice(jobsSectionStart + "\njobs:\n".length)
-      .matchAll(/^  ([A-Za-z_][A-Za-z0-9_-]*):\s*$/gmu),
+    ...triageWorkflow.slice(jobsSectionStart + "\njobs:\n".length).matchAll(/^  ([A-Za-z_][A-Za-z0-9_-]*):\s*$/gmu),
   ].map((match) => match[1]);
   assert.ok(jobIds.includes("branch-policy"));
   assert.ok(jobIds.includes("owner-approval"));
@@ -74,10 +73,7 @@ export function validatePullRequestTriage() {
   assert.match(ownerApprovalJob, /run: node scripts\/evaluate-owner-approval\.mjs/u);
   assert.doesNotMatch(ownerApprovalJob, /github\.event\.pull_request\.head/u);
 
-  assert.match(
-    reviewSignal,
-    /on:\n  pull_request_review:\n    types: \[submitted, edited, dismissed\]/u,
-  );
+  assert.match(reviewSignal, /on:\n  pull_request_review:\n    types: \[submitted, edited, dismissed\]/u);
   assert.match(reviewSignal, /permissions: \{\}/u);
   assert.doesNotMatch(reviewSignal, /secrets\.|github\.token|actions\/checkout|PASTA_DEVS_MEMBERS_TOKEN/u);
 
@@ -110,7 +106,7 @@ export function validatePullRequestTriage() {
     exemptionStep,
     [
       "      - name: Exempt trusted contributor",
-      "        if: contains(fromJSON('[\"MEMBER\",\"OWNER\",\"COLLABORATOR\"]'), github.event.pull_request.author_association)",
+      '        if: contains(fromJSON(\'["MEMBER","OWNER","COLLABORATOR"]\'), github.event.pull_request.author_association)',
       '        run: echo "Trusted contributor; pull request template validation is not required."',
     ].join("\n"),
   );
@@ -122,6 +118,7 @@ export function validatePullRequestTriage() {
   );
 
   assert.match(codeOwners, /^\* @SpicyMarinara$/mu);
+  assert.match(codeqlWorkflow, /pull_request:\s*\n\s*branches:\s*\[main, staging\]/u);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
> [!IMPORTANT]
> This targets staging. No release tag or main promotion is created by this PR.

## Linked issue

Closes #5510

## Why this change

Official release artifacts must not accept an untrusted or mismatched tag, and both protected promotion targets must retain the same CodeQL coverage.

## What changed

- Added one tested SemVer/tag-to-package-version guard for GitHub releases, Windows, Android, and full/lite containers.
- Passed release tag inputs through step environment variables before shell evaluation.
- Disabled persisted checkout credentials in release jobs.
- Added CodeQL pull-request coverage for staging and main.
- Updated repository rulesets to require Analyze actions and Analyze javascript-typescript on Engine staging and main.
- Enabled Dependabot security updates and secret-scanning push protection.

No application runtime, import/export path, extension permission, or local-first behavior changes.

## Validation

- [ ] pnpm check passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed CONTRIBUTING.md

### Manual verification notes

Automated evidence: pnpm check, pnpm version:check, pnpm credits:check, pnpm audit --audit-level low, pnpm regression:security, pnpm regression:release, pnpm guard:installer-artifacts, pull-request gate validation, both CodeQL analyses, and the hosted container build all passed. Malformed and mismatched tags were confirmed rejected. No UI or application runtime behavior changed, so browser verification is not applicable.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the docs-i18n branch updated to match, or a docs-i18n follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

SECURITY.md and CHANGELOG.md are updated. No version bump or translated user documentation change is included.

## UI evidence (if applicable)

Not applicable; this is release-workflow and repository-protection hardening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release workflows now validate tags consistently and ensure they match the application version before publishing artifacts.
  * Improved protection by preventing checkout credentials from persisting in build and release workflows.

* **Tests**
  * Added regression coverage for valid, invalid, prerelease, and mismatched release tags.
  * Release checks now run automatically with pull request validation.

* **Security**
  * CodeQL analysis now covers pull requests targeting both `main` and `staging`.

* **Documentation**
  * Updated the changelog and security guidance with release-validation and analysis coverage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->