### PR TITLE
fix(help): align responsive overlay targets

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,4 @@
-name: Playwright Browser Matrix
+name: Release Regression Matrix
 
 on:
   pull_request:
@@ -12,6 +12,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  node:
+    name: complete-node-regressions
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run complete Node regression suite
+        run: pnpm regression
+
   browser:
     name: ${{ matrix.project }}
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,67 @@
+name: Playwright Browser Matrix
+
+on:
+  pull_request:
+    branches: [staging]
+  push:
+    branches: [staging]
+  workflow_dispatch:
+
+concurrency:
+  group: playwright-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  browser:
+    name: ${{ matrix.project }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - project: desktop-chromium
+            browser: chromium
+          - project: mobile-chromium
+            browser: chromium
+          - project: mobile-webkit
+            browser: webkit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install ${{ matrix.browser }}
+        run: pnpm exec playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Run ${{ matrix.project }}
+        run: pnpm exec playwright test -c playwright.config.ts --project=${{ matrix.project }}
+
+      - name: Upload failure evidence
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-${{ matrix.project }}-failure
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
-- Hosted Playwright validation now covers desktop Chromium, Android-sized Chromium, and iPhone-sized WebKit independently on pull requests and staging pushes (#5518).
+- Hosted release validation now runs the complete Node regression suite and covers desktop Chromium, Android-sized Chromium, and iPhone-sized WebKit independently on pull requests and staging pushes (#5518, #5520).
 - Download Agents can now filter the existing Writer, Tracker, and Misc sections by Conversation, Roleplay, or Game support, and a Discovery Desk recommendation opens its exact Agent instead of the catalog's first entry (#5494, #5500).
 - Game HUD widgets now expose their unique model-facing ID for editing after creation (#5477).
 - Professor Mari's structured `app_data` helper can now list, search, inspect, and read bounded message ranges from chats without falling back to raw database commands (#5476).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Hosted Playwright validation now covers desktop Chromium, Android-sized Chromium, and iPhone-sized WebKit independently on pull requests and staging pushes (#5518).
 - Download Agents can now filter the existing Writer, Tracker, and Misc sections by Conversation, Roleplay, or Game support, and a Discovery Desk recommendation opens its exact Agent instead of the catalog's first entry (#5494, #5500).
 - Game HUD widgets now expose their unique model-facing ID for editing after creation (#5477).
 - Professor Mari's structured `app_data` helper can now list, search, inspect, and read bounded message ranges from chats without falling back to raw database commands (#5476).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+## [2.4.4]
+
 ### Added
 
 - Hosted release validation now runs the complete Node regression suite and covers desktop Chromium, Android-sized Chromium, and iPhone-sized WebKit independently on pull requests and staging pushes (#5518, #5520).
@@ -43,6 +45,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Help overlays now align compact desktop highlights exactly with their toolbar controls at responsive widths and keep mobile toolbar controls visible while people inspect highlighted sections (#5521).
 - Fixed the open-issues regression lane crashing at import time because a directly loaded client utility used the browser-only `@/lib` path alias (#5516).
 - Official release workflows now reject tags that do not match the canonical app version, avoid retaining checkout write credentials, and run CodeQL for both staging and main-targeted pull requests (#5510).
 - Matched character, persona, and agent tags plus chat branch counts to the shared compact search-tag shape instead of capsule badges.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Regression guards:
 
 - `pnpm regression` (or `pnpm regression:node`) builds the shared package once, discovers the complete Node regression set from the filesystem, and runs it serially.
 - `pnpm regression:prompt` runs fast deterministic checks for prompt assembly, lorebook keyword matching, macros, summaries, and mode-specific generation gates.
-- `pnpm regression:ui` runs the Playwright browser suite; `pnpm smoke:ui` remains a compatibility alias for the same full UI lane.
+- `pnpm regression:ui` runs the Playwright browser suite across desktop Chromium, Android-sized Chromium, and iPhone-sized WebKit; `pnpm smoke:ui` remains a compatibility alias for the same full UI lane. Pull requests and staging pushes run the same projects independently on hosted runners.
   Each run clears `.tmp/playwright-data` and starts separate desktop and mobile app servers so their mutable fixtures cannot overlap. Stop any process already using the configured Playwright ports before running it; existing fixture state is disposable and the suite does not reuse a running development server.
 - `pnpm test` checks the Windows installer layout, then runs the Node regression lane. It does not run the UI lane; invoke `pnpm regression:ui` explicitly for browser validation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ pnpm regression:ui
 
 Regression guards:
 
-- `pnpm regression` (or `pnpm regression:node`) builds the shared package once, discovers the complete Node regression set from the filesystem, and runs it serially.
+- `pnpm regression` (or `pnpm regression:node`) builds the shared package once, discovers the complete Node regression set from the filesystem, and runs it serially. Pull requests and staging pushes run this complete lane on a hosted runner.
 - `pnpm regression:prompt` runs fast deterministic checks for prompt assembly, lorebook keyword matching, macros, summaries, and mode-specific generation gates.
 - `pnpm regression:ui` runs the Playwright browser suite across desktop Chromium, Android-sized Chromium, and iPhone-sized WebKit; `pnpm smoke:ui` remains a compatibility alias for the same full UI lane. Pull requests and staging pushes run the same projects independently on hosted runners.
   Each run clears `.tmp/playwright-data` and starts separate desktop and mobile app servers so their mutable fixtures cannot overlap. Stop any process already using the configured Playwright ports before running it; existing fixture state is disposable and the suite does not reuse a running development server.

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -7220,6 +7220,53 @@ test("chat Help overlay labels visible controls in every mode", async ({ page, r
         module.useChatStore.getState().setActiveChatId(nextChatId);
       }, chatId);
     };
+    const expectDesktopToolbarHighlightsAligned = async (overlay: Locator) => {
+      const toolbarTargetIds = [
+        "help",
+        "branches",
+        "summary",
+        "context",
+        "author-notes",
+        "gallery",
+        "connected-chat",
+        "search",
+        "settings",
+        "retry",
+        "session",
+        "volume",
+        "assets",
+      ];
+      for (const targetId of toolbarTargetIds) {
+        const source = page.locator(`[data-chat-help="${targetId}"]`).filter({ visible: true }).first();
+        const highlight = overlay.locator(`[data-chat-help-highlight="${targetId}"]`);
+        if ((await source.count()) === 0 || (await highlight.count()) === 0) continue;
+        const sourceBox = await source.boundingBox();
+        const highlightBox = await highlight.boundingBox();
+        expect(sourceBox).not.toBeNull();
+        expect(highlightBox).not.toBeNull();
+        expect(sourceBox!.width, `${targetId} control width`).toBeCloseTo(32, 0);
+        expect(sourceBox!.height, `${targetId} control height`).toBeCloseTo(32, 0);
+        expect(Math.abs(highlightBox!.x - sourceBox!.x), `${targetId} highlight left edge`).toBeLessThanOrEqual(1);
+        expect(Math.abs(highlightBox!.y - sourceBox!.y), `${targetId} highlight top edge`).toBeLessThanOrEqual(1);
+        expect(Math.abs(highlightBox!.width - sourceBox!.width), `${targetId} highlight width`).toBeLessThanOrEqual(1);
+        expect(Math.abs(highlightBox!.height - sourceBox!.height), `${targetId} highlight height`).toBeLessThanOrEqual(
+          1,
+        );
+      }
+    };
+    const openHelp = async (mode: "conversation" | "roleplay" | "game") => {
+      let helpButton = page.getByRole("button", { name: "Help", exact: true }).filter({ visible: true });
+      if ((await helpButton.count()) === 0) {
+        const overflowName = mode === "game" ? "Game actions" : "More options";
+        await page.getByRole("button", { name: overflowName, exact: true }).filter({ visible: true }).click();
+        helpButton = page.getByRole("button", { name: "Help", exact: true }).filter({ visible: true });
+      }
+      await expect(helpButton).toHaveCount(1);
+      await helpButton.click();
+      const overlay = page.locator(`[data-chat-help-overlay="${mode}"]`);
+      await expect(overlay).toBeVisible();
+      return overlay;
+    };
 
     for (const [index, chat] of chats.entries()) {
       if (index > 0) await setActiveChat(chat.id);
@@ -7342,10 +7389,14 @@ test("chat Help overlay labels visible controls in every mode", async ({ page, r
         await keyboardTarget.focus();
         await page.keyboard.press("Enter");
         await expect(overlay.locator('[data-chat-help-mobile-detail="branches"]')).toBeVisible();
+        await expect(page.locator("[data-chat-toolbar-overflow-menu]")).toBeVisible();
         await overlay.locator(`[data-chat-help-highlight="${messageTarget}"]`).click();
         const detail = overlay.locator(`[data-chat-help-mobile-detail="${messageTarget}"]`);
         await expect(detail).toBeVisible();
         await expect(detail.locator(`[data-chat-help-action-legend="${chat.mode}"]`)).toBeVisible();
+        await expect(page.locator("[data-chat-toolbar-overflow-menu]")).toBeVisible();
+        await expect(overlay.locator('[data-chat-help-highlight="branches"]')).toBeVisible();
+        await expect(overlay.locator('[data-chat-help-highlight="settings"]')).toBeVisible();
         await overlay
           .getByRole("button", {
             name: "Tap a section you want to learn more about or this button to exit the help overlay.",
@@ -7353,6 +7404,8 @@ test("chat Help overlay labels visible controls in every mode", async ({ page, r
           })
           .click();
       } else {
+        await expectDesktopToolbarHighlightsAligned(overlay);
+
         const legend = overlay.locator("[data-chat-help-legend]");
         const legendBox = await legend.boundingBox();
         expect(legendBox).not.toBeNull();
@@ -7389,6 +7442,17 @@ test("chat Help overlay labels visible controls in every mode", async ({ page, r
         await overlay.dispatchEvent("pointerdown");
       }
       await expect(overlay).toHaveCount(0);
+      if (!mobile) {
+        for (const width of [1100, 1720]) {
+          await page.setViewportSize({ width, height: 900 });
+          await expect(page.locator(`[data-chat-mode="${chat.mode}"]`)).toBeVisible();
+          const responsiveOverlay = await openHelp(chat.mode);
+          await expectDesktopToolbarHighlightsAligned(responsiveOverlay);
+          await responsiveOverlay.dispatchEvent("pointerdown");
+          await expect(responsiveOverlay).toHaveCount(0);
+        }
+        await page.setViewportSize({ width: 1440, height: 900 });
+      }
     }
   } finally {
     const cleanupResponses = await Promise.all(chats.map((chat) => request.delete(`/api/chats/${chat.id}?force=true`)));

--- a/packages/client/src/components/chat/ChatHelpOverlay.tsx
+++ b/packages/client/src/components/chat/ChatHelpOverlay.tsx
@@ -274,6 +274,15 @@ const TARGETS_BY_MODE: Record<ChatMode, HelpTargetDefinition[]> = {
 const TARGET_PADDING = 5;
 const HIGHLIGHT_GAP = 5;
 const MOBILE_TOOLBAR_HIGHLIGHT_SIZE = 32;
+const PADDED_TARGET_IDS = new Set<HelpTargetId>([
+  "agents",
+  "messages",
+  "composer",
+  "map",
+  "party",
+  "widgets",
+  "dialogue",
+]);
 
 const ACTIONS_BY_MODE: Record<ChatMode, HelpActionDefinition[]> = {
   conversation: [
@@ -461,7 +470,10 @@ function expandRectWithin(rect: Rect, bounds: Rect, padding: number): Rect {
 }
 
 function separateHighlightRects(targets: MeasuredTarget[], bounds: Rect, padding = TARGET_PADDING): MeasuredTarget[] {
-  const separated = targets.map((target) => ({ ...target, rect: expandRectWithin(target.rect, bounds, padding) }));
+  const separated = targets.map((target) => ({
+    ...target,
+    rect: expandRectWithin(target.rect, bounds, PADDED_TARGET_IDS.has(target.id) ? padding : 0),
+  }));
   for (let firstIndex = 0; firstIndex < separated.length; firstIndex += 1) {
     for (let secondIndex = firstIndex + 1; secondIndex < separated.length; secondIndex += 1) {
       const first = separated[firstIndex]!;
@@ -826,7 +838,7 @@ export function ChatHelpOverlay({
           <mask id={maskId} maskUnits="userSpaceOnUse">
             <rect x={rootRect.left} y={rootRect.top} width={rootRect.width} height={rootRect.height} fill="white" />
             {targets.map(({ id, rect }) => (
-              <rect key={id} x={rect.left} y={rect.top} width={rect.width} height={rect.height} rx="10" fill="black" />
+              <rect key={id} x={rect.left} y={rect.top} width={rect.width} height={rect.height} rx="8" fill="black" />
             ))}
           </mask>
         </defs>
@@ -847,7 +859,7 @@ export function ChatHelpOverlay({
           key={target.id}
           data-chat-help-highlight={target.id}
           className={cn(
-            "fixed rounded-[0.625rem] bg-transparent ring-2 ring-[var(--marinara-chat-chrome-focus-ring)] shadow-[0_0_18px_color-mix(in_srgb,var(--marinara-chat-chrome-focus-ring)_45%,transparent)] outline-none transition-[box-shadow,background-color] duration-150 focus-visible:bg-[color-mix(in_srgb,var(--marinara-chat-chrome-focus-ring)_9%,transparent)] focus-visible:shadow-[0_0_30px_color-mix(in_srgb,var(--marinara-chat-chrome-focus-ring)_72%,transparent)]",
+            "fixed rounded-lg bg-transparent ring-2 ring-[var(--marinara-chat-chrome-focus-ring)] shadow-[0_0_18px_color-mix(in_srgb,var(--marinara-chat-chrome-focus-ring)_45%,transparent)] outline-none transition-[box-shadow,background-color] duration-150 focus-visible:bg-[color-mix(in_srgb,var(--marinara-chat-chrome-focus-ring)_9%,transparent)] focus-visible:shadow-[0_0_30px_color-mix(in_srgb,var(--marinara-chat-chrome-focus-ring)_72%,transparent)]",
             mobile
               ? "cursor-pointer"
               : "cursor-help hover:bg-[color-mix(in_srgb,var(--marinara-chat-chrome-focus-ring)_9%,transparent)] hover:shadow-[0_0_30px_color-mix(in_srgb,var(--marinara-chat-chrome-focus-ring)_72%,transparent)]",

--- a/packages/client/src/components/chat/ChatToolbarControls.tsx
+++ b/packages/client/src/components/chat/ChatToolbarControls.tsx
@@ -258,6 +258,7 @@ export function ChatToolbarMenu({
     if (!open) return;
     const handle = (event: MouseEvent) => {
       const target = event.target as Node;
+      if (target instanceof Element && target.closest("[data-chat-help-overlay]")) return;
       if (target instanceof Element && target.closest(`[data-chat-branch-popover],${CHAT_FLOATING_PANEL_SELECTOR}`)) {
         return;
       }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -81,5 +81,9 @@ export default defineConfig({
       name: "mobile-chromium",
       use: { ...devices["Pixel 7"], baseURL: mobileBaseURL, viewport: { width: 390, height: 844 } },
     },
+    {
+      name: "mobile-webkit",
+      use: { ...devices["iPhone 15 Pro"], baseURL: mobileBaseURL },
+    },
   ],
 });

--- a/scripts/regressions/agent-runtime.regression.ts
+++ b/scripts/regressions/agent-runtime.regression.ts
@@ -103,6 +103,7 @@ const EXPECTED_AGENT_RESULT_TYPE_VALUES = [
   "director_event",
   "lorebook_update",
   "character_card_update",
+  "character_card_create",
   "background_change",
   "character_tracker_update",
   "persona_stats_update",
@@ -122,6 +123,7 @@ const EXPECTED_AGENT_RESULT_TYPE_VALUES = [
   "character_activity_update",
   "frontend_theme_update",
   "about_me_update",
+  "memory_nag",
 ] as const;
 
 assert.deepEqual(


### PR DESCRIPTION
## Why

Help highlights around compact desktop toolbar controls were expanded and then trimmed against their neighbors, producing uneven boxes that no longer matched the real button borders. On mobile, tapping an overlay target counted as an outside click for the toolbar overflow menu, so the controls vanished before the user left Help.

## What changed

- Keep content-region padding while matching compact controls to their exact bounds and shared corner radius.
- Keep the mobile toolbar rail mounted until Help closes.
- Cover Conversation, Roleplay, and Game geometry at 1100, 1440, and 1720 pixel desktop widths.
- Cover retained toolbar controls in Android-sized Chromium and iPhone-sized WebKit.
- Move the complete Unreleased changelog into the 2.4.4 section.

Depends on #5519 for the hosted release regression matrix.

Closes #5521

## Test plan

- [ ] Run the hosted desktop Chromium Help overlay regression.
- [ ] Run the hosted mobile Chromium Help overlay regression.
- [ ] Run the hosted mobile WebKit Help overlay regression.
- [ ] Manually verify Help highlights at narrow and wide desktop resolutions.
- [ ] Manually verify toolbar controls remain visible while tapping Help targets on Android and iOS-sized layouts.