### PR TITLE
fix(e2e): stabilize the two remaining smoke flakes

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1,4 +1,12 @@
-import { expect, test, type APIRequestContext, type Locator, type Page, type Route, type TestInfo } from "@playwright/test";
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type Locator,
+  type Page,
+  type Route,
+  type TestInfo,
+} from "@playwright/test";
 import AdmZip from "adm-zip";
 import { readFileSync } from "node:fs";
 import { createServer } from "node:http";
@@ -406,9 +414,9 @@ test("Art scale sliders stay interactive at the largest display size", async ({ 
     await control.scrollIntoViewIfNeeded();
     await expect(slider).toBeVisible();
 
-    const box = await slider.boundingBox();
-    expect(box).not.toBeNull();
-    expect(box!.width).toBeGreaterThanOrEqual(80);
+    const initialBox = await slider.boundingBox();
+    expect(initialBox).not.toBeNull();
+    expect(initialBox!.width).toBeGreaterThanOrEqual(80);
     const min = Number((await slider.getAttribute("min")) ?? 0);
     const max = Number((await slider.getAttribute("max")) ?? 100);
     const midpoint = min + (max - min) / 2;
@@ -418,7 +426,15 @@ test("Art scale sliders stay interactive at the largest display size", async ({ 
       [0.25, "low"],
       [0.65, "high"],
     ] as const) {
-      await page.mouse.click(box!.x + box!.width * fraction, box!.y + box!.height / 2);
+      // Re-measure per click and click element-relative: changing a scale
+      // slider resizes content around it, and a raw page.mouse.click at
+      // absolute coordinates from a stale box lands off the slider with no
+      // stability wait — the click silently misses and the poll below times
+      // out (#5618). locator.click waits for the element to be stable and
+      // positions relative to its box at dispatch time.
+      const box = await slider.boundingBox();
+      expect(box).not.toBeNull();
+      await slider.click({ position: { x: box!.width * fraction, y: box!.height / 2 } });
       if (direction === "high") {
         await expect.poll(async () => Number(await slider.inputValue())).toBeGreaterThan(midpoint);
       } else {
@@ -8692,7 +8708,10 @@ test("Game widget editing and log deletion follow Chroma while weather effects r
     if (testInfo.project.name.includes("mobile")) {
       await page.getByTitle("Chroma clock", { exact: true }).click();
     }
-    const editWidgetButton = page.getByTitle("Edit Chroma clock");
+    // filter({ visible: true }): the desktop widget rail mounts CSS-hidden
+    // during layout transitions, and a hidden duplicate still trips strict
+    // mode even though only one copy is ever visible (#5618).
+    const editWidgetButton = page.getByTitle("Edit Chroma clock").filter({ visible: true });
     await expect(editWidgetButton).toBeVisible();
     await expect(editWidgetButton.locator("svg")).toHaveCSS("color", chromeTextColor);
 
@@ -16916,7 +16935,10 @@ test("home browser hub scales cleanly and opens FAQ as a bookmark window", async
   await expect(page.locator("[data-home-widget-id]")).toHaveCount(4);
   await expectHomeWidgetHeightsMatch(page, baselineCompactHeight);
 
-  await activateControl(widgetManager.getByRole("switch", { name: "Hide Daily encounter — Character of the Day" }), testInfo);
+  await activateControl(
+    widgetManager.getByRole("switch", { name: "Hide Daily encounter — Character of the Day" }),
+    testInfo,
+  );
   await expect(page.locator("[data-home-widget-id]")).toHaveCount(3);
   await expectHomeWidgetHeightsMatch(page, baselineCompactHeight);
 
@@ -18376,7 +18398,10 @@ test("mobile composers preserve history position and restore focus in Conversati
   // plain dispatchEvent evaluation) plus outright focus refusals — each time
   // through a different step of its dense interaction sequence. The same
   // contract runs in full on mobile-chromium.
-  test.skip(testInfo.project.name.includes("webkit"), "Quarantined on webkit: engine freeze/focus instability (#5594).");
+  test.skip(
+    testInfo.project.name.includes("webkit"),
+    "Quarantined on webkit: engine freeze/focus instability (#5594).",
+  );
   test.setTimeout(180_000);
 
   const chatIds: string[] = [];
@@ -18460,9 +18485,7 @@ test("mobile composers preserve history position and restore focus in Conversati
           .catch(() => false);
         if (!composerFocused) {
           await textarea.focus({ timeout: 2_000 }).catch(() => undefined);
-          composerFocused = await textarea
-            .evaluate((element) => document.activeElement === element)
-            .catch(() => false);
+          composerFocused = await textarea.evaluate((element) => document.activeElement === element).catch(() => false);
         }
         if (!composerFocused) await page.waitForTimeout(250);
       }

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -10516,9 +10516,16 @@ function GameSurfaceComponent({
 
   useEffect(() => {
     if (combatUiActive || normalizedWidgets.length === 0) {
-      compactHudWidgetsRef.current = false;
+      // Reset to the same width heuristic the state initializes with, NOT a
+      // flat false: widgets arrive after the queries resolve, and a false
+      // reset here mounts the (CSS-hidden) desktop widget rail on mobile for
+      // the frames until updateWidgetLayout measures — long enough on a slow
+      // device for both the mobile and desktop copies of a widget to coexist
+      // in the DOM (#5618).
+      const compactByWidth = typeof window !== "undefined" && window.innerWidth < 768;
+      compactHudWidgetsRef.current = compactByWidth;
       compactHudReleaseWidthRef.current = null;
-      setCompactHudWidgets(false);
+      setCompactHudWidgets(compactByWidth);
       return;
     }
 


### PR DESCRIPTION
Closes #5618. Root causes taken from the failed CI run's own artifacts (error context, trace, page snapshot) rather than guessed — and neither is a "slow runner needs longer timeouts" story, so no timeouts were touched.

## `core-flows.e2e.ts:398` — Art scale sliders (mobile-chromium)

The CI error shows the slider value stuck at 1.9 while the poll waited for < 1.625 — the *low* click never registered. The test read each slider's bounding box **once**, then fired three raw `page.mouse.click`s at absolute coordinates. `page.mouse` bypasses every actionability/stability wait, and changing a scale slider resizes live content around it, so on a slow runner the second click lands on a stale position and silently misses. Fix: element-relative `locator.click({ position })` with a **fresh bounding box per click** — Playwright now waits for the element to be stable and positions against its box at dispatch time.

## `core-flows.e2e.ts:8608` — Game widget Chroma (mobile-webkit)

Not a timing flake — a **strict-mode violation**: `getByTitle('Edit Chroma clock')` resolved to two buttons. The CI page snapshot shows only *one visible* button, which pins the second as a CSS-hidden duplicate: `GameSurface` resets `compactHudWidgets` to a flat `false` whenever the widget list is empty (i.e. during initial load, before the queries resolve), and `false` mounts the desktop widget rail — `hidden md:flex`, so invisible on mobile but **in the DOM** — until the layout effect re-measures and flips compact back on. On a slow WebKit runner the test's tap lands inside that window, and both the mobile expanded row and the hidden desktop `WidgetCard` carry the same title. This also explains the observed retry storms: the window is load-timing dependent, so a slow run can hit it on every attempt.

Two fixes, root cause first:

- **App**: the empty-list reset now uses the same `window.innerWidth < 768` heuristic the state initializes with, so the desktop rail never mounts on a mobile viewport, even transiently. (Desktop behavior unchanged — the heuristic evaluates to the old `false` there.)
- **Test**: the locator additionally filters to visible elements, as defense in depth for the `hidden md:*` responsive pattern generally — a hidden duplicate still trips strict mode even though only one copy can ever be interacted with.

## Correction for the record

The issue claimed both tests reproduce on a plain local staging checkout — that turned out to be contaminated evidence (a Playwright browser-binary version mismatch makes every test "fail" instantly). With browsers properly installed, both tests pass locally pre-fix; the flake is CI-timing-dependent, exactly as the run history suggested. Noted on the issue.

## Validation done

- Both tests pass **6/6 repeat runs** on their affected project locally after the fix (`--retries=0 --repeat-each=6`)
- Client typecheck clean; prettier clean
- The two regression lanes that pin these source files (`tracker-gallery-ui`, `open-issues`) pass

## Manually verify

- [ ] On a phone-sized window, open a Game chat with HUD widgets and confirm widgets render/expand normally during initial load
- [ ] On desktop, confirm the widget rail still appears and the compact fallback still engages when the window narrows
- [ ] Watch a few CI runs after merge for either test name reappearing in a failed lane

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved slider interactions for more reliable end-to-end behavior.
  - Ensured clock editing targets the visible control.
  - Fixed widget layout resets to correctly preserve compact mode on smaller screens, including during combat or when widgets are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->