### PR TITLE
fix: check out LF working trees on Windows so pnpm check matches CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,11 @@
-# Auto detect text files and perform LF normalization
-* text=auto
+# Auto detect text files, store them LF, and check them out LF on every
+# platform (#5598). Without eol=lf, Git for Windows' default autocrlf=true
+# produced CRLF working trees, which made prettier --check flag every file
+# and broke the regression lanes that match file contents against LF
+# patterns or hash file bytes. In-tree eol overrides core.autocrlf, so no
+# contributor git config is required — but clones made before this line
+# need a one-time refresh (see CONTRIBUTING.md § Validation).
+* text=auto eol=lf
 
 # Generated TypeScript registries are written with LF by the codegen script.
 # Keep Windows checkouts aligned so every launcher build does not dirty them.

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "singleQuote": false,
   "trailingComma": "all",
   "printWidth": 120,
-  "tabWidth": 2
+  "tabWidth": 2,
+  "endOfLine": "lf"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,14 @@ pnpm check
 
 This runs the Impeccable project-context guard, localization checks, Prettier verification, workspace lint/type checks, and the production build.
 
+**Windows note:** the repo checks out with LF line endings on every platform (`.gitattributes` sets `* text=auto eol=lf`, which overrides Git for Windows' `core.autocrlf=true` default), so `pnpm check` behaves identically to CI. A clone made before this rule existed still has CRLF in its working tree and will fail Prettier on every file until you refresh it once — commit or stash any work first, then run:
+
+```bash
+git rm -r --cached . -q && git reset --hard
+```
+
+A fresh clone needs nothing.
+
 Run the individual formatting and lint checks while iterating:
 
 ```bash


### PR DESCRIPTION
Closes #5598.

## Why

On every normal Windows clone, `pnpm check` — the baseline validation command CONTRIBUTING and CLAUDE.md tell every contributor to run — failed at the Prettier step with ~1,300 "unformatted" files on a completely clean tree. Nothing was unformatted: `.gitattributes` had `* text=auto` (stored LF, converted on checkout), Git for Windows defaults to `core.autocrlf=true` (so working trees became CRLF), and Prettier's `endOfLine` default is `lf` (so every CRLF line was a violation). CI runs on `ubuntu-latest` and never sees it — green in CI, red on every Windows machine, which trains Windows contributors to ignore the baseline gate. The same CRLF working tree also broke the regression lanes that match file contents against LF patterns or hash file bytes (`android-local-auth`, `maintenance-lifecycle`, `release-tag-version`, `runtime-integrity`, `tracker-gallery-ui`, and the `pnpm-runner` launcher lane).

## What changed

Three files, no code:

- **`.gitattributes`**: `* text=auto` → `* text=auto eol=lf`. The in-tree `eol` attribute overrides `core.autocrlf`, so Windows working trees check out LF with **no contributor configuration**. Every tracked text file is already committed LF (`git ls-files --eol` shows zero `i/crlf` / `i/mixed`), so this changes checkout behavior only — no content renormalization, no diff on any tracked file. The `*.bat text eol=crlf` exception is unchanged and still wins (last match). The two existing per-path `eol=lf` lines are kept: they force `text` outright rather than relying on auto-detection.
- **`.prettierrc`**: `"endOfLine": "lf"` added explicitly. This is Prettier's existing default — zero behavior change — but the LF contract is now stated in both places instead of resting on an implicit default.
- **`CONTRIBUTING.md § Validation`**: a Windows note documenting the rule and the one-time refresh a pre-existing clone needs (`git rm -r --cached . -q && git reset --hard`, clean tree first). Fresh clones need nothing. Not under `docs/`, so no docs-i18n mirror is triggered.

`win/launcher/build.ps1` (the only `.ps1`) stays under the LF default — it is committed LF and PowerShell parses LF scripts fine.

## Verification (fresh simulated Windows clone)

On the machine that reproduces #5598 (Windows 11, Git for Windows), cloned this branch into a temp dir with `git clone -c core.autocrlf=true` — exactly what a new Windows contributor gets:

- `git ls-files --eol`: 1,846 text files `w/lf`, exactly the 3 `.bat` files `w/crlf`, 163 binary — the attribute overrides `autocrlf` as documented.
- `git status` immediately after clone: clean (no phantom-dirty files, the classic `.gitattributes` pitfall — avoided here because nothing needed renormalizing).
- In the clone: `pnpm install`, then `pnpm format:check` passes, the six formerly CRLF-broken regression lanes pass, and full `pnpm check` passes — results pasted in a comment below.
- Linux CI is untouched: its checkouts were already LF, so `eol=lf` is a no-op there.

## Manual verification

- [ ] After merging, refresh your own clone once (clean tree first): `git rm -r --cached . -q && git reset --hard`, then confirm `pnpm check` passes on Windows with no real changes
- [ ] Confirm `start.bat` / `start-local.bat` / the installer batch file still run (they stay CRLF via the existing exception)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Windows-specific guidance for resolving line-ending issues in existing checkouts.
* **Chores**
  * Standardized files to use LF line endings across platforms.
  * Configured formatting tools to enforce LF endings.
  * Preserved CRLF endings for Windows batch files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->