### PR TITLE
Fix capability agent result finalization order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+### Fixed
+
+- Capability-package agents now publish post-processing results only after package validation, so rejected or normalized output cannot reach the browser as a successful tracker result (#5525).
+
 ## [2.4.4]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
-- Capability-package agents now publish post-processing results only after package validation, so rejected or normalized output cannot reach the browser as a successful tracker result (#5525).
+- Capability-package agents now publish post-processing results only after package validation, and package-defined built-ins can request a compact context instead of inheriting every lore source, so rejected or distracted tracker output cannot reach the browser as successful data (#5525).
 
 ## [2.4.4]
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -235,6 +235,7 @@ import {
 import {
   finalizeCapabilityAgentResults,
   prepareCapabilityAgentContexts,
+  shouldDeferCapabilityAgentResult,
 } from "../services/capability-packages/capability-agent-runtime.service.js";
 import { newId } from "../utils/id-generator.js";
 import {
@@ -4779,6 +4780,7 @@ export async function generateRoutes(app: FastifyInstance) {
         let deferParallelAgentEvents = false;
         let parallelAgentStartPending = false;
         const sendAgentEventAfterMainStream = (result: AgentResult, options?: { finalized?: boolean }) => {
+          if (shouldDeferCapabilityAgentResult(result.agentType, options?.finalized)) return;
           if (deferParallelAgentEvents) {
             deferredParallelAgentEvents.push({ result, options });
             return;
@@ -8437,6 +8439,11 @@ export async function generateRoutes(app: FastifyInstance) {
             resolvedAgents,
             preparedCapabilityPostContext ?? postAgentContext,
           );
+          for (const result of postResults) {
+            if (shouldDeferCapabilityAgentResult(result.agentType)) {
+              sendAgentEvent(result, { finalized: true });
+            }
+          }
 
           // Finalize expression results before streaming/persisting them so
           // required persona/character entries are visible immediately.

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -4795,7 +4795,7 @@ export async function generateRoutes(app: FastifyInstance) {
           if (deferredParallelAgentEvents.length === 0) return;
           const events = deferredParallelAgentEvents.splice(0);
           for (const event of events) {
-            sendAgentEvent(event.result, event.options);
+            sendAgentEventAfterMainStream(event.result, event.options);
           }
         };
 
@@ -8404,7 +8404,9 @@ export async function generateRoutes(app: FastifyInstance) {
                   retryCtx,
                 );
                 const finalizedRetry = finalizedRetryResults[0] ?? retried;
-                sendAgentEvent(finalizedRetry, { finalized: finalizedRetry.agentType === "spotify" });
+                sendAgentEventAfterMainStream(finalizedRetry, {
+                  finalized: finalizedRetry.agentType === "spotify",
+                });
                 retryResults.push(finalizedRetry);
               } catch {
                 retryResults.push(failed);

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -121,7 +121,9 @@ const ALL_AGENT_CONTEXT_SOURCES: CustomAgentContextSources = {
 function getAgentContextSources(
   config: Pick<AgentExecConfig, "isCustomAgent" | "settings">,
 ): CustomAgentContextSources {
-  return config.isCustomAgent ? normalizeCustomAgentContextSources(config.settings) : ALL_AGENT_CONTEXT_SOURCES;
+  return config.isCustomAgent || isRecord(config.settings.contextSources)
+    ? normalizeCustomAgentContextSources(config.settings)
+    : ALL_AGENT_CONTEXT_SOURCES;
 }
 
 function getBatchContextSources(configs: Array<Pick<AgentExecConfig, "isCustomAgent" | "settings">>) {

--- a/packages/server/src/services/capability-packages/capability-agent-runtime.service.ts
+++ b/packages/server/src/services/capability-packages/capability-agent-runtime.service.ts
@@ -34,6 +34,10 @@ function runtimeFor(agentType: string): CapabilityAgentRuntimeService | null {
   return getCapabilityService<CapabilityAgentRuntimeService>(`${SERVICE_PREFIX}${agentType}`);
 }
 
+export function shouldDeferCapabilityAgentResult(agentType: string, finalized = false): boolean {
+  return !finalized && typeof runtimeFor(agentType)?.finalizeResult === "function";
+}
+
 export async function prepareCapabilityAgentContexts(
   agents: AgentExecConfig[],
   context: AgentContext,

--- a/scripts/regressions/capability-agent-runtime.regression.ts
+++ b/scripts/regressions/capability-agent-runtime.regression.ts
@@ -5,6 +5,7 @@ import {
   assertCapabilityAgentRuntimeServiceRegistration,
   finalizeCapabilityAgentResults,
   prepareCapabilityAgentContexts,
+  shouldDeferCapabilityAgentResult,
 } from "../../packages/server/src/services/capability-packages/capability-agent-runtime.service.js";
 import {
   registerCapabilityService,
@@ -59,6 +60,9 @@ const release = registerCapabilityService("agent-runtime:memory-nag", {
     data: { nags_needed: true, memoryIds: ["promise"] },
   }),
 });
+assert.equal(shouldDeferCapabilityAgentResult("memory-nag"), true);
+assert.equal(shouldDeferCapabilityAgentResult("memory-nag", true), false);
+assert.equal(shouldDeferCapabilityAgentResult("ordinary-agent"), false);
 
 const prepared = await prepareCapabilityAgentContexts([agent], context);
 assert.deepEqual(prepared.memory._capabilityAgentContexts, {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -6659,6 +6659,39 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         assert.doesNotMatch(defaultRequest, new RegExp(excluded, "u"));
       }
 
+      const builtInCapture = makeCapturingProvider("Built-in context checked.");
+      await executeAgent(
+        makeRegressionAgentConfig({
+          id: "memory-nag",
+          type: "memory-nag",
+          name: "Memory Nag",
+          isCustomAgent: false,
+          promptTemplate: "Recall an eligible memory.",
+          settings: {
+            contextSize: 5,
+            maxTokens: 256,
+            resultType: "memory_nag",
+            contextSources: { chatHistory: true },
+          },
+        }) as any,
+        richContext,
+        builtInCapture.provider as any,
+        "regression-model",
+      );
+      const builtInRequest = builtInCapture.calls[0]!.map((message) => message.content).join("\n");
+      assert.match(builtInRequest, /CHAT_HISTORY_CONTEXT_SENTINEL/u);
+      for (const excluded of [
+        "CHARACTER_CONTEXT_SENTINEL",
+        "PERSONA_CONTEXT_SENTINEL",
+        "TRACKER_CONTEXT_SENTINEL",
+        "SUMMARY_CONTEXT_SENTINEL",
+        "AUTHOR_NOTES_CONTEXT_SENTINEL",
+        "ACTIVATED_LOREBOOK_CONTEXT_SENTINEL",
+        "RECALLED_MEMORY_CONTEXT_SENTINEL",
+      ]) {
+        assert.doesNotMatch(builtInRequest, new RegExp(excluded, "u"));
+      }
+
       const selectedCapture = makeCapturingProvider("Selected context checked.");
       await executeAgent(
         makeRegressionAgentConfig({


### PR DESCRIPTION
## Why

Capability-package post-processing output was reaching the browser before the package runtime could validate or normalize it. Memory Nag therefore exposed a model-selected character ID even though its finalizer would reject that value as a nonexistent memory. Package-defined built-ins also had no way to narrow the host lore sources supplied to their calls.

Closes #5525

Companion package: Pasta-Devs/Marinara-Agents#599

## What changed

- defer browser events for agents with a registered runtime finalizer
- publish the result once, after package finalization
- honor explicit `contextSources` on package-defined built-in Agents while preserving the full-context default for existing built-ins
- cover runtime event deferral and built-in context selection in focused regressions

## Validation

- [ ] `pnpm check`
- [ ] `pnpm exec tsx scripts/regressions/capability-agent-runtime.regression.ts`
- [ ] `pnpm regression:prompt`
- [ ] Manually update Memory Nag 1.0.16 and verify a turn publishes only its validated recall result

Local focused results: capability runtime and complete prompt regressions passed; Prettier and `git diff --check` passed. Full workspace validation is delegated to the hosted PR lane.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved capability-agent result processing so deferred and retry results are published only after finalization.
  - Applied configured context sources consistently to built-in agents.
  - Ensured built-in agents can use chat-history-only context without unrelated context being included.
  - Added validation before publishing post-processing results.

- **Tests**
  - Added regression coverage for deferred capability results and built-in agent context selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->