### PR TITLE
fix(storage): treat valid-JSON non-array shard roots as corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- A storage file whose content is valid JSON but not the expected shape (for example `{}` where a list of rows belongs) is now treated as corruption: it recovers from its backup when one exists and is quarantined for manual recovery otherwise, instead of silently loading as an empty chat while a healthy backup sat unused (#5601).
 - A transaction rollback no longer strands a storage self-heal mid-flight: a chat whose shard file held another chat's misfiled rows could lose those rows' only on-disk copy when a rolled-back request had loaded it, because the healing rewrite ran without the paired shard writes. Rollback now re-merges load-created healing marks so the repair stays atomic (#5606).
 - Memory Recall embeddings now live outside the JavaScript heap as packed vectors — the largest single memory block for long roleplay profiles on phones — and recall scoring reads them directly instead of re-parsing JSON per chunk, without changing the on-disk storage format (#5592).
 - Message swipe reads are now scoped to the requested chat instead of scanning every chat's swipes on each message list, made possible by resolving list-membership filters once per query rather than per row — the cost that originally motivated the unscoped scans (#3402, #5592).

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -1083,11 +1083,7 @@ function preserveMalformedRowSourceSync(path: string, table: string): Quarantine
  * fallback-with-unreadablePaths for the quarantine machinery downstream)
  * applies to shape corruption identically.
  */
-function parseJsonFile<T>(
-  path: string,
-  fallback: T,
-  validateRoot?: (value: unknown) => boolean,
-): ParseResult<T> {
+function parseJsonFile<T>(path: string, fallback: T, validateRoot?: (value: unknown) => boolean): ParseResult<T> {
   const read = (filePath: string): T => {
     const value = JSON.parse(readFileSync(filePath, "utf8")) as T;
     if (validateRoot && !validateRoot(value)) {
@@ -2544,7 +2540,26 @@ class FileTableStore {
 
     // The monolith loads through the exact pipeline the flat loader uses, so
     // .bak recovery, malformed-row quarantine, and normalizeRow all apply.
-    const { value: rows, recoveredFromBackup } = parseJsonFile<Row[]>(monolithPath, [], Array.isArray);
+    const {
+      value: rows,
+      recoveredFromBackup,
+      recoveredFromFallback,
+      unreadablePaths,
+    } = parseJsonFile<Row[]>(monolithPath, [], Array.isArray);
+    if (recoveredFromFallback && unreadablePaths.length > 0) {
+      // Neither the monolith nor its backup was usable (unparseable, or a
+      // valid-JSON non-array root — #5601). Quarantine them BEFORE the empty
+      // shard set lands: the tail rename would otherwise file corrupt bytes
+      // under the innocuous .pre-shard name and the table would come up
+      // empty with no signal to the user about why.
+      const files = await quarantineUnrecoverableFiles(unreadablePaths, `table ${table} monolith`);
+      if (files.length > 0) this.quarantinedTables.push({ table, files });
+      logger.error(
+        { table, files: files.map((file) => file.to) },
+        "[file-storage] Monolith for %s was unrecoverable from primary and backup; quarantined the corrupt files and sharded an empty table. Preserved files require manual recovery.",
+        table,
+      );
+    }
     const parsedRows = Array.isArray(rows) ? rows : [];
     const source = parsedRows.filter(isRowRecord);
     const malformedRowCount = parsedRows.length - source.length;
@@ -3528,7 +3543,11 @@ class FileTableStore {
     const known = this.knownShardFiles.get(table) ?? new Set<string>();
     this.knownShardFiles.set(table, known);
     const path = shardFilePath(this.rootDir, table, encoded);
-    const { value, recoveredFromBackup, recoveredFromFallback, unreadablePaths } = parseJsonFile<Row[]>(path, [], Array.isArray);
+    const { value, recoveredFromBackup, recoveredFromFallback, unreadablePaths } = parseJsonFile<Row[]>(
+      path,
+      [],
+      Array.isArray,
+    );
     const parsedRows = Array.isArray(value) ? value : [];
     const source = parsedRows.filter(isRowRecord);
     const malformedRowCount = parsedRows.length - source.length;

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -1073,12 +1073,33 @@ function preserveMalformedRowSourceSync(path: string, table: string): Quarantine
   }
 }
 
-function parseJsonFile<T>(path: string, fallback: T): ParseResult<T> {
+/**
+ * Reads and parses one JSON file with .bak fallback. `validateRoot` extends
+ * "unreadable" from "does not parse" to "parses to the wrong shape" (#5601):
+ * a shard file whose root is valid JSON but not an array used to load as
+ * ZERO rows with no error, no quarantine, and a valid .bak sitting unused —
+ * the rows silently vanished. A failed validation now throws inside the same
+ * read step, so the existing recovery ladder (backup fallback, then
+ * fallback-with-unreadablePaths for the quarantine machinery downstream)
+ * applies to shape corruption identically.
+ */
+function parseJsonFile<T>(
+  path: string,
+  fallback: T,
+  validateRoot?: (value: unknown) => boolean,
+): ParseResult<T> {
+  const read = (filePath: string): T => {
+    const value = JSON.parse(readFileSync(filePath, "utf8")) as T;
+    if (validateRoot && !validateRoot(value)) {
+      throw new Error(`Valid JSON with an unexpected root shape in ${filePath}`);
+    }
+    return value;
+  };
   if (!existsSync(path)) {
     const backupPath = `${path}.bak`;
     if (existsSync(backupPath)) {
       try {
-        const value = JSON.parse(readFileSync(backupPath, "utf8")) as T;
+        const value = read(backupPath);
         logger.warn(
           "[file-storage] %s is missing; recovering from %s. A fresh primary snapshot will be written on next save.",
           path,
@@ -1109,7 +1130,7 @@ function parseJsonFile<T>(path: string, fallback: T): ParseResult<T> {
   }
   try {
     return {
-      value: JSON.parse(readFileSync(path, "utf8")) as T,
+      value: read(path),
       recoveredFromBackup: false,
       recoveredFromFallback: false,
       unreadablePaths: [],
@@ -1119,7 +1140,7 @@ function parseJsonFile<T>(path: string, fallback: T): ParseResult<T> {
     if (existsSync(backupPath)) {
       const staleness = describeStaleness(path, backupPath);
       try {
-        const value = JSON.parse(readFileSync(backupPath, "utf8")) as T;
+        const value = read(backupPath);
         logger.error(
           err,
           "[file-storage] %s is corrupt; recovering from %s (backup is %s older). Edits made since the backup are unrecoverable.",
@@ -2523,7 +2544,7 @@ class FileTableStore {
 
     // The monolith loads through the exact pipeline the flat loader uses, so
     // .bak recovery, malformed-row quarantine, and normalizeRow all apply.
-    const { value: rows, recoveredFromBackup } = parseJsonFile<Row[]>(monolithPath, []);
+    const { value: rows, recoveredFromBackup } = parseJsonFile<Row[]>(monolithPath, [], Array.isArray);
     const parsedRows = Array.isArray(rows) ? rows : [];
     const source = parsedRows.filter(isRowRecord);
     const malformedRowCount = parsedRows.length - source.length;
@@ -3507,7 +3528,7 @@ class FileTableStore {
     const known = this.knownShardFiles.get(table) ?? new Set<string>();
     this.knownShardFiles.set(table, known);
     const path = shardFilePath(this.rootDir, table, encoded);
-    const { value, recoveredFromBackup, recoveredFromFallback, unreadablePaths } = parseJsonFile<Row[]>(path, []);
+    const { value, recoveredFromBackup, recoveredFromFallback, unreadablePaths } = parseJsonFile<Row[]>(path, [], Array.isArray);
     const parsedRows = Array.isArray(value) ? value : [];
     const source = parsedRows.filter(isRowRecord);
     const malformedRowCount = parsedRows.length - source.length;
@@ -4064,7 +4085,7 @@ class FileTableStore {
         recoveredFromBackup,
         recoveredFromFallback,
         unreadablePaths,
-      } = parseJsonFile<Row[]>(path, []);
+      } = parseJsonFile<Row[]>(path, [], Array.isArray);
       const parsedRows = Array.isArray(rows) ? rows : [];
       const source = parsedRows.filter(isRowRecord);
       const malformedRowCount = parsedRows.length - source.length;
@@ -4160,7 +4181,7 @@ class FileTableStore {
           for (const fileName of dataFiles) {
             const encoded = fileName.slice(0, -".json".length);
             const path = join(dir, fileName);
-            const { value, recoveredFromFallback, unreadablePaths } = parseJsonFile<Row[]>(path, []);
+            const { value, recoveredFromFallback, unreadablePaths } = parseJsonFile<Row[]>(path, [], Array.isArray);
             const parsedRows = Array.isArray(value) ? value : [];
             const usableRows = parsedRows.filter(isRowRecord);
             if (parsedRows.length > 0 && usableRows.length === 0) {
@@ -4230,7 +4251,7 @@ class FileTableStore {
           recoveredFromBackup,
           recoveredFromFallback,
           unreadablePaths,
-        } = parseJsonFile<Row[]>(path, []);
+        } = parseJsonFile<Row[]>(path, [], Array.isArray);
         const parsedRows = Array.isArray(rows) ? rows : [];
         const source = parsedRows.filter(isRowRecord);
         const malformedRowCount = parsedRows.length - source.length;

--- a/scripts/regressions/message-sharding.regression.ts
+++ b/scripts/regressions/message-sharding.regression.ts
@@ -896,6 +896,71 @@ for (const invalidExpectedCount of ["1", 1.5]) {
   }
 }
 
+// ── A valid-JSON non-array shard root is corruption, not emptiness (#5601) ──
+// A shard whose root parses but is not an array used to load as ZERO rows
+// with no error, no quarantine, and a valid .bak sitting unused. Shape
+// corruption now walks the same recovery ladder as parse corruption.
+
+{
+  const dir = tempStorageDir();
+  mkdirSync(join(dir, "tables", "chats"), { recursive: true });
+  writeFileSync(
+    join(dir, "tables", "chats", `${encodeShardKey("chat-x")}.json`),
+    JSON.stringify([{ id: "chat-x", name: "X", mode: "conversation" }]),
+  );
+  mkdirSync(join(dir, "tables", "messages"), { recursive: true });
+  const xShard = join(dir, "tables", "messages", `${encodeShardKey("chat-x")}.json`);
+  // Primary: valid JSON, wrong shape. Backup: the real rows.
+  writeFileSync(xShard, JSON.stringify({ rows: "not an array" }));
+  writeFileSync(`${xShard}.bak`, JSON.stringify([messageRow("m-x1", "chat-x", "from the backup")]));
+  const db = await createFileNativeDB();
+  try {
+    const rows = await db.select().from(messages).where(eq(messages.chatId, "chat-x"));
+    assert.deepEqual(
+      rows.map((row) => row.content),
+      ["from the backup"],
+      "a non-array primary recovers from the valid backup instead of loading empty",
+    );
+    const byId = await db.select().from(messages).where(eq(messages.id, "m-x1"));
+    assert.equal(byId.length, 1, "id-scoped reads see the recovered row too (the harvest reads the backup)");
+    await db._fileStore.flush();
+    const healed = JSON.parse(readFileSync(xShard, "utf8")) as Array<{ id: string }>;
+    assert.deepEqual(
+      healed.map((row) => row.id),
+      ["m-x1"],
+      "the healing flush rewrites the primary from the recovered rows",
+    );
+    assert.deepEqual(
+      JSON.parse(readFileSync(`${xShard}.bak`, "utf8")).map((row: { id: string }) => row.id),
+      ["m-x1"],
+      "the backup is never clobbered by the shape-corrupt primary",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── Non-array root with NO usable backup quarantines instead of vanishing ──
+
+{
+  const dir = tempStorageDir();
+  mkdirSync(join(dir, "tables", "messages"), { recursive: true });
+  const shardPath = join(dir, "tables", "messages", `${encodeShardKey("chat-x")}.json`);
+  writeFileSync(shardPath, JSON.stringify({ not: "rows" }));
+  const db = await createFileNativeDB();
+  try {
+    const rows = await db.select().from(messages);
+    assert.equal(rows.length, 0, "nothing usable loads from a shape-corrupt shard without a backup");
+    assert.equal(existsSync(shardPath), false, "the shape-corrupt file is quarantined away, not silently kept");
+    const quarantined = readdirSync(join(dir, "tables", "messages")).filter((name) => name.includes(".corrupt-"));
+    assert.equal(quarantined.length, 1, "the file is preserved under a .corrupt- name for manual recovery");
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 // ── A quarantined bak-only shard leaves no phantom manifest entry ──
 
 {

--- a/scripts/regressions/message-sharding.regression.ts
+++ b/scripts/regressions/message-sharding.regression.ts
@@ -827,6 +827,47 @@ for (const invalidExpectedCount of ["1", 1.5]) {
   }
 }
 
+// ── An unrecoverable monolith is quarantined by the migration, not disguised ──
+// (#5601 follow-through) When neither the monolith nor its .bak is usable —
+// unparseable OR valid JSON with a non-array root — the migration must route
+// the files through the quarantine machinery (visible in the corruption
+// notice) instead of renaming corrupt bytes to the innocuous .pre-shard name
+// and silently sharding an empty table.
+
+{
+  const dir = tempStorageDir();
+  mkdirSync(join(dir, "tables"), { recursive: true });
+  writeFileSync(join(dir, "tables", "messages.json"), JSON.stringify({ not: "rows" }));
+  writeFileSync(join(dir, "tables", "messages.json.bak"), JSON.stringify({ also: "not rows" }));
+  const db = await createFileNativeDB();
+  try {
+    const rows = await db.select().from(messages);
+    assert.equal(rows.length, 0, "nothing usable loads from the shape-corrupt monolith pair");
+    const tableFiles = readdirSync(join(dir, "tables"));
+    assert.equal(
+      tableFiles.some((name) => name.startsWith("messages.json.corrupt-")),
+      true,
+      "the corrupt monolith is preserved under a .corrupt- name",
+    );
+    assert.equal(
+      tableFiles.some((name) => name.includes("messages.json.pre-shard")),
+      false,
+      "corrupt bytes are never filed under the innocuous .pre-shard name",
+    );
+    const quarantined = db._fileStore.getQuarantinedTables().find((entry) => entry.table === "messages");
+    assert.ok(quarantined, "the corruption notice reports the quarantined monolith");
+    assert.equal(quarantined.files.length, 2, "both the monolith and its backup are preserved");
+    assert.equal(
+      existsSync(join(dir, "tables", "messages", ".migrating")),
+      false,
+      "the migration still completes and clears its sentinel",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 // ── A crashed-migration retry never deletes quarantine artifacts ──
 // The retry clears incomplete shard files, but .corrupt-* files are
 // user-recovery data the store must never delete on its own.


### PR DESCRIPTION
## Why

Closes #5601 (found during #5597's review cycle; the behavior is identical in the pre-lazy eager loader, so it has existed since sharding). `echo '{}' > <chat-shard>.json` made that chat silently render empty — no log, no quarantine — even with a perfectly good `.bak` next to it.

Independent of #5609 — based directly on staging; the two touch disjoint regions and merge in either order.

## What

`parseJsonFile` gains an optional root validator whose failure throws inside the same read step as `JSON.parse` — so shape corruption reuses the existing recovery ladder verbatim: primary fails → `.bak` is tried (and validated); both bad → fallback with `unreadablePaths`, which the existing downstream machinery turns into a `.corrupt-*` quarantine. All five row-array call sites pass `Array.isArray`: the eager boot loop, the lazy unit loader, the flat-table loop, the messages harvest (so id-scoped queries see backup-recovered rows too), and the monolith migration read. The manifest reader deliberately keeps its tolerant handling — its consumers already treat junk defensively and its root is an object.

Recovery composes with the existing heal: a backup-recovered shard is dirtied, the next flush rewrites the primary from the recovered rows with backup-refresh suppressed, so the corrupt primary can never clobber the good `.bak` (same #4708-era contract).

## Regressions

Two new blocks in `message-sharding.regression.ts` (runs in both lazy and eager modes): non-array primary + valid backup → rows recover, id-scoped harvest reads work, healing flush rewrites the primary and never touches the backup; non-array primary with no backup → quarantined under `.corrupt-*` instead of silently kept. Verified red against the pre-fix store on the issue's exact symptom. Lazy suite, shutdown, and slurp lanes green.

## Test plan

- [x] `pnpm check` on a non-Windows checkout
- [x] `pnpm regression`
- [x] Manually verify the issue's repro: overwrite a chat's messages shard with `{}`, restart — with a `.bak` present the chat recovers; without one the file lands in `.corrupt-*` and the log says so


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery for storage files containing valid JSON with an unexpected structure.
  - Restores data from valid backups when available and repairs affected files during subsequent saves.
  - Safely quarantines unusable files when no valid backup exists, preventing data from being treated as empty.

- **Tests**
  - Added regression coverage for malformed shard files and backup recovery scenarios.

- **Documentation**
  - Documented handling of valid-JSON storage corruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->