### PR TITLE
feat(server): add optional outbound proxy support (MARINARA_PROXY)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -248,3 +248,15 @@ GIPHY_API_KEY=
 #     or set SPOTIFY_REDIRECT_URI to your HTTPS URL).
 # Must exactly match a Redirect URI registered in your Spotify Developer Dashboard app.
 SPOTIFY_REDIRECT_URI=
+
+# Optional outbound proxy for non-local requests: agent and capability package
+# downloads, AI provider calls, media generation, and other HTTPS fetches. When
+# set, Marinara routes those requests through a SOCKS5, SOCKS5H, HTTP, or HTTPS
+# proxy instead of connecting directly. Useful when outbound GitHub or provider
+# access is blocked. Leave empty to connect directly. Examples:
+#   MARINARA_PROXY=socks5://127.0.0.1:1080
+#   MARINARA_PROXY=http://127.0.0.1:7890
+# Loopback and private-network provider requests always connect directly and
+# never use the proxy. When this is empty, the server also honors the standard
+# HTTPS_PROXY and ALL_PROXY environment variables.
+MARINARA_PROXY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Character cards now support editable metadata summaries, AI-generated summary drafts, and Character Library previews that use the saved summary when available.
 - Character card Conversation profiles now provide controls to generate About Me and Conversation behavior text from the card's available information.
 - The Home Character of the Day widget now uses saved character summaries and offers direct chat-start and character-view actions.
