### PR TITLE
Let the Local Model card header toggle in every state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+### Fixed
+
+- The Connections panel's Local Model card now expands and collapses from a header click in every state, so the tracker assignment action is no longer reachable only through the chevron once the model is downloaded (#5538).
+
 ## [2.4.4]
 
 ### Added

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -454,6 +454,11 @@ function SidecarCard() {
             title={
               expanded ? localizeUi("ui.panels.ttsconfigcard.collapse") : localizeUi("ui.panels.ttsconfigcard.expand")
             }
+            aria-label={
+              expanded ? localizeUi("ui.panels.ttsconfigcard.collapse") : localizeUi("ui.panels.ttsconfigcard.expand")
+            }
+            aria-expanded={expanded}
+            aria-controls="local-model-card-content"
           >
             {expanded ? <ChevronUp size="0.875rem" /> : <ChevronDown size="0.875rem" />}
           </button>
@@ -461,7 +466,7 @@ function SidecarCard() {
       </div>
       {/* Local model actions (only when model is downloaded) */}
       {expanded && (
-        <>
+        <div id="local-model-card-content">
           <div className="mt-2.5 rounded-lg border border-[var(--warning)]/30 bg-[var(--warning)]/10 p-2.5">
             <div className="flex items-center gap-2 text-xs font-semibold text-[var(--warning)]">
               <AlertTriangle size="0.875rem" className="shrink-0" />
@@ -692,7 +697,7 @@ function SidecarCard() {
               </button>
             </div>
           )}
-        </>
+        </div>
       )}
     </div>
   );

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -458,7 +458,11 @@ function SidecarCard() {
               expanded ? localizeUi("ui.panels.ttsconfigcard.collapse") : localizeUi("ui.panels.ttsconfigcard.expand")
             }
             aria-expanded={expanded}
-            aria-controls="local-model-card-content"
+            aria-controls={
+              // The body is conditionally rendered, so the IDREF resolves only
+              // while expanded; a dangling aria-controls is an authoring error.
+              expanded ? "local-model-card-content" : undefined
+            }
           >
             {expanded ? <ChevronUp size="0.875rem" /> : <ChevronDown size="0.875rem" />}
           </button>

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -416,9 +416,13 @@ function SidecarCard() {
       )}
     >
       <div
-        className={cn("flex items-center gap-2.5", !isDownloaded && "cursor-pointer")}
+        className="flex cursor-pointer items-center gap-2.5"
         onClick={() => {
-          if (!isDownloaded) setExpanded(true);
+          // Header click toggles in every state. Gating this on the model not
+          // being downloaded left the card body — including the tracker
+          // assignment button — reachable only through the small chevron for
+          // exactly the users who have the model installed (#5538).
+          setExpanded((current) => !current);
         }}
       >
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-sky-400 to-blue-500 text-white shadow-sm">


### PR DESCRIPTION
## Linked issue

Closes #5538

## Why this change

The Connections panel's Local Model card only expanded on a header click while the model was **not** downloaded (`if (!isDownloaded) setExpanded(true)`, introduced in `08583a7e7`). Once the download finished, the card body — including the **"Use local model for all tracker agents"** action — was reachable only through the small chevron. That hid the action from exactly the users who can use it: a user in the report behind #5537 concluded the button had been removed from the app and reassigned every agent's connection by hand.

## What changed

One conditional in `SidecarCard` (`packages/client/src/components/panels/ConnectionsPanel.tsx`): the header click now toggles expansion unconditionally (`setExpanded((current) => !current)`), matching what the chevron already does, and the `cursor-pointer` class is applied in every state. A comment records why the gate must not come back.

Safety of the wider click target: both header buttons (settings, chevron) already call `event.stopPropagation()`, and the expanded body is a **sibling** of the header div, not a child — so clicks on body controls never reach the new handler. The chevron is unchanged and keeps its `aria`/title behavior.

The existing e2e helper (`openExpandedLocalModel` in `e2e/core-flows.e2e.ts`) clicks the header while collapsed and expects the body — a first click still expands under the toggle, so it keeps passing.

## Validation

<!-- These are human tasks. Never tick a box for a check that was not actually performed. -->

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated, from this branch: client ESLint passes; the touched file is Prettier-clean (`--end-of-line auto`; repo-wide `format:check` fails pre-existing on CRLF Windows checkouts).

Manual steps for whoever ticks the boxes:

- With the local model **downloaded**: click anywhere on the Local Model card header (not the buttons) → body expands; click again → collapses.
- Click the settings gear and the chevron → they still do their own thing and do not double-toggle.
- With the model **not** downloaded: header click still expands (previous behavior preserved, now also collapses on second click).
- Confirm the "Use local model for all tracker agents" button is now reachable without knowing about the chevron.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

CHANGELOG entry added under `[Unreleased] → Fixed`. No user-facing docs describe this card, so no `docs/` or `docs-i18n` impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The Local Model card in the Connections panel can now be expanded or collapsed by clicking its header in any state.
  * Tracker assignment remains accessible after the model has finished downloading.
  * Improved accessibility for the card’s expansion controls, including clearer expanded and collapsed states.
  * Expansion behavior is now consistent before, during, and after model download.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->