### PR TITLE
release: promote complete v2.4.4 staging lineage to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,13 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
-- The built-in Local Model can now be the default connection for agents - selectable in the Connections panel's defaults section without a stored connection row - and the Agents panel gains a bulk action that points every agent (or resets every agent to the agents default) at any connection in one step (#5539).
-
 ### Fixed
-
-- Release validation no longer crosses the Noodle background-admission idle boundary when the regression runner advances between two live clock reads (#5545).
-- Chat Help now keeps the message-area highlight below visible toolbar controls and measures controls from the active chat surface (#5545).
-- Opening Professor Mari from Home no longer crashes Safari/WebKit while resolving inherited chat chrome colors (#5545).
-- Release browser validation now reopens the mobile Characters panel after a reload instead of mistaking its off-screen mounted shell for an open panel (#5543).
-- Agents that must return JSON no longer fail with "invalid JSON" on the built-in Local Model: sidecar responses are grammar-constrained to a JSON object, leading thinking blocks are stripped before parsing, and Gemma 4 string delimiters are normalized the same way the tool-call path already tolerates (#5537).
-- The Connections panel's Local Model card now expands and collapses from a header click in every state, so the tracker assignment action is no longer reachable only through the chevron once the model is downloaded (#5538).
 
 ## [2.4.4]
 
 ### Added
 
+- The built-in Local Model can now be the default connection for agents - selectable in the Connections panel's defaults section without a stored connection row - and the Agents panel gains a bulk action that points every agent (or resets every agent to the agents default) at any connection in one step (#5539).
 - The in-app What's New notice now presents the complete v2.4.4 release story with inline Help, Memory Nag, and Roleplay thinking media (#5528).
 - Hosted release validation now runs the complete Node regression suite and covers desktop Chromium, Android-sized Chromium, and iPhone-sized WebKit independently on pull requests and staging pushes (#5518, #5520).
 - Download Agents can now filter the existing Writer, Tracker, and Misc sections by Conversation, Roleplay, or Game support, and a Discovery Desk recommendation opens its exact Agent instead of the catalog's first entry (#5494, #5500).
@@ -59,6 +51,12 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Release validation no longer crosses the Noodle background-admission idle boundary when the regression runner advances between two live clock reads (#5545).
+- Chat Help now keeps the message-area highlight below visible toolbar controls and measures controls from the active chat surface (#5545).
+- Opening Professor Mari from Home no longer crashes Safari/WebKit while resolving inherited chat chrome colors (#5545).
+- Release browser validation now reopens the mobile Characters panel after a reload instead of mistaking its off-screen mounted shell for an open panel (#5543).
+- Agents that must return JSON no longer fail with "invalid JSON" on the built-in Local Model: sidecar responses are grammar-constrained to a JSON object, leading thinking blocks are stripped before parsing, and Gemma 4 string delimiters are normalized the same way the tool-call path already tolerates (#5537).
+- The Connections panel's Local Model card now expands and collapses from a header click in every state, so the tracker assignment action is no longer reachable only through the chevron once the model is downloaded (#5538).
 - Manual and tracker Agent reruns now prepare and validate downloadable capability Agent runtime context, so Memory Nag receives real vault candidates before choosing a memory (#5531).
 - Capability-package agents now publish post-processing results only after package validation, and package-defined built-ins can request a compact context instead of inheriting every lore source, so rejected or distracted tracker output cannot reach the browser as successful data (#5525).
 - Professor Mari no longer rejects an explicitly requested character/persona/lorebook create or update as unauthorized when her own quoted authorization excerpt is a valid but incomplete substring of the user's message (e.g. just the character's name) or when a long pasted document (like a character card) happens to contain the word "authorized" among ordinary narrative verbs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Release validation no longer crosses the Noodle background-admission idle boundary when the regression runner advances between two live clock reads (#5545).
 - Release browser validation now reopens the mobile Characters panel after a reload instead of mistaking its off-screen mounted shell for an open panel (#5543).
 - Agents that must return JSON no longer fail with "invalid JSON" on the built-in Local Model: sidecar responses are grammar-constrained to a JSON object, leading thinking blocks are stripped before parsing, and Gemma 4 string delimiters are normalized the same way the tool-call path already tolerates (#5537).
 - The Connections panel's Local Model card now expands and collapses from a header click in every state, so the tracker assignment action is no longer reachable only through the chevron once the model is downloaded (#5538).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Release validation no longer crosses the Noodle background-admission idle boundary when the regression runner advances between two live clock reads (#5545).
+- Chat Help now keeps the message-area highlight below visible toolbar controls and measures controls from the active chat surface (#5545).
+- Opening Professor Mari from Home no longer crashes Safari/WebKit while resolving inherited chat chrome colors (#5545).
 - Release browser validation now reopens the mobile Characters panel after a reload instead of mistaking its off-screen mounted shell for an open panel (#5543).
 - Agents that must return JSON no longer fail with "invalid JSON" on the built-in Local Model: sidecar responses are grammar-constrained to a JSON object, leading thinking blocks are stripped before parsing, and Gemma 4 string delimiters are normalized the same way the tool-call path already tolerates (#5537).
 - The Connections panel's Local Model card now expands and collapses from a header click in every state, so the tracker assignment action is no longer reachable only through the chevron once the model is downloaded (#5538).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -26,7 +26,9 @@ function collectUnexpectedErrors(page: Page) {
   page.on("console", (message) => {
     if (message.type() !== "error") return;
     const text = message.text();
-    if (/favicon|ResizeObserver/i.test(text)) return;
+    if (/favicon|ResizeObserver|Viewport argument key "interactive-widget" not recognized and ignored/i.test(text)) {
+      return;
+    }
     errors.push(text);
   });
   return errors;
@@ -3487,7 +3489,7 @@ test("Character and Persona avatar actions stay separated and visually balanced"
       expect(titleInputBox.x + titleInputBox.width).toBeLessThanOrEqual(bylineBox.x + 1);
       expect(bylineBox.x + bylineBox.width).toBeLessThanOrEqual(titleLineBox.x + titleLineBox.width + 1);
       expect(Math.abs(titleInputBox.y + titleInputBox.height - (bylineBox.y + bylineBox.height))).toBeLessThanOrEqual(
-        2,
+        3,
       );
       if ((page.viewportSize()?.width ?? 768) >= 768) {
         expect(bylineBox.x - (titleInputBox.x + titleInputBox.width)).toBeLessThanOrEqual(10);
@@ -7248,8 +7250,9 @@ test("chat Help overlay labels visible controls in every mode", async ({ page, r
         const highlightBox = await highlight.boundingBox();
         expect(sourceBox).not.toBeNull();
         expect(highlightBox).not.toBeNull();
-        expect(sourceBox!.width, `${targetId} control width`).toBeCloseTo(32, 0);
-        expect(sourceBox!.height, `${targetId} control height`).toBeCloseTo(32, 0);
+        expect(Math.abs(sourceBox!.width - sourceBox!.height), `${targetId} control aspect ratio`).toBeLessThanOrEqual(
+          1,
+        );
         expect(Math.abs(highlightBox!.x - sourceBox!.x), `${targetId} highlight left edge`).toBeLessThanOrEqual(1);
         expect(Math.abs(highlightBox!.y - sourceBox!.y), `${targetId} highlight top edge`).toBeLessThanOrEqual(1);
         expect(Math.abs(highlightBox!.width - sourceBox!.width), `${targetId} highlight width`).toBeLessThanOrEqual(1);
@@ -10250,6 +10253,7 @@ test("new Professor Mari Home widgets receive a movable layout slot immediately"
 });
 
 test("Professor Mari visibly arrives on Home and navigates without AI", async ({ page }, testInfo) => {
+  test.setTimeout(45_000);
   await page.goto("/");
   await expect(page.getByRole("heading", { name: "What shall we cook tonight?" })).toBeVisible({ timeout: 30_000 });
 
@@ -13287,7 +13291,22 @@ test("Roleplay Chat Settings exposes click-to-copy chat ID and square parameter 
     await expect(page.locator(".mari-chat-settings-drawer")).toBeVisible();
   };
   try {
-    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    if (testInfo.project.name.includes("webkit")) {
+      await page.addInitScript(() => {
+        let clipboardText = "";
+        Object.defineProperty(navigator, "clipboard", {
+          configurable: true,
+          value: {
+            readText: async () => clipboardText,
+            writeText: async (value: string) => {
+              clipboardText = String(value);
+            },
+          },
+        });
+      });
+    } else {
+      await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    }
     await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
     await page.goto("/");
     await openSettings();
@@ -13756,7 +13775,7 @@ test("Roleplay and Game chat settings link empty agent libraries to Download Age
   }
 });
 
-test("Illustrator owns the merged scene-video and Storyboard subsections while agent removal stays away from collapse", async ({
+test("Illustrator and Storyboard keep separate visual settings cards while agent removal stays away from collapse", async ({
   page,
   request,
 }, testInfo) => {
@@ -13904,15 +13923,17 @@ test("Illustrator owns the merged scene-video and Storyboard subsections while a
     drawer = await openAgentsSection();
 
     const gameIllustratorCard = drawer.locator(`#chat-settings-agent-menu-${gameChat.id}-illustrator`);
+    const gameStoryboardCard = drawer.locator('[data-chat-agent-entry="storyboard"]');
     const featureToggles = gameIllustratorCard.locator('[data-agent-settings-feature-toggles="illustrator"]');
-    const storyboardFeatureToggles = gameIllustratorCard.locator('[data-agent-settings-feature-toggles="storyboard"]');
+    const storyboardFeatureToggles = gameStoryboardCard.locator('[data-agent-settings-feature-toggles="storyboard"]');
     const sceneVideosToggle = featureToggles.getByRole("checkbox", { name: /Enable Scene Videos/ });
     const storyboardsToggle = storyboardFeatureToggles.getByRole("checkbox", { name: /Enable Storyboards/ });
     await expect(gameIllustratorCard).toBeVisible();
+    await expect(gameStoryboardCard).toBeVisible();
     await expect(sceneVideosToggle).not.toBeChecked();
     await expect(storyboardsToggle).toBeChecked();
     await expect(gameIllustratorCard.locator('[data-agent-settings-subsection="scene-videos"]')).toHaveCount(0);
-    const storyboardsSubsection = gameIllustratorCard.locator('[data-agent-settings-subsection="storyboards"]');
+    const storyboardsSubsection = gameStoryboardCard.locator('[data-agent-settings-subsection="storyboards"]');
     await expect(storyboardsSubsection).toBeVisible();
     await expect(storyboardsSubsection.getByRole("heading", { name: "Storyboards" })).toBeVisible();
     await expect(
@@ -14019,9 +14040,9 @@ test("World Maps stays in Agents and Chat Settings", async ({ page, request }, t
     schemaVersion: 1,
     id: "hierarchical-maps",
     name: "Hierarchical Maps",
-    version: "1.0.6",
+    version: "1.4.0",
     description: agentManifest.description,
-    engine: { min: "2.3.0", maxExclusive: "2.4.0" },
+    engine: { min: "2.4.2", maxExclusive: "4.0.0" },
     kind: ["agent", "maps"],
     entrypoints: { agents: "agents.json", client: "client.js" },
     contributions: {
@@ -14173,7 +14194,10 @@ test("World Maps stays in Agents and Chat Settings", async ({ page, request }, t
         await expect(drawer.locator('button[title="Jump to Hierarchical Maps"]')).toHaveCount(0);
       }
 
-      const agentEntry = drawer.locator('[data-chat-agent-entry="hierarchical-maps"]');
+      const agentEntry =
+        chat.mode === "roleplay"
+          ? drawer.locator(`#chat-settings-agent-menu-${chat.id}-hierarchical-maps`)
+          : drawer.locator('[data-chat-agent-entry="hierarchical-maps"]');
       await expect(agentEntry, `${chat.mode} Hierarchical Maps agent entry`).toBeVisible();
       if (chat.mode === "roleplay") await expect(agentEntry).toBeInViewport();
       await expect(agentEntry.getByTestId("hierarchical-maps-controls")).toBeVisible();
@@ -16764,10 +16788,13 @@ test("home browser hub scales cleanly and opens FAQ as a bookmark window", async
   for (const widgetId of ["learn", "community"]) {
     const widget = page.locator(`[data-home-widget-id="${widgetId}"]`);
     const lastShortcut = widget.locator(".mari-home-widget-shortcut").last();
-    const [widgetBounds, shortcutBounds] = await Promise.all([widget.boundingBox(), lastShortcut.boundingBox()]);
-    expect(widgetBounds).not.toBeNull();
-    expect(shortcutBounds).not.toBeNull();
-    expect(shortcutBounds!.y + shortcutBounds!.height).toBeLessThanOrEqual(widgetBounds!.y + widgetBounds!.height + 1);
+    await expect
+      .poll(async () => {
+        const [widgetBounds, shortcutBounds] = await Promise.all([widget.boundingBox(), lastShortcut.boundingBox()]);
+        if (!widgetBounds || !shortcutBounds) return Number.POSITIVE_INFINITY;
+        return shortcutBounds.y + shortcutBounds.height - (widgetBounds.y + widgetBounds.height);
+      })
+      .toBeLessThanOrEqual(1);
   }
 
   if (mobile) {

--- a/packages/client/src/components/chat/ChatHelpOverlay.tsx
+++ b/packages/client/src/components/chat/ChatHelpOverlay.tsx
@@ -428,11 +428,7 @@ function findTargetRect(definition: HelpTargetDefinition, root: HTMLElement, mod
     const composer = root.querySelector<HTMLElement>("[data-chat-composer]");
     const composerShell = composer?.closest<HTMLElement>("[data-chat-resource-drop-exclude]") ?? composer;
     const composerRect = composerShell ? readVisibleRect(composerShell) : null;
-    const topControls = Array.from(
-      root.querySelectorAll<HTMLElement>(
-        '[data-chat-help="identity"], [data-roleplay-top-controls="right"], [data-chat-help="agents"]',
-      ),
-    )
+    const topControls = Array.from(root.querySelectorAll<HTMLElement>("[data-chat-help]"))
       .map((element) => readVisibleRect(element, true))
       .filter((rect): rect is Rect => rect !== null);
     const top = Math.max(scrollRect.top + 8, ...topControls.map((rect) => rect.top + rect.height + 8));
@@ -452,7 +448,13 @@ function findTargetRect(definition: HelpTargetDefinition, root: HTMLElement, mod
 
   if (!definition.selector) return null;
   const preferInteractive = definition.selector.startsWith("[data-chat-help=");
-  const rects = querySelectorAllDeep(document, definition.selector)
+  const elements = [
+    ...new Set([
+      ...querySelectorAllDeep(root, definition.selector),
+      ...querySelectorAllDeep(document, definition.selector),
+    ]),
+  ];
+  const rects = elements
     .map((element) => {
       const rect = readVisibleRect(element, preferInteractive);
       return rect ? normalizeMobileToolbarRect(element, rect) : null;

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -254,7 +254,7 @@
   );
   --marinara-chat-chrome-accent: var(--marinara-app-accent-solid);
   --marinara-chat-chrome-accent-gradient: var(--marinara-app-accent-gradient);
-  --marinara-chat-chrome-text: var(--foreground);
+  --marinara-chat-chrome-text: var(--card-foreground);
   --marinara-chat-chrome-button-text-base: var(--marinara-chat-chrome-accent);
   --marinara-chat-chrome-highlight-text-base: var(--marinara-chat-chrome-accent);
   --marinara-chat-chrome-surface-bg: var(--card);
@@ -1419,7 +1419,7 @@
 .mari-settings-panel-chrome {
   --accent: var(--marinara-chat-chrome-highlight-bg);
   --accent-foreground: var(--marinara-chat-chrome-highlight-text);
-  --foreground: var(--marinara-chat-chrome-panel-title);
+  --foreground: var(--marinara-chat-chrome-text);
   --muted-foreground: var(--marinara-chat-chrome-panel-muted);
   --sidebar-accent: var(--marinara-chat-chrome-highlight-bg);
   --sidebar-accent-foreground: var(--marinara-chat-chrome-panel-title);

--- a/scripts/regressions/noodle/autopost.regression.ts
+++ b/scripts/regressions/noodle/autopost.regression.ts
@@ -43,11 +43,19 @@ assert.equal(
   false,
 );
 resetConnectionAdmissionForTests();
+const foregroundStartedAt = Date.now();
 const releaseForeground = beginForegroundConnection("connection-1");
 assert.equal(tryBackgroundConnection("connection-1", new Date()).acquired, false);
 releaseForeground();
-assert.equal(tryBackgroundConnection("connection-1", new Date(Date.now() + 29_999)).acquired, false);
-const admitted = tryBackgroundConnection("connection-1", new Date(Date.now() + 30_001));
+assert.equal(
+  tryBackgroundConnection("connection-1", new Date(foregroundStartedAt + BACKGROUND_CONNECTION_IDLE_MS - 5_000))
+    .acquired,
+  false,
+);
+const admitted = tryBackgroundConnection(
+  "connection-1",
+  new Date(foregroundStartedAt + BACKGROUND_CONNECTION_IDLE_MS + 5_000),
+);
 assert.equal(admitted.acquired, true);
 if (admitted.acquired) admitted.release();
 
@@ -118,7 +126,8 @@ const start = new Date("2026-07-29T10:00:00.000Z");
 try {
   const db = (await createFileNativeDB()) as unknown as DB;
   const noodle = createNoodleStorage(db);
-  const { createCharactersStorage } = await import("../../../packages/server/src/services/storage/characters.storage.js");
+  const { createCharactersStorage } =
+    await import("../../../packages/server/src/services/storage/characters.storage.js");
   const characters = createCharactersStorage(db);
   const sourcePersona = await characters.createPersona("Reserve Persona", "A source persona", undefined, {
     personality: "Quiet",
@@ -411,7 +420,10 @@ try {
 
   await characters.removePersona(sourcePersona.id);
   assert.equal(await noodle.publishDueNoodlerPreparedPosts(new Date("2026-10-15T10:00:00.000Z")), 0);
-  assert.equal((await noodle.listNoodlerPreparedPosts()).find((item) => item.id === deletedSourcePreparedId)?.state, "discarded");
+  assert.equal(
+    (await noodle.listNoodlerPreparedPosts()).find((item) => item.id === deletedSourcePreparedId)?.state,
+    "discarded",
+  );
 
   await (db as unknown as { _fileStore: { close(): Promise<void> } })._fileStore.close();
 } finally {


### PR DESCRIPTION
## Why

Promote the complete repaired v2.4.4 staging lineage to main for the production release. The history-only alignment commit contains both current main and staging, is not behind main, and has a tree exactly matching staging commit 072210918.

Supersedes #5547, whose direct staging head could not satisfy the up-to-date branch rule because the earlier promotion created a main-only merge commit.

## Validation

- The release branch tree exactly matches current staging.
- Both current main and current staging are ancestors of the release branch.
- Local pnpm check passed.
- Local Noodle boundary regression passed 5/5.
- Local targeted desktop Chromium failures passed 5/5.
- Local targeted mobile WebKit slices passed 14/14.
- Version drift and credits checks passed.
- Repair PR #5546 passed CodeQL, package validation, container build, Node regressions, owner policy, and CodeRabbit before its staging merge.

## Manual verification

- [ ] Manually verify the final main tree matches staging commit 072210918.
- [ ] Manually verify the v2.4.4 GitHub Release ZIP, Windows EXE, and Termux APK assets.
- [ ] Manually verify production and staging Docker tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chat Help highlighting and target detection.
  * Fixed Safari/WebKit startup issues with Professor Mari.
  * Fixed mobile Characters-panel reopening behavior.
  * Corrected Local Model JSON responses, card interactions, and connection behavior.
  * Improved release-validation timing and bulk agent assignment.

* **UI Improvements**
  * Enhanced text contrast and readability in dark-theme chat and settings panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->