### PR TITLE
fix(storage): scope residual lazy-table queries to their owning chat

### DIFF
--- a/packages/server/src/routes/agents.routes.ts
+++ b/packages/server/src/routes/agents.routes.ts
@@ -58,6 +58,9 @@ const IMPORT_UNSAFE_AGENT_SETTING_KEYS = new Set([
 
 const updateAgentRunSchema = z.object({
   resultData: z.unknown(),
+  // Optional owner hint: keeps the lazy file store from loading every chat's agent_runs
+  // shards for a bare-id lookup. The chat is always open when a run is edited.
+  chatId: z.string().min(1).optional(),
 });
 
 const AGENT_SUITE_REWRITE_SYSTEM_PROMPT = [
@@ -330,7 +333,7 @@ export async function agentsRoutes(app: FastifyInstance) {
   /** Edit the persisted output of a custom agent run. */
   app.patch<{ Params: { runId: string } }>("/runs/:runId", async (req, reply) => {
     const input = updateAgentRunSchema.parse(req.body);
-    const run = await storage.getRunWithConfig(req.params.runId);
+    const run = await storage.getRunWithConfig(req.params.runId, input.chatId);
     if (!run) return reply.status(404).send({ error: "Agent run not found" });
     if (BUILT_IN_AGENTS.some((agent) => agent.id === run.agentType)) {
       return reply.status(403).send({ error: "Built-in agent runs are not editable here" });

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -1702,6 +1702,7 @@ export async function charactersRoutes(app: FastifyInstance) {
 
       const chatsStorage = createChatsStorage(app.db);
       const sceneVideos = createGameSceneVideosStorage(app.db);
+      // Id-only lookup: the owning chat is only known after the read (permanent-lease risk accepted, #5611).
       const video = await sceneVideos.getById(sceneVideoId);
       if (!video) return reply.status(404).send({ error: "Clip not found" });
 
@@ -1711,7 +1712,7 @@ export async function charactersRoutes(app: FastifyInstance) {
       }
 
       await removeSavedVideoFromDisk(video.filePath);
-      await sceneVideos.remove(video.id);
+      await sceneVideos.remove(video.id, video.chatId);
       return { success: true };
     }
 

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -2360,8 +2360,8 @@ export async function chatsRoutes(app: FastifyInstance) {
     let updated: Awaited<ReturnType<typeof gameStateStore.updateLatest>> = null;
     if (hasExplicitTarget) {
       const targetMessage = await storage.getMessage(targetMessageId);
-      const targetSnapshot = await gameStateStore.getByMessage(targetMessageId, targetSwipeIndex);
-      if (targetMessage?.chatId === req.params.id || targetSnapshot?.chatId === req.params.id) {
+      const targetSnapshot = await gameStateStore.getByChatAndMessage(req.params.id, targetMessageId, targetSwipeIndex);
+      if (targetMessage?.chatId === req.params.id || targetSnapshot !== null) {
         updated = await gameStateStore.updateByMessage(
           targetMessageId,
           targetSwipeIndex,
@@ -2397,7 +2397,7 @@ export async function chatsRoutes(app: FastifyInstance) {
       await app.db
         .update(gameStateSnapshots)
         .set({ manualOverrides: null })
-        .where(eq(gameStateSnapshots.id, (updated as any).id));
+        .where(and(eq(gameStateSnapshots.chatId, req.params.id), eq(gameStateSnapshots.id, (updated as any).id)));
       updated = { ...updated, manualOverrides: null };
     }
     // If no snapshot exists yet, create one so manual edits aren't lost
@@ -4004,7 +4004,7 @@ export async function chatsRoutes(app: FastifyInstance) {
 
       // Helpers to create snapshots re-keyed for the new branch.
       const copySnapshot = async (
-        snapshot: NonNullable<Awaited<ReturnType<typeof gameStateStore.getByMessage>>>,
+        snapshot: NonNullable<Awaited<ReturnType<typeof gameStateStore.getByChatAndMessage>>>,
         targetMessageId: string,
         targetSwipeIndex: number,
       ) => {
@@ -4100,7 +4100,7 @@ export async function chatsRoutes(app: FastifyInstance) {
                 transitionPayloadHash: null,
               });
             }
-            const snapshot = await gameStateStore.getByMessage(srcMsg.id, swipeIndex);
+            const snapshot = await gameStateStore.getByChatAndMessage(req.params.id, srcMsg.id, swipeIndex);
             if (snapshot) {
               await copySnapshot(snapshot, branchedMsgId, swipeIndex);
             }

--- a/packages/server/src/routes/gallery.routes.ts
+++ b/packages/server/src/routes/gallery.routes.ts
@@ -716,7 +716,7 @@ export async function galleryRoutes(app: FastifyInstance) {
     const requestedGalleryImageId = input.galleryImageId?.trim();
     const galleryImages = requestedGalleryImageId ? [] : await storage.listByChatId(input.chatId);
     const galleryImage = requestedGalleryImageId
-      ? await storage.getById(requestedGalleryImageId)
+      ? await storage.getById(requestedGalleryImageId, input.chatId)
       : (galleryImages[0] ?? null);
     if (!galleryImage || galleryImage.chatId !== input.chatId) {
       throw new GallerySceneVideoRequestError(
@@ -1015,10 +1015,10 @@ export async function galleryRoutes(app: FastifyInstance) {
     if (!isValidChatId(chatId)) return reply.status(400).send({ error: "Invalid chatId" });
 
     const sceneVideos = createGameSceneVideosStorage(app.db);
-    const video = await sceneVideos.getById(id);
+    const video = await sceneVideos.getById(id, chatId);
     if (!video || video.chatId !== chatId) return reply.status(404).send({ error: "Scene video not found" });
 
-    await sceneVideos.remove(video.id);
+    await sceneVideos.remove(video.id, video.chatId);
     await removeSavedVideoFromDisk(video.filePath).catch((error) => {
       logger.warn(error, "[gallery/scene-videos] Failed to remove video file %s", video.filePath);
     });
@@ -1771,7 +1771,7 @@ export async function galleryRoutes(app: FastifyInstance) {
 
     let image = findGalleryRowByFilename(await storage.listByChatId(chatId), filename);
     if (!image) {
-      image = (await storage.listByFilePath(`${chatId}/${filename}`))[0] ?? null;
+      image = (await storage.listByChatAndFilePath(chatId, `${chatId}/${filename}`))[0] ?? null;
     }
     const storedFile = image ? resolveStoredGalleryFile(image.filePath, GALLERY_DIR) : null;
     if (!storedFile || !existsSync(storedFile.absolutePath)) {
@@ -1787,7 +1787,9 @@ export async function galleryRoutes(app: FastifyInstance) {
   // Delete a gallery image
   app.delete<{ Params: { id: string } }>("/:id", async (req, reply) => {
     const { id } = req.params;
-    const image = await storage.getById(id);
+    // Optional chatId keeps the lazy store from loading the whole table for a bare-id lookup.
+    const { chatId } = req.query as { chatId?: string };
+    const image = await storage.getById(id, typeof chatId === "string" && chatId ? chatId : undefined);
     if (!image) {
       return reply.status(404).send({ error: "Not found" });
     }

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -5852,7 +5852,7 @@ async function serializeGameTurnStoryboard(args: {
     let image: GameTurnStoryboardKeyframe["image"] = null;
     let video: GeneratedSceneVideo | null = null;
     if (frame.chatImageId) {
-      const imageRow = await args.gallery.getById(frame.chatImageId).catch(() => null);
+      const imageRow = await args.gallery.getById(frame.chatImageId, args.row.chatId).catch(() => null);
       if (imageRow) {
         image = {
           id: imageRow.id,
@@ -5865,7 +5865,7 @@ async function serializeGameTurnStoryboard(args: {
       }
     }
     if (frame.sceneVideoId) {
-      const videoRow = await args.sceneVideos.getById(frame.sceneVideoId).catch(() => null);
+      const videoRow = await args.sceneVideos.getById(frame.sceneVideoId, args.row.chatId).catch(() => null);
       if (videoRow) video = serializeGameSceneVideo(videoRow);
     }
 
@@ -13029,6 +13029,8 @@ export async function gameRoutes(app: FastifyInstance) {
     let referenceImage: VideoReferenceImage;
 
     if (requestedGalleryImageId) {
+      // Deliberately unscoped: galleryImageBelongsToGameScope accepts sibling-chat images,
+      // so the owning chat is not necessarily this one (permanent-lease risk accepted, #5611).
       const galleryImage = await gallery.getById(requestedGalleryImageId);
       if (!galleryImage || !(await galleryImageBelongsToGameScope(chats, chat, galleryImage.chatId))) {
         return reply.status(404).send({ error: "Gallery illustration not found" });
@@ -14198,8 +14200,10 @@ export async function gameRoutes(app: FastifyInstance) {
   // Delete a specific checkpoint.
   app.delete("/checkpoint/:id", async (req) => {
     const { id } = req.params as { id: string };
+    // Optional chatId keeps the lazy store from loading the whole table for a bare-id delete.
+    const { chatId } = req.query as { chatId?: string };
     const checkpoints = createCheckpointService(app.db);
-    await checkpoints.deleteById(id);
+    await checkpoints.deleteById(id, typeof chatId === "string" && chatId ? chatId : undefined);
     return { ok: true };
   });
 
@@ -14221,7 +14225,7 @@ export async function gameRoutes(app: FastifyInstance) {
     const chat = await chats.getById(input.chatId);
     if (!chat) throw new Error("Chat not found");
 
-    const cp = await checkpointSvc.getById(input.checkpointId);
+    const cp = await checkpointSvc.getById(input.checkpointId, input.chatId);
     if (!cp) throw new Error("Checkpoint not found");
     if (cp.chatId !== input.chatId) throw new Error("Checkpoint does not belong to this chat");
 
@@ -14229,14 +14233,14 @@ export async function gameRoutes(app: FastifyInstance) {
     // still be edited after capture. Older checkpoints fall back to their row IDs.
     const snapshot =
       parseJsonField<NonNullable<Awaited<ReturnType<typeof stateStore.getById>>> | null>(cp.snapshotData, null) ??
-      (await stateStore.getById(cp.snapshotId));
+      (await stateStore.getById(cp.snapshotId, input.chatId));
     if (!snapshot) throw new Error("Checkpoint snapshot was deleted and can no longer be restored");
     if (snapshot.chatId !== input.chatId) throw new Error("Checkpoint snapshot does not belong to this chat");
     const spatialSnapshot =
       parseJsonField<NonNullable<Awaited<ReturnType<typeof spatialStore.getById>>> | null>(
         cp.spatialSnapshotData,
         null,
-      ) ?? (cp.spatialSnapshotId ? await spatialStore.getById(cp.spatialSnapshotId) : null);
+      ) ?? (cp.spatialSnapshotId ? await spatialStore.getById(cp.spatialSnapshotId, input.chatId) : null);
     if (cp.spatialSnapshotId && !spatialSnapshot) {
       throw new Error("Checkpoint spatial snapshot was deleted and can no longer be restored");
     }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -219,7 +219,7 @@ import { executeKnowledgeRetrieval } from "../services/agents/knowledge-retrieva
 import { executeKnowledgeRouter } from "../services/agents/knowledge-router.js";
 import { extractFileText, getSourceFilePath } from "./knowledge-sources.routes.js";
 import { gameStateSnapshots as gameStateSnapshotsTable } from "../db/schema/index.js";
-import { eq } from "../db/file-query.js";
+import { and, eq } from "../db/file-query.js";
 import { PROFESSOR_MARI_ID, type GenerationParameterSendMap } from "@marinara-engine/shared";
 import { chunkAndEmbedMessages } from "../services/memory-recall.js";
 import {
@@ -1013,7 +1013,7 @@ export async function generateRoutes(app: FastifyInstance) {
         if (preMessages[i]!.role === "assistant") {
           const lastAsstMsg = preMessages[i]!;
           const gs = await gameStateStore
-            .getByMessage(lastAsstMsg.id, lastAsstMsg.activeSwipeIndex)
+            .getByChatAndMessage(input.chatId, lastAsstMsg.id, lastAsstMsg.activeSwipeIndex)
             .catch(releaseActiveGenerationAndRethrow);
           if (gs && input.pendingSpatialTransition && requestChatMode === "game") {
             spatialGameStateSnapshotId = gs.id;
@@ -3956,6 +3956,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
         // Batch-fetch committed game state snapshots for assistant messages in the agent context
         const committedSnapshots = await gameStateStore.getCommittedForMessages(
+          input.chatId,
           agentSlice.filter((m: any) => m.role === "assistant"),
         );
         const characterTrackerHistory = resolvedAgents.some((agent) => agent.type === "character-tracker")
@@ -7573,8 +7574,11 @@ export async function generateRoutes(app: FastifyInstance) {
                     if (latestLocation && persistedMsg?.id && ownerSpatialProjection?.ownerMode !== "game") {
                       const persistedSwipeIndex = persistedMsg.activeSwipeIndex ?? 0;
                       const targetSnapshot =
-                        (await gameStateStore.getByMessage(persistedMsg.id, persistedSwipeIndex)) ??
-                        baseGameStateSnapshot;
+                        (await gameStateStore.getByChatAndMessage(
+                          input.chatId,
+                          persistedMsg.id,
+                          persistedSwipeIndex,
+                        )) ?? baseGameStateSnapshot;
                       const locationPatch = applyTrackerFieldLocksToGameStatePatch(
                         { location: latestLocation },
                         targetSnapshot ? parseGameStateRow(targetSnapshot as Record<string, unknown>) : null,
@@ -8499,7 +8503,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 : 0;
           const siblingSwipeSnapshot = projectGameSnapshotLocation(
             input.regenerateMessageId && messageId && targetSwipeIndex > 0
-              ? await gameStateStore.getByMessage(messageId, targetSwipeIndex - 1)
+              ? await gameStateStore.getByChatAndMessage(input.chatId, messageId, targetSwipeIndex - 1)
               : null,
             ownerSpatialProjection,
           );
@@ -8877,7 +8881,11 @@ export async function generateRoutes(app: FastifyInstance) {
                   continue;
                 }
                 let chars = ctData.presentCharacters as any[];
-                const snapBeforeUpdate = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
+                const snapBeforeUpdate = await gameStateStore.getByChatAndMessage(
+                  input.chatId,
+                  messageId,
+                  targetSwipeIndex,
+                );
                 const previousCharacterSnapshot =
                   snapBeforeUpdate ??
                   trackerBaseGameStateSnapshot ??
@@ -9045,7 +9053,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
                         // Re-persist with avatar paths and notify client
                         const latestAvatarSnapshot =
-                          (await gameStateStore.getByMessage(messageId, targetSwipeIndex)) ??
+                          (await gameStateStore.getByChatAndMessage(input.chatId, messageId, targetSwipeIndex)) ??
                           trackerBaseGameStateSnapshot;
                         const latestAvatarState = latestAvatarSnapshot
                           ? parseGameStateRow(latestAvatarSnapshot as Record<string, unknown>)
@@ -9152,12 +9160,12 @@ export async function generateRoutes(app: FastifyInstance) {
                 // Ensure a snapshot exists for this (messageId, swipeIndex).
                 // If world-state didn't create one, updateByMessage clones the
                 // generation baseline into a new row so we don't corrupt old data.
-                let snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
+                let snap = await gameStateStore.getByChatAndMessage(input.chatId, messageId, targetSwipeIndex);
                 if (!snap) {
                   await gameStateStore.updateByMessage(messageId, targetSwipeIndex, input.chatId, {}, undefined, {
                     baseSnapshot: trackerBaseGameStateSnapshot,
                   });
-                  snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
+                  snap = await gameStateStore.getByChatAndMessage(input.chatId, messageId, targetSwipeIndex);
                 }
                 const personaLockState = snap ? parseGameStateRow(snap as Record<string, unknown>) : null;
                 const personaPatch = buildLockedPersonaTrackerPatch({
@@ -9172,7 +9180,9 @@ export async function generateRoutes(app: FastifyInstance) {
                   await app.db
                     .update(gameStateSnapshotsTable)
                     .set({ ...personaPatch.updates, fieldLocks: serializeMigratedTrackerLocks(personaLockState) })
-                    .where(eq(gameStateSnapshotsTable.id, snap.id));
+                    .where(
+                      and(eq(gameStateSnapshotsTable.chatId, input.chatId), eq(gameStateSnapshotsTable.id, snap.id)),
+                    );
                 }
                 if (personaPatch.changed) {
                   logger.debug("[game_state_patch] persona-stats: %j", personaPatch.patch);
@@ -9192,12 +9202,12 @@ export async function generateRoutes(app: FastifyInstance) {
               customAgentCanApplyResult(result, resolvedAgents, builtInAgentTypes, "edit_trackers")
             ) {
               try {
-                let snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
+                let snap = await gameStateStore.getByChatAndMessage(input.chatId, messageId, targetSwipeIndex);
                 if (!snap) {
                   await gameStateStore.updateByMessage(messageId, targetSwipeIndex, input.chatId, {}, undefined, {
                     baseSnapshot: trackerBaseGameStateSnapshot,
                   });
-                  snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
+                  snap = await gameStateStore.getByChatAndMessage(input.chatId, messageId, targetSwipeIndex);
                 }
                 const lockState = snap ? parseGameStateRow(snap as Record<string, unknown>) : null;
                 const previousPlayerStats = parseSnapshotPlayerStats(snap);
@@ -9213,7 +9223,9 @@ export async function generateRoutes(app: FastifyInstance) {
                       playerStats: JSON.stringify(inventoryTrackerPatch.playerStats),
                       fieldLocks: serializeMigratedTrackerLocks(lockState),
                     })
-                    .where(eq(gameStateSnapshotsTable.id, snap.id));
+                    .where(
+                      and(eq(gameStateSnapshotsTable.chatId, input.chatId), eq(gameStateSnapshotsTable.id, snap.id)),
+                    );
                 }
                 if (inventoryTrackerPatch.changed) {
                   const acquisitions = findInventoryTrackerAcquisitions(
@@ -9250,12 +9262,12 @@ export async function generateRoutes(app: FastifyInstance) {
                 const rawFields = hasFields ? (ctData.fields as any[]) : [];
                 if (hasFields) {
                   // Ensure a snapshot exists for this (messageId, swipeIndex)
-                  let snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
+                  let snap = await gameStateStore.getByChatAndMessage(input.chatId, messageId, targetSwipeIndex);
                   if (!snap) {
                     await gameStateStore.updateByMessage(messageId, targetSwipeIndex, input.chatId, {}, undefined, {
                       baseSnapshot: trackerBaseGameStateSnapshot,
                     });
-                    snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
+                    snap = await gameStateStore.getByChatAndMessage(input.chatId, messageId, targetSwipeIndex);
                   }
                   const customLockState = snap ? parseGameStateRow(snap as Record<string, unknown>) : null;
                   const customTrackerPatch = buildLockedPlayerStatsArrayPatch<any>({
@@ -9271,7 +9283,9 @@ export async function generateRoutes(app: FastifyInstance) {
                         playerStats: JSON.stringify(customTrackerPatch.playerStats),
                         fieldLocks: serializeMigratedTrackerLocks(customLockState),
                       })
-                      .where(eq(gameStateSnapshotsTable.id, snap.id));
+                      .where(
+                        and(eq(gameStateSnapshotsTable.chatId, input.chatId), eq(gameStateSnapshotsTable.id, snap.id)),
+                      );
                   }
                   if (customTrackerPatch.changed) {
                     logger.debug("[game_state_patch] custom-tracker: %j", customTrackerPatch.values);
@@ -9302,12 +9316,12 @@ export async function generateRoutes(app: FastifyInstance) {
                 );
                 if (updates.length > 0) {
                   // Ensure a snapshot exists for this (messageId, swipeIndex)
-                  let snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
+                  let snap = await gameStateStore.getByChatAndMessage(input.chatId, messageId, targetSwipeIndex);
                   if (!snap) {
                     await gameStateStore.updateByMessage(messageId, targetSwipeIndex, input.chatId, {}, undefined, {
                       baseSnapshot: trackerBaseGameStateSnapshot,
                     });
-                    snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
+                    snap = await gameStateStore.getByChatAndMessage(input.chatId, messageId, targetSwipeIndex);
                   }
                   const existingPS = parseSnapshotPlayerStats(snap);
                   const questMerge = applyQuestUpdatesToPlayerStats(existingPS, updates, {
@@ -9331,7 +9345,12 @@ export async function generateRoutes(app: FastifyInstance) {
                           playerStats: JSON.stringify(questTrackerPatch.playerStats),
                           fieldLocks: serializeMigratedTrackerLocks(questLockState),
                         })
-                        .where(eq(gameStateSnapshotsTable.id, snap.id));
+                        .where(
+                          and(
+                            eq(gameStateSnapshotsTable.chatId, input.chatId),
+                            eq(gameStateSnapshotsTable.id, snap.id),
+                          ),
+                        );
                     }
                     logger.debug("[game_state_patch] quests: %j", questTrackerPatch.values);
                     sendSseEvent(reply, { type: "game_state_patch", data: questTrackerPatch.patch });
@@ -9606,7 +9625,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     }
 
                     const latestSnapshot = messageId
-                      ? await gameStateStore.getByMessage(messageId, targetSwipeIndex)
+                      ? await gameStateStore.getByChatAndMessage(input.chatId, messageId, targetSwipeIndex)
                       : await gameStateStore.getForGeneration(input.chatId, { preferLatestVisible: true });
                     const latestGameState = latestSnapshot
                       ? parseGameStateRow(latestSnapshot as Record<string, unknown>)

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -33,7 +33,7 @@ import {
   type WrapFormat,
   type GenerationParameterSendMap,
 } from "@marinara-engine/shared";
-import { eq } from "../../db/file-query.js";
+import { and, eq } from "../../db/file-query.js";
 import { listCharacterSprites } from "../../services/game/sprite.service.js";
 import { DATA_DIR } from "../../utils/data-dir.js";
 import {
@@ -855,6 +855,7 @@ async function buildRetryAgentContext(args: {
     })),
   );
   const retryCommittedSnapshots = await gameStateStore.getCommittedForMessages(
+    chatId,
     agentSlice.filter((message: any) => message.role === "assistant"),
   );
   const retryVisibleAnchor =
@@ -2636,7 +2637,7 @@ async function applyRetryResultEffects(args: {
       assertRetryActive();
       return projectGameSnapshotLocation(created, retryOwnerSpatialProjection);
     }
-    const existing = await gameStateStore.getByMessage(retryMessageId, retrySwipeIndex);
+    const existing = await gameStateStore.getByChatAndMessage(chatId, retryMessageId, retrySwipeIndex);
     assertRetryActive();
     if (existing) return projectGameSnapshotLocation(existing, retryOwnerSpatialProjection);
     const updateOptions = await buildSnapshotUpdateOptions();
@@ -2930,7 +2931,7 @@ async function applyRetryResultEffects(args: {
             await app.db
               .update(gameStateSnapshotsTable)
               .set(personaPatch.updates)
-              .where(eq(gameStateSnapshotsTable.id, latest.id));
+              .where(and(eq(gameStateSnapshotsTable.chatId, chatId), eq(gameStateSnapshotsTable.id, latest.id)));
             assertRetryActive();
           }
         }
@@ -3059,7 +3060,7 @@ async function applyRetryResultEffects(args: {
               await app.db
                 .update(gameStateSnapshotsTable)
                 .set({ playerStats: JSON.stringify(questTrackerPatch.playerStats) })
-                .where(eq(gameStateSnapshotsTable.id, snap.id));
+                .where(and(eq(gameStateSnapshotsTable.chatId, chatId), eq(gameStateSnapshotsTable.id, snap.id)));
               assertRetryActive();
             }
             assertRetryActive();
@@ -3120,7 +3121,7 @@ async function applyRetryResultEffects(args: {
           await app.db
             .update(gameStateSnapshotsTable)
             .set({ playerStats: JSON.stringify(inventoryTrackerPatch.playerStats) })
-            .where(eq(gameStateSnapshotsTable.id, snap.id));
+            .where(and(eq(gameStateSnapshotsTable.chatId, chatId), eq(gameStateSnapshotsTable.id, snap.id)));
           assertRetryActive();
         }
         if (inventoryTrackerPatch.changed) {
@@ -3158,7 +3159,7 @@ async function applyRetryResultEffects(args: {
             await app.db
               .update(gameStateSnapshotsTable)
               .set({ playerStats: JSON.stringify(customTrackerPatch.playerStats) })
-              .where(eq(gameStateSnapshotsTable.id, snap.id));
+              .where(and(eq(gameStateSnapshotsTable.chatId, chatId), eq(gameStateSnapshotsTable.id, snap.id)));
             assertRetryActive();
           }
           if (customTrackerPatch.changed) {

--- a/packages/server/src/routes/professor-mari-workspace.routes.ts
+++ b/packages/server/src/routes/professor-mari-workspace.routes.ts
@@ -217,9 +217,12 @@ export async function professorMariWorkspaceRoutes(app: FastifyInstance) {
     return { ok: true, item };
   });
 
-  app.delete<{ Params: { id: string } }>("/context/:id", async (req, reply) => {
+  app.delete<{ Params: { id: string }; Querystring: { chatId?: string } }>("/context/:id", async (req, reply) => {
     if (!privileged(req, reply)) return;
-    const removed = await createMariWorkspaceContextStorage(app.db).remove(req.params.id);
+    // Optional chatId (same convention as GET /context) keeps the lazy store from
+    // loading the whole table for a bare-id delete.
+    const chatId = (req.query.chatId ?? "").trim();
+    const removed = await createMariWorkspaceContextStorage(app.db).remove(req.params.id, chatId || undefined);
     if (!removed) return reply.status(404).send({ error: "Attached context not found" });
     return { ok: true };
   });

--- a/packages/server/src/routes/professor-mari-workspace.routes.ts
+++ b/packages/server/src/routes/professor-mari-workspace.routes.ts
@@ -220,8 +220,10 @@ export async function professorMariWorkspaceRoutes(app: FastifyInstance) {
   app.delete<{ Params: { id: string }; Querystring: { chatId?: string } }>("/context/:id", async (req, reply) => {
     if (!privileged(req, reply)) return;
     // Optional chatId (same convention as GET /context) keeps the lazy store from
-    // loading the whole table for a bare-id delete.
-    const chatId = (req.query.chatId ?? "").trim();
+    // loading the whole table for a bare-id delete. The typeof guard also covers a
+    // repeated query param, which Fastify hands over as an array.
+    const chatIdRaw = req.query.chatId;
+    const chatId = typeof chatIdRaw === "string" ? chatIdRaw.trim() : "";
     const removed = await createMariWorkspaceContextStorage(app.db).remove(req.params.id, chatId || undefined);
     if (!removed) return reply.status(404).send({ error: "Attached context not found" });
     return { ok: true };

--- a/packages/server/src/services/capability-packages/capability-persistence.service.ts
+++ b/packages/server/src/services/capability-packages/capability-persistence.service.ts
@@ -270,8 +270,11 @@ function createDocumentStore(db: DB): CapabilityDocumentStore {
 
 function createSpatialSnapshotStore(db: DB): CapabilitySpatialSnapshotStore {
   const store: CapabilitySpatialSnapshotStore = {
-    async getById(id) {
-      const rows = await db.select().from(spatialContextSnapshots).where(eq(spatialContextSnapshots.id, id)).limit(1);
+    async getById(id, chatId) {
+      const condition = chatId
+        ? and(eq(spatialContextSnapshots.chatId, chatId), eq(spatialContextSnapshots.id, id))
+        : eq(spatialContextSnapshots.id, id);
+      const rows = await db.select().from(spatialContextSnapshots).where(condition).limit(1);
       return rows[0] ? mapSnapshot(rows[0]) : null;
     },
     async getByAnchor(chatId, messageId, swipeIndex) {

--- a/packages/server/src/services/game/checkpoint.service.ts
+++ b/packages/server/src/services/game/checkpoint.service.ts
@@ -148,7 +148,7 @@ export function createCheckpointService(db: DB) {
       const capturedGameRows = await db
         .select()
         .from(gameStateSnapshots)
-        .where(eq(gameStateSnapshots.id, input.snapshotId))
+        .where(and(eq(gameStateSnapshots.chatId, input.chatId), eq(gameStateSnapshots.id, input.snapshotId)))
         .limit(1);
       const capturedGameSnapshot = capturedGameRows[0];
       if (!capturedGameSnapshot || capturedGameSnapshot.chatId !== input.chatId) {
@@ -159,7 +159,12 @@ export function createCheckpointService(db: DB) {
         ? await db
             .select()
             .from(spatialContextSnapshots)
-            .where(eq(spatialContextSnapshots.id, input.spatialSnapshotId))
+            .where(
+              and(
+                eq(spatialContextSnapshots.chatId, input.chatId),
+                eq(spatialContextSnapshots.id, input.spatialSnapshotId),
+              ),
+            )
             .limit(1)
         : await db
             .select()
@@ -245,8 +250,11 @@ export function createCheckpointService(db: DB) {
       return rows as CheckpointRow[];
     },
 
-    async getById(id: string): Promise<StoredCheckpointRow | null> {
-      const rows = await db.select().from(gameCheckpoints).where(eq(gameCheckpoints.id, id)).limit(1);
+    async getById(id: string, chatId?: string): Promise<StoredCheckpointRow | null> {
+      const condition = chatId
+        ? and(eq(gameCheckpoints.chatId, chatId), eq(gameCheckpoints.id, id))
+        : eq(gameCheckpoints.id, id);
+      const rows = await db.select().from(gameCheckpoints).where(condition).limit(1);
       return (rows[0] as StoredCheckpointRow) ?? null;
     },
 
@@ -254,8 +262,11 @@ export function createCheckpointService(db: DB) {
       await db.delete(gameCheckpoints).where(eq(gameCheckpoints.chatId, chatId));
     },
 
-    async deleteById(id: string): Promise<void> {
-      await db.delete(gameCheckpoints).where(eq(gameCheckpoints.id, id));
+    async deleteById(id: string, chatId?: string): Promise<void> {
+      const condition = chatId
+        ? and(eq(gameCheckpoints.chatId, chatId), eq(gameCheckpoints.id, id))
+        : eq(gameCheckpoints.id, id);
+      await db.delete(gameCheckpoints).where(condition);
     },
   };
 }

--- a/packages/server/src/services/mari-db/mari-images.service.ts
+++ b/packages/server/src/services/mari-db/mari-images.service.ts
@@ -981,7 +981,7 @@ export class MariImagesService {
   }
 
   private async chatGalleryImageUrl(chatId: string, imageId: string) {
-    const image = await createGalleryStorage(this.db).getById(imageId);
+    const image = await createGalleryStorage(this.db).getById(imageId, chatId);
     if (!image || image.chatId !== chatId) throw new Error(`Chat gallery image not found: ${imageId}`);
     const filename = image.filePath.split("/").pop() ?? "";
     const ownerChatId = image.filePath.split("/").filter(Boolean).length > 1 ? image.filePath.split("/")[0]! : chatId;
@@ -1350,7 +1350,7 @@ export class MariImagesService {
 
   private async deleteChatGallery(chatId: string, imageId: string) {
     const store = createGalleryStorage(this.db);
-    const image = await store.getById(imageId);
+    const image = await store.getById(imageId, chatId);
     if (!image || image.chatId !== chatId) throw new Error(`Chat gallery image not found: ${imageId}`);
     const cleanup = await deleteChatGalleryImageEverywhere({ db: this.db, image });
     return { deleted: image, cleanup };

--- a/packages/server/src/services/storage/agents.storage.ts
+++ b/packages/server/src/services/storage/agents.storage.ts
@@ -430,12 +430,13 @@ export function createAgentsStorage(db: DB) {
       return rows.map((row) => serializeRunWithConfig(row));
     },
 
-    async getRunWithConfig(id: string) {
+    async getRunWithConfig(id: string, chatId?: string) {
+      const condition = chatId ? and(eq(agentRuns.chatId, chatId), eq(agentRuns.id, id)) : eq(agentRuns.id, id);
       const rows = await db
         .select()
         .from(agentRuns)
         .innerJoin(agentConfigs, eq(agentRuns.agentConfigId, agentConfigs.id))
-        .where(eq(agentRuns.id, id))
+        .where(condition)
         .limit(1);
       const row = rows[0];
       return row ? serializeRunWithConfig(row) : null;
@@ -447,7 +448,7 @@ export function createAgentsStorage(db: DB) {
         .update(agentRuns)
         .set({ resultData: JSON.stringify(resultData) })
         .where(condition);
-      return this.getRunWithConfig(id);
+      return this.getRunWithConfig(id, chatId);
     },
 
     // ── Agent Memory (persistent KV per agent per chat) ──

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -2179,10 +2179,22 @@ export function createChatsStorage(db: DB) {
           .where(and(eq(messageSwipes.messageId, messageId), eq(messageSwipes.id, target.id)));
         await db
           .delete(gameStateSnapshots)
-          .where(and(eq(gameStateSnapshots.messageId, messageId), eq(gameStateSnapshots.swipeIndex, index)));
+          .where(
+            and(
+              eq(gameStateSnapshots.chatId, msg.chatId),
+              eq(gameStateSnapshots.messageId, messageId),
+              eq(gameStateSnapshots.swipeIndex, index),
+            ),
+          );
         await db
           .delete(spatialContextSnapshots)
-          .where(and(eq(spatialContextSnapshots.messageId, messageId), eq(spatialContextSnapshots.swipeIndex, index)));
+          .where(
+            and(
+              eq(spatialContextSnapshots.chatId, msg.chatId),
+              eq(spatialContextSnapshots.messageId, messageId),
+              eq(spatialContextSnapshots.swipeIndex, index),
+            ),
+          );
 
         const swipesToShift = await db
           .select()
@@ -2198,39 +2210,63 @@ export function createChatsStorage(db: DB) {
         const snapshotsToShift = await db
           .select()
           .from(gameStateSnapshots)
-          .where(and(eq(gameStateSnapshots.messageId, messageId), gt(gameStateSnapshots.swipeIndex, index)));
+          .where(
+            and(
+              eq(gameStateSnapshots.chatId, msg.chatId),
+              eq(gameStateSnapshots.messageId, messageId),
+              gt(gameStateSnapshots.swipeIndex, index),
+            ),
+          );
         for (const snapshot of snapshotsToShift) {
           await db
             .update(gameStateSnapshots)
             .set({ swipeIndex: snapshot.swipeIndex - 1 })
-            .where(eq(gameStateSnapshots.id, snapshot.id));
+            .where(and(eq(gameStateSnapshots.chatId, msg.chatId), eq(gameStateSnapshots.id, snapshot.id)));
         }
 
         const spatialSnapshotsToShift = await db
           .select()
           .from(spatialContextSnapshots)
-          .where(and(eq(spatialContextSnapshots.messageId, messageId), gt(spatialContextSnapshots.swipeIndex, index)));
+          .where(
+            and(
+              eq(spatialContextSnapshots.chatId, msg.chatId),
+              eq(spatialContextSnapshots.messageId, messageId),
+              gt(spatialContextSnapshots.swipeIndex, index),
+            ),
+          );
         for (const snapshot of spatialSnapshotsToShift) {
           await db
             .update(spatialContextSnapshots)
             .set({ swipeIndex: snapshot.swipeIndex - 1 })
-            .where(eq(spatialContextSnapshots.id, snapshot.id));
+            .where(and(eq(spatialContextSnapshots.chatId, msg.chatId), eq(spatialContextSnapshots.id, snapshot.id)));
         }
 
         // Mirror the prune for turn-game (UNO) snapshots so anchors stay aligned
         // with the message's swipes after one is removed.
         await db
           .delete(gameEngineState)
-          .where(and(eq(gameEngineState.messageId, messageId), eq(gameEngineState.swipeIndex, index)));
+          .where(
+            and(
+              eq(gameEngineState.chatId, msg.chatId),
+              eq(gameEngineState.messageId, messageId),
+              eq(gameEngineState.swipeIndex, index),
+            ),
+          );
         const engineSnapshotsToShift = await db
           .select()
           .from(gameEngineState)
-          .where(and(eq(gameEngineState.messageId, messageId), gt(gameEngineState.swipeIndex, index)));
+          .where(
+            and(
+              eq(gameEngineState.chatId, msg.chatId),
+              eq(gameEngineState.messageId, messageId),
+              gt(gameEngineState.swipeIndex, index),
+            ),
+          );
         for (const snapshot of engineSnapshotsToShift) {
           await db
             .update(gameEngineState)
             .set({ swipeIndex: snapshot.swipeIndex - 1 })
-            .where(eq(gameEngineState.id, snapshot.id));
+            .where(and(eq(gameEngineState.chatId, msg.chatId), eq(gameEngineState.id, snapshot.id)));
         }
 
         await db

--- a/packages/server/src/services/storage/gallery.storage.ts
+++ b/packages/server/src/services/storage/gallery.storage.ts
@@ -35,8 +35,18 @@ export function createGalleryStorage(db: DB) {
       return db.select().from(chatImages).where(eq(chatImages.filePath, filePath)).orderBy(desc(chatImages.createdAt));
     },
 
-    async getById(id: string) {
-      const rows = await db.select().from(chatImages).where(eq(chatImages.id, id));
+    /** Chat-scoped filePath lookup (keeps the lazy file store from loading every chat's shards). */
+    async listByChatAndFilePath(chatId: string, filePath: string) {
+      return db
+        .select()
+        .from(chatImages)
+        .where(and(eq(chatImages.chatId, chatId), eq(chatImages.filePath, filePath)))
+        .orderBy(desc(chatImages.createdAt));
+    },
+
+    async getById(id: string, chatId?: string) {
+      const condition = chatId ? and(eq(chatImages.chatId, chatId), eq(chatImages.id, id)) : eq(chatImages.id, id);
+      const rows = await db.select().from(chatImages).where(condition);
       return rows[0] ?? null;
     },
 
@@ -53,11 +63,12 @@ export function createGalleryStorage(db: DB) {
         height: input.height ?? null,
         createdAt: now(),
       });
-      return this.getById(id);
+      return this.getById(id, input.chatId);
     },
 
-    async remove(id: string) {
-      await db.delete(chatImages).where(eq(chatImages.id, id));
+    async remove(id: string, chatId?: string) {
+      const condition = chatId ? and(eq(chatImages.chatId, chatId), eq(chatImages.id, id)) : eq(chatImages.id, id);
+      await db.delete(chatImages).where(condition);
     },
 
     async removeByChatAndFilePath(chatId: string, filePath: string) {

--- a/packages/server/src/services/storage/game-engine-state.storage.ts
+++ b/packages/server/src/services/storage/game-engine-state.storage.ts
@@ -271,8 +271,11 @@ export function createGameEngineStateStorage(db: DB) {
     },
 
     /** Re-anchor a snapshot to a (message, swipe) once the narration message exists. */
-    async reanchor(id: string, messageId: string, swipeIndex: number) {
-      await db.update(gameEngineState).set({ messageId, swipeIndex }).where(eq(gameEngineState.id, id));
+    async reanchor(id: string, messageId: string, swipeIndex: number, chatId?: string) {
+      const condition = chatId
+        ? and(eq(gameEngineState.chatId, chatId), eq(gameEngineState.id, id))
+        : eq(gameEngineState.id, id);
+      await db.update(gameEngineState).set({ messageId, swipeIndex }).where(condition);
     },
 
     async commit(id: string, chatId?: string) {
@@ -330,11 +333,15 @@ export function createGameEngineStateStorage(db: DB) {
         .orderBy(desc(gameEngineState.createdAt));
       const doomed = rows.slice(Math.max(0, keep));
       if (doomed.length === 0) return;
-      // One statement, one shard rewrite — not one per pruned row.
+      // One statement, one shard rewrite — not one per pruned row. The chatId conjunct keeps
+      // the id-list delete scoped to this chat's shard in the lazy store.
       await db.delete(gameEngineState).where(
-        inArray(
-          gameEngineState.id,
-          doomed.map((row) => row.id),
+        and(
+          eq(gameEngineState.chatId, chatId),
+          inArray(
+            gameEngineState.id,
+            doomed.map((row) => row.id),
+          ),
         ),
       );
     },

--- a/packages/server/src/services/storage/game-scene-videos.storage.ts
+++ b/packages/server/src/services/storage/game-scene-videos.storage.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "../../db/file-query.js";
+import { and, desc, eq } from "../../db/file-query.js";
 import type { DB } from "../../db/connection.js";
 import { gameSceneVideos } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
@@ -25,13 +25,19 @@ export function createGameSceneVideosStorage(db: DB) {
         .orderBy(desc(gameSceneVideos.createdAt));
     },
 
-    async getById(id: string) {
-      const rows = await db.select().from(gameSceneVideos).where(eq(gameSceneVideos.id, id));
+    async getById(id: string, chatId?: string) {
+      const condition = chatId
+        ? and(eq(gameSceneVideos.chatId, chatId), eq(gameSceneVideos.id, id))
+        : eq(gameSceneVideos.id, id);
+      const rows = await db.select().from(gameSceneVideos).where(condition);
       return rows[0] ?? null;
     },
 
-    async remove(id: string) {
-      await db.delete(gameSceneVideos).where(eq(gameSceneVideos.id, id));
+    async remove(id: string, chatId?: string) {
+      const condition = chatId
+        ? and(eq(gameSceneVideos.chatId, chatId), eq(gameSceneVideos.id, id))
+        : eq(gameSceneVideos.id, id);
+      await db.delete(gameSceneVideos).where(condition);
     },
 
     async create(input: CreateGameSceneVideoInput) {
@@ -50,7 +56,7 @@ export function createGameSceneVideosStorage(db: DB) {
         aspectRatio: input.aspectRatio,
         createdAt,
       });
-      return this.getById(id);
+      return this.getById(id, input.chatId);
     },
 
     async removeByChatId(chatId: string) {

--- a/packages/server/src/services/storage/game-state.storage.ts
+++ b/packages/server/src/services/storage/game-state.storage.ts
@@ -161,8 +161,11 @@ export function createGameStateStorage(db: DB) {
         .limit(Math.max(1, Math.min(500, limit)));
     },
 
-    async getById(id: string) {
-      const rows = await db.select().from(gameStateSnapshots).where(eq(gameStateSnapshots.id, id)).limit(1);
+    async getById(id: string, chatId?: string) {
+      const condition = chatId
+        ? and(eq(gameStateSnapshots.chatId, chatId), eq(gameStateSnapshots.id, id))
+        : eq(gameStateSnapshots.id, id);
+      const rows = await db.select().from(gameStateSnapshots).where(condition).limit(1);
       return rows[0] ?? null;
     },
 
@@ -273,17 +276,7 @@ export function createGameStateStorage(db: DB) {
       return rows[0] ?? null;
     },
 
-    async getByMessage(messageId: string, swipeIndex: number = 0) {
-      const rows = await db
-        .select()
-        .from(gameStateSnapshots)
-        .where(and(eq(gameStateSnapshots.messageId, messageId), eq(gameStateSnapshots.swipeIndex, swipeIndex)))
-        .orderBy(desc(gameStateSnapshots.createdAt))
-        .limit(1);
-      return rows[0] ?? null;
-    },
-
-    /** Chat-scoped variant of getByMessage (avoids cross-chat collisions for messageId=""). */
+    /** Chat-scoped message lookup (the chatId also keeps the lazy store from loading other chats' shards). */
     async getByChatAndMessage(chatId: string, messageId: string, swipeIndex: number = 0) {
       const rows = await db
         .select()
@@ -300,8 +293,11 @@ export function createGameStateStorage(db: DB) {
       return rows[0] ?? null;
     },
 
-    /** Batch-fetch committed snapshots for multiple messages. Returns a Map of messageId → row. */
-    async getCommittedForMessages(messagesOrIds: Array<string | { id: string; activeSwipeIndex?: number | null }>) {
+    /** Batch-fetch committed snapshots for multiple messages in one chat. Returns a Map of messageId → row. */
+    async getCommittedForMessages(
+      chatId: string,
+      messagesOrIds: Array<string | { id: string; activeSwipeIndex?: number | null }>,
+    ) {
       const activeSwipeByMessageId = new Map<string, number>();
       const messageIds = messagesOrIds.map((messageOrId) => {
         if (typeof messageOrId === "string") return messageOrId;
@@ -314,7 +310,13 @@ export function createGameStateStorage(db: DB) {
       const rows = await db
         .select()
         .from(gameStateSnapshots)
-        .where(and(inArray(gameStateSnapshots.messageId, messageIds), eq(gameStateSnapshots.committed, 1)))
+        .where(
+          and(
+            eq(gameStateSnapshots.chatId, chatId),
+            inArray(gameStateSnapshots.messageId, messageIds),
+            eq(gameStateSnapshots.committed, 1),
+          ),
+        )
         .orderBy(desc(gameStateSnapshots.createdAt));
       const map = new Map<string, typeof gameStateSnapshots.$inferSelect>();
       for (const row of rows) {
@@ -340,7 +342,11 @@ export function createGameStateStorage(db: DB) {
         await db
           .delete(gameStateSnapshots)
           .where(
-            and(eq(gameStateSnapshots.messageId, state.messageId), eq(gameStateSnapshots.swipeIndex, state.swipeIndex)),
+            and(
+              eq(gameStateSnapshots.chatId, state.chatId),
+              eq(gameStateSnapshots.messageId, state.messageId),
+              eq(gameStateSnapshots.swipeIndex, state.swipeIndex),
+            ),
           );
       }
       const id = newId();
@@ -401,7 +407,7 @@ export function createGameStateStorage(db: DB) {
         compatibilityLocation?: string | null;
       },
     ) {
-      const snap = await this.getByMessage(messageId, swipeIndex);
+      const snap = await this.getByChatAndMessage(chatId, messageId, swipeIndex);
       if (snap) return this._applyUpdate(snap, fields, manual);
 
       // No snapshot for this swipe yet — clone the chosen base into a new row
@@ -485,7 +491,7 @@ export function createGameStateStorage(db: DB) {
         : {};
       // Manual overrides are one-shot — carry only overrides from this edit.
       await this.create(baseState as any, Object.keys(manualOverrides).length > 0 ? manualOverrides : null);
-      return this.getByMessage(messageId, swipeIndex);
+      return this.getByChatAndMessage(chatId, messageId, swipeIndex);
     },
 
     /** Internal: apply field updates + optional manual-override tracking to a snapshot row. */

--- a/packages/server/src/services/storage/mari-workspace-context.storage.ts
+++ b/packages/server/src/services/storage/mari-workspace-context.storage.ts
@@ -87,8 +87,11 @@ export function createMariWorkspaceContextStorage(db: DB) {
       });
     },
 
-    async get(id: string): Promise<MariWorkspaceContextRow | null> {
-      const rows = await db.select().from(mariWorkspaceContext).where(eq(mariWorkspaceContext.id, id));
+    async get(id: string, chatId?: string): Promise<MariWorkspaceContextRow | null> {
+      const condition = chatId
+        ? and(eq(mariWorkspaceContext.chatId, chatId), eq(mariWorkspaceContext.id, id))
+        : eq(mariWorkspaceContext.id, id);
+      const rows = await db.select().from(mariWorkspaceContext).where(condition);
       const row = rows[0];
       return row ? mapRow(row) : null;
     },
@@ -114,8 +117,8 @@ export function createMariWorkspaceContextStorage(db: DB) {
       return mapRow(row);
     },
 
-    async remove(id: string): Promise<boolean> {
-      const existing = await this.get(id);
+    async remove(id: string, chatId?: string): Promise<boolean> {
+      const existing = await this.get(id, chatId);
       if (!existing) return false;
       await db
         .delete(mariWorkspaceContext)

--- a/packages/server/src/services/storage/spatial-context.storage.ts
+++ b/packages/server/src/services/storage/spatial-context.storage.ts
@@ -13,7 +13,8 @@ export interface CreateSpatialSnapshotInput {
 }
 
 export interface SpatialContextStorage {
-  getById(id: string): Promise<SpatialContextSnapshot | null>;
+  /** chatId is optional but keeps the lazy file store from loading every chat's shards for a bare-id probe. */
+  getById(id: string, chatId?: string): Promise<SpatialContextSnapshot | null>;
   getByAnchor(chatId: string, messageId: string, swipeIndex: number): Promise<SpatialContextSnapshot | null>;
   getByCommand(chatId: string, commandId: string): Promise<SpatialContextSnapshot | null>;
   listByAnchors(

--- a/packages/shared/src/types/capability-runtime.ts
+++ b/packages/shared/src/types/capability-runtime.ts
@@ -222,7 +222,8 @@ export interface CapabilitySpatialSnapshotWrite {
 }
 
 export interface CapabilitySpatialSnapshotStore {
-  getById(id: string): Promise<SpatialContextSnapshot | null>;
+  /** chatId is optional but keeps the lazy file store from loading every chat's shards for a bare-id probe. */
+  getById(id: string, chatId?: string): Promise<SpatialContextSnapshot | null>;
   getByAnchor(chatId: string, messageId: string, swipeIndex: number): Promise<SpatialContextSnapshot | null>;
   getByCommand(chatId: string, commandId: string): Promise<SpatialContextSnapshot | null>;
   listByAnchors(

--- a/scripts/regressions/lazy-chat-units.regression.ts
+++ b/scripts/regressions/lazy-chat-units.regression.ts
@@ -21,7 +21,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { eq, inArray } from "../../packages/server/src/db/file-query.js";
 import { createFileNativeDB, encodeShardKey } from "../../packages/server/src/db/file-backed-store.js";
-import { chats, memoryChunks, messages, messageSwipes } from "../../packages/server/src/db/schema/index.js";
+import { chats, gameStateSnapshots, memoryChunks, messages, messageSwipes } from "../../packages/server/src/db/schema/index.js";
 
 if (process.env.MARINARA_EAGER_STORAGE === "1" || process.env.MARINARA_EAGER_STORAGE === "true") {
   // The kill switch restores eager boot loading; these regressions assert
@@ -924,6 +924,80 @@ const loadedUnitsOf = (db: Awaited<ReturnType<typeof createFileNativeDB>>) => db
     assert.equal(loaded.has("chat-5"), true, "the most recent healthy unit stays resident");
   } finally {
     delete process.env.MARINARA_MAX_RESIDENT_CHATS;
+    await db._fileStore.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── #5611: chat-scoped game-state operations do not lease the whole table ──
+// Before the residual-lease fixes, the hot tracker path (getByMessage inside
+// updateByMessage, the create() dedupe delete, getCommittedForMessages) queried
+// game_state_snapshots without a chatId conjunct. The store cannot scope those
+// conditions, so the FIRST game-mode turn converted the table to permanently
+// fully-resident — silently defeating MARINARA_MAX_RESIDENT_CHATS. This block
+// drives the real storage layer through the same operations and asserts the
+// table is never leased and the other chat's unit is never loaded; the final
+// half runs a deliberately unscoped query to prove the lease tripwire (and the
+// diagnostics accessor) still detect exactly what the old code used to do.
+
+{
+  const dir = tempStorageDir();
+  const gameStateRow = (id: string, chatId: string, messageId: string, swipeIndex: number, committed: number) => ({
+    id,
+    chatId,
+    messageId,
+    swipeIndex,
+    date: null,
+    time: null,
+    location: null,
+    weather: null,
+    temperature: null,
+    worldCustomFields: "[]",
+    presentCharacters: "[]",
+    recentEvents: "[]",
+    playerStats: null,
+    personaStats: null,
+    manualOverrides: null,
+    fieldLocks: null,
+    hiddenTrackerFields: null,
+    committed,
+    createdAt: `2026-08-28T09:00:0${swipeIndex}.000Z`,
+  });
+  writeShard(dir, "chats", "chat-a", [chatRow("chat-a")]);
+  writeShard(dir, "chats", "chat-b", [chatRow("chat-b")]);
+  writeShard(dir, "game_state_snapshots", "chat-a", [gameStateRow("gs-a1", "chat-a", "m-a1", 0, 1)]);
+  writeShard(dir, "game_state_snapshots", "chat-b", [gameStateRow("gs-b1", "chat-b", "m-b1", 0, 1)]);
+  const db = await createFileNativeDB();
+  const { createGameStateStorage } = await import(
+    "../../packages/server/src/services/storage/game-state.storage.js"
+  );
+  const gameStateStore = createGameStateStorage(db as never);
+  const leasedTables = () => db._fileStore.getFullyResidentLazyTables();
+  try {
+    const found = await gameStateStore.getByChatAndMessage("chat-a", "m-a1", 0);
+    assert.equal(found?.id, "gs-a1", "the chat-scoped message lookup finds the snapshot");
+    assert.equal(leasedTables().size, 0, "a chat-scoped message lookup does not lease any table");
+    assert.equal(loadedUnitsOf(db).has("chat-b"), false, "the other chat's unit stays on disk");
+
+    // The clone path exercises create()'s dedupe delete AND the re-read after insert.
+    const cloned = await gameStateStore.updateByMessage("m-a2", 0, "chat-a", { location: "harbor" });
+    assert.equal(cloned?.messageId, "m-a2", "updateByMessage clones a snapshot for the new anchor");
+    assert.equal(leasedTables().size, 0, "the tracker write path (update + create dedupe) does not lease");
+
+    const committed = await gameStateStore.getCommittedForMessages("chat-a", ["m-a1"]);
+    assert.equal(committed.get("m-a1")?.id, "gs-a1", "the batch committed fetch finds the snapshot");
+    assert.equal(leasedTables().size, 0, "the batch committed fetch does not lease");
+    assert.equal(loadedUnitsOf(db).has("chat-b"), false, "chat-b is still untouched after the full hot path");
+
+    // Inversion: the pre-fix condition shape (messageId with no chatId) MUST
+    // still trip the lease — this pins the tripwire the fix is measured against.
+    await db.select().from(gameStateSnapshots).where(eq(gameStateSnapshots.messageId, "m-b1"));
+    assert.equal(
+      leasedTables().has("game_state_snapshots"),
+      true,
+      "an unscoped messageId query still converts the table to fully resident",
+    );
+  } finally {
     await db._fileStore.close();
     rmSync(dir, { recursive: true, force: true });
   }

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -6191,7 +6191,9 @@ assert.doesNotMatch(gameAssetsRoutesSource, /app\.get\("\/local-music-file\/:enc
 assert.match(galleryRoutesSource, /app\.delete<[\s\S]*>\("\/scene-videos\/:chatId\/:id"/u);
 assert.match(
   galleryRoutesSource,
-  /video\.chatId !== chatId[\s\S]*sceneVideos\.remove\(video\.id\)[\s\S]*removeSavedVideoFromDisk\(video\.filePath\)\.catch/u,
+  // remove() may carry the chat-scoping second argument (#5611) — the pin is the
+  // ordering (DB row first, disk file second, unlink failure tolerated), not the arity.
+  /video\.chatId !== chatId[\s\S]*sceneVideos\.remove\(video\.id[^)]*\)[\s\S]*removeSavedVideoFromDisk\(video\.filePath\)\.catch/u,
 );
 assert.match(galleryHooksSource, /api\.delete\(`\/gallery\/scene-videos\/\$\{chatId\}\/\$\{videoId\}`\)/u);
 assert.match(chatGallerySource, /handleDeleteVideo\(video\)/u);

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -6184,12 +6184,13 @@ assert.doesNotMatch(localMusicPlayerSource, /return `\/api\/game-assets\/local-m
 assert.match(gameAssetsRoutesSource, /app\.get\("\/local-music-file"/u);
 assert.match(gameAssetsRoutesSource, /const \{ path: encoded \} = \(req\.query as \{ path\?: string \}\)/u);
 assert.doesNotMatch(gameAssetsRoutesSource, /app\.get\("\/local-music-file\/:encoded"/u);
-assert.match(galleryRoutesSource, /app\.delete<[\s\S]*>\("\/scene-videos\/:chatId\/:id"/u);
 assert.match(
   galleryRoutesSource,
-  // remove() may carry the chat-scoping second argument (#5611) — the pin is the
-  // ordering (DB row first, disk file second, unlink failure tolerated), not the arity.
-  /video\.chatId !== chatId[\s\S]*sceneVideos\.remove\(video\.id[^)]*\)[\s\S]*removeSavedVideoFromDisk\(video\.filePath\)\.catch/u,
+  // Anchored at the one scene-video delete route, with bounded lazy gaps so the
+  // match cannot span into another handler: ownership check, then the DB row
+  // removal with its exact #5611 chat-scoping argument, then the tolerated disk
+  // unlink — in that order, all inside this handler.
+  /app\.delete<\{ Params: \{ chatId: string; id: string \} \}>\("\/scene-videos\/:chatId\/:id"[\s\S]{0,400}?video\.chatId !== chatId[\s\S]{0,200}?await sceneVideos\.remove\(video\.id, video\.chatId\);[\s\S]{0,120}?await removeSavedVideoFromDisk\(video\.filePath\)\.catch/u,
 );
 assert.match(galleryHooksSource, /api\.delete\(`\/gallery\/scene-videos\/\$\{chatId\}\/\$\{videoId\}`\)/u);
 assert.match(chatGallerySource, /handleDeleteVideo\(video\)/u);

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -5360,11 +5360,7 @@ for (const [name, source] of [
   ["mobile connection switcher", quickSwitcherMobileSource],
 ] as const) {
   assert.match(source, /<ContextBudgetIndicator budget=\{contextBudget\}/u, `${name} must show usage in its popup`);
-  assert.match(
-    source,
-    /relative flex h-\[1\.875rem\] w-\[1\.875rem\]/u,
-    `${name} must use the larger context gauge`,
-  );
+  assert.match(source, /relative flex h-\[1\.875rem\] w-\[1\.875rem\]/u, `${name} must use the larger context gauge`);
 }
 assert.equal(
   professorMariHomeSource.match(/<ContextBudgetIndicator budget=\{contextBudget\} professorMari \/>/gu)?.length,


### PR DESCRIPTION
Closes #5611. Part of the #5592 close-out (follows #5597/#5603/#5607–#5610).

## Why

Any query the lazy store cannot scope to specific chats trips the safety fallback: the whole table becomes **permanently fully resident** for the process (`Lazy table <name> is now fully resident` in the log). A post-merge audit found the residual sites — and the worst one (`getByMessage`, funneling ~16 callers including `updateByMessage`, which already *takes* the chatId) fires on essentially every Game-mode turn, so on game-heavy installs the `game_state_snapshots` memory cap silently stopped working the moment a tracker updated.

## What changed

- **Game-state hot path**: the unscoped `getByMessage` is deleted; all callers use the already-scoped `getByChatAndMessage` (compiler-enforced migration). `create()`'s dedupe delete and `getCommittedForMessages` gain the chatId conjunct, and the eight bare-PK tracker writes in `generate.routes.ts` / `retry-agents-route.ts` are scoped with them — they were only masked because `getByMessage` leased first, so fixing one without the other just relocates the lease.
- **`deleteSwipe`**: all nine cascade statements across `game_state_snapshots` / `spatial_context_snapshots` / `game_engine_state` now carry `msg.chatId` (already fetched at the top of the function).
- **Checkpoints**: the captured-snapshot reads on create are scoped (which also enforces the cross-chat validation the code already performed by hand); `getById`/`deleteById` accept an optional chatId, threaded from the load route.
- **Gallery / scene videos**: new `listByChatAndFilePath` for the image-serving route (the filePath argument literally embeds the chatId); `getById`/`remove` accept optional chatId, threaded at every warm caller.
- **Id-only endpoints** (gallery `DELETE /:id`, checkpoint `DELETE /:id`, workspace `DELETE /context/:id`, agents `PATCH /runs/:runId`): accept an optional chatId (query/body) so the client can start passing it; until it does, these few cold endpoints keep the lease, as documented in #5611.
- **Diagnostics**: `getFullyResidentLazyTables()` on the store controller, mirroring `getResidentChatUnits()` — empty is the healthy state.
- **Deliberately left unscoped** (commented in-code, referencing #5611): the game scene-video route's sibling-chat gallery lookup and the character/persona clip-delete lookups, where the owner is only known after the read. `galleryFileHasReferences` (#5613) and the boot gallery walk (#5612) are tracked separately.

The chatId conjunct is behavior-preserving for reads and writes alike: the store's scope resolver uses it only to decide which chat's shards to load, and every scoped condition still matches exactly the rows it matched before (each site's rows always belonged to the chat being threaded — most sites validated exactly that one line later).

## Regression

New block in `lazy-chat-units.regression.ts`: drives the **real** `createGameStateStorage` layer cold (scoped lookup, `updateByMessage` clone through `create()`'s dedupe, batch committed fetch) and asserts no table lease forms and the other chat's unit never loads — then runs the pre-fix condition shape and asserts the lease tripwire still fires. Verified red against the pre-fix storage layer (restored `game-state.storage.ts` from staging → suite fails; restored the fix → passes).

## Validation done

- `tsc --noEmit` all packages ✅ (shared rebuilt first)
- Server + shared `lint` scripts ✅
- Prettier (`--check --end-of-line auto`) on all 22 changed files ✅ (repo-wide `pnpm check` prettier step fails on this Windows box for all files — #5598, pre-existing)
- Regression lanes: `lazy-chat-units` (lazy + eager-skip) ✅, `message-sharding` (lazy + eager) ✅, `autonomous-check-storage` ✅

## Manual verification

- [ ] Play a Game-mode turn with a tracker enabled on an install with `MARINARA_MAX_RESIDENT_CHATS` set and confirm the log no longer prints `Lazy table game_state_snapshots is now fully resident`
- [ ] Delete a swipe in a chat with game state and confirm swipes/trackers still shift correctly
- [ ] Create + load + delete a checkpoint in Game mode
- [ ] Browse a chat gallery, delete an image, and delete a scene video
- [ ] Edit a custom agent run's output (PATCH runs path)

## Client follow-up (not in this PR)

The four id-only endpoints now accept an optional `chatId`; the client always has the chat open at those call sites and can start passing it to close the last cold leases. Happy to do that as a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat isolation for game states, snapshots, checkpoints, gallery assets, scene videos, workspace contexts, and agent runs.
  * Prevented cross-chat reads, updates, deletions, and cleanup of shared resources.
  * Improved swipe cleanup to include related game engine state.
  * Preserved safe fallback behavior when chat context is unavailable.
  * Reduced unnecessary loading of unrelated chat data.

* **Tests**
  * Added regression coverage for chat-scoped operations and efficient lazy loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->