### PR TITLE
Preserve the Universal Preset during Permanent Delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Permanent Delete now preserves Marinara's stock Universal Preset and its prompt structure while removing editable presets (#5568).
+
 ## [2.4.4]
 
 ### Added

--- a/packages/server/src/routes/admin.routes.ts
+++ b/packages/server/src/routes/admin.routes.ts
@@ -225,6 +225,12 @@ export async function adminRoutes(app: FastifyInstance) {
     }
 
     if (requestedScopes.includes("presets")) {
+      const defaultPreset = (
+        await db
+          .select({ id: schema.promptPresets.id })
+          .from(schema.promptPresets)
+          .where(eq(schema.promptPresets.isDefault, "true"))
+      )[0];
       const stockPreset = (
         await db
           .select({ id: schema.promptPresets.id })
@@ -254,6 +260,12 @@ export async function adminRoutes(app: FastifyInstance) {
           ? db.delete(schema.promptPresets).where(ne(schema.promptPresets.id, stockPresetId)).run()
           : db.delete(schema.promptPresets).run(),
       );
+      if (stockPresetId && defaultPreset && defaultPreset.id !== stockPresetId) {
+        await db
+          .update(schema.promptPresets)
+          .set({ isDefault: "true" })
+          .where(eq(schema.promptPresets.id, stockPresetId));
+      }
       await runDelete("library_folders:presets", () =>
         db.delete(schema.libraryFolders).where(eq(schema.libraryFolders.scope, "presets")).run(),
       );

--- a/packages/server/src/routes/admin.routes.ts
+++ b/packages/server/src/routes/admin.routes.ts
@@ -6,7 +6,7 @@ import { eq, ne } from "../db/file-query.js";
 import { spawn } from "node:child_process";
 import { existsSync, readdirSync, rmSync } from "fs";
 import { join } from "path";
-import { PROFESSOR_MARI_ID, TTS_SETTINGS_KEY } from "@marinara-engine/shared";
+import { MARINARA_UNIVERSAL_PRESET_SYSTEM_KEY, PROFESSOR_MARI_ID, TTS_SETTINGS_KEY } from "@marinara-engine/shared";
 import { DATA_DIR } from "../utils/data-dir.js";
 import * as schema from "../db/schema/index.js";
 import { requirePrivilegedAccess } from "../middleware/privileged-gate.js";
@@ -225,10 +225,35 @@ export async function adminRoutes(app: FastifyInstance) {
     }
 
     if (requestedScopes.includes("presets")) {
-      await runDelete("prompt_sections", () => db.delete(schema.promptSections).run());
-      await runDelete("prompt_groups", () => db.delete(schema.promptGroups).run());
-      await runDelete("choice_blocks", () => db.delete(schema.choiceBlocks).run());
-      await runDelete("prompt_presets", () => db.delete(schema.promptPresets).run());
+      const stockPreset = (
+        await db
+          .select({ id: schema.promptPresets.id })
+          .from(schema.promptPresets)
+          .where(eq(schema.promptPresets.systemKey, MARINARA_UNIVERSAL_PRESET_SYSTEM_KEY))
+          .limit(1)
+      )[0];
+      const stockPresetId = stockPreset?.id;
+
+      await runDelete("prompt_sections", () =>
+        stockPresetId
+          ? db.delete(schema.promptSections).where(ne(schema.promptSections.presetId, stockPresetId)).run()
+          : db.delete(schema.promptSections).run(),
+      );
+      await runDelete("prompt_groups", () =>
+        stockPresetId
+          ? db.delete(schema.promptGroups).where(ne(schema.promptGroups.presetId, stockPresetId)).run()
+          : db.delete(schema.promptGroups).run(),
+      );
+      await runDelete("choice_blocks", () =>
+        stockPresetId
+          ? db.delete(schema.choiceBlocks).where(ne(schema.choiceBlocks.presetId, stockPresetId)).run()
+          : db.delete(schema.choiceBlocks).run(),
+      );
+      await runDelete("prompt_presets", () =>
+        stockPresetId
+          ? db.delete(schema.promptPresets).where(ne(schema.promptPresets.id, stockPresetId)).run()
+          : db.delete(schema.promptPresets).run(),
+      );
       await runDelete("library_folders:presets", () =>
         db.delete(schema.libraryFolders).where(eq(schema.libraryFolders.scope, "presets")).run(),
       );

--- a/scripts/regressions/admin-preset-expunge.regression.ts
+++ b/scripts/regressions/admin-preset-expunge.regression.ts
@@ -108,10 +108,18 @@ try {
     payload: { confirm: true, scopes: ["presets"] },
   });
   assert.equal(scopedResponse.statusCode, 200, "scoped preset expunge must succeed");
-  assert.deepEqual(
-    await stockSnapshot(),
-    stockBeforeScopedExpunge,
-    "scoped preset expunge must preserve the stock preset and every owned child row",
+  const stockAfterScopedExpunge = await stockSnapshot();
+  assert.deepEqual(stockAfterScopedExpunge.groups, stockBeforeScopedExpunge.groups);
+  assert.deepEqual(stockAfterScopedExpunge.sections, stockBeforeScopedExpunge.sections);
+  assert.deepEqual(stockAfterScopedExpunge.choiceBlocks, stockBeforeScopedExpunge.choiceBlocks);
+  assert.deepEqual(stockAfterScopedExpunge.preset, {
+    ...stockBeforeScopedExpunge.preset,
+    isDefault: "true",
+  });
+  assert.equal(
+    (await presets.getDefault())?.id,
+    stockBeforeScopedExpunge.preset.id,
+    "scoped preset expunge must restore the stock preset as default",
   );
   await assertEditableFixtureDeleted(scopedEditablePresetId);
 
@@ -123,10 +131,18 @@ try {
     payload: { confirm: true },
   });
   assert.equal(clearAllResponse.statusCode, 200, "clear-all compatibility route must succeed");
-  assert.deepEqual(
-    await stockSnapshot(),
-    stockBeforeClearAll,
-    "clear-all must preserve the stock preset and every owned child row",
+  const stockAfterClearAll = await stockSnapshot();
+  assert.deepEqual(stockAfterClearAll.groups, stockBeforeClearAll.groups);
+  assert.deepEqual(stockAfterClearAll.sections, stockBeforeClearAll.sections);
+  assert.deepEqual(stockAfterClearAll.choiceBlocks, stockBeforeClearAll.choiceBlocks);
+  assert.deepEqual(stockAfterClearAll.preset, {
+    ...stockBeforeClearAll.preset,
+    isDefault: "true",
+  });
+  assert.equal(
+    (await presets.getDefault())?.id,
+    stockBeforeClearAll.preset.id,
+    "clear-all must preserve a valid stock preset default",
   );
   await assertEditableFixtureDeleted(clearAllEditablePresetId);
   assert.deepEqual(

--- a/scripts/regressions/admin-preset-expunge.regression.ts
+++ b/scripts/regressions/admin-preset-expunge.regression.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isStockMarinaraUniversalPreset } from "../../packages/shared/src/types/prompt.js";
+
+const dataDir = mkdtempSync(join(tmpdir(), "marinara-admin-preset-expunge-"));
+const previousDataDir = process.env.DATA_DIR;
+const previousFileStorageDir = process.env.FILE_STORAGE_DIR;
+const previousMarinaraFileStorageDir = process.env.MARINARA_FILE_STORAGE_DIR;
+const previousNodeEnv = process.env.NODE_ENV;
+const previousLiteMode = process.env.MARINARA_LITE;
+
+let app: {
+  close(): Promise<void>;
+  ready(): Promise<unknown>;
+  inject(options: Record<string, unknown>): Promise<{ statusCode: number }>;
+} | null = null;
+
+try {
+  const fileStorageDir = join(dataDir, "file-storage");
+  process.env.DATA_DIR = dataDir;
+  process.env.FILE_STORAGE_DIR = fileStorageDir;
+  process.env.MARINARA_FILE_STORAGE_DIR = fileStorageDir;
+  process.env.NODE_ENV = "test";
+  process.env.MARINARA_LITE = "true";
+
+  const [{ buildApp }, { getDB }, { createPromptsStorage }, { createLibraryFoldersStorage }] = await Promise.all([
+    import("../../packages/server/src/app.js"),
+    import("../../packages/server/src/db/connection.js"),
+    import("../../packages/server/src/services/storage/prompts.storage.js"),
+    import("../../packages/server/src/services/storage/library-folders.storage.js"),
+  ]);
+
+  app = await buildApp();
+  await app.ready();
+
+  const db = await getDB();
+  const presets = createPromptsStorage(db);
+  const folders = createLibraryFoldersStorage(db);
+
+  async function stockSnapshot() {
+    const stockPreset = (await presets.list()).find(isStockMarinaraUniversalPreset);
+    assert.ok(stockPreset, "startup must seed the stock Universal Preset");
+    const [groups, sections, choiceBlocks] = await Promise.all([
+      presets.listGroups(stockPreset.id),
+      presets.listSections(stockPreset.id),
+      presets.listChoiceBlocksForPreset(stockPreset.id),
+    ]);
+    return { preset: stockPreset, groups, sections, choiceBlocks };
+  }
+
+  async function createEditableFixture(label: string, makeDefault: boolean, imitateStock = false) {
+    const preset = await presets.create({
+      name: imitateStock ? "Marinara's Universal Preset" : `${label} preset`,
+      description: "Must be deleted",
+      author: imitateStock ? "Marinara" : undefined,
+    });
+    assert.ok(preset);
+    const group = await presets.createGroup({
+      presetId: preset.id,
+      name: `${label} group`,
+      parentGroupId: null,
+      order: 100,
+      enabled: true,
+    });
+    assert.ok(group);
+    const section = await presets.createSection({
+      presetId: preset.id,
+      identifier: `${label}-section`,
+      name: `${label} section`,
+      content: "Editable prompt content",
+      groupId: group.id,
+    });
+    assert.ok(section);
+    const choiceBlock = await presets.createChoiceBlock({
+      presetId: preset.id,
+      variableName: `${label}_choice`,
+      question: "Choose one",
+      options: [{ id: `${label}-option`, label: "Option", value: "option" }],
+      multiSelect: false,
+      separator: ", ",
+      randomPick: false,
+      displayMode: "auto",
+      optionSort: "manual",
+    });
+    assert.ok(choiceBlock);
+    const folder = await folders.create("presets", { name: `${label} folder` });
+    assert.ok(folder);
+    await folders.moveItems("presets", { folderId: folder.id, itemIds: [preset.id] });
+    if (makeDefault) await presets.setDefault(preset.id);
+    return preset.id;
+  }
+
+  async function assertEditableFixtureDeleted(presetId: string) {
+    assert.equal(await presets.getById(presetId), null, "editable preset row must be deleted");
+    assert.deepEqual(await presets.listGroups(presetId), [], "editable preset groups must be deleted");
+    assert.deepEqual(await presets.listSections(presetId), [], "editable preset sections must be deleted");
+    assert.deepEqual(await presets.listChoiceBlocksForPreset(presetId), [], "editable preset choices must be deleted");
+    assert.deepEqual(await folders.list("presets"), [], "editable preset folders must be deleted");
+  }
+
+  const scopedEditablePresetId = await createEditableFixture("scoped", true, true);
+  const stockBeforeScopedExpunge = await stockSnapshot();
+  const scopedResponse = await app.inject({
+    method: "POST",
+    url: "/api/admin/expunge",
+    payload: { confirm: true, scopes: ["presets"] },
+  });
+  assert.equal(scopedResponse.statusCode, 200, "scoped preset expunge must succeed");
+  assert.deepEqual(
+    await stockSnapshot(),
+    stockBeforeScopedExpunge,
+    "scoped preset expunge must preserve the stock preset and every owned child row",
+  );
+  await assertEditableFixtureDeleted(scopedEditablePresetId);
+
+  const clearAllEditablePresetId = await createEditableFixture("clear_all", false);
+  const stockBeforeClearAll = await stockSnapshot();
+  const clearAllResponse = await app.inject({
+    method: "POST",
+    url: "/api/admin/clear-all",
+    payload: { confirm: true },
+  });
+  assert.equal(clearAllResponse.statusCode, 200, "clear-all compatibility route must succeed");
+  assert.deepEqual(
+    await stockSnapshot(),
+    stockBeforeClearAll,
+    "clear-all must preserve the stock preset and every owned child row",
+  );
+  await assertEditableFixtureDeleted(clearAllEditablePresetId);
+  assert.deepEqual(
+    (await presets.list()).map((preset) => preset.id),
+    [stockBeforeClearAll.preset.id],
+    "only the stock Universal Preset may remain after clear-all",
+  );
+} finally {
+  await app?.close();
+  if (previousDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = previousDataDir;
+  if (previousFileStorageDir === undefined) delete process.env.FILE_STORAGE_DIR;
+  else process.env.FILE_STORAGE_DIR = previousFileStorageDir;
+  if (previousMarinaraFileStorageDir === undefined) delete process.env.MARINARA_FILE_STORAGE_DIR;
+  else process.env.MARINARA_FILE_STORAGE_DIR = previousMarinaraFileStorageDir;
+  if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = previousNodeEnv;
+  if (previousLiteMode === undefined) delete process.env.MARINARA_LITE;
+  else process.env.MARINARA_LITE = previousLiteMode;
+  rmSync(dataDir, { recursive: true, force: true });
+}
+
+console.info("Admin preset expunge regression passed.");


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #5568

## Why this change

Permanent Delete currently removes Marinara's immutable Universal Preset, leaving affected users without the stock prompt structure until startup seeding repairs it. The destructive action should remove only editable presets and their organization data.

## What changed

- Resolve the stock Universal Preset through its reserved `systemKey` before preset expunge.
- Preserve that preset and its groups, sections, and choice blocks in both scoped expunge and the Clear All compatibility route.
- Continue deleting editable presets, their child rows, and preset folders.
- Add a regression covering both routes, stock-name/author lookalikes, editable defaults, child rows, and folders.
- Add an `[Unreleased]` changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passed locally.
- `pnpm regression` passed: 159/159.
- Targeted `admin-preset-expunge` regression passed after the final negative-control update.
- Local CodeRabbit CLI review completed with zero findings across all three changed files.
- An isolated production server reached ready state, but browser click-through could not run on this host because Chromium requires the unavailable `libnspr4.so` shared library and no system browser is installed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

The user-visible fix is documented in `CHANGELOG.md`. No version, schema, public API, client, localization, or user-facing documentation changes are required.

## UI evidence (if applicable)

No UI code changed. Browser evidence is unavailable due to the host dependency limitation described above.

## Proof

The regression builds the real Fastify app, creates the seeded stock preset plus an editable preset and owned child rows, invokes both deletion endpoints, and verifies that the stock row and its original children remain byte-for-byte unchanged while editable data and preset folders are removed. A user preset imitating the stock name and author is also deleted, proving that only the reserved `marinara-universal-preset` system key grants protection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Permanent Delete now preserves the stock Universal Preset and its associated prompt structure.
  - Editable presets, folders, groups, sections, and choices continue to be removed as expected.
  - Scoped deletion and clear-all deletion now behave consistently.

- **Documentation**
  - Added an Unreleased changelog entry describing preset deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->