### PR TITLE
fix: keep staged profile imports until completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Profile preview uploads now remain available until they are imported, cancelled, or the server stops instead of expiring after 30 minutes and forcing another upload (#5624).
 - Profile imports now upload and scan the selected JSON or ZIP only once, reusing the reviewed server-side preview when import is confirmed; an unsupported or corrupt individual asset is skipped and reported as a warning while the rest of the valid profile continues restoring (#5624).
 - Profile ZIP import and export no longer impose archive, individual-asset, or restored-total byte ceilings, and native character, persona, PNG card, and CharX imports no longer reject otherwise valid image galleries by byte size; paths, media contents, and archive structure remain validated, while profile executable content stays quarantined (#5624).
 - Full profile backup restores no longer fail on the game-asset seeder's own empty `.native` directory markers: import now tolerates exactly that marker (empty and dot-prefixed) under `game-assets/` while still rejecting any non-empty file using the marker name, so a stock export restores cleanly on a fresh install (#5619).

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -87,7 +87,6 @@ const BACKUP_DIRS = [
   "long-term-memory",
 ];
 const ENCRYPTION_KEY_FILENAME = ".encryption-key";
-const PROFILE_IMPORT_PREVIEW_TTL_MS = 30 * 60 * 1_000;
 const PROFILE_ASSET_DIRS = BACKUP_DIRS.filter((dirName) => dirName !== "storage");
 const ZIP16_MAX_VALUE = 0xffff;
 const ZIP32_MAX_VALUE = 0xffffffff;
@@ -3245,40 +3244,25 @@ export async function backupRoutes(app: FastifyInstance) {
     await Promise.all([...backupDownloadJobs.keys()].map(removeBackupDownloadJob));
   });
 
-  type ProfileImportPreview = { input: ProfileImportInput; expiresAt: number };
-  const profileImportPreviews = new Map<string, ProfileImportPreview>();
+  const profileImportPreviews = new Map<string, ProfileImportInput>();
   const discardProfileImportPreview = async (token: string) => {
-    const preview = profileImportPreviews.get(token);
-    if (!preview) return false;
+    const input = profileImportPreviews.get(token);
+    if (!input) return false;
     profileImportPreviews.delete(token);
     try {
-      await preview.input.cleanup?.();
+      await input.cleanup?.();
     } catch (error) {
       logger.warn(error, "[backup] Failed to remove a staged profile preview");
     }
     return true;
   };
   const takeProfileImportPreview = async (token: string) => {
-    const preview = profileImportPreviews.get(token);
-    if (!preview) return null;
+    const input = profileImportPreviews.get(token);
+    if (!input) return null;
     profileImportPreviews.delete(token);
-    if (preview.expiresAt <= Date.now()) {
-      await preview.input.cleanup?.().catch((error) => {
-        logger.warn(error, "[backup] Failed to remove an expired profile preview");
-      });
-      return null;
-    }
-    return preview.input;
+    return input;
   };
-  const profileImportPreviewCleanupTimer = setInterval(() => {
-    const now = Date.now();
-    for (const [token, preview] of profileImportPreviews) {
-      if (preview.expiresAt <= now) void discardProfileImportPreview(token);
-    }
-  }, 60 * 1_000);
-  profileImportPreviewCleanupTimer.unref();
   app.addHook("onClose", async () => {
-    clearInterval(profileImportPreviewCleanupTimer);
     await Promise.all([...profileImportPreviews.keys()].map(discardProfileImportPreview));
   });
 
@@ -3667,8 +3651,8 @@ export async function backupRoutes(app: FastifyInstance) {
       const previewInput = await takeProfileImportPreview(providedPreviewToken);
       if (!previewInput) {
         return reply.status(410).send({
-          error: "Profile preview expired",
-          message: "Profile preview expired. Select the file again before importing.",
+          error: "Profile preview unavailable",
+          message: "Profile preview is no longer available. Select the file again before importing.",
         });
       }
       importInput = previewInput;
@@ -3711,10 +3695,7 @@ export async function backupRoutes(app: FastifyInstance) {
       if (previewOnly) {
         const imported = profileStoragePreviewStats ?? previewLegacyProfileImportStats(data, warnings);
         const previewToken = randomUUID();
-        profileImportPreviews.set(previewToken, {
-          input: importInput,
-          expiresAt: Date.now() + PROFILE_IMPORT_PREVIEW_TTL_MS,
-        });
+        profileImportPreviews.set(previewToken, importInput);
         retainInputForPreview = true;
         return {
           success: true,

--- a/scripts/regressions/profile-import-data-security.regression.ts
+++ b/scripts/regressions/profile-import-data-security.regression.ts
@@ -110,16 +110,22 @@ try {
     assert.equal(zipPreviewResponse.statusCode, 200, zipPreviewResponse.body);
     const zipPreview = zipPreviewResponse.json();
     assert.equal(typeof zipPreview.previewToken, "string");
-    const zipImportResponse = await app.inject({
-      method: "POST",
-      url: "/api/backup/import-profile",
-      headers: { "x-profile-preview-token": zipPreview.previewToken },
-    });
+    const realDateNow = Date.now;
+    Date.now = () => realDateNow() + 31 * 60 * 1_000;
+    const zipImportResponse = await app
+      .inject({
+        method: "POST",
+        url: "/api/backup/import-profile",
+        headers: { "x-profile-preview-token": zipPreview.previewToken },
+      })
+      .finally(() => {
+        Date.now = realDateNow;
+      });
     assert.equal(zipImportResponse.statusCode, 200, zipImportResponse.body);
     assert.deepEqual(
       await readFile(join(storageRoot, ...zipAssetPath.split("/"))),
       validPng,
-      "a ZIP import must reuse the preview upload and restore assets without a second request body",
+      "a ZIP import must reuse its staged preview after 30 minutes without a second request body",
     );
     const replayedZipImport = await app.inject({
       method: "POST",


### PR DESCRIPTION
## Linked issue

Closes #5624

## Why this change

- The single-upload profile import still deleted its staged archive 30 minutes after preview.
- A user who reviewed or paused beyond that arbitrary deadline had to upload a multi-gigabyte profile again, recreating the original failure mode.

## What changed

- Remove the staged-profile timestamp, expiry check, and periodic expiry timer.
- Keep the one-time import token valid until Import consumes it, Cancel deletes it, or the server shuts down/restarts.
- Preserve cleanup on every terminal path and keep tokens single-use.
- Add a regression that advances the clock past the former 30-minute boundary before confirming an empty-body import.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check`
- Focused `profile-import-data-security.regression.ts`: preview token remains valid after simulated 31-minute delay, confirmation has no upload body, restored asset matches, and replay returns 410

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Behavior-only lifecycle correction; no layout, styling, or user-facing UI copy changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile import previews remain available until they are imported, canceled, or the server shuts down.
  * Previews can now be used after more than 30 minutes without resubmitting the original upload.
  * Improved messaging when a preview is no longer available.

* **Documentation**
  * Updated the changelog to document the revised preview retention behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->