### PR TITLE
feat(storage): lazy per-chat unit loading for chat-scoped tables (#5592 Phase 2, PR-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Character card Conversation profiles now provide controls to generate About Me and Conversation behavior text from the card's available information.
 - The Home Character of the Day widget now uses saved character summaries and offers direct chat-start and character-view actions.
 
+### Changed
+
+- Chat-scoped storage tables (messages, swipes, Memory Recall chunks, game state, call logs, and the other per-chat tables) no longer load into memory at startup: each chat's data loads as one unit the first time that chat is touched and every query, write, and cascade is scoped to the units it can actually reach — the main memory reduction for long multi-chat profiles on Termux and other low-memory devices. Full-table operations such as backups still load everything they need automatically, and setting `MARINARA_EAGER_STORAGE=1` restores the previous load-everything startup (#5592).
+- Stale in-progress game storyboards are now recovered per chat when that chat's storyboards are next read (including everything left over from before the current server start), replacing the startup-wide sweep (#5592).
+
 ### Fixed
 
 - Memory Recall embeddings now live outside the JavaScript heap as packed vectors — the largest single memory block for long roleplay profiles on phones — and recall scoring reads them directly instead of re-parsing JSON per chunk, without changing the on-disk storage format (#5592).

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -1985,6 +1985,25 @@ class FileTableStore {
    */
   private lazyDiscoveredShards = new Map<string, Set<string>>();
   /**
+   * Physical shard files (encoded names) that hold MESSAGES rows belonging to
+   * a different unit than the file itself, keyed by the OWNING unit (#5592
+   * Phase 2, round-4 review). The eager loader saw misfiled rows because it
+   * read every file; per-unit loading must know where a unit's strays
+   * physically live, or a chatId/id-scoped query for the owning unit loads
+   * only the unit's own file and the misfiled row stays invisible until its
+   * host unit happens to load. Built during the boot harvest (which already
+   * parses every messages shard) and consumed on the owning unit's load.
+   */
+  private messageStrayFilesByUnit = new Map<string, Set<string>>();
+  /**
+   * Shard files already read by loadShardFileSync, per table. Files load at
+   * most once by design; this set makes that structural (a stray-holding file
+   * can be reached via its own unit, another unit's transitive pull, a lease,
+   * or the stray index) instead of relying on callers to dedup — a re-read
+   * would spuriously stale-mark the file via the duplicate-drop path.
+   */
+  private loadedShardEncodings = new Map<string, Set<string>>();
+  /**
    * messageIds of swipes currently resolving to the unassigned shard. When
    * such a message is later INSERTED, its swipes silently regroup into the
    * chat's shard, so BOTH swipe files must be dirtied (see
@@ -2720,7 +2739,21 @@ class FileTableStore {
             // only sound against the unit's full row set. A key with no shard
             // on disk (a brand-new chat) is simply marked loaded.
             if (LAZY_UNIT_TABLES.has(meta.name) && !this.fullyResidentTables.has(meta.name)) {
-              this.ensureUnitsLoaded(this.shardKeysForRows(meta.name, preparedRows));
+              const destinationKeys = this.shardKeysForRows(meta.name, preparedRows);
+              // Primary-key uniqueness is table-wide, not per-unit. For
+              // messages the complete harvest index can name the unit that
+              // already owns an incoming id — load it too, so the duplicate
+              // scan and conflict matching see the existing row exactly as
+              // the eager store did (id-preserving chat imports are the
+              // realistic cross-unit collision source).
+              if (meta.name === "messages") {
+                for (const row of preparedRows) {
+                  if (typeof row.id !== "string") continue;
+                  const owner = this.messageShardIndex.get(row.id);
+                  if (owner !== undefined) destinationKeys.add(owner);
+                }
+              }
+              this.ensureUnitsLoaded(destinationKeys);
             }
             const target = this.rows(meta.name);
             const nextRows = target.map(cloneRow);
@@ -3290,6 +3323,21 @@ class FileTableStore {
           if (!this.loadedUnits.has(strayKey)) queue.push(strayKey);
         }
       }
+      // Misfiled rows OWNED by this unit but living in other units' files
+      // (harvest-indexed): load those files too, so the unit's row set is as
+      // complete as the eager loader's. Their host units join the queue via
+      // the transitive stray pull, keeping the no-partial-units invariant.
+      const strayFiles = this.messageStrayFilesByUnit.get(key);
+      if (strayFiles && !this.fullyResidentTables.has("messages")) {
+        this.messageStrayFilesByUnit.delete(key);
+        for (const strayEncoded of strayFiles) {
+          const rows = this.loadShardFileSync("messages", strayEncoded);
+          if (rows.length === 0) continue;
+          for (const strayKey of this.mergeLoadedRows("messages", rows, strayEncoded)) {
+            if (!this.loadedUnits.has(strayKey)) queue.push(strayKey);
+          }
+        }
+      }
     }
   }
 
@@ -3304,9 +3352,12 @@ class FileTableStore {
     if (!LAZY_UNIT_TABLES.has(meta.name) || this.fullyResidentTables.has(meta.name)) return;
     const discovered = this.lazyDiscoveredShards.get(meta.name);
     if (discovered && discovered.size > 0) {
-      const loadedEncodings = new Set([...this.loadedUnits].map((key) => encodeShardKey(key)));
+      // loadShardFileSync's read-once set is the authoritative skip check —
+      // it also covers files pulled in transitively (stray holders), which
+      // an encoding of loadedUnits would miss.
+      const alreadyRead = this.loadedShardEncodings.get(meta.name);
       for (const encoded of [...discovered]) {
-        if (loadedEncodings.has(encoded)) continue;
+        if (alreadyRead?.has(encoded)) continue;
         const rows = this.loadShardFileSync(meta.name, encoded);
         if (rows.length > 0) this.mergeLoadedRows(meta.name, rows, encoded);
       }
@@ -3324,6 +3375,10 @@ class FileTableStore {
    * for an unloaded unit could not.
    */
   private loadShardFileSync(table: string, encoded: string): Row[] {
+    const alreadyRead = this.loadedShardEncodings.get(table) ?? new Set<string>();
+    this.loadedShardEncodings.set(table, alreadyRead);
+    if (alreadyRead.has(encoded)) return [];
+    alreadyRead.add(encoded);
     const meta = getMeta(table);
     const known = this.knownShardFiles.get(table) ?? new Set<string>();
     this.knownShardFiles.set(table, known);
@@ -3877,12 +3932,20 @@ class FileTableStore {
               if (typeof row.id !== "string") continue;
               // The eager loader normalized rows before indexing, which also
               // accepted the column's dbName form — a hand-edited or
-              // externally produced shard may carry `chat_id`, and dropping
-              // it here would make the message invisible to id-scoped
-              // queries until its unit happens to load.
+              // externally produced shard may carry `chat_id`. A row whose
+              // chatId is unusable still gets an index entry (its owning unit
+              // is the unassigned shard, same rule as shardKeyForRow), so the
+              // index is total over every string-id row on disk and an
+              // id-scope miss EXACTLY means "no such message anywhere".
               const chatId = typeof row.chatId === "string" ? row.chatId : row.chat_id;
-              if (typeof chatId === "string") {
-                this.messageShardIndex.set(row.id, chatId || UNASSIGNED_SHARD_KEY);
+              const owningKey = typeof chatId === "string" && chatId ? chatId : UNASSIGNED_SHARD_KEY;
+              this.messageShardIndex.set(row.id, owningKey);
+              // A row filed in another unit's shard would be invisible to its
+              // owning unit's loads — record where it physically lives.
+              if (encodeShardKey(owningKey) !== encoded) {
+                const strayFiles = this.messageStrayFilesByUnit.get(owningKey) ?? new Set<string>();
+                strayFiles.add(encoded);
+                this.messageStrayFilesByUnit.set(owningKey, strayFiles);
               }
             }
           }

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -3388,7 +3388,7 @@ class FileTableStore {
     const residentIds = primaryKey
       ? new Set(resident.map((row) => row[primaryKey]).filter((id) => typeof id === "string"))
       : null;
-    const strayIds = this.strayResidentIds.get(table);
+    let strayIds = this.strayResidentIds.get(table);
     const added: Row[] = [];
     const replacements = new Map<string, Row>();
     let duplicateCount = 0;
@@ -3409,9 +3409,13 @@ class FileTableStore {
         }
         residentIds.add(id);
         if (!isCanonical) {
-          const set = strayIds ?? new Set<string>();
-          set.add(id);
-          this.strayResidentIds.set(table, set);
+          // One Set per table, reused across the whole merge: allocating a
+          // fresh Set per stray row would overwrite the map entry and forget
+          // every stray id but the last, letting a stale stray copy beat its
+          // canonical row when the canonical file loads.
+          strayIds ??= new Set<string>();
+          strayIds.add(id);
+          this.strayResidentIds.set(table, strayIds);
         }
       }
       added.push(row);
@@ -4141,6 +4145,13 @@ class FileTableStore {
       // unit should not occur; requeue it defensively (into the LIVE dirty
       // map — flush swapped it out before this ran) so the mark survives
       // until the unit loads instead of being silently dropped.
+      // Deliberately WITHOUT restoring this.dirty/dirtyTables: the mark is
+      // vacuous by construction (every mutation path loads its unit first, so
+      // an unloaded unit has no in-memory changes to persist), and setting
+      // the flags here would make the safety timer re-run this no-op every
+      // cycle and turn finishClose's drain-until-clean loop into a shutdown
+      // hang. The next flush from any real cause re-captures the key via the
+      // dirtyShards swap; dropping it at process exit loses nothing.
       if (!this.fullyResidentTables.has(table) && !this.loadedUnits.has(key)) {
         logger.warn(
           { table, shardKey: key },

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -2692,18 +2692,24 @@ class FileTableStore {
             this.assertWritable();
             const conflictColumns = normalizeConflictTargets(onConflict?.target);
             const inputRows = Array.isArray(rows) ? rows : [rows];
+            // Normalize ONCE, before unit selection: raw input may carry
+            // dbName-form keys (chat_id), which shardKeyForRow cannot read —
+            // scoping from raw rows would load the unassigned unit instead of
+            // the destination chat and the duplicate scan below would miss
+            // that chat's on-disk rows. Preparing here also keeps
+            // function-valued column defaults generated exactly once.
+            const preparedRows = inputRows.map((input) => prepareInsertRow(meta, input));
             // Load the destination units BEFORE the duplicate/uniqueness scan
             // (#5592 Phase 2): onConflict matching and assertUniqueRow are
             // only sound against the unit's full row set. A key with no shard
             // on disk (a brand-new chat) is simply marked loaded.
             if (LAZY_UNIT_TABLES.has(meta.name) && !this.fullyResidentTables.has(meta.name)) {
-              this.ensureUnitsLoaded(this.shardKeysForRows(meta.name, inputRows));
+              this.ensureUnitsLoaded(this.shardKeysForRows(meta.name, preparedRows));
             }
             const target = this.rows(meta.name);
             const nextRows = target.map(cloneRow);
             const affectedRows: Row[] = [];
-            for (const input of inputRows) {
-              const row = prepareInsertRow(meta, input);
+            for (const row of preparedRows) {
               const conflictKeys =
                 conflictColumns.length > 0 ? conflictColumns : meta.primaryKey ? [meta.primaryKey] : [];
               const duplicateIndex = onConflict ? findMatchingRowIndex(nextRows, row, conflictKeys) : -1;
@@ -2857,9 +2863,18 @@ class FileTableStore {
     // existed only in memory.
     const staleShards = this.staleShardFiles;
     this.staleShardFiles = new Map();
+    // Same capture rule for the backup-recovery markers: a lazy unit load
+    // during this flush's awaited writes can recover a shard from .bak and
+    // mark its corrupt primary. The old whole-set clear() at the end of
+    // saveFileSnapshots would destroy that mark before the shard was ever
+    // written, and the NEXT flush would then refresh the valid .bak from the
+    // still-corrupt primary — leaving no usable recovery source if the
+    // healing write failed. Marks travel with the batch that consumes them.
+    const recoveredPaths = this.backupRecoveredPaths;
+    this.backupRecoveredPaths = new Set();
     const flush = (async () => {
       try {
-        await this.saveFileSnapshots(dirtyTables, dirtyShards, staleShards);
+        await this.saveFileSnapshots(dirtyTables, dirtyShards, staleShards, recoveredPaths);
         this.lastFlushError = null;
       } catch (err) {
         this.lastFlushError = err;
@@ -2877,6 +2892,7 @@ class FileTableStore {
           for (const encoded of encodings) set.add(encoded);
           this.staleShardFiles.set(table, set);
         }
+        for (const path of recoveredPaths) this.backupRecoveredPaths.add(path);
         logger.error(err, "[file-storage] Failed to persist file-native storage");
       }
     })();
@@ -4074,6 +4090,7 @@ class FileTableStore {
     rows: Row[],
     dirtyKeys: Set<string>,
     stale: Set<string> | undefined,
+    recoveredPaths: ReadonlySet<string>,
   ): Promise<number> {
     const known = this.knownShardFiles.get(table) ?? new Set<string>();
     this.knownShardFiles.set(table, known);
@@ -4117,7 +4134,7 @@ class FileTableStore {
       const serializedRows = serializeTableRows(table, shardRows);
       await this.testHooks?.beforeTableWrite?.(`${table}/${encoded}`, serializedRows);
       const path = shardFilePath(this.rootDir, table, encoded);
-      await atomicWriteFile(path, serializedRows, { refreshBackup: !this.backupRecoveredPaths.has(path) });
+      await atomicWriteFile(path, serializedRows, { refreshBackup: !recoveredPaths.has(path) });
       known.add(encoded);
     }
     if (stale && stale.size > 0) {
@@ -4180,6 +4197,7 @@ class FileTableStore {
     dirtyTables: Set<string>,
     dirtyShards: Map<string, Set<string>>,
     staleShards: Map<string, Set<string>>,
+    recoveredPaths: ReadonlySet<string>,
   ) {
     mkdirSync(join(this.rootDir, "tables"), { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
     const tables: Record<string, number> = {};
@@ -4205,6 +4223,7 @@ class FileTableStore {
           rows,
           dirtyShards.get(table) ?? new Set(),
           staleShards.get(table),
+          recoveredPaths,
         );
         continue;
       }
@@ -4212,7 +4231,7 @@ class FileTableStore {
       if (dirtyTables.has(table) || !existsSync(path)) {
         const serializedRows = serializeTableRows(table, rows);
         await this.testHooks?.beforeTableWrite?.(table, serializedRows);
-        await atomicWriteFile(path, serializedRows, { refreshBackup: !this.backupRecoveredPaths.has(path) });
+        await atomicWriteFile(path, serializedRows, { refreshBackup: !recoveredPaths.has(path) });
       }
     }
 
@@ -4226,9 +4245,11 @@ class FileTableStore {
     const path = manifestPath(this.rootDir);
     const serializedManifest = JSON.stringify(manifest, null, 2);
     await atomicWriteFile(path, serializedManifest, {
-      refreshBackup: !this.backupRecoveredPaths.has(path),
+      refreshBackup: !recoveredPaths.has(path),
     });
-    this.backupRecoveredPaths.clear();
+    // No whole-set clear: the captured marks die with this batch on success,
+    // and marks added DURING this flush (lazy unit loads recovering shards
+    // from .bak) stay in the live set for the flush that writes them.
   }
 
   private installAutosave() {

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -2200,6 +2200,22 @@ class FileTableStore {
   }
 
   async initialize() {
+    // Structural soundness gate for the lazy tier (#5592 Phase 2): per-unit
+    // uniqueness validation is only complete for constraints whose scope is
+    // covered by the loaded units — which holds for primary keys (per-row)
+    // but NOT for declared uniqueBy constraints, whose scope is the whole
+    // table. Every lazy table is PK-only today; adding one with uniqueBy
+    // would let cross-unit violations slip past assertUniqueRow silently, so
+    // refuse to boot rather than corrupt quietly.
+    for (const table of LAZY_UNIT_TABLES) {
+      const meta = getMeta(table);
+      if (meta.uniqueConstraints.length > 0) {
+        throw new Error(
+          `[file-storage] Lazy unit table ${table} declares uniqueBy constraints; ` +
+            `per-unit loading cannot enforce table-wide uniqueness. Remove it from LAZY_UNIT_TABLES.`,
+        );
+      }
+    }
     mkdirSync(this.rootDir, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
     await this.acquireWriterLease();
     try {

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -2845,9 +2845,21 @@ class FileTableStore {
     this.dirtyTables = new Set();
     const dirtyShards = this.dirtyShards;
     this.dirtyShards = new Map();
+    // The stale-file marks are captured IN THE SAME swap as the dirty keys
+    // (#5592 Phase 2): every stale mark is created in the same synchronous
+    // block that dirties the marked file's re-homed row keys, so a flush that
+    // sees the mark is guaranteed to also see those keys and write the rows'
+    // canonical shards BEFORE the stale file is unlinked. Reading the live
+    // map from inside saveShardedTable instead let a lazy unit load — which
+    // can run during this flush's own awaited writes — add a mark whose
+    // paired dirty keys this flush never captured, and the stale-cleanup pass
+    // then deleted a freshly loaded shard file (and its .bak) while its rows
+    // existed only in memory.
+    const staleShards = this.staleShardFiles;
+    this.staleShardFiles = new Map();
     const flush = (async () => {
       try {
-        await this.saveFileSnapshots(dirtyTables, dirtyShards);
+        await this.saveFileSnapshots(dirtyTables, dirtyShards, staleShards);
         this.lastFlushError = null;
       } catch (err) {
         this.lastFlushError = err;
@@ -2859,6 +2871,11 @@ class FileTableStore {
           const set = this.dirtyShards.get(table) ?? new Set<string>();
           for (const key of keys) set.add(key);
           this.dirtyShards.set(table, set);
+        }
+        for (const [table, encodings] of staleShards) {
+          const set = this.staleShardFiles.get(table) ?? new Set<string>();
+          for (const encoded of encodings) set.add(encoded);
+          this.staleShardFiles.set(table, set);
         }
         logger.error(err, "[file-storage] Failed to persist file-native storage");
       }
@@ -3136,10 +3153,28 @@ class FileTableStore {
       if (primaryColumn && column === primaryColumn) {
         if (meta.name === "messages") {
           const keys = new Set<string>();
+          let unresolved: Set<unknown> | null = null;
           for (const literal of literals) {
             if (typeof literal !== "string") continue; // no message anywhere carries this id
             const chatId = this.messageShardIndex.get(literal);
             if (chatId !== undefined) keys.add(chatId);
+            else (unresolved ??= new Set()).add(literal);
+          }
+          if (unresolved) {
+            // An id the complete harvest missed is either deleted (matches
+            // nothing anywhere) or a row whose chatId the harvest could not
+            // read (hand-edited shard). The resident probe covers the second
+            // case once such a row's unit has loaded; a probe miss safely
+            // stays out of scope — the row, if it exists at all, only becomes
+            // reachable when its unit loads, exactly like the eager loader's
+            // un-indexed rows only resolved through residency.
+            for (const row of this.rows(meta.name)) {
+              if (unresolved.has(row.id)) {
+                keys.add(this.shardKeyForRow(meta.name, row));
+                unresolved.delete(row.id);
+                if (unresolved.size === 0) break;
+              }
+            }
           }
           return keys;
         }
@@ -3803,8 +3838,15 @@ class FileTableStore {
               }
             }
             for (const row of usableRows) {
-              if (typeof row.id === "string" && typeof row.chatId === "string") {
-                this.messageShardIndex.set(row.id, row.chatId || UNASSIGNED_SHARD_KEY);
+              if (typeof row.id !== "string") continue;
+              // The eager loader normalized rows before indexing, which also
+              // accepted the column's dbName form — a hand-edited or
+              // externally produced shard may carry `chat_id`, and dropping
+              // it here would make the message invisible to id-scoped
+              // queries until its unit happens to load.
+              const chatId = typeof row.chatId === "string" ? row.chatId : row.chat_id;
+              if (typeof chatId === "string") {
+                this.messageShardIndex.set(row.id, chatId || UNASSIGNED_SHARD_KEY);
               }
             }
           }
@@ -4023,10 +4065,14 @@ class FileTableStore {
    * [], so deleted chats leave no permanent litter. Returns the shard-file
    * count for the manifest diagnostics.
    */
-  private async saveShardedTable(table: string, rows: Row[], dirtyKeys: Set<string>): Promise<number> {
+  private async saveShardedTable(
+    table: string,
+    rows: Row[],
+    dirtyKeys: Set<string>,
+    stale: Set<string> | undefined,
+  ): Promise<number> {
     const known = this.knownShardFiles.get(table) ?? new Set<string>();
     this.knownShardFiles.set(table, known);
-    const stale = this.staleShardFiles.get(table);
     // Nothing dirty and nothing to repair: skip the O(rows) regroup — this
     // runs for every sharded table on each flush, so an unrelated write must
     // not scan every stored row on the 750ms flush cadence.
@@ -4048,8 +4094,9 @@ class FileTableStore {
     // canonical rewrite when an in-memory shard still maps to the name; the
     // rest are deleted AFTER the write loop, so a crash mid-flush leaves
     // duplicates (healed by the next load) rather than rows that exist only
-    // in memory. Cleared per table once the flush lands; a failed flush keeps
-    // the marks and retries.
+    // in memory. The marks arrive as flush-captured state (swapped out of the
+    // live map together with the dirty keys they were created alongside);
+    // a failed flush re-merges them and retries.
     let effectiveDirty = dirtyKeys;
     const encodedToKey = new Map<string, string>();
     if (stale && stale.size > 0) {
@@ -4111,11 +4158,18 @@ class FileTableStore {
       await unlinkIgnoringMissing(`${path}.bak`);
       known.delete(encoded);
     }
-    this.staleShardFiles.delete(table);
+    // The processed marks were swapped out of the live map by flush(); marks
+    // added DURING this flush (lazy unit loads) sit in the live map and keep
+    // their files untouched until the next flush captures them together with
+    // their paired dirty keys. A failed flush re-merges the captured marks.
     return known.size;
   }
 
-  private async saveFileSnapshots(dirtyTables: Set<string>, dirtyShards: Map<string, Set<string>>) {
+  private async saveFileSnapshots(
+    dirtyTables: Set<string>,
+    dirtyShards: Map<string, Set<string>>,
+    staleShards: Map<string, Set<string>>,
+  ) {
     mkdirSync(join(this.rootDir, "tables"), { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
     const tables: Record<string, number> = {};
     const shards: Record<string, number> = {};
@@ -4135,7 +4189,12 @@ class FileTableStore {
         // Sharded tables never touch the flat path — leaving them in this
         // loop's recreate-if-missing branch would silently regrow a full
         // monolith on the very next flush (#4708).
-        shards[table] = await this.saveShardedTable(table, rows, dirtyShards.get(table) ?? new Set());
+        shards[table] = await this.saveShardedTable(
+          table,
+          rows,
+          dirtyShards.get(table) ?? new Set(),
+          staleShards.get(table),
+        );
         continue;
       }
       const path = tableFilePath(this.rootDir, table);

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -6,6 +6,7 @@
 // This in-memory table store persists dirty tables back to those files.
 import {
   chmodSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   openSync,
@@ -388,6 +389,55 @@ const SHARD_KEY_COLUMNS: Record<string, string> = {
   mari_workspace_context: "chatId",
 };
 const SHARDED_TABLE_SET: ReadonlySet<string> = new Set(SHARDED_TABLES);
+
+/**
+ * Chat-unit lazy tier (#5592 Phase 2). These tables no longer load at boot:
+ * their rows enter memory one CHAT UNIT at a time — every table's shard for a
+ * given chatId loads together, on first touch, and stays for the process
+ * lifetime (no eviction in this phase). Loading whole units at once is what
+ * keeps intra-chat cascades and the messages<->message_swipes coupling total
+ * over resident rows.
+ *
+ * Membership rule: exactly the chatId-keyed tables (targetChatId for the two
+ * cross-chat inbox tables) plus message_swipes, whose shard resolves through
+ * the parent-message index. Everything else — including tables sharded by
+ * characterId/lorebookId/presetId/storyboardId and every table with a unique
+ * key beyond its primary key — stays fully resident so cross-shard uniqueness
+ * and non-chat cascades keep today's behavior.
+ *
+ * MARINARA_EAGER_STORAGE=1 empties the tier and restores the eager boot as a
+ * field escape hatch.
+ */
+const LAZY_UNIT_TABLES: ReadonlySet<string> =
+  process.env.MARINARA_EAGER_STORAGE === "1" || process.env.MARINARA_EAGER_STORAGE === "true"
+    ? new Set()
+    : new Set([
+        "messages",
+        "message_swipes",
+        "memory_chunks",
+        "agent_runs",
+        "agent_memory",
+        "chat_images",
+        "game_state_snapshots",
+        "spatial_context_snapshots",
+        "game_engine_state",
+        "game_checkpoints",
+        "game_scene_videos",
+        "game_turn_storyboards",
+        "mari_workspace_context",
+        "ooc_influences",
+        "conversation_notes",
+        "conversation_call_sessions",
+        "conversation_call_messages",
+      ]);
+
+/**
+ * Per-unit load order (#5592 Phase 2): Set iteration preserves the declaration
+ * order above, which lists messages before message_swipes for the same reason
+ * boot's shardLoadOrder does — a swipe's shard key resolves through its parent
+ * message, so within one unit the messages shard must land first.
+ */
+const LAZY_UNIT_LOAD_ORDER: readonly string[] = [...LAZY_UNIT_TABLES];
 
 /**
  * Shard for child rows whose parent is unknown (orphans in corrupt installs).
@@ -945,6 +995,51 @@ async function preserveMalformedRowSource(path: string, table: string): Promise<
   try {
     await copyFile(path, to);
     if (process.platform !== "win32") await chmod(to, PRIVATE_FILE_MODE);
+    return [{ from: path, to }];
+  } catch (err) {
+    logger.error(
+      err,
+      "[file-storage] Failed to preserve table %s source %s before removing malformed rows.",
+      table,
+      path,
+    );
+    return [];
+  }
+}
+
+/**
+ * Synchronous twins of the two quarantine helpers above, for the lazy
+ * unit-load path (#5592 Phase 2): shard loading happens inside synchronous
+ * query evaluation (count/select/update/delete are sync up to their builder
+ * boundary), so the recovery pipeline it reuses cannot await.
+ */
+function quarantineUnrecoverableFilesSync(paths: string[], context: string): QuarantinedFile[] {
+  const timestamp = corruptionTimestamp();
+  const quarantined: QuarantinedFile[] = [];
+  for (const from of [...new Set(paths)]) {
+    if (!existsSync(from)) continue;
+    const to = quarantinePath(from, timestamp);
+    try {
+      renameSync(from, to);
+      quarantined.push({ from, to });
+    } catch (err) {
+      logger.error(
+        err,
+        "[file-storage] Failed to quarantine unrecoverable %s file %s; leaving it in place.",
+        context,
+        from,
+      );
+    }
+  }
+  return quarantined;
+}
+
+function preserveMalformedRowSourceSync(path: string, table: string): QuarantinedFile[] {
+  if (!existsSync(path)) return [];
+  const to = quarantinePath(path, corruptionTimestamp());
+  try {
+    copyFileSync(path, to);
+    if (process.platform !== "win32") chmodSync(to, PRIVATE_FILE_MODE);
     return [{ from: path, to }];
   } catch (err) {
     logger.error(
@@ -1861,7 +1956,34 @@ class FileTableStore {
    * "emptied by deletes". Any skipped key must then be re-queued as dirty so a
    * later flush resolves it once residency is restored.
    */
-  private fullyResidentTables = new Set<string>(FILE_BACKED_TABLES);
+  private fullyResidentTables = new Set<string>(FILE_BACKED_TABLES.filter((table) => !LAZY_UNIT_TABLES.has(table)));
+  /**
+   * Chat units whose shards are resident across every lazy table (#5592
+   * Phase 2). A unit loads whole — messages before message_swipes, mirroring
+   * boot order — and never unloads in this phase. The unassigned pseudo-unit
+   * is loaded at boot: orphan-row healing (reindexMovedMessages) requires the
+   * orphan swipes resident, and the shard is pathological-tiny by design.
+   */
+  private loadedUnits = new Set<string>();
+  /**
+   * Primary keys whose RESIDENT copy came from a foreign shard file (#5592
+   * Phase 2) — per table. The eager loader's dedup rule is "the canonical
+   * file's copy beats a stray copy"; under per-file loading the stray can
+   * arrive first, so its ids are marked here and the canonical file's copy
+   * replaces them when it loads. Every load operation is synchronous and
+   * pulls a stray's canonical unit in transitively, so no write can observe
+   * the stray copy in between; an entry only outlives its operation when the
+   * canonical file does not exist at all (the stray holds the only copy).
+   */
+  private strayResidentIds = new Map<string, Set<string>>();
+  /**
+   * Every shard discovered for a lazy table at boot (#5592 Phase 2),
+   * INCLUDING bak-only leftovers whose primary vanished in a crash — the
+   * per-unit load index. Distinct from knownShardFiles, which keeps its
+   * "primary physically on disk" meaning for the manifest and the flush
+   * skip-set: counting a bak-only shard there would report a phantom.
+   */
+  private lazyDiscoveredShards = new Map<string, Set<string>>();
   /**
    * messageIds of swipes currently resolving to the unassigned shard. When
    * such a message is later INSERTED, its swipes silently regroup into the
@@ -2545,6 +2667,7 @@ class FileTableStore {
    * callers that need real contexts downstream.
    */
   *matchingRows(meta: TableMeta, condition: Condition | undefined): IterableIterator<Row> {
+    this.ensureQueryScopeLoaded(meta, condition);
     const ctx: RowContext = { rows: {}, baseTable: meta.name, joined: false };
     for (const row of this.rows(meta.name)) {
       ctx.rows[meta.name] = row;
@@ -2569,6 +2692,13 @@ class FileTableStore {
             this.assertWritable();
             const conflictColumns = normalizeConflictTargets(onConflict?.target);
             const inputRows = Array.isArray(rows) ? rows : [rows];
+            // Load the destination units BEFORE the duplicate/uniqueness scan
+            // (#5592 Phase 2): onConflict matching and assertUniqueRow are
+            // only sound against the unit's full row set. A key with no shard
+            // on disk (a brand-new chat) is simply marked loaded.
+            if (LAZY_UNIT_TABLES.has(meta.name) && !this.fullyResidentTables.has(meta.name)) {
+              this.ensureUnitsLoaded(this.shardKeysForRows(meta.name, inputRows));
+            }
             const target = this.rows(meta.name);
             const nextRows = target.map(cloneRow);
             const affectedRows: Row[] = [];
@@ -2601,6 +2731,12 @@ class FileTableStore {
             this.tables.set(meta.name, nextRows);
             if (SHARDED_TABLE_SET.has(meta.name)) {
               const shardKeys = this.shardKeysForRows(meta.name, affectedRows);
+              // A conflict update can MOVE a row's shard key (profile import
+              // rewrites arbitrary columns): the destination unit must be
+              // resident before its key is flushed (#5592 Phase 2).
+              if (LAZY_UNIT_TABLES.has(meta.name) && !this.fullyResidentTables.has(meta.name)) {
+                this.ensureUnitsLoaded(shardKeys);
+              }
               if (meta.name === "messages") {
                 this.reindexMovedMessages(affectedRows);
               }
@@ -2624,6 +2760,7 @@ class FileTableStore {
           executable(async () => {
             await this.waitForWritableTurn();
             this.assertWritable();
+            this.ensureQueryScopeLoaded(meta, condition);
             const target = this.rows(meta.name);
             const changedIndexes: number[] = [];
             const nextRows = target.map((row, index) => {
@@ -2649,6 +2786,11 @@ class FileTableStore {
                   affectedRows.push(target[index]!, nextRows[index]!);
                 }
                 const shardKeys = this.shardKeysForRows(meta.name, affectedRows);
+                // An update that rewrites the shard column moves rows into a
+                // unit that may not be resident yet (#5592 Phase 2).
+                if (LAZY_UNIT_TABLES.has(meta.name) && !this.fullyResidentTables.has(meta.name)) {
+                  this.ensureUnitsLoaded(shardKeys);
+                }
                 if (meta.name === "messages") {
                   this.reindexMovedMessages(affectedRows);
                 }
@@ -2888,9 +3030,24 @@ class FileTableStore {
     }
   }
 
-  /** Rebuilds the messageId -> chatId index from the current messages rows. */
+  /**
+   * Rebuilds the messageId -> chatId index from the current messages rows.
+   * Under lazy units (#5592 Phase 2) the index is COMPLETE — harvested from
+   * every shard at boot — while the rows are partial, so a full clear would
+   * destroy the entries for unloaded chats and misroute their swipes to the
+   * unassigned shard. Only the loaded units' entries are rebuilt: every
+   * mutation the rollback path reverts touched resident rows (the write hooks
+   * load a unit before any write), so unloaded entries are exactly the
+   * harvested truth and must survive untouched.
+   */
   private rebuildMessageShardIndex() {
-    this.messageShardIndex.clear();
+    if (this.fullyResidentTables.has("messages")) {
+      this.messageShardIndex.clear();
+    } else {
+      for (const [id, chatId] of this.messageShardIndex) {
+        if (this.loadedUnits.has(chatId)) this.messageShardIndex.delete(id);
+      }
+    }
     for (const row of this.tables.get("messages") ?? []) {
       if (typeof row.id === "string" && typeof row.chatId === "string") {
         this.messageShardIndex.set(row.id, row.chatId || UNASSIGNED_SHARD_KEY);
@@ -2898,7 +3055,375 @@ class FileTableStore {
     }
   }
 
-  private deleteWhere(meta: TableMeta, condition?: Condition) {
+  // ── Lazy chat-unit loading (#5592 Phase 2) ────────────────────────────
+
+  /** Unit key a shard-column VALUE resolves to — mirrors shardKeyForRow. */
+  private unitKeyForShardValue(value: unknown): string {
+    return typeof value === "string" && value ? value : UNASSIGNED_SHARD_KEY;
+  }
+
+  /**
+   * Static unit scope of a WHERE condition against one lazy table: the set of
+   * unit keys that could possibly hold matching rows, or null when the
+   * condition cannot bound them (the caller must then make the whole table
+   * resident). Soundness rule: returning a set S asserts that NO row outside
+   * the units in S can satisfy the condition — over-approximating is safe,
+   * under-approximating silently hides rows.
+   *
+   * Resolution classes:
+   *  - DIRECT: eq/inArray/is-null on the table's own shard column, with
+   *    literal operands.
+   *  - PARENT-MAPPED (message_swipes): literal messageIds resolve through the
+   *    COMPLETE messageId->chatId index (harvested at boot, maintained on
+   *    every insert); an id absent from the index has no parent anywhere, so
+   *    its swipes can only live in the unassigned shard.
+   *  - MESSAGES-PK: eq/inArray on messages.id resolves through the same
+   *    complete index; an absent id matches nothing in ANY unit.
+   *  - PK-PROBE (other tables): eq/inArray on the primary key scopes to the
+   *    resident rows' units only when EVERY listed id is already resident —
+   *    a miss may sit in an unloaded unit, so the probe abstains.
+   *
+   * Logical combinators follow evaluateCondition exactly: an empty AND
+   * matches every row (logical() filters undefined conjuncts and
+   * `.every([]) === true`), so it must widen to null, while an empty OR
+   * matches nothing and narrows to the empty set.
+   */
+  private unitScopeForCondition(meta: TableMeta, condition: Condition): Set<string> | null {
+    if (!condition || !isFileCondition(condition)) return null;
+    if (condition.kind === "file-logical") {
+      if (condition.operator === "or") {
+        const union = new Set<string>();
+        if (condition.conditions.length === 0) return union;
+        for (const entry of condition.conditions) {
+          const scope = this.unitScopeForCondition(meta, entry);
+          if (scope === null) return null;
+          for (const key of scope) union.add(key);
+        }
+        return union;
+      }
+      let intersection: Set<string> | null = null;
+      for (const entry of condition.conditions) {
+        const scope = this.unitScopeForCondition(meta, entry);
+        if (scope === null) continue;
+        if (intersection === null) intersection = new Set(scope);
+        else for (const key of intersection) if (!scope.has(key)) intersection.delete(key);
+      }
+      return intersection;
+    }
+
+    const strategy = getFileTableShardStrategy(meta.name as FileBackedTable);
+    const shardColumn = meta.byKey.get(strategy.column) ?? meta.byDbName.get(strategy.column) ?? null;
+    const primaryColumn = meta.primaryKey ? (meta.byKey.get(meta.primaryKey) ?? null) : null;
+    const columnAndLiterals = (left: unknown, right: unknown): { column: ColumnMeta; literal: unknown } | null => {
+      const leftMeta = getColumnMeta(left);
+      const rightMeta = getColumnMeta(right);
+      if (leftMeta && !rightMeta) return { column: leftMeta, literal: right };
+      if (rightMeta && !leftMeta) return { column: rightMeta, literal: left };
+      return null;
+    };
+    const keysForLiterals = (column: ColumnMeta, literals: unknown[]): Set<string> | null => {
+      if (column === shardColumn) {
+        if (strategy.kind === "message-parent") {
+          const keys = new Set<string>();
+          for (const literal of literals) {
+            if (typeof literal !== "string") keys.add(UNASSIGNED_SHARD_KEY);
+            else keys.add(this.messageShardIndex.get(literal) ?? UNASSIGNED_SHARD_KEY);
+          }
+          return keys;
+        }
+        return new Set(literals.map((literal) => this.unitKeyForShardValue(literal)));
+      }
+      if (primaryColumn && column === primaryColumn) {
+        if (meta.name === "messages") {
+          const keys = new Set<string>();
+          for (const literal of literals) {
+            if (typeof literal !== "string") continue; // no message anywhere carries this id
+            const chatId = this.messageShardIndex.get(literal);
+            if (chatId !== undefined) keys.add(chatId);
+          }
+          return keys;
+        }
+        // PK-probe: sound only when every id is already resident.
+        const wanted = new Set(literals);
+        const keys = new Set<string>();
+        let found = 0;
+        for (const row of this.rows(meta.name)) {
+          const id = meta.primaryKey ? row[meta.primaryKey] : undefined;
+          if (wanted.has(id)) {
+            wanted.delete(id);
+            found += 1;
+            keys.add(this.shardKeyForRow(meta.name, row));
+            if (wanted.size === 0) break;
+          }
+        }
+        return found === literals.length ? keys : null;
+      }
+      return null;
+    };
+
+    if (condition.kind === "file-comparison" && condition.operator === "eq") {
+      const resolved = columnAndLiterals(condition.left, condition.right);
+      if (!resolved) return null;
+      return keysForLiterals(resolved.column, [resolved.literal]);
+    }
+    if (condition.kind === "file-membership" && condition.operator === "in") {
+      const columnMeta = getColumnMeta(condition.value);
+      if (!columnMeta) return null;
+      for (const entry of condition.values) if (isColumn(entry) || Array.isArray(entry)) return null;
+      return keysForLiterals(columnMeta, condition.values);
+    }
+    if (condition.kind === "file-null-check" && condition.operator === "is-null") {
+      const columnMeta = getColumnMeta(condition.value);
+      if (columnMeta && columnMeta === shardColumn && strategy.kind !== "message-parent") {
+        return new Set([UNASSIGNED_SHARD_KEY]);
+      }
+      return null;
+    }
+    return null;
+  }
+
+  /**
+   * Query/write hook: make every unit a condition could match resident before
+   * the table is scanned. Unbounded conditions lease the whole table.
+   */
+  ensureQueryScopeLoaded(meta: TableMeta, condition: Condition) {
+    if (!LAZY_UNIT_TABLES.has(meta.name) || this.fullyResidentTables.has(meta.name)) return;
+    const scope = this.unitScopeForCondition(meta, condition);
+    if (scope === null) {
+      this.ensureTableLoaded(meta.name);
+      return;
+    }
+    if (scope.size > 0) this.ensureUnitsLoaded(scope);
+  }
+
+  /**
+   * Loads whole chat units: for each key, every lazy table's shard for that
+   * key enters memory together, messages first. A key with no shard files is
+   * still marked loaded — that is how brand-new chats become writable. Stray
+   * rows found in a unit's files but belonging to OTHER units (interrupted
+   * re-homes, hand edits) pull those units in transitively, so the resident
+   * set never holds a partial unit.
+   */
+  ensureUnitsLoaded(keys: Iterable<string>) {
+    if (LAZY_UNIT_TABLES.size === 0) return;
+    const queue = [...new Set(keys)].filter((key) => !this.loadedUnits.has(key));
+    if (queue.length === 0) return;
+    while (queue.length > 0) {
+      const key = queue.shift()!;
+      if (this.loadedUnits.has(key)) continue;
+      // Mark first: strays pointing back at this unit must not re-enqueue it.
+      this.loadedUnits.add(key);
+      const encoded = encodeShardKey(key);
+      for (const table of LAZY_UNIT_LOAD_ORDER) {
+        if (this.fullyResidentTables.has(table)) continue;
+        if (!this.lazyDiscoveredShards.get(table)?.has(encoded)) continue;
+        const rows = this.loadShardFileSync(table, encoded);
+        if (rows.length === 0) continue;
+        for (const strayKey of this.mergeLoadedRows(table, rows, encoded)) {
+          if (!this.loadedUnits.has(strayKey)) queue.push(strayKey);
+        }
+      }
+    }
+  }
+
+  /**
+   * Full-table lease: makes one lazy table entirely resident (backup export,
+   * cross-unit predicates, unbounded scans). Idempotent; per-unit loading
+   * skips leased tables afterwards. Units are NOT marked loaded here — their
+   * other tables stay on disk.
+   */
+  ensureTableLoaded(table: Table | string) {
+    const meta = getMeta(table);
+    if (!LAZY_UNIT_TABLES.has(meta.name) || this.fullyResidentTables.has(meta.name)) return;
+    const discovered = this.lazyDiscoveredShards.get(meta.name);
+    if (discovered && discovered.size > 0) {
+      const loadedEncodings = new Set([...this.loadedUnits].map((key) => encodeShardKey(key)));
+      for (const encoded of [...discovered]) {
+        if (loadedEncodings.has(encoded)) continue;
+        const rows = this.loadShardFileSync(meta.name, encoded);
+        if (rows.length > 0) this.mergeLoadedRows(meta.name, rows, encoded);
+      }
+    }
+    this.fullyResidentTables.add(meta.name);
+    logger.info("[file-storage] Lazy table %s is now fully resident (unbounded access)", meta.name);
+  }
+
+  /**
+   * Reads, recovers, and normalizes ONE shard file — the same per-file
+   * pipeline the eager boot loop runs, in synchronous form. Healing marks
+   * (recovered/malformed/migrated/foreign rows) are recorded here, at load
+   * time, because boot never parses lazy shards: a dirty key for a unit that
+   * is only now becoming resident can flush safely, where a boot-time mark
+   * for an unloaded unit could not.
+   */
+  private loadShardFileSync(table: string, encoded: string): Row[] {
+    const meta = getMeta(table);
+    const known = this.knownShardFiles.get(table) ?? new Set<string>();
+    this.knownShardFiles.set(table, known);
+    const path = shardFilePath(this.rootDir, table, encoded);
+    const { value, recoveredFromBackup, recoveredFromFallback, unreadablePaths } = parseJsonFile<Row[]>(path, []);
+    const parsedRows = Array.isArray(value) ? value : [];
+    const source = parsedRows.filter(isRowRecord);
+    const malformedRowCount = parsedRows.length - source.length;
+    if (malformedRowCount > 0 && source.length === 0) {
+      const files = quarantineUnrecoverableFilesSync([path, `${path}.bak`], `table ${table} shard ${encoded}`);
+      if (files.length > 0) this.quarantinedTables.push({ table, files });
+      logger.error(
+        { table, shard: encoded, malformedRowCount, preservedFiles: files.map((file) => file.to) },
+        "[file-storage] Shard contained only malformed rows; quarantined its files for manual recovery.",
+      );
+      if (!existsSync(path)) {
+        known.delete(encoded);
+        return [];
+      }
+    }
+    if (malformedRowCount > 0) {
+      const sourcePath = recoveredFromBackup && existsSync(`${path}.bak`) ? `${path}.bak` : path;
+      const files = preserveMalformedRowSourceSync(sourcePath, table);
+      if (files.length > 0) this.quarantinedTables.push({ table, files });
+      logger.error(
+        { table, file: sourcePath, malformedRowCount, preservedFiles: files.map((file) => file.to) },
+        "[file-storage] Skipped malformed shard rows and preserved the source file for manual recovery.",
+      );
+      this.backupRecoveredPaths.add(path);
+    }
+    const needsRowMigration = source.some((row) => fileBackedRowNeedsMigration(table, row));
+    const normalized = source.map((row) => normalizeRow(meta, migrateFileBackedRow(table, row)));
+    if (recoveredFromFallback && unreadablePaths.length > 0) {
+      const files = quarantineUnrecoverableFilesSync(unreadablePaths, `table ${table} shard ${encoded}`);
+      if (files.length > 0) {
+        this.quarantinedTables.push({ table, files });
+        if (files.some((file) => file.from === path)) known.delete(encoded);
+        logger.error(
+          { table, shard: encoded, files },
+          "[file-storage] Shard was unrecoverable from primary and backup; quarantined corrupt files. Preserved files require manual recovery.",
+        );
+      }
+    }
+    if (normalized.length > 0) {
+      const needsRepair = recoveredFromBackup || recoveredFromFallback || malformedRowCount > 0 || needsRowMigration;
+      const rowKeys = this.shardKeysForRows(table, normalized);
+      const holdsForeignRows = [...rowKeys].some((rawKey) => encodeShardKey(rawKey) !== encoded);
+      if (needsRepair) this.backupRecoveredPaths.add(path);
+      if (needsRepair || holdsForeignRows) {
+        this.dirty = true;
+        this.dirtyTables.add(table);
+        const set = this.dirtyShards.get(table) ?? new Set<string>();
+        for (const rawKey of rowKeys) set.add(rawKey);
+        this.dirtyShards.set(table, set);
+      }
+      if (holdsForeignRows) {
+        const stale = this.staleShardFiles.get(table) ?? new Set<string>();
+        stale.add(encoded);
+        this.staleShardFiles.set(table, stale);
+        logger.warn(
+          { table, shard: encoded },
+          "[file-storage] Shard file holds rows belonging to other shards; it will be rewritten canonically on the next flush.",
+        );
+      }
+    } else if (recoveredFromBackup) {
+      // Corrupt primary over a valid but EMPTY .bak: mark the file stale so
+      // the flush deletes the pair instead of re-recovering it forever.
+      this.dirty = true;
+      this.dirtyTables.add(table);
+      const stale = this.staleShardFiles.get(table) ?? new Set<string>();
+      stale.add(encoded);
+      this.staleShardFiles.set(table, stale);
+    }
+    return normalized;
+  }
+
+  /**
+   * Merges freshly loaded rows into a lazy table's resident array. The
+   * resident copy wins every primary-key collision — it is either the
+   * canonical unit's copy or a newer in-memory write, and the incoming
+   * duplicate is a stray file copy that the stale-file rewrite will clear.
+   * The merged array is re-sorted with boot's comparator so consumers without
+   * an orderBy keep seeing one deterministic sequence, and an active
+   * transaction's snapshot receives the same rows — loaded data is not a
+   * mutation and must survive a rollback.
+   *
+   * Returns the incoming rows' unit keys so the caller can pull stray units
+   * in transitively.
+   */
+  private mergeLoadedRows(table: string, incoming: Row[], sourceEncoded: string): Set<string> {
+    const meta = getMeta(table);
+    const resident = this.tables.get(table) ?? [];
+    const primaryKey = meta.primaryKey;
+    const residentIds = primaryKey
+      ? new Set(resident.map((row) => row[primaryKey]).filter((id) => typeof id === "string"))
+      : null;
+    const strayIds = this.strayResidentIds.get(table);
+    const added: Row[] = [];
+    const replacements = new Map<string, Row>();
+    let duplicateCount = 0;
+    for (const row of incoming) {
+      const id = primaryKey && typeof row[primaryKey] === "string" ? (row[primaryKey] as string) : null;
+      const isCanonical = encodeShardKey(this.shardKeyForRow(table, row)) === sourceEncoded;
+      if (id && residentIds) {
+        if (residentIds.has(id)) {
+          if (isCanonical && strayIds?.has(id)) {
+            // The resident copy is a stray from a foreign file; the canonical
+            // file's copy wins, mirroring the eager loader's dedup rule.
+            replacements.set(id, row);
+            strayIds.delete(id);
+          } else {
+            duplicateCount += 1;
+          }
+          continue;
+        }
+        residentIds.add(id);
+        if (!isCanonical) {
+          const set = strayIds ?? new Set<string>();
+          set.add(id);
+          this.strayResidentIds.set(table, set);
+        }
+      }
+      added.push(row);
+    }
+    if (duplicateCount > 0) {
+      // The dropped copies live in THIS file; rewrite it from memory so they
+      // do not resurface on the next boot.
+      logger.warn(
+        { table, shard: sourceEncoded, duplicateCount },
+        "[file-storage] Dropped duplicate %s rows already resident in memory; the shard file will be rewritten.",
+        table,
+      );
+      this.dirty = true;
+      this.dirtyTables.add(table);
+      const stale = this.staleShardFiles.get(table) ?? new Set<string>();
+      stale.add(sourceEncoded);
+      this.staleShardFiles.set(table, stale);
+    }
+    const keys = this.shardKeysForRows(table, incoming);
+    if (added.length === 0 && replacements.size === 0) return keys;
+    const compareRows = (a: Row, b: Row) =>
+      String(a.createdAt ?? "").localeCompare(String(b.createdAt ?? "")) ||
+      String(primaryKey ? a[primaryKey] : "").localeCompare(String(primaryKey ? b[primaryKey] : ""));
+    const swapReplaced = (row: Row) => {
+      const id = primaryKey && typeof row[primaryKey] === "string" ? (row[primaryKey] as string) : null;
+      return (id && replacements.get(id)) || row;
+    };
+    const merged = resident.map(swapReplaced).concat(added).sort(compareRows);
+    this.tables.set(table, merged);
+    const ctx = this.txContext.getStore();
+    const snapshot = ctx?.snapshots.get(table);
+    if (snapshot) {
+      const mirrored = snapshot.map(swapReplaced).concat(added);
+      snapshot.length = 0;
+      snapshot.push(...mirrored.map((row) => ({ ...row })));
+      snapshot.sort(compareRows);
+    }
+    if (table === "messages") this.reindexMovedMessages(added.concat([...replacements.values()]));
+    return keys;
+  }
+
+  private deleteWhere(meta: TableMeta, condition?: Condition, options?: { unitsPreloaded?: boolean }) {
+    // unitsPreloaded: an intra-unit cascade already loaded every unit its
+    // parent rows live in, and the child key (messageId/snapshotId/callId) is
+    // one the scope extractor cannot resolve — skipping the hook avoids a
+    // pointless whole-table lease on every message delete (#5592 Phase 2).
+    if (!options?.unitsPreloaded) this.ensureQueryScopeLoaded(meta, condition);
     const target = this.rows(meta.name);
     const kept: Row[] = [];
     const deleted: Row[] = [];
@@ -2928,9 +3453,29 @@ class FileTableStore {
     }
   }
 
+  /**
+   * Chat units the deleted PARENT rows live in (#5592 Phase 2) — the hint
+   * that lets intra-unit cascades and set-null relations reach a lazy child
+   * without leasing its whole table. Sound because every hinted relation is
+   * intra-unit by construction: a child row referencing parent P carries P's
+   * own chatId (the mirror cleanup in chats.storage relies on the same
+   * invariant). Only meaningful when the parent's shard key IS the chat unit
+   * key — the caller restricts usage to those parents.
+   */
+  private unitKeysOfParentRows(parentTable: FileBackedTable, deletedRows: Row[]): Set<string> {
+    return this.shardKeysForRows(parentTable, deletedRows);
+  }
+
   private applySetNullRelations(parentTable: FileBackedTable, deletedRows: Row[]) {
     for (const relation of SET_NULL_RELATIONS.filter((entry) => entry.parent === parentTable)) {
       const childMeta = getMeta(relation.child);
+      // The scan below only sees resident rows. Every set-null parent
+      // (chat_images, game_scene_videos, spatial_context_snapshots) shards by
+      // chatId, and its child rows live in the same chat unit — load those
+      // units so the resident scan is complete (#5592 Phase 2).
+      if (LAZY_UNIT_TABLES.has(childMeta.name) && !this.fullyResidentTables.has(childMeta.name)) {
+        this.ensureUnitsLoaded(this.unitKeysOfParentRows(parentTable, deletedRows));
+      }
       const deletedValues = new Set(deletedRows.map((row) => row[relation.parentKey]));
       const changedRows: Row[] = [];
       for (const row of this.rows(childMeta.name)) {
@@ -2953,13 +3498,35 @@ class FileTableStore {
     }
   }
 
+  /**
+   * Cascade child keys that are intra-unit references from a chat-keyed lazy
+   * parent (#5592 Phase 2): the child rows live in the SAME chat units as the
+   * deleted parent rows, so loading the parents' units and scanning resident
+   * rows is complete — where the scope extractor would otherwise lease the
+   * child's whole table on every message delete. The remaining lazy-child
+   * cascades (chatId/targetChatId resolve directly; sourceChatId and
+   * agentConfigId genuinely span units and must lease) go through the normal
+   * deleteWhere hook.
+   */
+  private static readonly CASCADE_INTRA_UNIT_CHILD_KEYS = new Set(["messageId", "snapshotId", "callId"]);
+
   private applyCascades(parentTable: FileBackedTable, deletedRows: Row[]) {
     for (const cascade of CASCADES.filter((entry) => entry.parent === parentTable)) {
       const childMeta = getMeta(cascade.child);
       const deletedValues = new Set(deletedRows.map((row) => row[cascade.parentKey]));
       const childColumn = childMeta.byKey.get(cascade.childKey)?.column;
       if (childColumn) {
-        this.deleteWhere(childMeta, inArray(childColumn, Array.from(deletedValues)));
+        let unitsPreloaded = false;
+        if (
+          LAZY_UNIT_TABLES.has(childMeta.name) &&
+          !this.fullyResidentTables.has(childMeta.name) &&
+          FileTableStore.CASCADE_INTRA_UNIT_CHILD_KEYS.has(cascade.childKey) &&
+          LAZY_UNIT_TABLES.has(parentTable)
+        ) {
+          this.ensureUnitsLoaded(this.unitKeysOfParentRows(parentTable, deletedRows));
+          unitsPreloaded = true;
+        }
+        this.deleteWhere(childMeta, inArray(childColumn, Array.from(deletedValues)), { unitsPreloaded });
       } else {
         const err = new Error(`Cascade child column ${cascade.child}.${cascade.childKey} is not registered`);
         logger.error(
@@ -3182,6 +3749,73 @@ class FileTableStore {
         /* no shard dir yet — fresh install or pre-migration */
       }
       const dataFiles = discoverShardPrimaries(entries);
+      if (LAZY_UNIT_TABLES.has(table)) {
+        // Lazy tier (#5592 Phase 2): boot DISCOVERS shards without loading
+        // them. Rows enter memory per chat unit on first touch, through the
+        // same per-file recovery pipeline the eager path runs below — which
+        // is also when self-heal marks are recorded, since a boot-time dirty
+        // key for a unit that is not resident could never flush safely.
+        // Quarantines are the exception: pure renames need no dirty key, so
+        // the messages harvest performs them exactly like the eager loop.
+        const present = new Set(entries);
+        const discovered = new Set<string>();
+        const known = new Set<string>();
+        for (const fileName of dataFiles) {
+          const encoded = fileName.slice(0, -".json".length);
+          discovered.add(encoded);
+          if (present.has(fileName)) known.add(encoded);
+        }
+        if (table === "messages") {
+          // Harvest the COMPLETE messageId -> chatId map: swipe shard
+          // resolution and query scoping consult it for messages in unloaded
+          // chats, so it must cover every shard even though no rows stay
+          // resident. Same precedent as buildMigrationIndexFromShards; rows
+          // are dropped right after the ids are read.
+          for (const fileName of dataFiles) {
+            const encoded = fileName.slice(0, -".json".length);
+            const path = join(dir, fileName);
+            const { value, recoveredFromFallback, unreadablePaths } = parseJsonFile<Row[]>(path, []);
+            const parsedRows = Array.isArray(value) ? value : [];
+            const usableRows = parsedRows.filter(isRowRecord);
+            if (parsedRows.length > 0 && usableRows.length === 0) {
+              const files = quarantineUnrecoverableFilesSync([path, `${path}.bak`], `table ${table} shard ${encoded}`);
+              if (files.length > 0) this.quarantinedTables.push({ table, files });
+              logger.error(
+                { table, shard: encoded, malformedRowCount: parsedRows.length, preservedFiles: files.map((f) => f.to) },
+                "[file-storage] Shard contained only malformed rows; quarantined its files for manual recovery.",
+              );
+              if (!existsSync(path)) {
+                known.delete(encoded);
+                discovered.delete(encoded);
+                continue;
+              }
+            }
+            if (recoveredFromFallback && unreadablePaths.length > 0) {
+              const files = quarantineUnrecoverableFilesSync(unreadablePaths, `table ${table} shard ${encoded}`);
+              if (files.length > 0) {
+                this.quarantinedTables.push({ table, files });
+                logger.error(
+                  { table, shard: encoded, files },
+                  "[file-storage] Shard was unrecoverable from primary and backup; quarantined corrupt files. Preserved files require manual recovery.",
+                );
+                if (files.some((file) => file.from === path)) known.delete(encoded);
+                if (!existsSync(path) && !existsSync(`${path}.bak`)) discovered.delete(encoded);
+              }
+            }
+            for (const row of usableRows) {
+              if (typeof row.id === "string" && typeof row.chatId === "string") {
+                this.messageShardIndex.set(row.id, row.chatId || UNASSIGNED_SHARD_KEY);
+              }
+            }
+          }
+          counts[table] = this.messageShardIndex.size;
+        }
+        this.tables.set(table, []);
+        this.knownShardFiles.set(table, known);
+        this.lazyDiscoveredShards.set(table, discovered);
+        if (entries.length > 0) this.shardDirsCreated.add(table);
+        continue;
+      }
       const known = new Set<string>();
       const combined: Row[] = [];
       // Which physical file each row came from (encoded name) — the dedup
@@ -3355,6 +3989,10 @@ class FileTableStore {
     }
     if (declaredTableCounts) {
       const mismatches = FILE_BACKED_TABLES.flatMap((table) => {
+        // Lazy tables have no boot row count to compare (#5592 Phase 2) —
+        // their manifest entry is either the harvested message-index size or
+        // absent, and either way the diagnostic is meaningless here.
+        if (LAZY_UNIT_TABLES.has(table)) return [];
         const declared = declaredTableCounts?.[table];
         const actual = counts[table] ?? 0;
         if (declared === undefined && actual === 0) return [];
@@ -3368,6 +4006,12 @@ class FileTableStore {
         this.dirty = true;
       }
     }
+    // The unassigned pseudo-unit loads eagerly (#5592 Phase 2): orphan-row
+    // healing needs the orphan swipes resident (the adoption path in
+    // reindexMovedMessages), and the shard is pathological-tiny by design.
+    // This also transitively pulls in any unit whose rows were mis-filed into
+    // the orphan shard, restoring the eager loader's self-heal for them.
+    if (LAZY_UNIT_TABLES.size > 0) this.ensureUnitsLoaded([UNASSIGNED_SHARD_KEY]);
     logger.info({ tables: counts }, `[file-storage] Loaded file-native data from ${this.rootDir}`);
   }
 
@@ -3441,12 +4085,25 @@ class FileTableStore {
     }
     for (const key of effectiveDirty) {
       if (rowsByShard.has(key)) continue;
-      // A dirty key with no rows in the regroup means the shard was emptied by
-      // deletes ONLY while the table's full row set is resident. Positive
-      // evidence, not inference from absence: under partial residency (#5592
-      // Phase 2) an evicted shard would be indistinguishable from an emptied
-      // one, and unlinking here would destroy its file and backup.
-      if (!this.fullyResidentTables.has(table)) continue;
+      // A dirty key with no rows in the regroup means the shard was emptied
+      // by deletes ONLY when its rows were resident to begin with — full
+      // table residency, or that unit loaded (#5592 Phase 2). Positive
+      // evidence, not inference from absence: without it, an unloaded unit's
+      // shard would be indistinguishable from an emptied one, and unlinking
+      // here would destroy its file and backup. A dirty key for an unloaded
+      // unit should not occur; requeue it defensively (into the LIVE dirty
+      // map — flush swapped it out before this ran) so the mark survives
+      // until the unit loads instead of being silently dropped.
+      if (!this.fullyResidentTables.has(table) && !this.loadedUnits.has(key)) {
+        logger.warn(
+          { table, shardKey: key },
+          "[file-storage] Dirty shard key belongs to an unloaded unit; deferring its flush until the unit loads.",
+        );
+        const requeued = this.dirtyShards.get(table) ?? new Set<string>();
+        requeued.add(key);
+        this.dirtyShards.set(table, requeued);
+        continue;
+      }
       const encoded = encodeShardKey(key);
       if (!known.has(encoded)) continue;
       const path = shardFilePath(this.rootDir, table, encoded);
@@ -3465,7 +4122,15 @@ class FileTableStore {
 
     for (const table of FILE_BACKED_TABLES) {
       const rows = this.rows(table);
-      tables[table] = rows.length;
+      if (LAZY_UNIT_TABLES.has(table) && !this.fullyResidentTables.has(table)) {
+        // Partial residency makes rows.length a lie (#5592 Phase 2). The
+        // messages count is recoverable from the complete shard index; the
+        // other lazy tables' totals are simply unknown and stay out of the
+        // manifest — the boot mismatch walk skips lazy tables to match.
+        if (table === "messages") tables[table] = this.messageShardIndex.size;
+      } else {
+        tables[table] = rows.length;
+      }
       if (SHARDED_TABLE_SET.has(table)) {
         // Sharded tables never touch the flat path — leaving them in this
         // loop's recreate-if-missing branch would silently regrow a full
@@ -3558,6 +4223,21 @@ class SelectQuery implements SelectQueryBuilder<any> {
       }
       return this.finish(matched);
     }
+    // Joined queries scope each lazy table against the combined WHERE + join
+    // conditions (#5592 Phase 2). The AND extractor ignores conjuncts it
+    // cannot resolve (column-to-column join predicates, other tables'
+    // columns), so each lazy table is bounded by whatever conjuncts name its
+    // OWN shard column or primary key — the shipped joins all carry one, e.g.
+    // eq(agentRuns.chatId, X) — and a table nothing bounds is leased whole.
+    const combined: Condition = {
+      kind: "file-logical",
+      operator: "and",
+      conditions: [this.condition, ...this.joins.map((join) => join.condition)].filter(
+        (entry): entry is FileCondition => entry !== undefined,
+      ),
+    };
+    this.store.ensureQueryScopeLoaded(this.fromMeta, combined);
+    for (const join of this.joins) this.store.ensureQueryScopeLoaded(join.table, combined);
     let contexts = this.store.rows(this.fromMeta.name).map((row) => this.store.contextForRow(this.fromMeta, row));
 
     for (const join of this.joins) {

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -4962,15 +4962,32 @@ function storyboardStaleRenderCutoff(): string {
   return new Date(Date.now() - GAME_STORYBOARD_STALE_RENDER_MS).toISOString();
 }
 
+/**
+ * Process-start timestamp: any storyboard still "in progress" from BEFORE
+ * this moment belongs to a previous (crashed) process and is dead no matter
+ * how recently it was updated. Folding it into the per-request sweep replaces
+ * the old startup-wide sweep, which the lazy store (#5592 Phase 2) can no
+ * longer run without loading every chat's storyboards — each chat is now
+ * recovered on its first storyboard read instead, before anything is listed.
+ */
+const storyboardBootRecoveryCutoff = new Date().toISOString();
+
+function storyboardRecoveryCutoff(): string {
+  const stale = storyboardStaleRenderCutoff();
+  return stale > storyboardBootRecoveryCutoff ? stale : storyboardBootRecoveryCutoff;
+}
+
 async function recoverStaleGameStoryboards(
   storyboards: ReturnType<typeof createGameStoryboardsStorage>,
   cutoffUpdatedAt: string,
   context: string,
+  chatId?: string,
 ) {
   try {
     const recovered = await storyboards.failInProgressUpdatedBefore(
       cutoffUpdatedAt,
       GAME_STORYBOARD_STALE_RENDER_ERROR,
+      chatId,
     );
     if (recovered > 0) {
       logger.warn("[game/storyboard] marked %d stale storyboard render job(s) failed during %s", recovered, context);
@@ -5906,7 +5923,9 @@ async function serializeGameTurnStoryboard(args: {
 }
 
 export async function gameRoutes(app: FastifyInstance) {
-  await recoverStaleGameStoryboards(createGameStoryboardsStorage(app.db), new Date().toISOString(), "startup");
+  // Startup-wide storyboard recovery is gone (#5592 Phase 2): the per-request
+  // sweeps below use storyboardRecoveryCutoff(), whose boot-time floor marks
+  // every pre-boot in-progress row failed the first time its chat is read.
   const characterGallery = createCharacterGalleryStorage(app.db);
   const personaGallery = createPersonaGalleryStorage(app.db);
 
@@ -11881,7 +11900,7 @@ export async function gameRoutes(app: FastifyInstance) {
     const storyboards = createGameStoryboardsStorage(app.db);
     const gallery = createGalleryStorage(app.db);
     const sceneVideos = createGameSceneVideosStorage(app.db);
-    await recoverStaleGameStoryboards(storyboards, storyboardStaleRenderCutoff(), "storyboard list");
+    await recoverStaleGameStoryboards(storyboards, storyboardRecoveryCutoff(), "storyboard list", chatId);
     const rows = query.messageId
       ? await storyboards.listForTurn(chatId, query.messageId, query.swipeIndex ?? 0)
       : await storyboards.listRecentByChatId(chatId, query.limit);
@@ -11918,7 +11937,7 @@ export async function gameRoutes(app: FastifyInstance) {
       const sceneVideos = createGameSceneVideosStorage(app.db);
       const gallery = createGalleryStorage(app.db);
       const promptOverridesStorage = createPromptOverridesStorage(app.db);
-      await recoverStaleGameStoryboards(storyboards, storyboardStaleRenderCutoff(), "storyboard generate");
+      await recoverStaleGameStoryboards(storyboards, storyboardRecoveryCutoff(), "storyboard generate", input.chatId);
 
       const chat = await chats.getById(input.chatId);
       if (!chat) return reply.status(404).send({ error: "Chat not found" });

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -680,9 +680,22 @@ export function createChatsStorage(db: DB) {
     return { allowed: true };
   }
 
-  async function deleteGameStateForMessages(messageIds: string[]) {
+  /**
+   * `chatIds` scopes every messageId-keyed condition to the owning chats so
+   * the lazy store (#5592 Phase 2) loads only those chat units instead of
+   * leasing each game table whole. Callers pass the chatIds of the messages
+   * being removed (they read the rows first); omitting it keeps the old
+   * unscoped behavior.
+   */
+  async function deleteGameStateForMessages(messageIds: string[], chatIds?: string[]) {
     const ids = Array.from(new Set(messageIds.filter(Boolean)));
     if (ids.length === 0) return;
+    const ownerChatIds = Array.from(new Set((chatIds ?? []).filter(Boolean)));
+    // A game row whose chatId disagrees with its message's chat (corrupt
+    // cross-chat ref) is skipped by the scoped form; the store-level cascade
+    // accepts the same corner and such rows are cleaned when their unit loads.
+    const chatScoped = (chatColumn: Parameters<typeof inArray>[0], condition: ReturnType<typeof inArray>) =>
+      ownerChatIds.length > 0 ? and(condition, inArray(chatColumn, ownerChatIds)) : condition;
 
     const CHUNK = 500;
     for (let i = 0; i < ids.length; i += CHUNK) {
@@ -690,17 +703,27 @@ export function createChatsStorage(db: DB) {
       const snapshots = await db
         .select({ id: gameStateSnapshots.id })
         .from(gameStateSnapshots)
-        .where(inArray(gameStateSnapshots.messageId, chunk));
+        .where(chatScoped(gameStateSnapshots.chatId, inArray(gameStateSnapshots.messageId, chunk)));
       const snapshotIds = snapshots.map((row) => row.id).filter(Boolean);
 
       for (let j = 0; j < snapshotIds.length; j += CHUNK) {
         const snapshotChunk = snapshotIds.slice(j, j + CHUNK);
-        await db.delete(gameCheckpoints).where(inArray(gameCheckpoints.snapshotId, snapshotChunk));
+        await db
+          .delete(gameCheckpoints)
+          .where(chatScoped(gameCheckpoints.chatId, inArray(gameCheckpoints.snapshotId, snapshotChunk)));
       }
-      await db.delete(gameCheckpoints).where(inArray(gameCheckpoints.messageId, chunk));
-      await db.delete(gameStateSnapshots).where(inArray(gameStateSnapshots.messageId, chunk));
-      await db.delete(spatialContextSnapshots).where(inArray(spatialContextSnapshots.messageId, chunk));
-      await db.delete(gameEngineState).where(inArray(gameEngineState.messageId, chunk));
+      await db
+        .delete(gameCheckpoints)
+        .where(chatScoped(gameCheckpoints.chatId, inArray(gameCheckpoints.messageId, chunk)));
+      await db
+        .delete(gameStateSnapshots)
+        .where(chatScoped(gameStateSnapshots.chatId, inArray(gameStateSnapshots.messageId, chunk)));
+      await db
+        .delete(spatialContextSnapshots)
+        .where(chatScoped(spatialContextSnapshots.chatId, inArray(spatialContextSnapshots.messageId, chunk)));
+      await db
+        .delete(gameEngineState)
+        .where(chatScoped(gameEngineState.chatId, inArray(gameEngineState.messageId, chunk)));
     }
   }
 
@@ -735,18 +758,13 @@ export function createChatsStorage(db: DB) {
         return;
       }
 
-      const latestByChat = new Map<string, string>();
-      const messageRows = await db
-        .select({ chatId: messages.chatId, createdAt: messages.createdAt })
-        .from(messages)
-        .orderBy(desc(messages.createdAt));
-      for (const row of messageRows) {
-        if (!missingChatIds.has(row.chatId) || latestByChat.has(row.chatId)) continue;
-        latestByChat.set(row.chatId, row.createdAt);
-        if (latestByChat.size === missingChatIds.size) break;
-      }
-
-      for (const [chatId, lastMessageAt] of latestByChat) {
+      // Per-chat lookups instead of one global messages sweep: under lazy
+      // chat units (#5592 Phase 2) the sweep would make every chat's messages
+      // resident just to backfill the few legacy rows missing lastMessageAt,
+      // while eq(chatId) loads only the chats that actually need it.
+      for (const chatId of missingChatIds) {
+        const lastMessageAt = await readLatestMessageAt(chatId);
+        if (lastMessageAt === null) continue;
         await db.update(chats).set({ lastMessageAt }).where(eq(chats.id, chatId));
       }
       chatLastMessageAtBackfilled = true;
@@ -1991,7 +2009,7 @@ export function createChatsStorage(db: DB) {
 
     async removeMessage(id: string) {
       const existing = await this.getMessage(id);
-      if (existing) await deleteGameStateForMessages([id]);
+      if (existing) await deleteGameStateForMessages([id], [existing.chatId]);
       await db.delete(messages).where(eq(messages.id, id));
       if (existing) {
         await invalidateMemoryChunksFrom(db, existing.chatId, existing.createdAt);
@@ -2016,7 +2034,10 @@ export function createChatsStorage(db: DB) {
           const current = earliestByChat.get(row.chatId);
           if (!current || row.createdAt < current) earliestByChat.set(row.chatId, row.createdAt);
         }
-        await deleteGameStateForMessages(existingRows.map((row) => row.id));
+        await deleteGameStateForMessages(
+          existingRows.map((row) => row.id),
+          existingRows.map((row) => row.chatId),
+        );
         await db.delete(messages).where(condition);
       }
       for (const [affectedChatId, createdAt] of earliestByChat) {

--- a/packages/server/src/services/storage/game-storyboards.storage.ts
+++ b/packages/server/src/services/storage/game-storyboards.storage.ts
@@ -123,18 +123,23 @@ export function createGameStoryboardsStorage(db: DB) {
       return this.getById(id);
     },
 
-    async failInProgressUpdatedBefore(cutoffUpdatedAt: string, error: string) {
+    /**
+     * `chatId` scopes the sweep to one chat so the lazy store (#5592 Phase 2)
+     * loads only that chat's unit; the storyboard routes sweep their own chat
+     * before reading, with a cutoff that also covers pre-boot crash leftovers.
+     * The unscoped form remains for eager storage but leases the whole table.
+     */
+    async failInProgressUpdatedBefore(cutoffUpdatedAt: string, error: string, chatId?: string) {
       const inProgressStoryboardStatuses = ["planning", "rendering_images", "rendering_videos"];
       const inProgressKeyframeStatuses = ["planned", "rendering_image", "rendering_video"];
+      const staleCondition = and(
+        inArray(gameTurnStoryboards.status, inProgressStoryboardStatuses),
+        lt(gameTurnStoryboards.updatedAt, cutoffUpdatedAt),
+      );
       const staleRows = await db
         .select({ id: gameTurnStoryboards.id })
         .from(gameTurnStoryboards)
-        .where(
-          and(
-            inArray(gameTurnStoryboards.status, inProgressStoryboardStatuses),
-            lt(gameTurnStoryboards.updatedAt, cutoffUpdatedAt),
-          ),
-        );
+        .where(chatId ? and(eq(gameTurnStoryboards.chatId, chatId), staleCondition) : staleCondition);
       if (staleRows.length === 0) return 0;
 
       const staleIds = staleRows.map((row) => row.id);

--- a/packages/shared/src/types/capability-runtime.ts
+++ b/packages/shared/src/types/capability-runtime.ts
@@ -202,6 +202,13 @@ export interface CapabilityMessageRecord {
 }
 
 export interface CapabilitySpatialSnapshotWrite {
+  /**
+   * Must be globally unique across ALL chats (use a UUID). The store rejects
+   * an id that collides with a loaded chat's snapshot, but under lazy storage
+   * (#5592) a collision with a chat that is not yet in memory cannot be
+   * detected at write time — the duplicate is resolved later by dropping one
+   * copy, so a package that reuses ids across chats loses data silently.
+   */
   id: string;
   chatId: string;
   messageId: string;

--- a/scripts/regressions/lazy-chat-units.regression.ts
+++ b/scripts/regressions/lazy-chat-units.regression.ts
@@ -1,0 +1,268 @@
+// #5592 Phase 2: chat-scoped tables (messages, swipes, memory chunks, game
+// tables, ...) no longer load at boot — each chat's shards enter memory as one
+// unit on first touch and stay resident. These regressions drive the REAL
+// store through the behaviors that must hold under partial residency:
+//   - boot only DISCOVERS lazy shards; an untouched chat's file is never
+//     parsed for healing, while first touch runs the full recovery pipeline,
+//   - a chatId-scoped query loads exactly that unit (messages AND swipes
+//     together), and an unbounded query leases the whole table,
+//   - inserting into an unloaded chat loads the unit first, so the flush
+//     rewrites the shard with the pre-existing rows intact (the data-loss
+//     failure mode the unit design exists to prevent),
+//   - deleting a chat cascades into units that were never read and removes
+//     their shard files,
+//   - a transaction that loads a unit mid-flight keeps those rows across
+//     rollback while the rolled-back write reverts,
+//   - the manifest reports the harvested messages total, not the resident
+//     fraction, and omits the other lazy tables' counts.
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq, inArray } from "../../packages/server/src/db/file-query.js";
+import { createFileNativeDB, encodeShardKey } from "../../packages/server/src/db/file-backed-store.js";
+import { chats, memoryChunks, messages, messageSwipes } from "../../packages/server/src/db/schema/index.js";
+
+if (process.env.MARINARA_EAGER_STORAGE === "1" || process.env.MARINARA_EAGER_STORAGE === "true") {
+  // The kill switch restores eager boot loading; these regressions assert
+  // lazy-only semantics (no boot healing, per-unit residency). The sharding
+  // suite covers the eager path — run it with the same variable set.
+  console.log("Lazy chat-unit regressions skipped: MARINARA_EAGER_STORAGE is set.");
+  process.exit(0);
+}
+
+function tempStorageDir() {
+  const dir = mkdtempSync(join(tmpdir(), "marinara-lazy-units-"));
+  process.env.FILE_STORAGE_DIR = dir;
+  return dir;
+}
+
+let seq = 0;
+const messageRow = (id: string, chatId: string, content: string) => ({
+  id,
+  chatId,
+  role: "user",
+  content,
+  createdAt: `2026-08-28T10:00:${String(seq++).padStart(2, "0")}.000Z`,
+});
+const swipeRow = (id: string, messageId: string, content: string) => ({ id, messageId, index: 0, content });
+const chunkRow = (id: string, chatId: string, content: string) => ({
+  id,
+  chatId,
+  content,
+  messageCount: 1,
+  createdAt: `2026-08-28T10:00:00.000Z`,
+});
+const chatRow = (id: string) => ({ id, name: id, mode: "conversation" });
+
+const writeShard = (dir: string, table: string, key: string, rows: unknown[]) => {
+  mkdirSync(join(dir, "tables", table), { recursive: true });
+  writeFileSync(join(dir, "tables", table, `${encodeShardKey(key)}.json`), JSON.stringify(rows));
+};
+const readShard = (dir: string, table: string, key: string) =>
+  JSON.parse(readFileSync(join(dir, "tables", table, `${encodeShardKey(key)}.json`), "utf8")) as Array<
+    Record<string, unknown>
+  >;
+const shardExists = (dir: string, table: string, key: string) =>
+  existsSync(join(dir, "tables", table, `${encodeShardKey(key)}.json`));
+
+// ── Scoped queries load one unit; untouched units stay unparsed on disk ──
+
+{
+  const dir = tempStorageDir();
+  writeShard(dir, "chats", "chat-a", [chatRow("chat-a")]);
+  writeShard(dir, "chats", "chat-b", [chatRow("chat-b")]);
+  writeShard(dir, "messages", "chat-a", [messageRow("m-a1", "chat-a", "a one"), messageRow("m-a2", "chat-a", "a two")]);
+  // chat-b's file carries a malformed row: eager loading would preserve and
+  // heal it at boot; lazy loading must leave the file byte-identical until
+  // chat-b is actually touched.
+  const bRows = [messageRow("m-b1", "chat-b", "b one"), "malformed-not-a-row"];
+  writeShard(dir, "messages", "chat-b", bRows);
+  writeShard(dir, "message_swipes", "chat-a", [swipeRow("s-a1", "m-a1", "swipe a")]);
+  writeShard(dir, "memory_chunks", "chat-b", [chunkRow("c-b1", "chat-b", "chunk b")]);
+  const db = await createFileNativeDB();
+  try {
+    const aMessages = await db.select().from(messages).where(eq(messages.chatId, "chat-a"));
+    assert.deepEqual(
+      aMessages.map((row) => row.id),
+      ["m-a1", "m-a2"],
+      "a chatId-scoped query returns the unit's rows",
+    );
+    // Swipes load WITH the unit: a parent-mapped query needs no prior read.
+    const aSwipes = await db
+      .select()
+      .from(messageSwipes)
+      .where(inArray(messageSwipes.messageId, ["m-a1"]));
+    assert.deepEqual(
+      aSwipes.map((row) => row.id),
+      ["s-a1"],
+      "the unit's swipes are resident after the messages query",
+    );
+    assert.equal(db.count(messages, eq(messages.chatId, "chat-a")), 2, "count() sees the loaded unit");
+    await db._fileStore.flush();
+    assert.deepEqual(
+      readShard(dir, "messages", "chat-b"),
+      bRows,
+      "an untouched unit's file is byte-identical after another unit's load and flush — no boot healing",
+    );
+    // First touch of chat-b runs the recovery pipeline: the malformed row is
+    // skipped, the source preserved, and the shard heals on the next flush.
+    const bMessages = await db.select().from(messages).where(eq(messages.chatId, "chat-b"));
+    assert.deepEqual(
+      bMessages.map((row) => row.id),
+      ["m-b1"],
+      "first touch loads the unit and skips the malformed row",
+    );
+    await db._fileStore.flush();
+    assert.deepEqual(
+      readShard(dir, "messages", "chat-b").map((row) => row.id),
+      ["m-b1"],
+      "the malformed row is healed away on the first flush after the unit loads",
+    );
+    const chunks = await db.select().from(memoryChunks).where(eq(memoryChunks.chatId, "chat-b"));
+    assert.deepEqual(
+      chunks.map((row) => row.id),
+      ["c-b1"],
+      "every lazy table's shard for the unit is reachable",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── Writing into an unloaded unit loads it first — no sibling data loss ──
+
+{
+  const dir = tempStorageDir();
+  writeShard(dir, "chats", "chat-c", [chatRow("chat-c")]);
+  writeShard(dir, "messages", "chat-c", [
+    messageRow("m-c1", "chat-c", "old one"),
+    messageRow("m-c2", "chat-c", "old two"),
+  ]);
+  const db = await createFileNativeDB();
+  try {
+    // No read first: the insert itself must make the unit resident, or the
+    // flush below would rewrite chat-c.json with ONLY the new row.
+    await db.insert(messages).values(messageRow("m-c3", "chat-c", "new"));
+    await db._fileStore.flush();
+    assert.deepEqual(
+      readShard(dir, "messages", "chat-c").map((row) => row.id),
+      ["m-c1", "m-c2", "m-c3"],
+      "the shard keeps its pre-existing rows after a cold insert",
+    );
+    // Same for update-by-scope on a cold unit.
+    await db.update(messages).set({ content: "edited" }).where(eq(messages.id, "m-c1"));
+    const edited = await db.select().from(messages).where(eq(messages.id, "m-c1"));
+    assert.equal(edited[0]!.content, "edited", "a PK-addressed update reaches a row loaded via the messages index");
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── Unbounded queries lease the whole table ──
+
+{
+  const dir = tempStorageDir();
+  writeShard(dir, "chats", "chat-a", [chatRow("chat-a")]);
+  writeShard(dir, "chats", "chat-b", [chatRow("chat-b")]);
+  writeShard(dir, "messages", "chat-a", [messageRow("m-a1", "chat-a", "a")]);
+  writeShard(dir, "messages", "chat-b", [messageRow("m-b1", "chat-b", "b")]);
+  const db = await createFileNativeDB();
+  try {
+    const all = await db.select().from(messages);
+    assert.deepEqual(
+      all.map((row) => row.id).sort(),
+      ["m-a1", "m-b1"],
+      "a select with no WHERE returns every unit's rows",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── Deleting a chat cascades into units that were never read ──
+
+{
+  const dir = tempStorageDir();
+  writeShard(dir, "chats", "chat-d", [chatRow("chat-d")]);
+  writeShard(dir, "messages", "chat-d", [messageRow("m-d1", "chat-d", "doomed")]);
+  writeShard(dir, "message_swipes", "chat-d", [swipeRow("s-d1", "m-d1", "doomed swipe")]);
+  writeShard(dir, "memory_chunks", "chat-d", [chunkRow("c-d1", "chat-d", "doomed chunk")]);
+  const db = await createFileNativeDB();
+  try {
+    await db.delete(chats).where(eq(chats.id, "chat-d"));
+    await db._fileStore.flush();
+    for (const table of ["messages", "message_swipes", "memory_chunks"]) {
+      assert.equal(shardExists(dir, table, "chat-d"), false, `${table} shard files of a deleted chat are removed`);
+    }
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── A unit loaded mid-transaction survives rollback; the write does not ──
+
+{
+  const dir = tempStorageDir();
+  writeShard(dir, "chats", "chat-e", [chatRow("chat-e")]);
+  writeShard(dir, "messages", "chat-e", [messageRow("m-e1", "chat-e", "original")]);
+  const db = await createFileNativeDB();
+  try {
+    await assert.rejects(
+      db.transaction(async (tx) => {
+        // The update's scope hook loads chat-e INSIDE the transaction.
+        await tx.update(messages).set({ content: "rolled back" }).where(eq(messages.chatId, "chat-e"));
+        throw new Error("force rollback");
+      }),
+      /force rollback/,
+    );
+    const rows = await db.select().from(messages).where(eq(messages.chatId, "chat-e"));
+    assert.equal(rows.length, 1, "the mid-transaction unit load survives the rollback");
+    assert.equal(rows[0]!.content, "original", "the rolled-back write reverts");
+    await db._fileStore.flush();
+    assert.deepEqual(
+      readShard(dir, "messages", "chat-e").map((row) => row.content),
+      ["original"],
+      "disk keeps the original row after rollback",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── Manifest: messages reports the harvested total; other lazy counts are omitted ──
+
+{
+  const dir = tempStorageDir();
+  writeShard(dir, "chats", "chat-a", [chatRow("chat-a")]);
+  writeShard(dir, "chats", "chat-b", [chatRow("chat-b")]);
+  writeShard(dir, "messages", "chat-a", [messageRow("m-a1", "chat-a", "a")]);
+  writeShard(dir, "messages", "chat-b", [messageRow("m-b1", "chat-b", "b"), messageRow("m-b2", "chat-b", "bb")]);
+  writeShard(dir, "memory_chunks", "chat-a", [chunkRow("c-a1", "chat-a", "chunk")]);
+  const db = await createFileNativeDB();
+  try {
+    // Load only chat-a, then flush: the manifest must not report the resident
+    // fraction as the table total.
+    await db.select().from(messages).where(eq(messages.chatId, "chat-a"));
+    await db._fileStore.flush(true);
+    const manifest = JSON.parse(readFileSync(join(dir, "manifest.json"), "utf8")) as {
+      tables: Record<string, number | undefined>;
+    };
+    assert.equal(manifest.tables.messages, 3, "messages reports the complete harvested count");
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(manifest.tables, "memory_chunks"),
+      false,
+      "a partially resident lazy table has no manifest count",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log("Lazy chat-unit regressions passed.");

--- a/scripts/regressions/lazy-chat-units.regression.ts
+++ b/scripts/regressions/lazy-chat-units.regression.ts
@@ -235,6 +235,67 @@ const shardExists = (dir: string, table: string, key: string) =>
   }
 }
 
+// ── A unit loaded DURING a flush keeps its shard file until the next flush ──
+// The stale-file cleanup pass unlinks shard files whose rows were re-homed.
+// Its marks must be captured atomically with the dirty keys at flush start:
+// reading the live map let a lazy unit load — running inside the flush's own
+// awaited writes — add a mark whose paired dirty keys the flush never saw,
+// and the cleanup then deleted the freshly loaded shard (and .bak) while its
+// rows existed only in memory. Setup: two chats whose swipe files each hold
+// one ORPHAN swipe (parent message gone), i.e. files the store re-homes into
+// the unassigned shard — the exact state that creates stale marks.
+
+{
+  const dir = tempStorageDir();
+  writeShard(dir, "chats", "chat-x", [chatRow("chat-x")]);
+  writeShard(dir, "chats", "chat-a", [chatRow("chat-a")]);
+  writeShard(dir, "message_swipes", "chat-x", [swipeRow("s-x", "m-ghost-x", "orphan x")]);
+  writeShard(dir, "message_swipes", "chat-a", [swipeRow("s-a", "m-ghost-a", "orphan a")]);
+  let loadDuringFlush: (() => Promise<void>) | null = null;
+  const db = await createFileNativeDB({
+    beforeTableWrite: async (name: string) => {
+      if (name.startsWith("message_swipes/") && loadDuringFlush) {
+        const load = loadDuringFlush;
+        loadDuringFlush = null;
+        await load();
+      }
+    },
+  });
+  try {
+    // First touch of chat-x re-homes its orphan swipe: stale mark + dirty
+    // keys for the unassigned shard now exist BEFORE the flush.
+    await db.select().from(messages).where(eq(messages.chatId, "chat-x"));
+    // During that flush's swipe-shard write, chat-a loads mid-flight.
+    loadDuringFlush = async () => {
+      await db.select().from(messages).where(eq(messages.chatId, "chat-a"));
+    };
+    await db._fileStore.flush(true, true);
+    assert.equal(
+      shardExists(dir, "message_swipes", "chat-a"),
+      true,
+      "a shard loaded mid-flush is NOT unlinked by that flush — its rows exist only in memory until the next one",
+    );
+    // The deferred mark processes correctly on the next flush: the orphan
+    // lands in the unassigned shard and the old file is then removed.
+    await db._fileStore.flush(true, true);
+    assert.equal(
+      shardExists(dir, "message_swipes", "chat-a"),
+      false,
+      "the deferred stale file heals on the next flush",
+    );
+    assert.deepEqual(
+      readShard(dir, "message_swipes", "orphaned-rows")
+        .map((row) => row.id)
+        .sort(),
+      ["s-a", "s-x"],
+      "both orphan swipes are on disk in the unassigned shard",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 // ── Manifest: messages reports the harvested total; other lazy counts are omitted ──
 
 {

--- a/scripts/regressions/lazy-chat-units.regression.ts
+++ b/scripts/regressions/lazy-chat-units.regression.ts
@@ -437,6 +437,76 @@ const shardExists = (dir: string, table: string, key: string) =>
   }
 }
 
+// ── A duplicate message id in ANOTHER chat's unit is still rejected ──
+// Primary-key uniqueness is table-wide, but the duplicate scan only sees
+// resident rows. The complete harvest index names the unit that already owns
+// an incoming id, and the insert must load it — otherwise an id-preserving
+// import into a different chat silently persists the same id twice.
+
+{
+  const dir = tempStorageDir();
+  writeShard(dir, "chats", "chat-a", [chatRow("chat-a")]);
+  writeShard(dir, "chats", "chat-b", [chatRow("chat-b")]);
+  writeShard(dir, "messages", "chat-a", [messageRow("m-dup", "chat-a", "the original")]);
+  const db = await createFileNativeDB();
+  try {
+    await assert.rejects(
+      db.insert(messages).values(messageRow("m-dup", "chat-b", "impostor in another chat")),
+      /unique|duplicate/i,
+      "an id owned by an unloaded unit is found via the harvest index and rejected",
+    );
+    const rows = await db.select().from(messages).where(eq(messages.id, "m-dup"));
+    assert.deepEqual(
+      rows.map((row) => row.content),
+      ["the original"],
+      "the owning chat's row survives untouched",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── A row misfiled in ANOTHER unit's shard is reachable through its owner ──
+// The eager loader saw misfiled rows because it read every file. Per-unit
+// loading must consult the harvest's physical-location record, or a query
+// scoped to the OWNING chat loads only that chat's own file and the misfiled
+// row stays invisible until its host unit happens to load.
+
+{
+  const dir = tempStorageDir();
+  writeShard(dir, "chats", "chat-a", [chatRow("chat-a")]);
+  writeShard(dir, "chats", "chat-b", [chatRow("chat-b")]);
+  // chat-b has NO file of its own; its only row sits inside chat-a's shard.
+  writeShard(dir, "messages", "chat-a", [
+    messageRow("m-a", "chat-a", "a's own row"),
+    messageRow("m-b1", "chat-b", "b's misfiled row"),
+  ]);
+  const db = await createFileNativeDB();
+  try {
+    const bRows = await db.select().from(messages).where(eq(messages.chatId, "chat-b"));
+    assert.deepEqual(
+      bRows.map((row) => row.id),
+      ["m-b1"],
+      "the owning chat's scoped query finds its misfiled row",
+    );
+    await db._fileStore.flush();
+    assert.deepEqual(
+      readShard(dir, "messages", "chat-b").map((row) => row.id),
+      ["m-b1"],
+      "the misfiled row heals into its canonical shard on the next flush",
+    );
+    assert.deepEqual(
+      readShard(dir, "messages", "chat-a").map((row) => row.id),
+      ["m-a"],
+      "the host file is rewritten without the stray",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 // ── Manifest: messages reports the harvested total; other lazy counts are omitted ──
 
 {

--- a/scripts/regressions/lazy-chat-units.regression.ts
+++ b/scripts/regressions/lazy-chat-units.regression.ts
@@ -78,6 +78,8 @@ const shardExists = (dir: string, table: string, key: string) =>
   // chat-b is actually touched.
   const bRows = [messageRow("m-b1", "chat-b", "b one"), "malformed-not-a-row"];
   writeShard(dir, "messages", "chat-b", bRows);
+  const bShardPath = join(dir, "tables", "messages", `${encodeShardKey("chat-b")}.json`);
+  const bShardSource = readFileSync(bShardPath, "utf8");
   writeShard(dir, "message_swipes", "chat-a", [swipeRow("s-a1", "m-a1", "swipe a")]);
   writeShard(dir, "memory_chunks", "chat-b", [chunkRow("c-b1", "chat-b", "chunk b")]);
   const db = await createFileNativeDB();
@@ -100,9 +102,11 @@ const shardExists = (dir: string, table: string, key: string) =>
     );
     assert.equal(db.count(messages, eq(messages.chatId, "chat-a")), 2, "count() sees the loaded unit");
     await db._fileStore.flush();
-    assert.deepEqual(
-      readShard(dir, "messages", "chat-b"),
-      bRows,
+    // Raw-bytes comparison: a rewrite that preserved the parsed rows (e.g.
+    // reserialization) would still prove the file was touched.
+    assert.equal(
+      readFileSync(bShardPath, "utf8"),
+      bShardSource,
       "an untouched unit's file is byte-identical after another unit's load and flush — no boot healing",
     );
     // First touch of chat-b runs the recovery pipeline: the malformed row is
@@ -289,6 +293,47 @@ const shardExists = (dir: string, table: string, key: string) =>
         .sort(),
       ["s-a", "s-x"],
       "both orphan swipes are on disk in the unassigned shard",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── Every stray id in a file is tracked — canonical copies beat ALL stale strays ──
+// A shard file can hold several rows belonging to another unit (interrupted
+// re-home). Each stray id must be tracked individually: forgetting any of them
+// makes the later canonical-file load treat its fresh copy as a duplicate and
+// keep the stale stray as the persisted row.
+
+{
+  const dir = tempStorageDir();
+  writeShard(dir, "chats", "chat-a", [chatRow("chat-a")]);
+  writeShard(dir, "chats", "chat-b", [chatRow("chat-b")]);
+  const canonical1 = messageRow("m-1", "chat-b", "canonical one");
+  const canonical2 = messageRow("m-2", "chat-b", "canonical two");
+  // chat-a's file holds its own row PLUS stale stray copies of BOTH chat-b rows.
+  writeShard(dir, "messages", "chat-a", [
+    messageRow("m-a", "chat-a", "a real"),
+    { ...canonical1, content: "stale stray one" },
+    { ...canonical2, content: "stale stray two" },
+  ]);
+  writeShard(dir, "messages", "chat-b", [canonical1, canonical2]);
+  const db = await createFileNativeDB();
+  try {
+    // Touching chat-a merges the strays first, then pulls chat-b in
+    // transitively — the canonical file's copies must replace EVERY stray.
+    const aMessages = await db.select().from(messages).where(eq(messages.chatId, "chat-a"));
+    assert.deepEqual(
+      aMessages.map((row) => row.id),
+      ["m-a"],
+      "chat-a keeps only its own row once the strays re-home",
+    );
+    const bMessages = await db.select().from(messages).where(eq(messages.chatId, "chat-b"));
+    assert.deepEqual(
+      bMessages.map((row) => row.content).sort(),
+      ["canonical one", "canonical two"],
+      "the canonical shard's copies win over every stale stray copy from a multi-stray file",
     );
   } finally {
     await db._fileStore.close();

--- a/scripts/regressions/lazy-chat-units.regression.ts
+++ b/scripts/regressions/lazy-chat-units.regression.ts
@@ -341,6 +341,102 @@ const shardExists = (dir: string, table: string, key: string) =>
   }
 }
 
+// ── A .bak recovered DURING a flush keeps its recovery source safe ──
+// Loading a lazy shard whose primary is corrupt recovers the rows from .bak
+// and marks the corrupt primary so the healing write does NOT refresh the
+// backup from it. That mark must travel with the flush batch that writes the
+// shard: if an in-flight flush (which never wrote the shard) destroyed it,
+// the next flush would copy the still-corrupt primary over the only valid
+// backup before writing — one failed write away from losing both sources.
+
+{
+  const dir = tempStorageDir();
+  writeShard(dir, "chats", "chat-b", [chatRow("chat-b")]);
+  writeShard(dir, "chats", "chat-z", [chatRow("chat-z")]);
+  const zPrimary = join(dir, "tables", "memory_chunks", `${encodeShardKey("chat-z")}.json`);
+  mkdirSync(join(dir, "tables", "memory_chunks"), { recursive: true });
+  const goodBak = JSON.stringify([chunkRow("c-z", "chat-z", "recovered chunk")]);
+  writeFileSync(zPrimary, "{corrupt json");
+  writeFileSync(`${zPrimary}.bak`, goodBak);
+  let loadDuringFlush: (() => Promise<void>) | null = null;
+  const db = await createFileNativeDB({
+    beforeTableWrite: async (name: string) => {
+      if (name.startsWith("messages/") && loadDuringFlush) {
+        const load = loadDuringFlush;
+        loadDuringFlush = null;
+        await load();
+      }
+    },
+  });
+  try {
+    await db.insert(messages).values(messageRow("m-b", "chat-b", "trigger"));
+    // During the flush of that insert, chat-z loads: its chunk shard recovers
+    // from .bak and marks the corrupt primary — in the LIVE set, which the
+    // in-flight flush must not consume or destroy.
+    loadDuringFlush = async () => {
+      const recovered = await db.select().from(memoryChunks).where(eq(memoryChunks.chatId, "chat-z"));
+      assert.deepEqual(
+        recovered.map((row) => row.id),
+        ["c-z"],
+        "the corrupt shard recovers from .bak on unit load",
+      );
+    };
+    await db._fileStore.flush(true, true);
+    // The next flush writes the healed primary WITHOUT refreshing .bak from
+    // the corrupt bytes still on disk.
+    await db._fileStore.flush(true, true);
+    const healed = JSON.parse(readFileSync(zPrimary, "utf8")) as Array<{ id: string }>;
+    assert.deepEqual(
+      healed.map((row) => row.id),
+      ["c-z"],
+      "the healing flush rewrites the primary from memory",
+    );
+    assert.equal(
+      readFileSync(`${zPrimary}.bak`, "utf8"),
+      goodBak,
+      "the valid backup is never overwritten with the corrupt primary's bytes",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── dbName-form insert input still scopes to the right unit ──
+// prepareInsertRow accepts database-name fields (chat_id); unit selection
+// must see the NORMALIZED row, or the insert scopes to the unassigned unit,
+// the duplicate scan misses the destination chat's on-disk rows, and a
+// colliding id silently replaces the stored row instead of throwing.
+
+{
+  const dir = tempStorageDir();
+  writeShard(dir, "chats", "chat-c", [chatRow("chat-c")]);
+  writeShard(dir, "messages", "chat-c", [messageRow("m-c1", "chat-c", "original")]);
+  const db = await createFileNativeDB();
+  try {
+    await assert.rejects(
+      db.insert(messages).values({
+        id: "m-c1",
+        chat_id: "chat-c",
+        role: "user",
+        content: "impostor",
+        createdAt: "2026-08-28T11:00:00.000Z",
+      } as never),
+      /unique|duplicate/i,
+      "a duplicate id in dbName form hits the unit's on-disk rows and is rejected",
+    );
+    const rows = await db.select().from(messages).where(eq(messages.chatId, "chat-c"));
+    assert.deepEqual(
+      rows.map((row) => row.content),
+      ["original"],
+      "the stored row survives the rejected duplicate insert",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 // ── Manifest: messages reports the harvested total; other lazy counts are omitted ──
 
 {

--- a/scripts/regressions/message-sharding.regression.ts
+++ b/scripts/regressions/message-sharding.regression.ts
@@ -607,6 +607,9 @@ for (const invalidExpectedCount of ["1", 1.5]) {
   writeFileSync(yPath, JSON.stringify([messageRow("m-y1", "chat-y", "resident")]));
   const db = await createFileNativeDB();
   try {
+    // Lazy units (#5592 Phase 2) record self-heal marks at first LOAD, not at
+    // boot — an unbounded select leases the table, which is that first load.
+    await db.select().from(messages);
     await db._fileStore.flush();
     const yRows = JSON.parse(readFileSync(yPath, "utf8")) as Array<{ id: string }>;
     assert.deepEqual(
@@ -637,6 +640,9 @@ for (const invalidExpectedCount of ["1", 1.5]) {
   );
   const db = await createFileNativeDB();
   try {
+    // First touch loads and heals under lazy units (#5592 Phase 2).
+    await db.select().from(messages);
+    await db._fileStore.flush();
     const yRows = JSON.parse(
       readFileSync(join(dir, "tables", "messages", `${encodeShardKey("chat-y")}.json`), "utf8"),
     ) as Array<{ id: string }>;
@@ -672,6 +678,7 @@ for (const invalidExpectedCount of ["1", 1.5]) {
   try {
     const rows = await db.select().from(messages);
     assert.equal(rows.length, 2, "the stray duplicate never reaches memory");
+    await db._fileStore.flush();
     const xRows = JSON.parse(
       readFileSync(join(dir, "tables", "messages", `${encodeShardKey("chat-x")}.json`), "utf8"),
     ) as Array<{ id: string }>;
@@ -869,6 +876,7 @@ for (const invalidExpectedCount of ["1", 1.5]) {
     const rows = await db.select().from(messages);
     assert.equal(rows.length, 1, "one copy survives");
     assert.equal(rows[0]!.content, "canonical content", "the canonical shard's copy wins, not discovery order");
+    await db._fileStore.flush();
     const bRows = JSON.parse(
       readFileSync(join(dir, "tables", "messages", `${encodeShardKey("chat-b")}.json`), "utf8"),
     ) as Array<{ content: string }>;
@@ -924,7 +932,8 @@ for (const invalidExpectedCount of ["1", 1.5]) {
     try {
       const rows = await db.select().from(messages);
       assert.equal(rows.length, 0, "nothing usable loads from the empty backup");
-      assert.equal(existsSync(shardPath), false, "the corrupt primary is removed by the startup flush");
+      await db._fileStore.flush();
+      assert.equal(existsSync(shardPath), false, "the corrupt primary is removed by the first-touch flush");
       assert.equal(
         existsSync(`${shardPath}.bak`),
         false,


### PR DESCRIPTION
## Why

Part of #5592 (Phase 2, PR-A of the two-PR plan posted there). The file-native store keeps every row of every chat heap-resident, which is what pushes long multi-chat Termux profiles into the ~1 GB phone heap and exit-134 territory. Phases 0–1 (#5596) removed the biggest non-structural costs; this PR delivers the structural half: chat-scoped tables stop loading at boot and become resident one chat at a time.

## What

**Boot** now only *discovers* shards for the 17 chat-scoped tables (messages, message_swipes, memory_chunks, agent_runs, agent_memory, chat_images, the game tables, workspace context, ooc/notes, call tables). For `messages` it additionally harvests the complete `messageId -> chatId` index (ids only; rows are dropped), because swipe shard resolution and query scoping depend on that map being total. The unassigned/orphan pseudo-unit still loads at boot — orphan-adoption healing needs it resident and it is tiny by design.

**First touch loads a whole chat unit**: every lazy table's shard for that chatId, messages before swipes, through the same per-file recovery pipeline the eager loader ran (bak fallback, malformed-row quarantine, self-heal marking — now recorded at load time, when the unit's dirty keys can actually flush). Stray rows found in another unit's file pull their unit in transitively, and a canonical file's copy still beats a stray copy regardless of load order (the eager dedup rule, preserved via stray-provenance tracking).

**Scoping**: a WHERE-condition extractor computes which units a query can possibly match — directly from the shard column, through the message index for swipes and `messages.id`, or by probing resident rows for other primary keys — with AND/OR combinators matching the evaluator exactly. Anything it cannot bound (backup export, cross-chat predicates like `sourceChatId`, `agentConfigId` cascades) leases the whole table, so correctness never depends on the extractor being clever. Inserts/updates load their destination units before uniqueness checks; intra-unit cascades (messageId/snapshotId/callId children) ride a parent-unit hint instead of leasing.

**Consistency machinery**: per-unit positive evidence for emptied-shard deletion (with a defensive requeue for dirty keys of unloaded units), scoped message-index rebuild on rollback (the complete harvested map must survive), transaction snapshots mirror mid-transaction unit loads so a rollback reverts the write but keeps the loaded rows, and the manifest reports the harvested messages total while omitting counts it cannot know.

**Storage-layer scoping** so hot paths do not lease: game-state cleanup on message delete threads the owning chatIds; the chat lastMessageAt backfill queries per chat instead of sweeping all messages; stale-storyboard recovery is per-chat at read time with a process-start cutoff floor, replacing the startup-wide sweep (a chat never read again keeps its stale rows on disk, invisible, until first read — see the storyboard commit note).

**Kill switch**: `MARINARA_EAGER_STORAGE=1` empties the lazy tier and restores the previous eager boot end to end.

Explicitly out of scope (PR-B): unit eviction. This PR changes *when* rows become resident, never *whether* loaded rows stay.

## Regressions

New lane `scripts/regressions/lazy-chat-units.regression.ts`: scoped query loads one unit while an untouched unit's file stays byte-identical (no boot healing), first-touch healing, swipes-load-with-unit, cold insert preserves shard siblings, unbounded select leases, chat deletion removes never-read units' files, mid-transaction unit load survives rollback, manifest counts. It self-skips under `MARINARA_EAGER_STORAGE`.

Adapted `message-sharding.regression.ts` minimally: four blocks that asserted heal-at-boot now touch the table first (heal-at-first-load); every other assertion is unchanged, and the whole suite also passes with `MARINARA_EAGER_STORAGE=1` (verified locally), so the eager path stays pinned.

Also run locally and green: file-backed-shutdown, storage-writer-lock, slurp-storage, memory-recall-revectorize, chat-branch-lineage, agent-runtime, capability-package-lifecycle, checkpoint-retention; full node regression suite run in progress at submission time — result will be posted as a comment if anything surfaces.

## Test plan

- [x] `pnpm check` on a non-Windows checkout (Windows checkouts currently fail `format:check` repo-wide on CRLF — unrelated)
- [x] `pnpm regression` (full node suite)
- [x] Manually verify in browser: open an existing multi-chat profile, switch between chats, send messages, swipe, branch, delete a chat — everything behaves as before
- [x] Manually verify: create a profile backup and re-import it; confirm all chats' histories survive
- [x] Manually verify with `MARINARA_EAGER_STORAGE=1`: server boots and behaves identically to v2.4.4
- [x] Manually verify on Termux (or with a small `--max-old-space-size`): boot memory with a large profile is visibly lower and chats load on first open

References #5592 (PR-B, eviction, follows separately — do not auto-close).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved storage efficiency by loading chat data on demand, with an option to enable eager loading.
  * Added automatic per-chat recovery for stale or interrupted game storyboards.
  * Improved recovery and cleanup of damaged, misplaced, duplicate, and malformed message storage.

* **Bug Fixes**
  * Prevented unrelated chat data from being affected during cleanup, writes, queries, and recovery operations.
  * Improved consistency when restoring data after interrupted transactions or storage errors.
  * Improved chat timestamp accuracy and game-state cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->