### PR TITLE
feat(client): send the owning chatId on the id-only endpoints

### DIFF
--- a/packages/client/src/components/chat/AgentSuiteModal.tsx
+++ b/packages/client/src/components/chat/AgentSuiteModal.tsx
@@ -1078,7 +1078,7 @@ export function AgentSuiteModal({ chat, open, onClose, onCloseGuardChange, agent
                           value={serializeValue(run.resultData, mode)}
                           onSave={async (draftText) => {
                             const parsed: unknown = mode === "json" ? JSON.parse(draftText) : draftText;
-                            await updateRunData.mutateAsync({ id: run.id, chatId: chat.id, resultData: parsed });
+                            await updateRunData.mutateAsync({ id: run.id, chatId: run.chatId, resultData: parsed });
                           }}
                           onDirtyChange={handleBlockDirtyChange}
                           disabled={isAgentProcessing}

--- a/packages/client/src/components/chat/ChatGallery.tsx
+++ b/packages/client/src/components/chat/ChatGallery.tsx
@@ -257,15 +257,21 @@ export function ChatGallery({
     unpinImage(id);
     setConfirmDeleteId(null);
     if (lightbox?.id === id) setLightbox(null);
-    remove.mutate(id, {
-      onSuccess: () => {
-        toast.success(localizeUi("ui.chat.chatgallery.imageDeleted"));
+    // The image's own chatId is the owner (a Game-mode gallery shows sibling
+    // sessions' images too); fall back to the open chat only if the row is
+    // somehow not in the list.
+    remove.mutate(
+      { imageId: id, chatId: image?.chatId ?? chatId },
+      {
+        onSuccess: () => {
+          toast.success(localizeUi("ui.chat.chatgallery.imageDeleted"));
+        },
+        onError: (error) => {
+          if (wasPinned && image) pinImage({ ...image, chatId });
+          toast.error(error instanceof Error ? error.message : localizeUi("ui.chat.chatgallery.failedToDeleteImage"));
+        },
       },
-      onError: (error) => {
-        if (wasPinned && image) pinImage({ ...image, chatId });
-        toast.error(error instanceof Error ? error.message : localizeUi("ui.chat.chatgallery.failedToDeleteImage"));
-      },
-    });
+    );
   };
 
   const handleBatchDownload = useCallback(async () => {
@@ -331,7 +337,7 @@ export function ChatGallery({
         const wasPinned = useGalleryStore.getState().pinnedImages.some((item) => item.id === image.id);
         unpinImage(image.id);
         try {
-          await remove.mutateAsync(image.id);
+          await remove.mutateAsync({ imageId: image.id, chatId: image.chatId });
         } catch {
           failedDeletes += 1;
           if (wasPinned) pinImage({ ...image, chatId });

--- a/packages/client/src/components/chat/MariContextViewer.tsx
+++ b/packages/client/src/components/chat/MariContextViewer.tsx
@@ -84,7 +84,7 @@ export function MariContextViewer({ open, onClose, workspaceChatId }: Props) {
                     type="button"
                     onClick={async () => {
                       try {
-                        await removeContext.mutateAsync(item.id);
+                        await removeContext.mutateAsync({ id: item.id, chatId: item.chatId });
                       } catch {
                         toast.error(localizeUi("ui.chat.homeprofessormarichat.contextViewerRemoveFailed"));
                       }

--- a/packages/client/src/hooks/use-agents.ts
+++ b/packages/client/src/hooks/use-agents.ts
@@ -196,8 +196,10 @@ export function useAgentSuiteRewrite() {
 export function useUpdateAgentRunData() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, resultData }: { id: string; chatId: string; resultData: unknown }) =>
-      api.patch(`/agents/runs/${id}`, { resultData }),
+    mutationFn: ({ id, chatId, resultData }: { id: string; chatId: string; resultData: unknown }) =>
+      // chatId is the run's owning chat — the server uses it to scope the
+      // run lookup to one chat's storage instead of loading every chat's (#5615).
+      api.patch(`/agents/runs/${id}`, { resultData, chatId }),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: agentKeys.customRuns(variables.chatId) });
     },

--- a/packages/client/src/hooks/use-gallery.ts
+++ b/packages/client/src/hooks/use-gallery.ts
@@ -143,8 +143,15 @@ export function useGenerateGallerySelfie(chatId: string) {
 export function useDeleteGalleryImage(chatId: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (imageId: string) => api.delete(`/gallery/${imageId}`),
-    onMutate: async (imageId) => {
+    // The wire-level chatId is the image row's OWN owner, not this hook's
+    // ambient chatId: a Game-mode gallery aggregates sibling sessions'
+    // images, so the two can differ. The server scopes the lookup by the
+    // hint (#5615), and a wrong owner would 404 the delete. The ambient
+    // chatId stays correct for the cache keys — that is what the list
+    // queries are keyed on.
+    mutationFn: ({ imageId, chatId: ownerChatId }: { imageId: string; chatId: string }) =>
+      api.delete(`/gallery/${imageId}?chatId=${encodeURIComponent(ownerChatId)}`),
+    onMutate: async ({ imageId }) => {
       await Promise.all([
         qc.cancelQueries({ queryKey: galleryKeys.chat(chatId) }),
         qc.cancelQueries({ queryKey: galleryKeys.assets(chatId) }),
@@ -160,13 +167,19 @@ export function useDeleteGalleryImage(chatId: string) {
 
       return { previousImages, previousAssets };
     },
-    onError: (_error, _imageId, context) => {
+    onError: (_error, _variables, context) => {
       if (context?.previousImages) qc.setQueryData(galleryKeys.chat(chatId), context.previousImages);
       if (context?.previousAssets) qc.setQueryData(galleryKeys.assets(chatId), context.previousAssets);
     },
-    onSettled: () => {
+    onSettled: (_data, _error, variables) => {
       qc.invalidateQueries({ queryKey: galleryKeys.chat(chatId) });
       qc.invalidateQueries({ queryKey: galleryKeys.assets(chatId) });
+      // A Game-mode gallery can delete a sibling session's image; that
+      // session's own cached lists must not keep showing the deleted row.
+      if (variables && variables.chatId !== chatId) {
+        qc.invalidateQueries({ queryKey: galleryKeys.chat(variables.chatId) });
+        qc.invalidateQueries({ queryKey: galleryKeys.assets(variables.chatId) });
+      }
     },
   });
 }

--- a/packages/client/src/hooks/use-mari-workspace-context.ts
+++ b/packages/client/src/hooks/use-mari-workspace-context.ts
@@ -62,8 +62,11 @@ export function useAddMariWorkspaceContext() {
 export function useRemoveMariWorkspaceContext(chatId: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async (id: string) => {
-      await api.delete(`/professor-mari/workspace/context/${id}`);
+    // The wire-level chatId is the item row's owning workspace chat (#5615):
+    // it lets the server scope the lookup to one chat's storage instead of
+    // loading every chat's. The hook's ambient chatId stays for the cache key.
+    mutationFn: async ({ id, chatId: ownerChatId }: { id: string; chatId: string }) => {
+      await api.delete(`/professor-mari/workspace/context/${id}?chatId=${encodeURIComponent(ownerChatId)}`);
       return id;
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: mariWorkspaceContextKeys.list(chatId) }),


### PR DESCRIPTION
Closes #5615. The client half of the #5592 close-out: #5614 taught the id-only endpoints to accept an optional owning-chat hint; this makes the client send it, closing the last cold paths that could convert a lazy table to permanently fully-resident.

## What changed

Three of the four endpoints get their hint (all pure `packages/client/` changes; the server treats a missing value exactly as before, so this is safe to ship independently):

- **`DELETE /gallery/:id`** now carries `?chatId=` — and the value is the **image row's own `chatId`**, not the open chat. That distinction is load-bearing: a Game-mode gallery aggregates images from sibling game sessions into one list, so the open chat is the *wrong* owner for those rows, and a wrong hint 404s the delete. The `useDeleteGalleryImage` mutation widened from a bare id to `{ imageId, chatId }`; the hook's ambient chatId stays as-is for the react-query cache keys (that's what the list queries are keyed on — the two ids serve different purposes and legitimately differ).
- **`DELETE /professor-mari-workspace/context/:id`** now carries `?chatId=` from the context item row's own `chatId` (the owning workspace chat — deliberately *not* `sourceChatId`, which is the chat the slice was copied from). Same mutation-widening pattern.
- **`PATCH /agents/runs/:runId`** now sends `chatId` in the body. The mutation variables already carried it (for cache invalidation) — it was just never put on the wire. Also switched `AgentSuiteModal`'s call from the ambient `chat.id` to the row's own `run.chatId`, matching the pattern `RoleplayHUDActionsMenu` already used; they're equal today (the runs list is chat-scoped), but the row's own field survives any future cross-chat runs view.

**The fourth endpoint (`DELETE /game/checkpoint/:id`) has no client caller at all** — verified by exhaustive search, there is no checkpoint-management UI yet. The server-side hint is already wired (#5614); whenever a checkpoint UI is built, its delete call should pass the checkpoint row's `chatId` from day one. Nothing to change here.

One adjacent (pre-existing) gap fixed alongside, because this PR makes the path it affects explicit: deleting a sibling session's image only invalidated the *open* chat's gallery caches, so the sibling's own cached list kept showing the deleted image for up to its 5-minute stale window. `onSettled` now also invalidates the owner chat's keys when they differ.

## Why wrong-owner matters (and why this is still just a perf change)

The server uses the hint purely to scope the storage lookup to one chat's shard instead of loading every chat's — it is **not** an authorization check. Sending it wrong yields a 404 (nothing acts); omitting it falls back to today's unscoped lookup. So every threaded value here is taken from the resource row itself wherever the surface can display cross-chat rows.

## Validation done

- Full `pnpm check` ✅ (guard, localization, prettier, client+server lint/type checks, production build)
- Verified no regression-lane or e2e source-pattern pins reference the changed call sites (the lanes that read these files pin unrelated things)
- An independent verification pass reviewed the diff for owner-identity mistakes across every reachable render path — all clean, including an empirical Fastify query-string round-trip test for exotic ids, confirmation that the agents PATCH schema accepts the new field (no `.strict()`), and confirmation these three are the complete set of client-reachable hint-bearing routes. It also corrected one of my own audit notes: the `pinImage({ ...image, chatId })` pattern is *deliberate* (pinned-media `chatId` means "pinned to this chat", filtered by the active chat), so no follow-up issue is warranted there.

## Manually verify

- [ ] Delete a gallery image from a normal chat and from a Game-mode chat whose gallery shows sibling-session images (both should delete; watch the request for `?chatId=`)
- [ ] Remove an attached context item in the Professor Mari Context Viewer
- [ ] Edit a custom agent run's output in the Agent Suite panel and in the Roleplay HUD agents menu
- [ ] On a `MARINARA_MAX_RESIDENT_CHATS` install, confirm none of these actions logs `Lazy table … is now fully resident`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Edited agent responses are now saved to the correct conversation.
  * Deleting images from the gallery now consistently removes them from their owning conversation, including batch deletions.
  * Removing workspace context items now targets the correct conversation.
  * Improved synchronization of galleries, assets, and context after changes across conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->