### PR TITLE
test(e2e): follow the relocated context usage indicator in the Professor Mari budget case

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -14814,17 +14814,18 @@ test("Professor Mari shows the latest context budget when token usage is enabled
         useUIStore: {
           getState: () => {
             setChatChromeTextColor: (value: string) => void;
-            setShowTokenUsage: (value: boolean) => void;
+            setShowContextUsage: (value: boolean) => void;
           };
         };
       };
       useUIStore.getState().setChatChromeTextColor("#14b8a6");
-      useUIStore.getState().setShowTokenUsage(true);
+      useUIStore.getState().setShowContextUsage(true);
     });
     await page.getByRole("tab", { name: "Professor", exact: true }).click();
 
     const window = page.locator('[data-component="HomeProfessorMariChat.Window"]');
-    const budget = window.locator('[data-component="HomeProfessorMariChat.ContextBudget"]');
+    await window.getByRole("button", { name: "Select connection" }).click();
+    const budget = window.locator('[data-component="ContextBudget"]');
     const configuredChromeTextColor = await page.evaluate(() =>
       document.documentElement.style.getPropertyValue("--marinara-chat-chrome-text").trim(),
     );


### PR DESCRIPTION
## Linked issue

Closes #5589 (the consistently failing `core-flows.e2e.ts:14754` half; the rotating flaky cases listed there are a separate follow-up)

## Why this change

The Release Regression Matrix has been red on every `staging` push since 2026-08-25. The one case failing consistently in all three browser lanes is `core-flows.e2e.ts:14754` — "Professor Mari shows the latest context budget when token usage is enabled" — failing with `expect(locator).toContainText → element(s) not found`.

Root cause: the context-usage work from #5577 (PR #5579, commits d3c4a97 and cd87709) reworked the Professor Mari budget display:

- The inline `ProfessorMariContextBudgetIndicator` (`data-component="HomeProfessorMariChat.ContextBudget"`) was replaced by the shared `ContextBudgetIndicator` (`data-component="ContextBudget"`).
- The gate moved from the `showTokenUsage` UI-store flag to the new `showContextUsage` setting.
- The indicator no longer renders inline above the composer — it now lives inside the connection menu popover (with a gauge ring on the connection button).

The e2e case was never updated, so its locator matches nothing and the matrix inherits a guaranteed red lane on every run — which buries any real e2e regression a PR introduces.

## What changed

- `e2e/core-flows.e2e.ts` (the `14754` case only):
  - enable `showContextUsage` via `setShowContextUsage(true)` instead of the old `setShowTokenUsage(true)`;
  - open the connection menu (`Select connection` button) before asserting;
  - target `[data-component="ContextBudget"]` inside the Professor Mari window.
- All existing assertions (label/value text, chrome-token colors, progressbar `aria-valuenow`/`aria-valuemax`) are unchanged — they pass against the relocated indicator as-is.

Test-only diff; no application code touched.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran the updated case locally in all three matrix lanes: `desktop-chromium`, `mobile-chromium`, and `mobile-webkit` — all pass (previously "element(s) not found" in all three).
- The Release Regression Matrix on this PR is the real proof — the `14754` case should go green in every lane. The rotating flaky cases from #5589 may still fail; those are tracked separately.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable — test-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context usage display in end-to-end flows.
  * Updated the connection selector flow to show the simplified context budget indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->