+- Outbound requests can now route through an optional local proxy via the new `MARINARA_PROXY` setting (SOCKS5/SOCKS5H/HTTP/HTTPS, with `HTTPS_PROXY`/`ALL_PROXY` fallback), so agent and capability-package downloads and provider calls work on networks that block direct GitHub access. Loopback and private-network provider requests always connect directly (#5588).
 
 ### Fixed
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -316,6 +316,7 @@ Scene video providers are set up as connections inside the app, not as environme
 | Variable                          | Default                                    | What it does                                                                      |
 | --------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------- |
 | `DOCS_I18N_BASE_URL`              | official `docs-i18n` branch                | Where translated documentation packs download from (Settings → General → Documentation Language). Must be a public `https://` host; forks and mirrors can point it at their own copy of the `docs-i18n` branch. |
+| `MARINARA_PROXY`                  | empty                                      | Optional outbound proxy for non-local requests. Accepts `socks5://`, `socks5h://`, `http://`, or `https://`; local and private-network provider requests never use it. See below. |
 | `GIPHY_API_KEY`                   | empty                                      | Giphy key for GIF search in Conversation mode. Search is off when unset.          |
 | `INTIFACE_URL`                    | `ws://127.0.0.1:12345`                     | Default address for the Intiface haptic app.                                      |
 | `SPOTIFY_REDIRECT_URI`            | derived from request                       | Override for the Spotify login callback URL. Set it when TLS is handled upstream. |
@@ -327,6 +328,8 @@ Scene video providers are set up as connections inside the app, not as environme
 | `SSL_KEY`                         | empty                                      | Path to a TLS private key. See Access control above.                              |
 
 For a Giphy key, note that GIF search stays unavailable until you set `GIPHY_API_KEY` and restart. For the built-in local model, see [Local Model Setup](connections/local-model.md).
+
+`MARINARA_PROXY` optionally routes every non-local outbound request — agent and capability package downloads, provider API calls, media generation, wiki reads, and translated documentation — through a SOCKS5, SOCKS5H, HTTP, or HTTPS proxy. Set it when the server cannot reach GitHub or a provider directly, for example `MARINARA_PROXY=socks5://127.0.0.1:1080`. Loopback and private-network provider requests always connect directly and never use the proxy. When it is empty, the server also honors the standard `HTTPS_PROXY` and `ALL_PROXY` environment variables. A malformed or unsupported proxy URL is reported when the first request tries to use it.
 
 ## Related guides
 

--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -2,7 +2,7 @@ import { promises as dns } from "node:dns";
 import { createHash, timingSafeEqual } from "node:crypto";
 import { basename, extname, relative, resolve, sep, win32 } from "node:path";
 import { brotliDecompressSync, gunzipSync, zstdDecompressSync } from "node:zlib";
-import { Agent } from "undici";
+import { Agent, ProxyAgent, Socks5ProxyAgent, type Dispatcher } from "undici";
 import { isLoopbackIp, isPrivateNetworkIp } from "../middleware/ip-allowlist.js";
 import { logger } from "../lib/logger.js";
 import { CSRF_HEADER, CSRF_HEADER_VALUE } from "@marinara-engine/shared";
@@ -371,12 +371,42 @@ export async function validateOutboundUrl(url: string | URL, policy: OutboundUrl
   return parsed;
 }
 
+const OUTBOUND_PROXY_ENV_VARS = ["MARINARA_PROXY", "HTTPS_PROXY", "ALL_PROXY"] as const;
+
+function resolveOutboundProxyUrl(): string | null {
+  for (const name of OUTBOUND_PROXY_ENV_VARS) {
+    const raw = process.env[name];
+    if (raw && raw.trim()) return raw.trim();
+  }
+  return null;
+}
+
+function createOutboundProxyDispatcher(proxyUrl: string): Dispatcher {
+  let parsed: URL;
+  try {
+    parsed = new URL(proxyUrl);
+  } catch {
+    throw new Error(`Invalid outbound proxy URL: ${proxyUrl}`);
+  }
+  const protocol = parsed.protocol.toLowerCase();
+  if (protocol === "socks5h:" || protocol === "socks5:" || protocol === "socks:") {
+    // undici's Socks5ProxyAgent sends hostnames to the proxy for remote DNS
+    // resolution and only accepts the socks5:// scheme.
+    parsed.protocol = "socks5:";
+    return new Socks5ProxyAgent(parsed.toString());
+  }
+  if (protocol === "http:" || protocol === "https:") {
+    return new ProxyAgent(proxyUrl);
+  }
+  throw new Error(`Unsupported outbound proxy protocol '${parsed.protocol}' (use socks5://, http://, or https://)`);
+}
+
 async function validateOutboundUrlForFetch(
   url: string | URL,
   policy: OutboundUrlPolicy = {},
   agentOptions?: Omit<AgentOptions, "connect">,
   keepAliveInitialDelayMs?: number,
-): Promise<{ url: URL; dispatcher?: Agent }> {
+): Promise<{ url: URL; dispatcher?: Dispatcher }> {
   const parsed = await validateOutboundUrl(url, policy);
   if (policy.allowLocal) {
     const dispatcher =
@@ -391,6 +421,10 @@ async function validateOutboundUrlForFetch(
 
   const original = typeof url === "string" ? url : parsed.toString();
   const addresses = await validateResolvedAddresses(parsed.hostname, policy, original);
+  const proxyUrl = resolveOutboundProxyUrl();
+  if (proxyUrl) {
+    return { url: parsed, dispatcher: createOutboundProxyDispatcher(proxyUrl) };
+  }
   let used = false;
   const dispatcher = new Agent({
     ...(agentOptions ?? {}),
@@ -415,7 +449,7 @@ async function validateOutboundUrlForFetch(
 async function readCappedResponse(
   response: Response,
   maxBytes: number,
-  dispatcher?: Agent,
+  dispatcher?: Dispatcher,
   decodeCompressedResponse = false,
 ): Promise<Response> {
   if (!response.body) {
@@ -472,7 +506,7 @@ function normalizeCompressedBody(body: Buffer, headers: Headers, maxBytes: numbe
   return { body, headers };
 }
 
-function capStreamingResponse(response: Response, maxBytes: number, dispatcher?: Agent): Response {
+function capStreamingResponse(response: Response, maxBytes: number, dispatcher?: Dispatcher): Response {
   if (!response.body) {
     void dispatcher?.close().catch(() => undefined);
     return response;


### PR DESCRIPTION
# PR title

feat(server): add optional outbound proxy support (MARINARA_PROXY)

---

> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- Change the PR base branch from `main` to `staging` before submitting. -->

## Linked issue

Closes #5588

## Why this change

On networks where direct GitHub (or provider) access is blocked, Marinara Engine cannot download agents or capability packages, and provider requests can time out: `safeFetch()` is backed by undici's `fetch` plus a self-built `Agent`, and undici ignores both the OS proxy and the `HTTP_PROXY`/`HTTPS_PROXY` environment variables.

This adds an opt-in outbound proxy so restricted-network installs can route non-local outbound requests through a local SOCKS5 or HTTP(S) proxy. Behavior is unchanged when no proxy is configured.

## What changed

- `packages/server/src/utils/security.ts`
  - Import `ProxyAgent`, `Socks5ProxyAgent`, and `type Dispatcher` from `undici`.
  - Add `resolveOutboundProxyUrl()` (reads `MARINARA_PROXY` → `HTTPS_PROXY` → `ALL_PROXY`) and `createOutboundProxyDispatcher()` (SOCKS5/SOCKS5H/HTTP/HTTPS).
  - In `validateOutboundUrlForFetch()`, after SSRF validation, return a proxy dispatcher when a proxy is configured; otherwise keep the existing direct `Agent` path unchanged.
  - Widen the dispatcher parameter of `readCappedResponse()` / `capStreamingResponse()` from `Agent` to `Dispatcher`.
- `.env.example` — document the new `MARINARA_PROXY` setting.
- `docs/CONFIGURATION.md` — document the setting and its scope.

Reviewer notes:

- SSRF validation (protocol/hostname allowlists plus DNS and private/loopback/reserved-IP checks) still runs before the proxy branch, and `policy.allowLocal` requests (Ollama, LM Studio, loopback) never use the proxy.
- The proxy applies to **all** non-local outbound fetches — provider calls, media, wiki, docs — not just GitHub downloads. This is intentional.
- When `MARINARA_PROXY` is unset, the standard `HTTPS_PROXY` / `ALL_PROXY` env vars are honored, so an ambient host proxy is picked up automatically.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- [x] Verify `Download Agents` lists packages when `MARINARA_PROXY=socks5://...` is set on a network that blocks direct GitHub access.
- [x] Verify an agent/package download succeeds through the proxy.
- [x] Verify behavior is unchanged (direct path) when `MARINARA_PROXY` is empty or unset.
- [ ] Verify a local provider (e.g. Ollama) still connects directly and is not routed through the proxy.
- [ ] Verify an unsupported or malformed proxy URL raises the descriptive error.

## Docs and release impact

- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional outbound proxy configuration through `MARINARA_PROXY`.
  * Supports SOCKS5, SOCKS5H, HTTP, and HTTPS proxies for external requests, including provider calls and downloads.
  * Automatically falls back to `HTTPS_PROXY` or `ALL_PROXY` when the new setting is not configured.
* **Documentation**
  * Documented proxy configuration, supported formats, local-network bypass behavior, and configuration error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->