### PR TITLE
fix(storage): stop boot gallery recovery from loading every chat with images

### DIFF
--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -461,6 +461,16 @@ const LAZY_UNIT_TABLES: ReadonlySet<string> =
 const LAZY_UNIT_LOAD_ORDER: readonly string[] = [...LAZY_UNIT_TABLES];
 
 /**
+ * Whether a table participates in lazy per-chat residency in THIS process
+ * (false for every table under MARINARA_EAGER_STORAGE). Callers that read
+ * shard files from disk directly (#5612) must check this first: for an eager
+ * or fully-resident table the in-memory rows are the truth, not the files.
+ */
+export function isLazyUnitTable(table: string): boolean {
+  return LAZY_UNIT_TABLES.has(table);
+}
+
+/**
  * Shard for child rows whose parent is unknown (orphans in corrupt installs).
  * Chosen to encode to itself for a readable filename; a real owner key equal
  * to this string would merely share the file — rows carry their own keys, so

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -188,6 +188,11 @@ export type FileNativeStoreController = {
   /** Chat units currently resident under lazy loading (#5592) — diagnostics and regression introspection. */
   getResidentChatUnits: () => ReadonlySet<string>;
   /**
+   * Lazy tables that an unscopable query permanently converted to fully resident
+   * (#5611) — diagnostics and regression introspection. Empty is the healthy state.
+   */
+  getFullyResidentLazyTables: () => ReadonlySet<string>;
+  /**
    * Marks shard keys dirty without touching LRU state. Present ONLY when the
    * store was created with test hooks — production controllers never expose
    * an arbitrary dirty-mark mutation.
@@ -461,10 +466,13 @@ const LAZY_UNIT_TABLES: ReadonlySet<string> =
 const LAZY_UNIT_LOAD_ORDER: readonly string[] = [...LAZY_UNIT_TABLES];
 
 /**
- * Whether a table participates in lazy per-chat residency in THIS process
- * (false for every table under MARINARA_EAGER_STORAGE). Callers that read
- * shard files from disk directly (#5612) must check this first: for an eager
- * or fully-resident table the in-memory rows are the truth, not the files.
+ * Whether a table is in the lazy per-chat residency TIER in this process
+ * (false for every table under MARINARA_EAGER_STORAGE). This is static tier
+ * membership only — a lazy table can still have been converted to fully
+ * resident at runtime by an unscopable query, in which case memory (not the
+ * shard files) is the truth. Callers that read shard files from disk directly
+ * (#5612) must check BOTH: this predicate AND the store controller's
+ * getFullyResidentLazyTables().
  */
 export function isLazyUnitTable(table: string): boolean {
   return LAZY_UNIT_TABLES.has(table);
@@ -3171,6 +3179,17 @@ class FileTableStore {
     return new Set(this.loadedUnits);
   }
 
+  getFullyResidentLazyTables(): ReadonlySet<string> {
+    // Same snapshot rule as getResidentChatUnits. Eager tables live in
+    // fullyResidentTables from construction, so report only the lazy tier —
+    // an entry here means an unscopable query leased the whole table (#5611).
+    const leased = new Set<string>();
+    for (const table of this.fullyResidentTables) {
+      if (LAZY_UNIT_TABLES.has(table)) leased.add(table);
+    }
+    return leased;
+  }
+
   markDirty(table: string, shardKeys?: Iterable<string>) {
     // The generation stays keyed on the BARE logical table name for every
     // shard write — the #4705 contract ("something in this table changed")
@@ -4808,6 +4827,7 @@ export async function createFileNativeDB(testHooks?: FileNativeStoreTestHooks): 
     getQuarantinedTables: () => store.getQuarantinedTables(),
     getTableWriteGeneration: (table) => store.getTableWriteGeneration(table),
     getResidentChatUnits: () => store.getResidentChatUnits(),
+    getFullyResidentLazyTables: () => store.getFullyResidentLazyTables(),
     ...(testHooks
       ? { markShardDirty: (table: string, shardKeys: Iterable<string>) => store.markDirty(table, shardKeys) }
       : {}),

--- a/packages/server/src/services/storage/gallery-recovery.ts
+++ b/packages/server/src/services/storage/gallery-recovery.ts
@@ -4,51 +4,118 @@
 // Scans data/gallery/ on startup. For every image file on disk that
 // has no matching chat_images row (but whose parent chat still exists),
 // a new DB record is inserted so the gallery UI shows the image again.
-import { existsSync, readdirSync, statSync } from "fs";
+//
+// #5612: the scan must not defeat lazy chat-unit residency. Querying
+// chat_images per chat looks harmless — every query is chatId-scoped —
+// but any row read pulls that chat's ENTIRE storage unit (all lazy
+// tables' shards) into memory, so on installs where most chats have
+// images this walk quietly reproduced the eager boot #5592 removed.
+// For chats whose unit is not resident we therefore peek the chat's
+// chat_images shard file straight off disk instead: a non-resident unit
+// can hold no unflushed writes (writes force residency first, and
+// eviction only runs after a successful flush), so the file IS the
+// current state. Anything unreadable falls back to the real loader so
+// the full recovery ladder (.bak fallback, quarantine) stays in charge
+// of corruption — and only that one chat's unit loads.
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { logger } from "../../lib/logger.js";
 import { join, extname } from "path";
 import { eq } from "../../db/file-query.js";
 import type { DB } from "../../db/connection.js";
+import { encodeShardKey, isLazyUnitTable, type FileNativeStoreController } from "../../db/file-backed-store.js";
 import { chatImages, chats } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
-import { DATA_DIR } from "../../utils/data-dir.js";
+import { getDataDir } from "../../utils/data-dir.js";
 
-const GALLERY_DIR = join(DATA_DIR, "gallery");
 const IMAGE_EXTS = new Set([".jpg", ".jpeg", ".png", ".gif", ".webp", ".avif"]);
 
-export async function recoverGalleryImages(db: DB) {
-  if (!existsSync(GALLERY_DIR)) return;
+/**
+ * The filePaths recorded in one chat's chat_images shard file, read without
+ * loading the unit. Returns null when the peek cannot be trusted — an
+ * unreadable file, a non-array root, or a lone .bak from an interrupted
+ * flush — so the caller falls back to the real loader.
+ */
+function peekChatImageFilePaths(storageRootDir: string, chatId: string): Set<string> | null {
+  const shardPath = join(storageRootDir, "tables", "chat_images", `${encodeShardKey(chatId)}.json`);
+  if (!existsSync(shardPath)) {
+    // No shard and no backup means the chat truly has no rows. A lone .bak is
+    // an interrupted flush — let the loader's recovery ladder arbitrate.
+    return existsSync(`${shardPath}.bak`) ? null : new Set();
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(shardPath, "utf8")) as unknown;
+    if (!Array.isArray(parsed)) return null;
+    const paths = new Set<string>();
+    for (const row of parsed) {
+      // Skip what a real load would also drop or not attribute to this chat:
+      // malformed rows heal away at first touch, and a misfiled stray row
+      // belongs to another chat's gallery.
+      if (!row || typeof row !== "object") continue;
+      const candidate = row as { chatId?: unknown; filePath?: unknown };
+      if (candidate.chatId !== chatId) continue;
+      if (typeof candidate.filePath === "string") paths.add(candidate.filePath);
+    }
+    return paths;
+  } catch {
+    return null;
+  }
+}
 
-  const chatDirs = readdirSync(GALLERY_DIR, { withFileTypes: true }).filter((d) => d.isDirectory());
+async function knownFilePathsFor(
+  db: DB,
+  store: FileNativeStoreController,
+  chatId: string,
+  chatImagesIsLazy: boolean,
+): Promise<Set<string>> {
+  if (chatImagesIsLazy && !store.getResidentChatUnits().has(chatId)) {
+    const peeked = peekChatImageFilePaths(store.rootDir, chatId);
+    if (peeked) return peeked;
+    logger.warn(
+      "[gallery-recovery] chat_images shard for chat %s is not directly readable; loading the unit to recover it",
+      chatId,
+    );
+  }
+  // Resident unit, eager mode, or an unreadable shard: the store answers, from
+  // memory in the first two cases and via a single unit load in the third.
+  const rows = await db.select({ filePath: chatImages.filePath }).from(chatImages).where(eq(chatImages.chatId, chatId));
+  return new Set(rows.map((r) => r.filePath));
+}
+
+export async function recoverGalleryImages(db: DB) {
+  const galleryDir = join(getDataDir(), "gallery");
+  if (!existsSync(galleryDir)) return;
+
+  const chatDirs = readdirSync(galleryDir, { withFileTypes: true }).filter((d) => d.isDirectory());
   let recovered = 0;
+  const store = db._fileStore;
+  const chatImagesIsLazy = isLazyUnitTable("chat_images");
 
   for (const dir of chatDirs) {
     try {
       const chatId = dir.name;
 
-      // Only recover for chats that still exist
+      // Only recover for chats that still exist (chats is an eager table, so
+      // this lookup never loads a chat unit).
       const chatRow = await db.select({ id: chats.id }).from(chats).where(eq(chats.id, chatId)).limit(1);
       if (chatRow.length === 0) continue;
 
-      // Get existing DB records for this chat
-      const existingRecords = await db
-        .select({ filePath: chatImages.filePath })
-        .from(chatImages)
-        .where(eq(chatImages.chatId, chatId));
-      const knownPaths = new Set(existingRecords.map((r) => r.filePath));
-
-      // Scan image files on disk
-      const chatGalleryDir = join(GALLERY_DIR, chatId);
+      // Scan image files on disk before touching chat_images at all: a
+      // directory with nothing recoverable costs no storage access.
+      const chatGalleryDir = join(galleryDir, chatId);
       const files = readdirSync(chatGalleryDir).filter((f) => {
         const ext = extname(f).toLowerCase();
         return IMAGE_EXTS.has(ext) && statSync(join(chatGalleryDir, f)).isFile();
       });
+      if (files.length === 0) continue;
+
+      const knownPaths = await knownFilePathsFor(db, store, chatId, chatImagesIsLazy);
 
       for (const file of files) {
         const relativePath = `${chatId}/${file}`;
         if (knownPaths.has(relativePath)) continue;
 
-        // Orphaned file — recreate DB record
+        // Orphaned file — recreate the DB record. The insert loads this one
+        // chat's unit through the normal path (heal ladder included).
         await db.insert(chatImages).values({
           id: newId(),
           chatId,

--- a/packages/server/src/services/storage/gallery-recovery.ts
+++ b/packages/server/src/services/storage/gallery-recovery.ts
@@ -61,8 +61,10 @@ function peekChatImageFilePaths(storageRootDir: string, chatId: string): Set<str
     const paths = new Set<string>();
     const seenIds = new Set<string>();
     for (const row of parsed) {
-      // A malformed row heals away at first touch, so the loader drops it too.
-      if (!row || typeof row !== "object") continue;
+      // A malformed row is the loader's business: it drops the row AND
+      // schedules the shard for repair. Skipping it here would return the
+      // correct set while leaving that repair blocked indefinitely.
+      if (!row || typeof row !== "object") return null;
       const candidate = row as { id?: unknown; chatId?: unknown; filePath?: unknown };
       // A clean stray — canonical shape, some OTHER chat's id — is the one
       // non-matching row the loader also would not attribute to this chat.

--- a/packages/server/src/services/storage/gallery-recovery.ts
+++ b/packages/server/src/services/storage/gallery-recovery.ts
@@ -11,12 +11,21 @@
 // tables' shards) into memory, so on installs where most chats have
 // images this walk quietly reproduced the eager boot #5592 removed.
 // For chats whose unit is not resident we therefore peek the chat's
-// chat_images shard file straight off disk instead: a non-resident unit
-// can hold no unflushed writes (writes force residency first, and
-// eviction only runs after a successful flush), so the file IS the
-// current state. Anything unreadable falls back to the real loader so
-// the full recovery ladder (.bak fallback, quarantine) stays in charge
-// of corruption — and only that one chat's unit loads.
+// chat_images shard file straight off disk instead. That is sound while
+// chat_images has not been converted to fully resident (checked below):
+// a non-resident unit then holds no unflushed writes — writes force
+// residency first, and eviction only runs after a successful flush — so
+// the file IS the current state. Anything the peek cannot interpret
+// exactly the way the loader would (unreadable file, non-canonical row
+// shapes, duplicate ids) falls back to the real loader so the full
+// recovery ladder (.bak fallback, quarantine, heal) stays in charge —
+// and only that one chat's unit loads.
+//
+// Known accepted gap (matches lazy scoped-query semantics generally): a
+// row misfiled into ANOTHER chat's shard file is invisible here until
+// its host unit loads, so its image can be re-registered as a duplicate
+// row. The pre-#5612 scan only avoided that by loading every unit —
+// the exact behavior this fix removes.
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { logger } from "../../lib/logger.js";
 import { join, extname } from "path";
@@ -31,9 +40,13 @@ const IMAGE_EXTS = new Set([".jpg", ".jpeg", ".png", ".gif", ".webp", ".avif"]);
 
 /**
  * The filePaths recorded in one chat's chat_images shard file, read without
- * loading the unit. Returns null when the peek cannot be trusted — an
- * unreadable file, a non-array root, or a lone .bak from an interrupted
- * flush — so the caller falls back to the real loader.
+ * loading the unit. Returns null whenever the peek cannot mirror the loader
+ * EXACTLY — an unreadable file, a non-array root, a lone .bak from an
+ * interrupted flush, a duplicate primary key (the loader dedupes), or any row
+ * not in the canonical serializer shape (the loader's normalizeRow also
+ * accepts dbName-form keys like chat_id/file_path, and attribution of rows
+ * with a missing chatId is the loader's call) — so the caller falls back to
+ * the real loader instead of risking duplicate re-registration.
  */
 function peekChatImageFilePaths(storageRootDir: string, chatId: string): Set<string> | null {
   const shardPath = join(storageRootDir, "tables", "chat_images", `${encodeShardKey(chatId)}.json`);
@@ -46,14 +59,21 @@ function peekChatImageFilePaths(storageRootDir: string, chatId: string): Set<str
     const parsed = JSON.parse(readFileSync(shardPath, "utf8")) as unknown;
     if (!Array.isArray(parsed)) return null;
     const paths = new Set<string>();
+    const seenIds = new Set<string>();
     for (const row of parsed) {
-      // Skip what a real load would also drop or not attribute to this chat:
-      // malformed rows heal away at first touch, and a misfiled stray row
-      // belongs to another chat's gallery.
+      // A malformed row heals away at first touch, so the loader drops it too.
       if (!row || typeof row !== "object") continue;
-      const candidate = row as { chatId?: unknown; filePath?: unknown };
-      if (candidate.chatId !== chatId) continue;
-      if (typeof candidate.filePath === "string") paths.add(candidate.filePath);
+      const candidate = row as { id?: unknown; chatId?: unknown; filePath?: unknown };
+      // A clean stray — canonical shape, some OTHER chat's id — is the one
+      // non-matching row the loader also would not attribute to this chat.
+      if (typeof candidate.chatId === "string" && candidate.chatId !== chatId) continue;
+      // Everything else must be exactly the serializer's own output for this
+      // chat. Anything off-shape goes to the loader.
+      if (candidate.chatId !== chatId) return null;
+      if (typeof candidate.id !== "string" || typeof candidate.filePath !== "string") return null;
+      if (seenIds.has(candidate.id)) return null;
+      seenIds.add(candidate.id);
+      paths.add(candidate.filePath);
     }
     return paths;
   } catch {
@@ -67,7 +87,11 @@ async function knownFilePathsFor(
   chatId: string,
   chatImagesIsLazy: boolean,
 ): Promise<Set<string>> {
-  if (chatImagesIsLazy && !store.getResidentChatUnits().has(chatId)) {
+  if (
+    chatImagesIsLazy &&
+    !store.getFullyResidentLazyTables().has("chat_images") &&
+    !store.getResidentChatUnits().has(chatId)
+  ) {
     const peeked = peekChatImageFilePaths(store.rootDir, chatId);
     if (peeked) return peeked;
     logger.warn(
@@ -75,8 +99,10 @@ async function knownFilePathsFor(
       chatId,
     );
   }
-  // Resident unit, eager mode, or an unreadable shard: the store answers, from
-  // memory in the first two cases and via a single unit load in the third.
+  // Resident unit, whole-table lease, eager mode, or an unreadable shard: the
+  // store answers — from memory in the first three cases (a leased table's
+  // pending writes never reach disk between flushes, so the files cannot be
+  // trusted there), via a single unit load in the last.
   const rows = await db.select({ filePath: chatImages.filePath }).from(chatImages).where(eq(chatImages.chatId, chatId));
   return new Set(rows.map((r) => r.filePath));
 }

--- a/scripts/regressions/gallery-recovery.regression.ts
+++ b/scripts/regressions/gallery-recovery.regression.ts
@@ -139,11 +139,7 @@ const bShardBytes = readFileSync(shardPath("chat_images", "chat-b"), "utf8");
     assert.equal(resident.has("chat-d"), true, "the chat with an unreadable shard loads (recovery ladder handoff)");
     assert.equal(resident.has("chat-g"), true, "the dbName-form shard is handed to the loader, not misread as empty");
     assert.equal(resident.has("chat-h"), true, "the duplicate-id shard is handed to the loader, not counted twice");
-    assert.equal(
-      db._fileStore.getFullyResidentLazyTables().size,
-      0,
-      "the scan itself never leases a whole table",
-    );
+    assert.equal(db._fileStore.getFullyResidentLazyTables().size, 0, "the scan itself never leases a whole table");
 
     const cRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-c"));
     assert.deepEqual(

--- a/scripts/regressions/gallery-recovery.regression.ts
+++ b/scripts/regressions/gallery-recovery.regression.ts
@@ -1,0 +1,166 @@
+// #5612: the boot-time gallery recovery scan must not defeat lazy chat-unit
+// residency. Its per-chat chat_images queries were individually scoped, but a
+// scoped query still loads that chat's ENTIRE storage unit — so on installs
+// where most chats have images, boot walked nearly every unit into memory and
+// silently reproduced the eager boot #5592 removed. The fixed scan peeks the
+// chat_images shard file straight off disk for non-resident units (a
+// non-resident unit can hold no unflushed writes, so the file is the current
+// state) and only loads a unit when it actually has to: an orphaned file to
+// re-register, or a shard the peek cannot trust.
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "../../packages/server/src/db/file-query.js";
+import { createFileNativeDB, encodeShardKey } from "../../packages/server/src/db/file-backed-store.js";
+import { chatImages } from "../../packages/server/src/db/schema/index.js";
+import { recoverGalleryImages } from "../../packages/server/src/services/storage/gallery-recovery.js";
+
+if (process.env.MARINARA_EAGER_STORAGE === "1" || process.env.MARINARA_EAGER_STORAGE === "true") {
+  // Under the kill switch chat_images is fully resident from boot and the scan
+  // keeps its original whole-table behavior; these regressions assert the
+  // lazy-mode peek semantics.
+  console.log("Gallery-recovery regressions skipped: MARINARA_EAGER_STORAGE is set.");
+  process.exit(0);
+}
+
+// One environment for every block: a data dir (holding gallery/) and a storage
+// dir, torn down together. Each block uses distinct chat ids.
+const dataDir = mkdtempSync(join(tmpdir(), "marinara-gallery-recovery-"));
+const storeDir = join(dataDir, "storage");
+process.env.DATA_DIR = dataDir;
+process.env.FILE_STORAGE_DIR = storeDir;
+
+const chatRow = (id: string) => ({ id, name: id, mode: "conversation" });
+const imageRow = (id: string, chatId: string, filePath: string) => ({
+  id,
+  chatId,
+  filePath,
+  prompt: "",
+  provider: "",
+  model: "",
+  width: null,
+  height: null,
+  createdAt: "2026-08-28T10:00:00.000Z",
+});
+const messageRow = (id: string, chatId: string) => ({
+  id,
+  chatId,
+  role: "user",
+  content: "ballast so a unit load is observable",
+  createdAt: "2026-08-28T10:00:00.000Z",
+});
+
+const shardPath = (table: string, key: string) => join(storeDir, "tables", table, `${encodeShardKey(key)}.json`);
+const writeShard = (table: string, key: string, rows: unknown[]) => {
+  mkdirSync(join(storeDir, "tables", table), { recursive: true });
+  writeFileSync(shardPath(table, key), JSON.stringify(rows));
+};
+const writeGalleryFile = (chatId: string, filename: string) => {
+  mkdirSync(join(dataDir, "gallery", chatId), { recursive: true });
+  writeFileSync(join(dataDir, "gallery", chatId, filename), "not-a-real-png");
+};
+
+// Seed BEFORE the store boots, like a real install.
+// chat-a / chat-b: healthy chats whose images are all recorded — the common
+// case, which must not load anything.
+for (const chatId of ["chat-a", "chat-b"]) {
+  writeShard("chats", chatId, [chatRow(chatId)]);
+  writeShard("messages", chatId, [messageRow(`m-${chatId}`, chatId)]);
+  writeShard("chat_images", chatId, [imageRow(`img-${chatId}`, chatId, `${chatId}/pic.png`)]);
+  writeGalleryFile(chatId, "pic.png");
+}
+// chat-c: one recorded image, one orphaned file — the only unit that may load.
+writeShard("chats", "chat-c", [chatRow("chat-c")]);
+writeShard("chat_images", "chat-c", [imageRow("img-c1", "chat-c", "chat-c/known.png")]);
+writeGalleryFile("chat-c", "known.png");
+writeGalleryFile("chat-c", "orphan.png");
+// chat-d: unreadable chat_images shard with a valid .bak recording its file —
+// the peek must hand off to the real loader (which recovers from the .bak), and
+// the recovered row must prevent a duplicate insert.
+writeShard("chats", "chat-d", [chatRow("chat-d")]);
+writeShard("chat_images", "chat-d", [imageRow("img-d1", "chat-d", "chat-d/saved.png")]);
+writeFileSync(`${shardPath("chat_images", "chat-d")}.bak`, readFileSync(shardPath("chat_images", "chat-d")));
+writeFileSync(shardPath("chat_images", "chat-d"), "{corrupt json!");
+writeGalleryFile("chat-d", "saved.png");
+// chat-e: exists but its gallery directory holds nothing recoverable.
+writeShard("chats", "chat-e", [chatRow("chat-e")]);
+writeShard("messages", "chat-e", [messageRow("m-e", "chat-e")]);
+mkdirSync(join(dataDir, "gallery", "chat-e"), { recursive: true });
+// chat-f: a file on disk with NO chat_images shard at all — a genuine orphan
+// whose insert must create the shard.
+writeShard("chats", "chat-f", [chatRow("chat-f")]);
+writeGalleryFile("chat-f", "fresh.png");
+// chat-x: gallery directory for a chat that no longer exists — skipped.
+writeGalleryFile("chat-x", "ghost.png");
+
+const aShardBytes = readFileSync(shardPath("chat_images", "chat-a"), "utf8");
+const bShardBytes = readFileSync(shardPath("chat_images", "chat-b"), "utf8");
+
+const db = await createFileNativeDB();
+try {
+  await recoverGalleryImages(db);
+  const resident = db._fileStore.getResidentChatUnits();
+
+  // The headline assertion: recovery visited every chat but loaded only the
+  // units it had a concrete reason to touch. Before the fix, chat-a and
+  // chat-b (fully recorded) loaded too — every chat with images did.
+  assert.equal(resident.has("chat-a"), false, "a fully-recorded chat's unit is not loaded by the boot scan");
+  assert.equal(resident.has("chat-b"), false, "no fully-recorded chat's unit is loaded by the boot scan");
+  assert.equal(resident.has("chat-e"), false, "a chat with an empty gallery directory is not loaded");
+  assert.equal(resident.has("chat-x"), false, "a deleted chat's leftover directory is not loaded");
+  assert.equal(resident.has("chat-c"), true, "the chat with an orphaned file loads (the insert needs its unit)");
+  assert.equal(resident.has("chat-d"), true, "the chat with an unreadable shard loads (recovery ladder handoff)");
+
+  const cRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-c"));
+  assert.deepEqual(
+    cRows.map((row) => row.filePath).sort(),
+    ["chat-c/known.png", "chat-c/orphan.png"],
+    "the orphaned file is re-registered and the recorded row is preserved",
+  );
+  const dRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-d"));
+  assert.deepEqual(
+    dRows.map((row) => row.filePath),
+    ["chat-d/saved.png"],
+    "the .bak-recovered row is honored — no duplicate insert for the corrupt-shard chat",
+  );
+  const fRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-f"));
+  assert.deepEqual(
+    fRows.map((row) => row.filePath),
+    ["chat-f/fresh.png"],
+    "a file with no shard at all is recovered",
+  );
+  const xRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-x"));
+  assert.equal(xRows.length, 0, "no rows are created for a chat that no longer exists");
+
+  await db._fileStore.flush();
+  assert.equal(
+    readFileSync(shardPath("chat_images", "chat-a"), "utf8"),
+    aShardBytes,
+    "an untouched chat's shard file is byte-identical after recovery and flush",
+  );
+  assert.equal(
+    readFileSync(shardPath("chat_images", "chat-b"), "utf8"),
+    bShardBytes,
+    "no untouched chat's shard file is rewritten",
+  );
+  assert.equal(existsSync(shardPath("chat_images", "chat-f")), true, "the recovered orphan's shard exists after flush");
+
+  // Second run right after the first: everything is recorded now, so nothing
+  // new may load and nothing may be inserted twice (peek sees the flushed
+  // shards; chat-c/d stay resident from the first pass).
+  const residentBefore = new Set(db._fileStore.getResidentChatUnits());
+  await recoverGalleryImages(db);
+  assert.deepEqual(
+    [...db._fileStore.getResidentChatUnits()].sort(),
+    [...residentBefore].sort(),
+    "a re-run with everything recorded loads no additional units",
+  );
+  const fRowsAfter = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-f"));
+  assert.equal(fRowsAfter.length, 1, "a re-run does not duplicate the recovered row");
+} finally {
+  await db._fileStore.close();
+  rmSync(dataDir, { recursive: true, force: true });
+}
+
+console.log("Gallery-recovery regressions passed.");

--- a/scripts/regressions/gallery-recovery.regression.ts
+++ b/scripts/regressions/gallery-recovery.regression.ts
@@ -116,6 +116,13 @@ writeShard("chat_images", "chat-h", [
 ]);
 writeGalleryFile("chat-h", "first.png");
 writeGalleryFile("chat-h", "second.png");
+// chat-i: a primitive (malformed) entry alongside a recorded row. The loader
+// drops the entry AND schedules the shard for repair — the peek must hand off
+// so that repair is not blocked forever, while the recorded row still
+// prevents a duplicate insert.
+writeShard("chats", "chat-i", [chatRow("chat-i")]);
+writeShard("chat_images", "chat-i", ["malformed-not-a-row", imageRow("img-i1", "chat-i", "chat-i/whole.png")]);
+writeGalleryFile("chat-i", "whole.png");
 // chat-x: gallery directory for a chat that no longer exists — skipped.
 writeGalleryFile("chat-x", "ghost.png");
 
@@ -139,6 +146,7 @@ const bShardBytes = readFileSync(shardPath("chat_images", "chat-b"), "utf8");
     assert.equal(resident.has("chat-d"), true, "the chat with an unreadable shard loads (recovery ladder handoff)");
     assert.equal(resident.has("chat-g"), true, "the dbName-form shard is handed to the loader, not misread as empty");
     assert.equal(resident.has("chat-h"), true, "the duplicate-id shard is handed to the loader, not counted twice");
+    assert.equal(resident.has("chat-i"), true, "a malformed row is handed to the loader so shard repair can run");
     assert.equal(db._fileStore.getFullyResidentLazyTables().size, 0, "the scan itself never leases a whole table");
 
     const cRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-c"));
@@ -170,6 +178,12 @@ const bShardBytes = readFileSync(shardPath("chat_images", "chat-b"), "utf8");
       hRows.map((row) => row.filePath).sort(),
       ["chat-h/first.png", "chat-h/second.png"],
       "the loader-dropped duplicate's file is re-registered like the old scan did",
+    );
+    const iRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-i"));
+    assert.deepEqual(
+      iRows.map((row) => row.filePath),
+      ["chat-i/whole.png"],
+      "the malformed entry is dropped, the recorded row survives, no duplicate insert",
     );
     const xRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-x"));
     assert.equal(xRows.length, 0, "no rows are created for a chat that no longer exists");
@@ -205,11 +219,12 @@ const bShardBytes = readFileSync(shardPath("chat_images", "chat-b"), "utf8");
     await recoverGalleryImages(db);
     const resident = db._fileStore.getResidentChatUnits();
     // chat-a/b were never rewritten; chat-c/d/f/h were flushed by the FIRST
-    // boot in the store's own canonical shape — none of them may load now.
-    // (chat-g is the deliberate exception: the loader accepts a dbName-form
-    // shard without rewriting it, so its conservative loader handoff repeats
-    // each boot until some write canonicalizes the file.)
-    for (const chatId of ["chat-a", "chat-b", "chat-c", "chat-d", "chat-f", "chat-h"]) {
+    // boot in the store's own canonical shape, and chat-i's malformed entry
+    // was repaired away by that flush — none of them may load now. (chat-g is
+    // the deliberate exception: the loader accepts a dbName-form shard
+    // without rewriting it, so its conservative loader handoff repeats each
+    // boot until some write canonicalizes the file.)
+    for (const chatId of ["chat-a", "chat-b", "chat-c", "chat-d", "chat-f", "chat-h", "chat-i"]) {
       assert.equal(
         resident.has(chatId),
         false,
@@ -217,13 +232,13 @@ const bShardBytes = readFileSync(shardPath("chat_images", "chat-b"), "utf8");
       );
     }
     const counts = new Map<string, number>();
-    for (const chatId of ["chat-a", "chat-b", "chat-c", "chat-d", "chat-f", "chat-g", "chat-h"]) {
+    for (const chatId of ["chat-a", "chat-b", "chat-c", "chat-d", "chat-f", "chat-g", "chat-h", "chat-i"]) {
       const rows = await db.select().from(chatImages).where(eq(chatImages.chatId, chatId));
       counts.set(chatId, rows.length);
     }
     assert.deepEqual(
       [...counts.values()],
-      [1, 1, 2, 1, 1, 1, 2],
+      [1, 1, 2, 1, 1, 1, 2, 1],
       "no chat gains or loses rows on a fully-recorded re-boot",
     );
   } finally {

--- a/scripts/regressions/gallery-recovery.regression.ts
+++ b/scripts/regressions/gallery-recovery.regression.ts
@@ -4,17 +4,19 @@
 // where most chats have images, boot walked nearly every unit into memory and
 // silently reproduced the eager boot #5592 removed. The fixed scan peeks the
 // chat_images shard file straight off disk for non-resident units (a
-// non-resident unit can hold no unflushed writes, so the file is the current
-// state) and only loads a unit when it actually has to: an orphaned file to
-// re-register, or a shard the peek cannot trust.
+// non-resident unit can hold no unflushed writes while the table is not
+// fully leased, so the file is the current state) and only loads a unit when
+// it actually has to: an orphaned file to re-register, or a shard the peek
+// cannot interpret exactly the way the loader would.
+//
+// Project imports are DYNAMIC, after the env assignments below — data-dir.ts
+// freezes a DATA_DIR constant at module load, so hoisted static imports would
+// point the pre-fix scan (and any future module-const regression) at the
+// default data dir instead of this fixture, making red/green runs vacuous.
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { eq } from "../../packages/server/src/db/file-query.js";
-import { createFileNativeDB, encodeShardKey } from "../../packages/server/src/db/file-backed-store.js";
-import { chatImages } from "../../packages/server/src/db/schema/index.js";
-import { recoverGalleryImages } from "../../packages/server/src/services/storage/gallery-recovery.js";
 
 if (process.env.MARINARA_EAGER_STORAGE === "1" || process.env.MARINARA_EAGER_STORAGE === "true") {
   // Under the kill switch chat_images is fully resident from boot and the scan
@@ -30,6 +32,11 @@ const dataDir = mkdtempSync(join(tmpdir(), "marinara-gallery-recovery-"));
 const storeDir = join(dataDir, "storage");
 process.env.DATA_DIR = dataDir;
 process.env.FILE_STORAGE_DIR = storeDir;
+
+const { eq } = await import("../../packages/server/src/db/file-query.js");
+const { createFileNativeDB, encodeShardKey } = await import("../../packages/server/src/db/file-backed-store.js");
+const { chatImages } = await import("../../packages/server/src/db/schema/index.js");
+const { recoverGalleryImages } = await import("../../packages/server/src/services/storage/gallery-recovery.js");
 
 const chatRow = (id: string) => ({ id, name: id, mode: "conversation" });
 const imageRow = (id: string, chatId: string, filePath: string) => ({
@@ -70,7 +77,7 @@ for (const chatId of ["chat-a", "chat-b"]) {
   writeShard("chat_images", chatId, [imageRow(`img-${chatId}`, chatId, `${chatId}/pic.png`)]);
   writeGalleryFile(chatId, "pic.png");
 }
-// chat-c: one recorded image, one orphaned file — the only unit that may load.
+// chat-c: one recorded image, one orphaned file — the insert loads this unit.
 writeShard("chats", "chat-c", [chatRow("chat-c")]);
 writeShard("chat_images", "chat-c", [imageRow("img-c1", "chat-c", "chat-c/known.png")]);
 writeGalleryFile("chat-c", "known.png");
@@ -91,76 +98,142 @@ mkdirSync(join(dataDir, "gallery", "chat-e"), { recursive: true });
 // whose insert must create the shard.
 writeShard("chats", "chat-f", [chatRow("chat-f")]);
 writeGalleryFile("chat-f", "fresh.png");
+// chat-g: a shard in dbName form (chat_id / file_path) — the loader's
+// normalizeRow accepts that shape, so the peek must NOT treat it as "no rows"
+// (which would duplicate every recorded image); it must hand off to the loader.
+writeShard("chats", "chat-g", [chatRow("chat-g")]);
+writeShard("chat_images", "chat-g", [
+  { id: "img-g1", chat_id: "chat-g", file_path: "chat-g/named.png", createdAt: "2026-08-28T10:00:00.000Z" },
+]);
+writeGalleryFile("chat-g", "named.png");
+// chat-h: two rows sharing one primary key with different filePaths, both
+// files on disk. The loader drops the duplicate, so its file IS an orphan —
+// the peek must not count both and skip the recovery the old scan performed.
+writeShard("chats", "chat-h", [chatRow("chat-h")]);
+writeShard("chat_images", "chat-h", [
+  imageRow("img-h", "chat-h", "chat-h/first.png"),
+  imageRow("img-h", "chat-h", "chat-h/second.png"),
+]);
+writeGalleryFile("chat-h", "first.png");
+writeGalleryFile("chat-h", "second.png");
 // chat-x: gallery directory for a chat that no longer exists — skipped.
 writeGalleryFile("chat-x", "ghost.png");
 
 const aShardBytes = readFileSync(shardPath("chat_images", "chat-a"), "utf8");
 const bShardBytes = readFileSync(shardPath("chat_images", "chat-b"), "utf8");
 
-const db = await createFileNativeDB();
-try {
-  await recoverGalleryImages(db);
-  const resident = db._fileStore.getResidentChatUnits();
+{
+  const db = await createFileNativeDB();
+  try {
+    await recoverGalleryImages(db);
+    const resident = db._fileStore.getResidentChatUnits();
 
-  // The headline assertion: recovery visited every chat but loaded only the
-  // units it had a concrete reason to touch. Before the fix, chat-a and
-  // chat-b (fully recorded) loaded too — every chat with images did.
-  assert.equal(resident.has("chat-a"), false, "a fully-recorded chat's unit is not loaded by the boot scan");
-  assert.equal(resident.has("chat-b"), false, "no fully-recorded chat's unit is loaded by the boot scan");
-  assert.equal(resident.has("chat-e"), false, "a chat with an empty gallery directory is not loaded");
-  assert.equal(resident.has("chat-x"), false, "a deleted chat's leftover directory is not loaded");
-  assert.equal(resident.has("chat-c"), true, "the chat with an orphaned file loads (the insert needs its unit)");
-  assert.equal(resident.has("chat-d"), true, "the chat with an unreadable shard loads (recovery ladder handoff)");
+    // The headline assertion: recovery visited every chat but loaded only the
+    // units it had a concrete reason to touch. Before the fix, chat-a and
+    // chat-b (fully recorded) loaded too — every chat with images did.
+    assert.equal(resident.has("chat-a"), false, "a fully-recorded chat's unit is not loaded by the boot scan");
+    assert.equal(resident.has("chat-b"), false, "no fully-recorded chat's unit is loaded by the boot scan");
+    assert.equal(resident.has("chat-e"), false, "a chat with an empty gallery directory is not loaded");
+    assert.equal(resident.has("chat-x"), false, "a deleted chat's leftover directory is not loaded");
+    assert.equal(resident.has("chat-c"), true, "the chat with an orphaned file loads (the insert needs its unit)");
+    assert.equal(resident.has("chat-d"), true, "the chat with an unreadable shard loads (recovery ladder handoff)");
+    assert.equal(resident.has("chat-g"), true, "the dbName-form shard is handed to the loader, not misread as empty");
+    assert.equal(resident.has("chat-h"), true, "the duplicate-id shard is handed to the loader, not counted twice");
+    assert.equal(
+      db._fileStore.getFullyResidentLazyTables().size,
+      0,
+      "the scan itself never leases a whole table",
+    );
 
-  const cRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-c"));
-  assert.deepEqual(
-    cRows.map((row) => row.filePath).sort(),
-    ["chat-c/known.png", "chat-c/orphan.png"],
-    "the orphaned file is re-registered and the recorded row is preserved",
-  );
-  const dRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-d"));
-  assert.deepEqual(
-    dRows.map((row) => row.filePath),
-    ["chat-d/saved.png"],
-    "the .bak-recovered row is honored — no duplicate insert for the corrupt-shard chat",
-  );
-  const fRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-f"));
-  assert.deepEqual(
-    fRows.map((row) => row.filePath),
-    ["chat-f/fresh.png"],
-    "a file with no shard at all is recovered",
-  );
-  const xRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-x"));
-  assert.equal(xRows.length, 0, "no rows are created for a chat that no longer exists");
+    const cRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-c"));
+    assert.deepEqual(
+      cRows.map((row) => row.filePath).sort(),
+      ["chat-c/known.png", "chat-c/orphan.png"],
+      "the orphaned file is re-registered and the recorded row is preserved",
+    );
+    const dRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-d"));
+    assert.deepEqual(
+      dRows.map((row) => row.filePath),
+      ["chat-d/saved.png"],
+      "the .bak-recovered row is honored — no duplicate insert for the corrupt-shard chat",
+    );
+    const fRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-f"));
+    assert.deepEqual(
+      fRows.map((row) => row.filePath),
+      ["chat-f/fresh.png"],
+      "a file with no shard at all is recovered",
+    );
+    const gRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-g"));
+    assert.deepEqual(
+      gRows.map((row) => row.filePath),
+      ["chat-g/named.png"],
+      "the dbName-form row is recognized as recorded — no duplicate insert",
+    );
+    const hRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-h"));
+    assert.deepEqual(
+      hRows.map((row) => row.filePath).sort(),
+      ["chat-h/first.png", "chat-h/second.png"],
+      "the loader-dropped duplicate's file is re-registered like the old scan did",
+    );
+    const xRows = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-x"));
+    assert.equal(xRows.length, 0, "no rows are created for a chat that no longer exists");
 
-  await db._fileStore.flush();
-  assert.equal(
-    readFileSync(shardPath("chat_images", "chat-a"), "utf8"),
-    aShardBytes,
-    "an untouched chat's shard file is byte-identical after recovery and flush",
-  );
-  assert.equal(
-    readFileSync(shardPath("chat_images", "chat-b"), "utf8"),
-    bShardBytes,
-    "no untouched chat's shard file is rewritten",
-  );
-  assert.equal(existsSync(shardPath("chat_images", "chat-f")), true, "the recovered orphan's shard exists after flush");
+    await db._fileStore.flush();
+    assert.equal(
+      readFileSync(shardPath("chat_images", "chat-a"), "utf8"),
+      aShardBytes,
+      "an untouched chat's shard file is byte-identical after recovery and flush",
+    );
+    assert.equal(
+      readFileSync(shardPath("chat_images", "chat-b"), "utf8"),
+      bShardBytes,
+      "no untouched chat's shard file is rewritten",
+    );
+    assert.equal(
+      existsSync(shardPath("chat_images", "chat-f")),
+      true,
+      "the recovered orphan's shard exists after flush",
+    );
+  } finally {
+    await db._fileStore.close();
+  }
+}
 
-  // Second run right after the first: everything is recorded now, so nothing
-  // new may load and nothing may be inserted twice (peek sees the flushed
-  // shards; chat-c/d stay resident from the first pass).
-  const residentBefore = new Set(db._fileStore.getResidentChatUnits());
-  await recoverGalleryImages(db);
-  assert.deepEqual(
-    [...db._fileStore.getResidentChatUnits()].sort(),
-    [...residentBefore].sort(),
-    "a re-run with everything recorded loads no additional units",
-  );
-  const fRowsAfter = await db.select().from(chatImages).where(eq(chatImages.chatId, "chat-f"));
-  assert.equal(fRowsAfter.length, 1, "a re-run does not duplicate the recovered row");
-} finally {
-  await db._fileStore.close();
-  rmSync(dataDir, { recursive: true, force: true });
+// ── Second boot: every shard the peek now reads was written by the STORE ──
+// This pins peek-vs-persisted-shape compatibility: if the serializer's on-disk
+// row shape ever diverged from what the peek reads, this pass would either
+// load units it must not or re-register recorded images.
+{
+  const db = await createFileNativeDB();
+  try {
+    await recoverGalleryImages(db);
+    const resident = db._fileStore.getResidentChatUnits();
+    // chat-a/b were never rewritten; chat-c/d/f/h were flushed by the FIRST
+    // boot in the store's own canonical shape — none of them may load now.
+    // (chat-g is the deliberate exception: the loader accepts a dbName-form
+    // shard without rewriting it, so its conservative loader handoff repeats
+    // each boot until some write canonicalizes the file.)
+    for (const chatId of ["chat-a", "chat-b", "chat-c", "chat-d", "chat-f", "chat-h"]) {
+      assert.equal(
+        resident.has(chatId),
+        false,
+        `${chatId} is not loaded on re-boot — the peek reads the store's own flushed shards`,
+      );
+    }
+    const counts = new Map<string, number>();
+    for (const chatId of ["chat-a", "chat-b", "chat-c", "chat-d", "chat-f", "chat-g", "chat-h"]) {
+      const rows = await db.select().from(chatImages).where(eq(chatImages.chatId, chatId));
+      counts.set(chatId, rows.length);
+    }
+    assert.deepEqual(
+      [...counts.values()],
+      [1, 1, 2, 1, 1, 1, 2],
+      "no chat gains or loses rows on a fully-recorded re-boot",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(dataDir, { recursive: true, force: true });
+  }
 }
 
 console.log("Gallery-recovery regressions passed.");


### PR DESCRIPTION
Closes #5612. Part of the #5592 close-out (follows #5597/#5603; sibling of #5614).

## Why

The startup gallery-recovery scan (re-registering orphaned image files) queried `chat_images` once per `data/gallery/<chatId>` directory. Every query was correctly chatId-scoped — which is exactly why no query audit ever flagged it — but any row read pulls that chat's **entire storage unit** (all 17 lazy tables' shards) into memory. On an install where most chats have generated images, boot walked nearly every chat unit into memory before the server even started listening, quietly reproducing the eager-boot footprint #5592 removed, and leaving eviction to claw it back down afterward.

## What changed

For a chat whose unit is **not resident**, the scan now reads the chat's `chat_images` shard file straight off disk instead of going through the store. This is sound because a non-resident unit can hold no unflushed state: writes force the unit resident first, and eviction only runs at the tail of a successful flush and skips units with pending state — so an evicted unit's shard file is always the current state.

The peek is deliberately conservative: anything it cannot fully trust (unreadable file, valid-JSON-but-non-array root, a lone `.bak` from an interrupted flush) falls back to the normal scoped query, so the store's full recovery ladder stays in charge of corruption — and only that one chat's unit loads. Same for a genuine orphan: the insert goes through the normal path, loading just that chat.

Net effect at boot:

| Case | Before | After |
|---|---|---|
| Chat with images, all recorded (the overwhelming majority) | whole unit loaded | **zero storage access** beyond one eager `chats` lookup + one shard-file read |
| Empty gallery directory / deleted chat's leftover directory | whole unit loaded / none | zero storage access |
| Chat with an orphaned file | whole unit loaded | that one unit loads (insert path, heal ladder included) |
| Unreadable `chat_images` shard | whole unit loaded | that one unit loads (recovery ladder handoff) |
| `MARINARA_EAGER_STORAGE` | whole-table query (already resident) | unchanged — old path kept verbatim |

Also exports `isLazyUnitTable()` and a `getFullyResidentLazyTables()` controller accessor from the store (the peek must not run against an eager, whole-table-leased, or otherwise fully-resident table, where memory — not disk — is the truth; the accessor is line-identical to the one #5614 adds, so whichever merges second rebases cleanly). `GALLERY_DIR` moved from a module-load constant to a call-time `getDataDir()` so the function honors the environment it runs in.

## Regression

New suite `gallery-recovery.regression.ts` (auto-discovered by the runner): six chats covering fully-recorded (must load **nothing** — the headline assert), orphaned file (loads exactly that unit, preserves the recorded row), corrupt shard with valid `.bak` (loader handoff recovers the row, no duplicate insert), no shard at all (recovers, shard created on flush), empty directory and deleted-chat directory (no storage access), untouched shards byte-identical after flush, and an idempotent second run. A/B-verified: red against the pre-fix scan (fully-recorded chats' units load), green with the fix. Self-skips under `MARINARA_EAGER_STORAGE` like the sibling lazy suite.

An adversarial verification pass (three independent reviewers on the residency invariant, peek-vs-load semantics, and regression validity) ran before opening this PR and caught five real problems in the first draft, all fixed and now pinned by the suite:

- **dbName-form rows** (`chat_id`/`file_path`) are a loader-accepted on-disk shape the peek read as "no rows" — every recorded image in such a shard would have been re-registered as a duplicate. The peek now hands any non-canonical row shape to the loader (chat-g fixture).
- **Duplicate primary keys** in one shard: the loader dedupes, so the dropped row's file is a genuine orphan the peek would have wrongly counted as recorded. Duplicate ids now hand off to the loader (chat-h fixture).
- **Whole-table lease blind spot**: if `chat_images` were ever fully leased, memory (with unflushed writes) is the truth, not the files — the peek now checks `getFullyResidentLazyTables()` first. Not reachable in today's boot (verified: nothing before the scan touches `chat_images`), fixed defensively.
- **The first A/B was red for the wrong reason**: the pre-fix module froze `DATA_DIR` at import time, so it scanned a nonexistent default dir instead of the fixture. The suite now uses dynamic imports after the env assignments; the re-run fails pre-fix on exactly the headline "no unit loads" assert.
- **The suite never peeked a store-written shard**: a second-boot block now reopens a fresh store over the first boot's flushed shards and asserts none of them load — pinning peek compatibility with the serializer's actual output shape.

One accepted limitation, documented in-code: a row misfiled into *another* chat's shard file is invisible to the peek until its host unit loads, so its image can be re-registered as a duplicate. This matches lazy scoped-query semantics generally — the pre-fix scan only avoided it by loading every unit, which is the exact behavior being removed. The reviewers also confirmed the load-bearing invariants clean by execution: eviction only at the successful-flush tail, no write path that leaves a non-resident unit dirty, transaction rollback re-pairing, and byte-identical path/key derivation between the peek and the store.

## Validation done

- `tsc --noEmit` all packages ✅
- Prettier (`--check --end-of-line auto`) on the three changed files ✅ (repo-wide `pnpm check` prettier step fails on this Windows box for all files — #5598, pre-existing)
- Regression lanes: `gallery-recovery` (lazy + eager-skip) ✅, `lazy-chat-units` ✅, `message-sharding` ✅

## Manual verification

- [ ] On an install with images in several chats, start the server and confirm the gallery still lists every image per chat
- [ ] Drop a stray `.png` into `data/gallery/<some-chat>/`, restart, and confirm it appears in that chat's gallery (`[gallery-recovery] Recovered 1 orphaned gallery image(s)` in the log)
- [ ] On Termux (or with `MARINARA_MAX_RESIDENT_CHATS` set), watch boot memory: it should no longer climb toward the old eager-boot level during startup on image-heavy installs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved gallery recovery when lazy storage is enabled.
  - Gallery data can now be recovered without unnecessarily loading all chat image data into memory.
  - Recovery better handles missing, deleted, corrupt, duplicate, orphaned, and alternate-format gallery files.
  - Empty storage directories are ignored, and valid gallery files remain stable across server restarts.

- **Diagnostics**
  - Added visibility into lazy tables that have been fully loaded into memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->