### PR TITLE
Store memory groundwork for #5592: scoped swipe reads, shared scan, and off-heap Memory Recall embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Memory Recall embeddings now live outside the JavaScript heap as packed vectors — the largest single memory block for long roleplay profiles on phones — and recall scoring reads them directly instead of re-parsing JSON per chunk, without changing the on-disk storage format (#5592).
+- Message swipe reads are now scoped to the requested chat instead of scanning every chat's swipes on each message list, made possible by resolving list-membership filters once per query rather than per row — the cost that originally motivated the unscoped scans (#3402, #5592).
+- The file store's count queries, single-table selects, boot ordering, and emptied-shard cleanup now share hardened iteration and positive-evidence semantics, groundwork pinned by regressions for the planned partial-residency work (#5592).
 - Linux and Termux now reclaim a same-host file-storage writer lease from an earlier device boot even when the operating system has reused its recorded process ID (#5580).
 
 - Avatar generation now preserves the complete user Avatar Prompt, and OpenRouter caching remains enabled for eligible unknown models (#5552, #5574).

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -1468,7 +1468,66 @@ function defaultForColumn(column: ColumnMeta) {
   return null;
 }
 
+/**
+ * Columns whose JSON-array-of-floats string values are held in memory as
+ * Float64Array (#5592 Phase 1). Embeddings are the single largest block in a
+ * heavy profile's heap: an ~8 KB one-byte string per chunk becomes ~6 KB of
+ * off-V8-heap ArrayBuffer, and recall consumes the parsed vector directly
+ * instead of JSON.parsing every chunk per query. On disk nothing changes —
+ * rows are serialized back to the exact original text (packVectorValue packs
+ * only when the round trip is byte-identical), so this needs no
+ * STORAGE_VERSION bump and no migration.
+ */
+const VECTOR_TEXT_COLUMNS: Record<string, ReadonlySet<string>> = {
+  memory_chunks: new Set(["embedding"]),
+};
+
+function packVectorValue(value: unknown): unknown {
+  if (typeof value !== "string" || value.length < 2 || value.charCodeAt(0) !== 91 /* "[" */) return value;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed) || parsed.length === 0) return value;
+    const vector = new Float64Array(parsed.length);
+    for (let index = 0; index < parsed.length; index += 1) {
+      const entry: unknown = parsed[index];
+      if (typeof entry !== "number") return value;
+      vector[index] = entry;
+    }
+    // Pack only when re-serialization is byte-identical, so a flush can never
+    // rewrite a stored value — non-canonical text (e.g. "1.0") stays a string.
+    if (JSON.stringify(Array.from(vector)) !== value) return value;
+    return vector;
+  } catch {
+    return value;
+  }
+}
+
+function unpackVectorValue(value: unknown): unknown {
+  if (value instanceof Float64Array) return JSON.stringify(Array.from(value));
+  return value;
+}
+
+/**
+ * Serialize rows for a shard/table file, restoring packed vector columns to
+ * their original strings. A packed Float64Array would otherwise stringify as
+ * an index-keyed object and corrupt the shard. Tables without vector columns
+ * pass through with zero copying.
+ */
+function serializeTableRows(table: string, rows: Row[]): string {
+  const vectorColumns = VECTOR_TEXT_COLUMNS[table];
+  if (!vectorColumns) return JSON.stringify(rows);
+  return JSON.stringify(
+    rows.map((row) => {
+      for (const key of vectorColumns) {
+        if (row[key] instanceof Float64Array) return unpackVectorColumns(table, { ...row });
+      }
+      return row;
+    }),
+  );
+}
+
 function normalizeRow(meta: TableMeta, row: Row) {
+  const vectorColumns = VECTOR_TEXT_COLUMNS[meta.name];
   const normalized: Row = {};
   for (const column of meta.columns) {
     if (Object.prototype.hasOwnProperty.call(row, column.key)) {
@@ -1477,6 +1536,9 @@ function normalizeRow(meta: TableMeta, row: Row) {
       normalized[column.key] = row[column.dbName] ?? null;
     } else {
       normalized[column.key] = defaultForColumn(column);
+    }
+    if (vectorColumns?.has(column.key)) {
+      normalized[column.key] = packVectorValue(normalized[column.key]);
     }
   }
   return normalized;
@@ -1638,6 +1700,29 @@ function parseJsonRecord(value: unknown): Record<string, unknown> {
   }
 }
 
+/**
+ * Membership sets resolved once per condition object (#5592 Phase 0). The
+ * per-row form re-materialized the values array and ran Array.includes for
+ * EVERY scanned row — O(rows x values) plus one array allocation per row, the
+ * quadratic factor behind the #3402 post-generation stall. Entries that are
+ * neither columns nor arrays are exactly the ones resolveValue returns
+ * unchanged, so their resolved set is row-independent and cacheable. Condition
+ * objects are created fresh by file-query.ts and never mutated, which makes
+ * the WeakMap key stable even for module-scope conditions.
+ */
+const membershipSetCache = new WeakMap<object, Set<unknown>>();
+
+function membershipSet(condition: { values: unknown[] }): Set<unknown> | null {
+  const cached = membershipSetCache.get(condition);
+  if (cached) return cached;
+  for (const entry of condition.values) {
+    if (isColumn(entry) || Array.isArray(entry)) return null;
+  }
+  const set = new Set(condition.values);
+  membershipSetCache.set(condition, set);
+  return set;
+}
+
 function evaluateCondition(condition: Condition, ctx: RowContext): boolean {
   if (!condition) return true;
   if (!isFileCondition(condition)) return false;
@@ -1653,6 +1738,11 @@ function evaluateCondition(condition: Condition, ctx: RowContext): boolean {
   }
   if (condition.kind === "file-membership") {
     const value = resolveValue(condition.value, ctx);
+    // Set.has and Array.includes both compare with SameValueZero, so the fast
+    // path is behavior-identical; the per-row path remains for the (currently
+    // unused) case of column- or array-valued membership entries.
+    const set = membershipSet(condition);
+    if (set) return condition.operator === "in" ? set.has(value) : !set.has(value);
     const values = condition.values.map((entry) => resolveValue(entry, ctx));
     return condition.operator === "in" ? values.includes(value) : !values.includes(value);
   }
@@ -1693,12 +1783,28 @@ function orderSpec(ordering: Ordering, ctx: RowContext): { value: unknown; direc
   return { value: undefined, direction: "asc" };
 }
 
+/** Restore packed vector columns to their original string form on a row copy. */
+function unpackVectorColumns(table: string, row: Row): Row {
+  const vectorColumns = VECTOR_TEXT_COLUMNS[table];
+  if (!vectorColumns) return row;
+  for (const key of vectorColumns) {
+    if (row[key] instanceof Float64Array) row[key] = unpackVectorValue(row[key]);
+  }
+  return row;
+}
+
 function projectRow(ctx: RowContext, projection?: Projection) {
   if (!projection) {
+    // Unprojected selects are the compatibility surface (backup export,
+    // mari-db raw reads, generic row consumers): they receive the original
+    // string form. Projected selects keep the packed Float64Array — the fast
+    // path memory recall reads (#5592 Phase 1).
     if (ctx.joined) {
-      return Object.fromEntries(Object.entries(ctx.rows).map(([table, row]) => [table, cloneRow(row)]));
+      return Object.fromEntries(
+        Object.entries(ctx.rows).map(([table, row]) => [table, unpackVectorColumns(table, cloneRow(row))]),
+      );
     }
-    return cloneRow(ctx.rows[ctx.baseTable] ?? {});
+    return unpackVectorColumns(ctx.baseTable, cloneRow(ctx.rows[ctx.baseTable] ?? {}));
   }
 
   const output: Row = {};
@@ -1744,6 +1850,18 @@ class FileTableStore {
    * rewrites each canonically or deletes it; cleared per table afterwards.
    */
   private staleShardFiles = new Map<string, Set<string>>();
+  /**
+   * Tables whose in-memory rows are the complete row set (#5592 Phase 0).
+   * Today every table is fully resident from boot, so this always contains
+   * every table and the flush's "dirty key with no rows means the shard was
+   * emptied" inference below stays valid. A future partial-residency mode
+   * (#5592 Phase 2) must remove evicted tables from this set BEFORE dropping
+   * rows — the shard-deletion gate in saveShardedTable refuses to unlink files
+   * for tables not in it, because "no resident rows" would no longer prove
+   * "emptied by deletes". Any skipped key must then be re-queued as dirty so a
+   * later flush resolves it once residency is restored.
+   */
+  private fullyResidentTables = new Set<string>(FILE_BACKED_TABLES);
   /**
    * messageIds of swipes currently resolving to the unassigned shard. When
    * such a message is later INSERTED, its swipes silently regroup into the
@@ -2236,9 +2354,13 @@ class FileTableStore {
       else rowsByShard.set(key, [row]);
     }
     for (const [key, shardRows] of rowsByShard) {
-      await atomicWriteFile(shardFilePath(this.rootDir, table, encodeShardKey(key)), JSON.stringify(shardRows), {
-        refreshBackup: true,
-      });
+      await atomicWriteFile(
+        shardFilePath(this.rootDir, table, encodeShardKey(key)),
+        serializeTableRows(table, shardRows),
+        {
+          refreshBackup: true,
+        },
+      );
     }
 
     // Only after EVERY shard write: rename the monolith and its .bak aside.
@@ -2414,12 +2536,26 @@ class FileTableStore {
     };
   }
 
+  /**
+   * Single-table WHERE evaluation shared by count() and the no-join select path
+   * (#5592 Phase 0). One RowContext is reused across the whole scan: the
+   * evaluator reads it synchronously and never retains the reference, so
+   * per-row context allocation — previously two objects for EVERY row of the
+   * table before any filtering — only happens for rows that match, in the
+   * callers that need real contexts downstream.
+   */
+  *matchingRows(meta: TableMeta, condition: Condition | undefined): IterableIterator<Row> {
+    const ctx: RowContext = { rows: {}, baseTable: meta.name, joined: false };
+    for (const row of this.rows(meta.name)) {
+      ctx.rows[meta.name] = row;
+      if (evaluateCondition(condition, ctx)) yield row;
+    }
+  }
+
   count(table: Table, condition?: Condition) {
     const meta = getMeta(table);
     let count = 0;
-    for (const row of this.rows(meta.name)) {
-      if (evaluateCondition(condition, this.contextForRow(meta, row))) count += 1;
-    }
+    for (const _row of this.matchingRows(meta, condition)) count += 1;
     return count;
   }
 
@@ -3032,8 +3168,11 @@ class FileTableStore {
     // chats-driven alternative would strand forever. Per-shard recovery uses
     // the exact per-file pipeline the flat loop uses (.bak fallback, malformed
     // row quarantine, normalizeRow). Order matters: messages first, so the
-    // shard index exists before swipes need it.
-    for (const table of SHARDED_TABLES) {
+    // messageId->chatId shard index exists before message_swipes resolves
+    // against it — enforced structurally here rather than by the declaration
+    // order of FILE_BACKED_TABLES (#5592 Phase 0).
+    const shardLoadOrder = ["messages", ...SHARDED_TABLES.filter((table) => table !== "messages")];
+    for (const table of shardLoadOrder) {
       const meta = getMeta(table);
       const dir = shardDirPath(this.rootDir, table);
       let entries: string[] = [];
@@ -3280,7 +3419,7 @@ class FileTableStore {
     for (const [key, shardRows] of rowsByShard) {
       const encoded = encodeShardKey(key);
       if (!effectiveDirty.has(key) && known.has(encoded)) continue;
-      const serializedRows = JSON.stringify(shardRows);
+      const serializedRows = serializeTableRows(table, shardRows);
       await this.testHooks?.beforeTableWrite?.(`${table}/${encoded}`, serializedRows);
       const path = shardFilePath(this.rootDir, table, encoded);
       await atomicWriteFile(path, serializedRows, { refreshBackup: !this.backupRecoveredPaths.has(path) });
@@ -3302,6 +3441,12 @@ class FileTableStore {
     }
     for (const key of effectiveDirty) {
       if (rowsByShard.has(key)) continue;
+      // A dirty key with no rows in the regroup means the shard was emptied by
+      // deletes ONLY while the table's full row set is resident. Positive
+      // evidence, not inference from absence: under partial residency (#5592
+      // Phase 2) an evicted shard would be indistinguishable from an emptied
+      // one, and unlinking here would destroy its file and backup.
+      if (!this.fullyResidentTables.has(table)) continue;
       const encoded = encodeShardKey(key);
       if (!known.has(encoded)) continue;
       const path = shardFilePath(this.rootDir, table, encoded);
@@ -3330,7 +3475,7 @@ class FileTableStore {
       }
       const path = tableFilePath(this.rootDir, table);
       if (dirtyTables.has(table) || !existsSync(path)) {
-        const serializedRows = JSON.stringify(rows);
+        const serializedRows = serializeTableRows(table, rows);
         await this.testHooks?.beforeTableWrite?.(table, serializedRows);
         await atomicWriteFile(path, serializedRows, { refreshBackup: !this.backupRecoveredPaths.has(path) });
       }
@@ -3403,6 +3548,16 @@ class SelectQuery implements SelectQueryBuilder<any> {
   }
 
   async run() {
+    // No-join fast path (#5592 Phase 0): filter raw rows through the shared
+    // scan and build contexts only for matches. Joined queries keep the eager
+    // context array below — the join loop needs a context per base row.
+    if (this.joins.length === 0) {
+      const matched: RowContext[] = [];
+      for (const row of this.store.matchingRows(this.fromMeta, this.condition)) {
+        matched.push(this.store.contextForRow(this.fromMeta, row));
+      }
+      return this.finish(matched);
+    }
     let contexts = this.store.rows(this.fromMeta.name).map((row) => this.store.contextForRow(this.fromMeta, row));
 
     for (const join of this.joins) {
@@ -3424,7 +3579,11 @@ class SelectQuery implements SelectQueryBuilder<any> {
     }
 
     contexts = contexts.filter((ctx) => evaluateCondition(this.condition, ctx));
+    return this.finish(contexts);
+  }
 
+  /** Ordering, offset/limit, and projection shared by both run() paths. */
+  private finish(contexts: RowContext[]) {
     if (this.orderings.length > 0) {
       contexts = [...contexts].sort((left, right) => {
         for (const ordering of this.orderings) {

--- a/packages/server/src/db/file-schema.ts
+++ b/packages/server/src/db/file-schema.ts
@@ -144,6 +144,18 @@ export function text<const TValues extends readonly string[] = readonly string[]
   return column<TValues extends readonly [] ? string : TValues[number]>(name);
 }
 
+/**
+ * A text column holding a JSON-serialized float vector that the store may keep
+ * in memory as a parsed Float64Array (#5592 Phase 1). On disk the value is a
+ * plain JSON string, identical to text(); only the resident representation
+ * differs. Consumers must accept both shapes: unprojected selects return the
+ * original string, projected selects return the packed Float64Array. Packed
+ * values are shared by reference and must never be mutated.
+ */
+export function vectorText(name: string): FileColumn<string | Float64Array, false, false> {
+  return column<string | Float64Array>(name);
+}
+
 export function integer(name: string): FileColumn<number, false, false> {
   return column<number>(name);
 }

--- a/packages/server/src/db/schema/chats.ts
+++ b/packages/server/src/db/schema/chats.ts
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // Schema: Chats, Messages & Folders
 // ──────────────────────────────────────────────
-import { fileTable, text, integer } from "../file-schema.js";
+import { fileTable, text, integer, vectorText } from "../file-schema.js";
 
 export const chatFolders = fileTable("chat_folders", {
   id: text("id").primaryKey(),
@@ -125,7 +125,7 @@ export const memoryChunks = fileTable("memory_chunks", {
   /** Formatted conversation text: "Name: message\n\nName: message\n\n..." */
   content: text("content").notNull(),
   /** JSON-serialized float[] embedding (null until vectorized) */
-  embedding: text("embedding"),
+  embedding: vectorText("embedding"),
   /** Stable provider/model/profile identity for the stored embedding */
   embeddingSpaceId: text("embedding_space_id"),
   /** How many messages were grouped into this chunk */

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -258,8 +258,11 @@ function normalizeMemoryEmbedding(value: unknown): number[] | null {
   return vector;
 }
 
-function parseMemoryEmbedding(raw: string | null): number[] | null {
+function parseMemoryEmbedding(raw: string | Float64Array | null): number[] | null {
   if (!raw) return null;
+  // Projected selects hand back the store's packed vector (#5592 Phase 1); the
+  // export payload keeps its plain-array JSON shape either way.
+  if (raw instanceof Float64Array) return normalizeMemoryEmbedding(Array.from(raw));
   try {
     return normalizeMemoryEmbedding(JSON.parse(raw));
   } catch {

--- a/packages/server/src/services/memory-recall.ts
+++ b/packages/server/src/services/memory-recall.ts
@@ -46,7 +46,7 @@ async function serializeMemoryMutation<T>(chatId: string, task: () => Promise<T>
 
 // ── Cosine similarity ──
 
-function cosineSimilarity(a: number[], b: number[]): number {
+function cosineSimilarity(a: ArrayLike<number>, b: ArrayLike<number>): number {
   if (a.length !== b.length || a.length === 0) return 0;
   let dot = 0,
     magA = 0,
@@ -60,8 +60,14 @@ function cosineSimilarity(a: number[], b: number[]): number {
   return denom === 0 ? 0 : dot / denom;
 }
 
-function parseStoredEmbedding(value: string | null): number[] | null {
+function parseStoredEmbedding(value: string | Float64Array | null): number[] | Float64Array | null {
   if (!value) return null;
+  // The store holds memory_chunks embeddings as packed Float64Arrays (#5592
+  // Phase 1); projected selects hand the vector back directly, so recall skips
+  // the per-chunk JSON.parse entirely. The string branch remains for values
+  // the store declined to pack (non-canonical text) and for callers that pass
+  // freshly serialized embeddings.
+  if (value instanceof Float64Array) return value;
   try {
     const parsed = JSON.parse(value);
     return Array.isArray(parsed) && parsed.every((item) => typeof item === "number" && Number.isFinite(item))
@@ -408,11 +414,7 @@ async function chunkAndEmbedMessagesUnlocked(
     .where(and(eq(memoryChunks.chatId, chatId), isNull(memoryChunks.sourceChatId), isNotNull(memoryChunks.embedding)))
     .limit(1);
   const existingEmbedding = parseStoredEmbedding(existingEmbeddedChunk[0]?.embedding ?? null);
-  if (
-    Array.isArray(existingEmbedding) &&
-    existingEmbedding.length > 0 &&
-    existingEmbedding.length !== embeddingDimension
-  ) {
+  if (existingEmbedding !== null && existingEmbedding.length > 0 && existingEmbedding.length !== embeddingDimension) {
     logger.warn(
       "[memory-recall] Skipping memory chunk insert for chat %s because embedding dimension changed from %d to %d. Rebuild memories before mixing embedding models.",
       chatId,

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -594,8 +594,9 @@ async function invalidateMemoryChunksFrom(db: DB, chatId: string, createdAt: str
  * Count swipes per message id, scoped to the requested messages. The WHERE-less
  * scan this replaces existed because `inArray` used to cost O(ids) plus an array
  * allocation per scanned row (#3402); the store now resolves membership sets
- * once per condition, so the scoped form is O(totalSwipes + ids) — as fast as
- * the full scan was, without reading every other chat's swipes (#5592 Phase 0).
+ * once per condition, so the scoped form is O(totalSwipes + ids) — the store
+ * still walks every swipe row, but nonmatching rows are no longer materialized
+ * or handed back for JS-side filtering (#5592 Phase 0).
  */
 async function countSwipesByMessageId(db: DB, ids: string[]): Promise<Map<string, number>> {
   const counts = new Map<string, number>();

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -591,21 +591,21 @@ async function invalidateMemoryChunksFrom(db: DB, chatId: string, createdAt: str
 }
 
 /**
- * Count swipes per message id. Avoids `inArray(messageSwipes.messageId, ids)`,
- * which the file-native store evaluates as `ids.includes()` for every swipe row
- * (re-materializing the ids array each row) — O(swipeRows * ids) = O(n^2) for a
- * large chat and a prime cause of the post-generation stall (#3402). One scan of
- * the swipes table + a Set of the wanted ids is O(totalSwipes) instead.
+ * Count swipes per message id, scoped to the requested messages. The WHERE-less
+ * scan this replaces existed because `inArray` used to cost O(ids) plus an array
+ * allocation per scanned row (#3402); the store now resolves membership sets
+ * once per condition, so the scoped form is O(totalSwipes + ids) — as fast as
+ * the full scan was, without reading every other chat's swipes (#5592 Phase 0).
  */
 async function countSwipesByMessageId(db: DB, ids: string[]): Promise<Map<string, number>> {
   const counts = new Map<string, number>();
   if (ids.length === 0) return counts;
-  const wanted = new Set(ids);
-  const rows = await db.select({ messageId: messageSwipes.messageId }).from(messageSwipes);
+  const rows = await db
+    .select({ messageId: messageSwipes.messageId })
+    .from(messageSwipes)
+    .where(inArray(messageSwipes.messageId, ids));
   for (const row of rows) {
-    if (wanted.has(row.messageId)) {
-      counts.set(row.messageId, (counts.get(row.messageId) ?? 0) + 1);
-    }
+    counts.set(row.messageId, (counts.get(row.messageId) ?? 0) + 1);
   }
   return counts;
 }
@@ -2029,15 +2029,14 @@ export function createChatsStorage(db: DB) {
     },
 
     /**
-     * Read swipe rows for a message set with one linear file-store scan.
-     * The file-native store scans the table for `inArray` too, where membership
-     * is O(ids) per row; chunking that query would also rescan the table.
+     * Read swipe rows for a message set. Scoped via `inArray`, which the store
+     * now evaluates against a per-condition Set (#3402's cost is gone), so only
+     * the matching rows are cloned instead of every swipe in the install
+     * (#5592 Phase 0).
      */
     async listSwipesByMessageIds(messageIds: string[]) {
       if (messageIds.length === 0) return [];
-      const wanted = new Set(messageIds);
-      const rows = await db.select().from(messageSwipes);
-      return rows.filter((row) => wanted.has(row.messageId));
+      return db.select().from(messageSwipes).where(inArray(messageSwipes.messageId, messageIds));
     },
 
     async addSwipe(messageId: string, content: string, silent?: boolean) {

--- a/scripts/regressions/message-sharding.regression.ts
+++ b/scripts/regressions/message-sharding.regression.ts
@@ -18,7 +18,17 @@ import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { and, desc, eq, jsonFlagsNotTrue, ne, stringIsNonBlank } from "../../packages/server/src/db/file-query.js";
+import {
+  and,
+  desc,
+  eq,
+  inArray,
+  isNotNull,
+  jsonFlagsNotTrue,
+  ne,
+  notInArray,
+  stringIsNonBlank,
+} from "../../packages/server/src/db/file-query.js";
 import {
   createFileNativeDB,
   encodeShardKey,
@@ -1475,6 +1485,243 @@ for (const invalidExpectedCount of ["1", 1.5]) {
       /Invalid message cursor/u,
       "history cursors must identify a message in the current snapshot",
     );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── #5592 Phase 0: swipe reads are chat-scoped and inArray stays linear ──
+// The WHERE-less swipe scans existed because inArray membership used to cost
+// O(ids) per scanned row (#3402). The store now resolves membership Sets once
+// per condition, so the scoped form is both correct across chats and linear.
+
+{
+  const dir = tempStorageDir();
+  const db = await createFileNativeDB();
+  try {
+    for (const chatId of ["chat-a", "chat-b"]) {
+      await db.insert(chats).values({ id: chatId, name: chatId, mode: "conversation" });
+      await db.insert(messages).values(messageRow(`${chatId}-m1`, chatId, "hello"));
+      await db.insert(messageSwipes).values({
+        id: `${chatId}-m1-s1`,
+        messageId: `${chatId}-m1`,
+        index: 1,
+        content: "alt",
+        createdAt: "2026-08-08T10:00:00.000Z",
+      });
+    }
+    // A second swipe only in chat B: scoped counts must never bleed across.
+    await db.insert(messageSwipes).values({
+      id: "chat-b-m1-s2",
+      messageId: "chat-b-m1",
+      index: 2,
+      content: "alt-2",
+      createdAt: "2026-08-08T10:00:01.000Z",
+    });
+
+    const storage = createChatsStorage(db);
+    const chatAMessages = await storage.listMessages("chat-a");
+    assert.equal(chatAMessages.length, 1);
+    assert.equal(chatAMessages[0]!.swipeCount, 1, "chat A sees only its own swipe count");
+    const chatBMessages = await storage.listMessages("chat-b");
+    assert.equal(chatBMessages[0]!.swipeCount, 2, "chat B keeps its own two swipes");
+
+    const scoped = await storage.listSwipesByMessageIds(["chat-a-m1"]);
+    assert.deepEqual(
+      scoped.map((swipe) => swipe.id),
+      ["chat-a-m1-s1"],
+      "swipe listing returns only the requested messages' swipes",
+    );
+
+    const viaInArray = await db
+      .select()
+      .from(messageSwipes)
+      .where(inArray(messageSwipes.messageId, ["chat-a-m1", "chat-b-m1"]));
+    assert.equal(viaInArray.length, 3, "the Set-based membership evaluator matches Array.includes semantics");
+    const excluded = await db
+      .select()
+      .from(messageSwipes)
+      .where(notInArray(messageSwipes.messageId, ["chat-a-m1"]));
+    assert.deepEqual(
+      excluded.map((swipe) => swipe.id).sort(),
+      ["chat-b-m1-s1", "chat-b-m1-s2"],
+      "notInArray shares the cached membership set",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── #5592 Phase 0: an emptied shard's file deletion survives a failed flush ──
+// "Dirty key with no rows" may only unlink the shard file on positive evidence
+// (the table's full row set resident). A flush failure between the delete and
+// the write must retry into the same deletion, never strand or double-free.
+
+{
+  const dir = tempStorageDir();
+  let failChunkWrites = false;
+  const db = await createFileNativeDB({
+    beforeTableWrite: (table) => {
+      if (failChunkWrites && table.startsWith("memory_chunks/")) {
+        throw new Error("injected flush failure");
+      }
+    },
+  });
+  try {
+    for (const chatId of ["chat-a", "chat-b"]) {
+      await db.insert(chats).values({ id: chatId, name: chatId, mode: "conversation" });
+      await db.insert(memoryChunks).values({
+        id: `chunk-${chatId}`,
+        chatId,
+        content: "chunked",
+        messageCount: 1,
+        firstMessageAt: "2026-08-08T10:00:00.000Z",
+        lastMessageAt: "2026-08-08T10:00:00.000Z",
+        createdAt: "2026-08-08T10:00:00.000Z",
+      });
+    }
+    await db._fileStore.flush();
+    const emptiedShard = join(dir, "tables", "memory_chunks", `${encodeShardKey("chat-a")}.json`);
+    assert.ok(existsSync(emptiedShard), "the chunk shard exists before the delete");
+
+    // Empty chat A's shard and dirty chat B's in the same cycle; the injected
+    // failure on B's write aborts the flush BEFORE the deletion loop runs.
+    await db.delete(memoryChunks).where(eq(memoryChunks.id, "chunk-chat-a"));
+    await db.update(memoryChunks).set({ content: "rewritten" }).where(eq(memoryChunks.id, "chunk-chat-b"));
+    failChunkWrites = true;
+    await assert.rejects(
+      db._fileStore.flush(true, true),
+      /injected flush failure/u,
+      "a failing shard write propagates when the flush is asked to throw",
+    );
+    assert.ok(existsSync(emptiedShard), "a failed flush must not have unlinked the emptied shard yet");
+
+    // The failure path re-marks the dirty keys, so the retry both writes B and
+    // completes A's deletion — the emptied key is never stranded.
+    failChunkWrites = false;
+    await db._fileStore.flush(true, true);
+    assert.equal(existsSync(emptiedShard), false, "the emptied shard file is removed by the retry flush");
+    assert.equal(existsSync(`${emptiedShard}.bak`), false, "the backup goes with it");
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── #5592 Phase 1: memory_chunks embeddings pack to Float64Array off the V8 heap ──
+// On-disk bytes must stay identical (no STORAGE_VERSION bump): rows serialize
+// back to the exact original text, unprojected selects return the original
+// string, and only projected selects observe the packed vector.
+
+{
+  const dir = tempStorageDir();
+  const db = await createFileNativeDB();
+  const embeddingText = JSON.stringify([0.125, -0.25, 0.0000001, 3]);
+  try {
+    await db.insert(chats).values({ id: "chat-a", name: "A", mode: "conversation" });
+    await db.insert(memoryChunks).values({
+      id: "chunk-a",
+      chatId: "chat-a",
+      content: "chunked",
+      embedding: embeddingText,
+      embeddingSpaceId: "space-1",
+      messageCount: 1,
+      firstMessageAt: "2026-08-08T10:00:00.000Z",
+      lastMessageAt: "2026-08-08T10:00:00.000Z",
+      createdAt: "2026-08-08T10:00:00.000Z",
+    });
+    await db.insert(memoryChunks).values({
+      id: "chunk-null",
+      chatId: "chat-a",
+      content: "not vectorized",
+      embedding: null,
+      messageCount: 1,
+      firstMessageAt: "2026-08-08T10:00:01.000Z",
+      lastMessageAt: "2026-08-08T10:00:01.000Z",
+      createdAt: "2026-08-08T10:00:01.000Z",
+    });
+    await db._fileStore.flush();
+
+    const shardPath = join(dir, "tables", "memory_chunks", `${encodeShardKey("chat-a")}.json`);
+    const persisted = readFileSync(shardPath, "utf8");
+    assert.ok(
+      persisted.includes(JSON.stringify(embeddingText)),
+      "the shard file stores the embedding as the exact original JSON string",
+    );
+    assert.ok(!persisted.includes('"0":'), "no index-keyed typed-array serialization ever reaches disk");
+
+    const unprojected = await db.select().from(memoryChunks).where(eq(memoryChunks.id, "chunk-a"));
+    assert.equal(typeof unprojected[0]!.embedding, "string", "unprojected selects return the original string form");
+    assert.equal(unprojected[0]!.embedding, embeddingText, "the string round-trips byte-identically");
+
+    const projected = await db
+      .select({ embedding: memoryChunks.embedding })
+      .from(memoryChunks)
+      .where(eq(memoryChunks.id, "chunk-a"));
+    assert.ok(projected[0]!.embedding instanceof Float64Array, "projected selects hand back the packed vector");
+    assert.deepEqual(
+      Array.from(projected[0]!.embedding as Float64Array),
+      [0.125, -0.25, 0.0000001, 3],
+      "packed values are exact",
+    );
+
+    const vectorized = await db
+      .select({ id: memoryChunks.id })
+      .from(memoryChunks)
+      .where(isNotNull(memoryChunks.embedding));
+    assert.deepEqual(
+      vectorized.map((row) => row.id),
+      ["chunk-a"],
+      "isNotNull keeps matching packed embeddings and excluding null ones",
+    );
+
+    // Updating an unrelated column must leave the packed value and the
+    // persisted bytes untouched.
+    await db.update(memoryChunks).set({ content: "rewritten" }).where(eq(memoryChunks.id, "chunk-a"));
+    await db._fileStore.flush();
+    assert.ok(
+      readFileSync(shardPath, "utf8").includes(JSON.stringify(embeddingText)),
+      "a content update leaves the stored embedding text byte-identical",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// Non-canonical embedding text (hand-written or foreign tooling) must never be
+// reformatted: the store packs only values whose serialization round-trips.
+
+{
+  const dir = tempStorageDir();
+  mkdirSync(join(dir, "tables", "memory_chunks"), { recursive: true });
+  const nonCanonical = "[1.0, 1E-3]";
+  writeFileSync(
+    join(dir, "tables", "memory_chunks", `${encodeShardKey("chat-a")}.json`),
+    JSON.stringify([
+      {
+        id: "chunk-a",
+        chat_id: "chat-a",
+        content: "chunked",
+        embedding: nonCanonical,
+        embedding_space_id: "space-1",
+        message_count: 1,
+        first_message_at: "2026-08-08T10:00:00.000Z",
+        last_message_at: "2026-08-08T10:00:00.000Z",
+        created_at: "2026-08-08T10:00:00.000Z",
+      },
+    ]),
+  );
+  const db = await createFileNativeDB();
+  try {
+    const rows = await db.select().from(memoryChunks);
+    assert.equal(rows[0]!.embedding, nonCanonical, "non-canonical text is left as a string");
+    await db.update(memoryChunks).set({ content: "touched" }).where(eq(memoryChunks.id, "chunk-a"));
+    await db._fileStore.flush();
+    const persisted = readFileSync(join(dir, "tables", "memory_chunks", `${encodeShardKey("chat-a")}.json`), "utf8");
+    assert.ok(persisted.includes(JSON.stringify(nonCanonical)), "a rewrite preserves the non-canonical text verbatim");
   } finally {
     await db._fileStore.close();
     rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Linked issue

Part of #5592 (Phase 0 + Phase 1 of the plan in the issue's audit comment — Phase 2, partial residency, deliberately stays parked, so this PR does not close the issue).

## Why this change

Termux servers keep dying with `FATAL ERROR: Reached heap limit` (#4730, #4936, #5585) because the file-native store holds every row of every table on the V8 heap and several hot paths add O(whole-table) allocation on top. A pre-implementation audit (132 consumer classifications, 51 hazards — recorded on #5592) showed the eventual fix, partial residency, has hard prerequisites. This PR ships those prerequisites plus the single biggest memory win, each independently valuable today and none changing behavior or the on-disk format.

## What changed

**Phase 0 — store groundwork (no behavior change):**

1. **Membership conditions resolve once per query.** `inArray`/`notInArray` used to re-materialize the values array and run `Array.includes` for *every scanned row* — O(rows × values), the measured cause of the #3402 post-generation stall. They now build a `Set` once per condition object (WeakMap-cached; `Set.has` and `includes` share SameValueZero semantics; column/array-valued entries keep the old path — no call site in the repo uses those today).
2. **Swipe reads are chat-scoped again.** `countSwipesByMessageId` and `listSwipesByMessageIds` dropped their WHERE deliberately in #3402 because of (1); with (1) fixed at the root, the scoped form is exactly as fast as the full scan and stops reading — and in the list case *cloning* — every other chat's swipes on the hottest read path in the app. No caller changes; both callers already pass the right ids.
3. **`count()` and no-join selects share one iteration.** Previously every select materialized two objects for *every row of the table* before the WHERE ran (and `count()` did the same per call). The shared scan reuses a single `RowContext` — safe because the evaluator never retains it — and allocates contexts only for matching rows. `count()` keeps exact integer semantics (the paginated-cursor `!== 1` check and `upperRowid` arithmetic depend on it).
4. **Two partial-residency preconditions become structural.** Boot loads `messages` first explicitly (the `messageId→chatId` swipe-shard index depended on array declaration order enforced only by a comment), and the flush's "dirty key with no rows ⇒ shard emptied ⇒ delete its file" inference is now gated on positive evidence (`fullyResidentTables` — always true today, inert; exactly the gate Phase 2 needs so an evicted shard can never be mistaken for an emptied one and unlinked).

**Phase 1 — Memory Recall embeddings off the V8 heap:**

`memory_chunks.embedding` (a JSON float-array *string* per 5-message chunk, ~8 KB each, resident forever) is plausibly the largest single heap block for a long roleplay profile with recall enabled — the #5585 reporter's diagnostics showed 1.1 GiB steady-state against a 1.6 GiB cap. The store now packs these to `Float64Array` at its boundary: ~6 KB of ArrayBuffer *outside* the V8 heap, which is what the Android 134-aborts actually measure. Recall scoring receives the packed vector directly through its projected select and skips the per-chunk `JSON.parse` (the recon measured 229 ms → 13 ms for a 20k-chunk scoring pass, and removes ~60 MB of transient parse allocation per recall — the same burst shape as the crash trace).

Compatibility is by construction, not enumeration:

- **On-disk format unchanged** — values pack only when re-serialization is *byte-identical* (non-canonical text like `[1.0, 1E-3]` stays a string verbatim), and every write site restores the text. **No `STORAGE_VERSION` bump, no migration**; the launcher format-guard regression still passes.
- **Unprojected selects return the original string** — backup/profile export, mari-db raw reads, and every generic consumer read exactly what they always read, with zero edits in those files. Only projected selects (the recall hot path) see the packed form. The compiler enumerated the three consumers needing widening (`parseStoredEmbedding`, `cosineSimilarity`, `parseMemoryEmbedding`) via the new `vectorText` column type.

## Validation

<!-- These are human tasks. Never tick a box for a check that was not actually performed. -->

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated, from this branch:

- `pnpm lint` and `pnpm build` pass.
- Regression lanes green: `message-sharding` (extended with 4 new blocks / ~20 assertions: chat-scoped swipe counts and listings, `inArray`/`notInArray` Set semantics, emptied-shard unlink surviving a failed flush and completing on retry, byte-identical embedding round-trips, string-vs-packed select shapes, `isNotNull` over packed values, non-canonical text preserved verbatim), `memory-recall-revectorize`, `file-backed-shutdown`, `storage-writer-lock`, `slurp-storage`, `capability-package-lifecycle`, `agent-runtime`, `launcher/format-guard`.
- Touched files are Prettier-clean under the repo config (repo-wide `format:check` fails pre-existing on CRLF Windows checkouts).

Worth a human pass:

- A real long-roleplay profile with Memory Recall enabled: confirm recall answers are unchanged and Settings → Advanced shows a visibly lower heap number after restart (the `Server memory` diagnostics line from #5515 makes this directly observable).
- Chat with multiple swipes: swipe arrows, "Delete only this swipe (2/2)" label, and swipe navigation across two different chats (the counts are now chat-scoped).
- Export → import a profile containing vectorized memories; export a chat's memories (`/memories/export`) — payload shapes unchanged.
- On Termux if available: the #5585 reproduction (heavy profile, normal chatting) with this branch — expected: measurably more headroom before any abort.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

Three CHANGELOG entries under `[Unreleased] → Fixed`. No user-facing docs describe the store internals; no docs-i18n impact. **Explicitly: no `STORAGE_VERSION`/`storage-format.json` change** — the format-guard regression pins that the pairing is intact and this PR alters no on-disk layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory recall embedding storage and retrieval for more reliable performance.
  * Corrected chat-scoped message swipe counts and listings.
  * Hardened file-backed storage filtering, counting, shard loading, and cleanup.
  * Ensured interrupted cleanup safely retries without removing partially available data.

* **Tests**
  * Added regression coverage for embedding persistence, swipe queries, filtering, and shard recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->