### PR TITLE
fix(storage): re-merge load-created healing marks on transaction rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- A transaction rollback no longer strands a storage self-heal mid-flight: a chat whose shard file held another chat's misfiled rows could lose those rows' only on-disk copy when a rolled-back request had loaded it, because the healing rewrite ran without the paired shard writes. Rollback now re-merges load-created healing marks so the repair stays atomic (#5606).
 - Memory Recall embeddings now live outside the JavaScript heap as packed vectors — the largest single memory block for long roleplay profiles on phones — and recall scoring reads them directly instead of re-parsing JSON per chunk, without changing the on-disk storage format (#5592).
 - Message swipe reads are now scoped to the requested chat instead of scanning every chat's swipes on each message list, made possible by resolving list-membership filters once per query rather than per row — the cost that originally motivated the unscoped scans (#3402, #5592).
 - The file store's count queries, single-table selects, boot ordering, and emptied-shard cleanup now share hardened iteration and positive-evidence semantics, groundwork pinned by regressions for the planned partial-residency work (#5592).

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -113,6 +113,19 @@ type FileTransactionContext = {
   dirtyTables: Set<string>;
   /** Shard keys written during this transaction, for the durable-rollback re-add (#4708). */
   dirtyShards: Map<string, Set<string>>;
+  /**
+   * Healing marks created by LAZY UNIT LOADS that ran inside this
+   * transaction (#5606). Loads are not transaction mutations — their rows
+   * deliberately survive a rollback via the snapshot mirror — but their
+   * dirty keys lived only in the live maps, which rollback restores from the
+   * pre-transaction snapshot. That stranded the paired stale-file marks:
+   * the next flush would rewrite a stray-holding file canonically while the
+   * stray rows' own shard was skipped as clean, erasing their only on-disk
+   * copy. Rollback re-merges these so a stale mark never reaches a flush
+   * without the dirty keys it was created with.
+   */
+  loadHealDirtyShards: Map<string, Set<string>>;
+  loadHealDirtyTables: Set<string>;
   flushed: boolean;
 };
 
@@ -2613,6 +2626,8 @@ class FileTableStore {
       snapshots: new Map<string, Row[]>(),
       dirtyTables: new Set<string>(),
       dirtyShards: new Map<string, Set<string>>(),
+      loadHealDirtyShards: new Map<string, Set<string>>(),
+      loadHealDirtyTables: new Set<string>(),
       flushed: false,
     };
     const dirtySnapshot = this.dirty;
@@ -2645,6 +2660,22 @@ class FileTableStore {
       this.dirty = dirtySnapshot;
       this.dirtyTables = dirtyTablesSnapshot;
       this.dirtyShards = dirtyShardsSnapshot;
+      // Re-merge healing marks created by lazy unit loads inside the
+      // transaction (#5606): the loads' rows survive the rollback (the
+      // snapshot mirror), and their stale-file marks were never rolled back
+      // — restoring the pre-tx dirty maps alone would strand those marks
+      // without their paired dirty keys, letting the next flush rewrite a
+      // stray-holding file canonically while the strays' own shard is
+      // skipped as clean, erasing their only on-disk copy.
+      if (ctx.loadHealDirtyTables.size > 0) {
+        this.dirty = true;
+        for (const table of ctx.loadHealDirtyTables) this.dirtyTables.add(table);
+        for (const [table, keys] of ctx.loadHealDirtyShards) {
+          const set = this.dirtyShards.get(table) ?? new Set<string>();
+          for (const key of keys) set.add(key);
+          this.dirtyShards.set(table, set);
+        }
+      }
       // Rollback restored the full messages array — the shard index must
       // match the restored rows, not the rolled-back ones (#4708).
       if (ctx.dirtyTables.has("messages")) this.rebuildMessageShardIndex();
@@ -2712,6 +2743,21 @@ class FileTableStore {
    * the table has already been snapshotted this transaction. Must be called
    * BEFORE the in-place mutation so the snapshot captures the pre-mutation state.
    */
+  /**
+   * Mirrors a LOAD-created healing mark into the active transaction so a
+   * rollback can re-merge it (#5606) — see FileTransactionContext.
+   */
+  private recordLoadHealMarks(table: string, keys?: Iterable<string>) {
+    const ctx = this.txContext.getStore();
+    if (!ctx) return;
+    ctx.loadHealDirtyTables.add(table);
+    if (keys) {
+      const set = ctx.loadHealDirtyShards.get(table) ?? new Set<string>();
+      for (const key of keys) set.add(key);
+      ctx.loadHealDirtyShards.set(table, set);
+    }
+  }
+
   private recordTxMutation(tableName: string) {
     const ctx = this.txContext.getStore();
     if (!ctx) return;
@@ -3499,6 +3545,7 @@ class FileTableStore {
       if (needsRepair || holdsForeignRows) {
         this.dirty = true;
         this.dirtyTables.add(table);
+        this.recordLoadHealMarks(table, rowKeys);
         const set = this.dirtyShards.get(table) ?? new Set<string>();
         for (const rawKey of rowKeys) set.add(rawKey);
         this.dirtyShards.set(table, set);
@@ -3517,6 +3564,7 @@ class FileTableStore {
       // the flush deletes the pair instead of re-recovering it forever.
       this.dirty = true;
       this.dirtyTables.add(table);
+      this.recordLoadHealMarks(table);
       const stale = this.staleShardFiles.get(table) ?? new Set<string>();
       stale.add(encoded);
       this.staleShardFiles.set(table, stale);
@@ -3588,6 +3636,7 @@ class FileTableStore {
       );
       this.dirty = true;
       this.dirtyTables.add(table);
+      this.recordLoadHealMarks(table);
       const stale = this.staleShardFiles.get(table) ?? new Set<string>();
       stale.add(sourceEncoded);
       this.staleShardFiles.set(table, stale);

--- a/scripts/regressions/lazy-chat-units.regression.ts
+++ b/scripts/regressions/lazy-chat-units.regression.ts
@@ -507,6 +507,55 @@ const shardExists = (dir: string, table: string, key: string) =>
   }
 }
 
+// ── A rollback keeps load-created healing marks paired with their dirty keys ──
+// (#5606) A lazy unit load INSIDE a transaction creates healing marks: dirty
+// keys for the rows' real shards plus a stale mark on the stray-holding file.
+// Rollback restores the pre-transaction dirty maps — which would strand the
+// stale mark alone, and the next flush would then rewrite the host file
+// canonically while the stray rows' own shard is skipped as clean, erasing
+// their only on-disk copy. The marks must be re-merged on rollback.
+
+{
+  const dir = tempStorageDir();
+  writeShard(dir, "chats", "chat-a", [chatRow("chat-a")]);
+  writeShard(dir, "chats", "chat-b", [chatRow("chat-b")]);
+  // chat-a's file holds chat-b's ONLY copy of m-b2; chat-b's own file exists
+  // (if it did not, the flush's recreate-if-missing rule would mask the bug).
+  writeShard(dir, "messages", "chat-a", [
+    messageRow("m-a1", "chat-a", "a's own row"),
+    messageRow("m-b2", "chat-b", "b's only copy, misfiled"),
+  ]);
+  writeShard(dir, "messages", "chat-b", [messageRow("m-b1", "chat-b", "b's resident row")]);
+  const db = await createFileNativeDB();
+  try {
+    await assert.rejects(
+      db.transaction(async (tx) => {
+        // The scope hook loads chat-a (and, transitively, chat-b) INSIDE the
+        // transaction, creating the healing marks mid-tx.
+        await tx.update(messages).set({ content: "rolled back" }).where(eq(messages.chatId, "chat-a"));
+        throw new Error("force rollback");
+      }),
+      /force rollback/,
+    );
+    await db._fileStore.flush();
+    assert.deepEqual(
+      readShard(dir, "messages", "chat-b")
+        .map((row) => row.id)
+        .sort(),
+      ["m-b1", "m-b2"],
+      "the misfiled row's only copy is re-homed to its canonical shard, not erased by the healing rewrite",
+    );
+    assert.deepEqual(
+      readShard(dir, "messages", "chat-a").map((row) => row.id),
+      ["m-a1"],
+      "the host file is rewritten canonically without the stray",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 // ── Manifest: messages reports the harvested total; other lazy counts are omitted ──
 
 {


### PR DESCRIPTION
## Why

Closes #5606 — the pre-existing data-loss corner found during #5603's adversarial verification (reproduced on the parent commit with eviction disabled, so it has been latent since #5597 merged). A chat shard file holding another chat's misfiled rows — the exact state the store's self-healing exists to repair — could lose those rows' **only on-disk copy** if the unit loaded inside a transaction that rolled back.

## What

A lazy unit load creates its healing marks in one synchronous block: dirty keys for every row's real shard, plus a stale mark on the stray-holding file. The flush's write-then-unlink ordering is only safe because those travel together. Rollback broke the pairing: it restored `dirtyShards`/`dirtyTables` from the pre-transaction snapshot (erasing the load's keys) while the stale mark — correctly never rolled back — survived alone. The next flush rewrote the host file canonically without the stray, and the stray's own shard was skipped by the clean-shard fast path.

Loads are deliberately not transaction mutations — their rows survive rollback via the existing snapshot mirror. Now their marks do too: the transaction context records load-created dirty keys/tables (all three creation sites: shard-file heal, empty-`.bak` stale, duplicate drop), and rollback re-merges them. The invariant restored: **a stale mark never reaches a flush without the dirty keys it was created with** — the same pairing rule the flush-capture work in #5597/#5603 enforced for in-flight flushes, now enforced across rollbacks.

## Regressions

New block in `lazy-chat-units.regression.ts` staging the exact interleaving (misfiled row whose canonical shard file exists — the file-absent variant is masked by the recreate-if-missing rule; mid-transaction load; forced rollback; flush) asserting the misfiled row is re-homed rather than erased. Verified red against the pre-fix store on exactly that assertion. Full lazy suite plus message-sharding in both lazy and eager modes green locally.

## Test plan

- [x] `pnpm check` on a non-Windows checkout
- [x] `pnpm regression`
- [x] Manually verify: normal chat use, a failed/aborted request mid-chat, then restart — no message loss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage recovery during transaction rollbacks.
  * Prevented chat rows loaded from misplaced storage files from being lost.
  * Ensured recovered rows are moved to the correct location and removed from stale locations after saving.

* **Tests**
  * Added regression coverage for storage recovery following a rolled-back transaction.

* **Documentation**
  * Documented the fix in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->