### PR TITLE
ci: shard the browser matrix, cache browsers, and gate unaffected PRs

### DIFF
--- a/.github/actions/playwright-shard/action.yml
+++ b/.github/actions/playwright-shard/action.yml
@@ -1,0 +1,68 @@
+name: Run one Playwright shard
+description: >-
+  Set up pnpm/Node, restore the Playwright browser cache, and run one shard of
+  one browser project. Each shard job runs on its own runner with its own app
+  servers, which is what makes sharding safe despite fullyParallel: false —
+  that setting guards test isolation within ONE run's shared servers, and
+  shards never share a run (#5622).
+inputs:
+  project:
+    description: Playwright project name (desktop-chromium, mobile-chromium, mobile-webkit)
+    required: true
+  browser:
+    description: Browser bundle to install (chromium, webkit)
+    required: true
+  shard:
+    description: 1-based shard index
+    required: true
+  total-shards:
+    description: Total shard count
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Set up pnpm
+      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      with:
+        run_install: false
+
+    - name: Set up Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: 24
+        cache: pnpm
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: Resolve Playwright version
+      id: playwright-version
+      shell: bash
+      run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ inputs.browser }}-${{ steps.playwright-version.outputs.version }}
+
+    - name: Install ${{ inputs.browser }}
+      # On a cache hit the download is a no-op; --with-deps still installs the
+      # OS packages, which are not cacheable.
+      shell: bash
+      run: pnpm exec playwright install --with-deps ${{ inputs.browser }}
+
+    - name: Run ${{ inputs.project }} shard ${{ inputs.shard }}/${{ inputs.total-shards }}
+      # --fully-parallel changes only the SHARDING granularity: with the
+      # config's fullyParallel:false the whole single-file suite is one
+      # indivisible group and every test lands in shard 1. Pairing it with
+      # --workers=1 keeps execution inside each shard strictly serial in file
+      # order, so tests never run concurrently against the shard's servers —
+      # the property fullyParallel:false exists to protect.
+      shell: bash
+      run: >-
+        pnpm exec playwright test -c playwright.config.ts
+        --project=${{ inputs.project }}
+        --fully-parallel --workers=1
+        --shard=${{ inputs.shard }}/${{ inputs.total-shards }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -43,10 +43,69 @@ jobs:
       - name: Run complete Node regression suite
         run: pnpm regression
 
-  browser:
-    name: ${{ matrix.project }}
+  # The browser suite boots the real server and client, so almost any code
+  # change can affect it — the skip list is deliberately narrow (#5622): only
+  # files the running app can never load. This is an in-workflow gate, not a
+  # workflow-level paths filter, so the fan-in jobs below still report green
+  # for branch protection instead of hanging as "Expected".
+  changes:
+    name: browser-lane-gate
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+
+    outputs:
+      browser: ${{ steps.decide.outputs.browser }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 2
+
+      - name: Decide whether the browser lanes can be skipped
+        id: decide
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+            echo "Not a pull request — browser lanes always run."
+            echo "browser=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # pull_request checks out the merge commit; its first parent is the
+          # base branch head, so this diff is exactly the PR's change set.
+          if ! git rev-parse HEAD^2 >/dev/null 2>&1; then
+            echo "Cannot determine the change set — running the browser lanes."
+            echo "browser=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          mapfile -t files < <(git diff --name-only HEAD^1 HEAD)
+          needed=false
+          for file in "${files[@]}"; do
+            case "$file" in
+              docs/*|*.md|.gitattributes|win/*|android/*|scripts/regressions/*) ;;
+              *)
+                needed=true
+                echo "Browser-affecting change: $file"
+                break
+                ;;
+            esac
+          done
+          if [[ "$needed" == "false" ]]; then
+            echo "Only files the running app never loads changed:"
+            printf '  %s\n' "${files[@]}"
+          fi
+          echo "browser=$needed" >> "$GITHUB_OUTPUT"
+
+  desktop-chromium-shards:
+    name: desktop-chromium ${{ matrix.shard }}/3
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: changes
+    if: needs.changes.outputs.browser == 'true'
 
     permissions:
       contents: read
@@ -54,13 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - project: desktop-chromium
-            browser: chromium
-          - project: mobile-chromium
-            browser: chromium
-          - project: mobile-webkit
-            browser: webkit
+        shard: [1, 2, 3]
 
     steps:
       - name: Checkout
@@ -68,31 +121,196 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - name: Run shard
+        uses: ./.github/actions/playwright-shard
         with:
-          run_install: false
-
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install ${{ matrix.browser }}
-        run: pnpm exec playwright install --with-deps ${{ matrix.browser }}
-
-      - name: Run ${{ matrix.project }}
-        run: pnpm exec playwright test -c playwright.config.ts --project=${{ matrix.project }}
+          project: desktop-chromium
+          browser: chromium
+          shard: ${{ matrix.shard }}
+          total-shards: 3
 
       - name: Upload failure evidence
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: playwright-${{ matrix.project }}-failure
+          name: playwright-desktop-chromium-shard-${{ matrix.shard }}-failure
           path: test-results/
           if-no-files-found: ignore
           retention-days: 7
+
+  mobile-chromium-shards:
+    name: mobile-chromium ${{ matrix.shard }}/3
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: changes
+    if: needs.changes.outputs.browser == 'true'
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run shard
+        uses: ./.github/actions/playwright-shard
+        with:
+          project: mobile-chromium
+          browser: chromium
+          shard: ${{ matrix.shard }}
+          total-shards: 3
+
+      - name: Upload failure evidence
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-mobile-chromium-shard-${{ matrix.shard }}-failure
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  mobile-webkit-shards:
+    name: mobile-webkit ${{ matrix.shard }}/3
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: changes
+    if: needs.changes.outputs.browser == 'true'
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run shard
+        uses: ./.github/actions/playwright-shard
+        with:
+          project: mobile-webkit
+          browser: webkit
+          shard: ${{ matrix.shard }}
+          total-shards: 3
+
+      - name: Upload failure evidence
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-mobile-webkit-shard-${{ matrix.shard }}-failure
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # Fan-in jobs carrying the pre-#5622 check names, so any branch-protection
+  # rule pointing at "desktop-chromium" / "mobile-chromium" / "mobile-webkit"
+  # keeps working across the sharded layout. They pass when every shard
+  # passed, pass with a note when the gate proved the lanes unaffected, and
+  # fail otherwise — including when the gate itself broke.
+  desktop-chromium:
+    name: desktop-chromium
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [changes, desktop-chromium-shards]
+    if: always()
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Verdict
+        shell: bash
+        env:
+          GATE_RESULT: ${{ needs.changes.result }}
+          GATE_BROWSER: ${{ needs.changes.outputs.browser }}
+          SHARDS_RESULT: ${{ needs.desktop-chromium-shards.result }}
+        run: |
+          if [[ "$GATE_RESULT" != "success" ]]; then
+            echo "Gate job did not succeed: $GATE_RESULT"
+            exit 1
+          fi
+          if [[ "$GATE_BROWSER" != "true" ]]; then
+            echo "Skipped: this change cannot affect the browser lanes."
+            exit 0
+          fi
+          if [[ "$SHARDS_RESULT" == "success" ]]; then
+            exit 0
+          fi
+          echo "Shard result: $SHARDS_RESULT"
+          exit 1
+
+  mobile-chromium:
+    name: mobile-chromium
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [changes, mobile-chromium-shards]
+    if: always()
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Verdict
+        shell: bash
+        env:
+          GATE_RESULT: ${{ needs.changes.result }}
+          GATE_BROWSER: ${{ needs.changes.outputs.browser }}
+          SHARDS_RESULT: ${{ needs.mobile-chromium-shards.result }}
+        run: |
+          if [[ "$GATE_RESULT" != "success" ]]; then
+            echo "Gate job did not succeed: $GATE_RESULT"
+            exit 1
+          fi
+          if [[ "$GATE_BROWSER" != "true" ]]; then
+            echo "Skipped: this change cannot affect the browser lanes."
+            exit 0
+          fi
+          if [[ "$SHARDS_RESULT" == "success" ]]; then
+            exit 0
+          fi
+          echo "Shard result: $SHARDS_RESULT"
+          exit 1
+
+  mobile-webkit:
+    name: mobile-webkit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [changes, mobile-webkit-shards]
+    if: always()
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Verdict
+        shell: bash
+        env:
+          GATE_RESULT: ${{ needs.changes.result }}
+          GATE_BROWSER: ${{ needs.changes.outputs.browser }}
+          SHARDS_RESULT: ${{ needs.mobile-webkit-shards.result }}
+        run: |
+          if [[ "$GATE_RESULT" != "success" ]]; then
+            echo "Gate job did not succeed: $GATE_RESULT"
+            exit 1
+          fi
+          if [[ "$GATE_BROWSER" != "true" ]]; then
+            echo "Skipped: this change cannot affect the browser lanes."
+            exit 0
+          fi
+          if [[ "$SHARDS_RESULT" == "success" ]]; then
+            exit 0
+          fi
+          echo "Shard result: $SHARDS_RESULT"
+          exit 1


### PR DESCRIPTION
Closes #5622 — items 1–4. The smoke-subset policy variant is deliberately **not** included, per maintainer decision.

## What changed

`playwright.yml` is restructured around a shared composite action (`.github/actions/playwright-shard`); the node lane is untouched.

**1. Sharding (the big one).** Each browser lane now runs as 3 parallel shard jobs (`--shard=k/3`), taking wall time from 15–21 min toward the length of one third of the suite. One discovery en route: with the config's `fullyParallel: false`, Playwright's shard unit is the *file* — and this suite is one 19,800-line file, so plain `--shard` put all 197 tests in shard 1 and zero elsewhere. The fix is `--fully-parallel --workers=1` on the CI invocation only: `--fully-parallel` changes just the sharding granularity to individual tests, while `--workers=1` keeps execution inside each shard strictly serial in file order — the no-concurrent-tests-against-one-server property that `fullyParallel: false` exists to protect. Each shard job is its own runner booting its own servers with a fresh data dir. Distribution verified: 66/66/65.

**2. "Build once" — implemented as its honest version.** The issue's premise that each job rebuilds the app turned out to overstate: the Playwright webServer builds only the shared package (~40s) and then runs *dev* servers; the client is never production-built in this workflow. A serial prebuild job would add more gate latency than nine parallel 40-second shared builds cost, so there is no artifact hand-off — the per-job work that actually dominated (browser downloads, suite runtime) is what items 1 and 3 remove. Prebuilding the client for tests would mean testing `vite preview` instead of the dev server the suite was written against — out of scope.

**3. Playwright browser cache.** `~/.cache/ms-playwright`, keyed on OS + browser + the installed `@playwright/test` version. On a hit, `playwright install` skips the download (the WebKit bundle is the chunky one); `--with-deps`' OS packages still install, as they must.

**4. Skip gate for unaffected PRs.** A fast `browser-lane-gate` job diffs the PR's merge commit against its first parent (exactly the PR's change set) and skips the shard jobs when **every** changed file matches the narrow skip list: `docs/**`, `**/*.md`, `.gitattributes`, `win/**`, `android/**`, `scripts/regressions/**` — files the running app can never load. Anything else (server, client, e2e, workflows, lockfile, launcher scripts) runs the lanes; so does any push, `workflow_dispatch`, or a diff the gate can't determine (conservative fallback). This is an in-workflow gate, **not** a workflow-level `paths:` filter, for the required-checks reason documented in the issue.

**Branch-protection compatibility:** the shard jobs have new names (`desktop-chromium 1/3`, …), but three fan-in jobs carry the exact pre-existing check names — `desktop-chromium`, `mobile-chromium`, `mobile-webkit`. Each passes when its shards all passed, passes with a "skipped: cannot affect the browser lanes" note when the gate proved it, and fails otherwise — including when the gate job itself fails, so a broken gate can never green the matrix.

## The honest risk, and how it was validated

Mid-file shards start against a fresh server with none of the earlier tests' accumulated state, so any test that silently depended on a predecessor's side effects would fail in shards 2/3. All three desktop-chromium shards were run locally from cold starts: **shard 2 — 64/64 passed, shard 3 — 54/54 passed** (remainder skipped by project gates), **shard 1 — 63 passed with one failure of the pre-existing "Echo Chamber size persistence" pixel-tolerance flake, which passes 3/3 solo** — an independent intermittent, not order coupling (worth its own #5618-style look if it recurs in CI). Two earlier local shard-2 runs failed en masse with `ECONNREFUSED` — that turned out to be this Windows machine's known consecutive-run server-startup artifact, not the sharding (the clean re-runs above are decisive). The mobile lanes run the same single file with the same ordering profile, and this PR's own CI run exercises all nine shard jobs end-to-end on the runners that matter.

## Validation done

- YAML parse-validated; gate pattern logic unit-tested against 10 change-set shapes (docs-only/installer/regressions-only skip; server/client/e2e/workflow/lockfile/launcher run)
- Shard distribution verified 66/66/65 per project
- All 3 desktop-chromium shards run locally to completion
- This PR's CI run is itself the end-to-end proof: it exercises the gate (this PR touches workflows → lanes run), all nine shards, the cache (cold then warm on re-run), and the fan-ins

## Manually verify

- [ ] Confirm the fan-in checks (`desktop-chromium`, `mobile-chromium`, `mobile-webkit`) appear on this PR and match whatever branch protection requires
- [ ] After merge, open a docs-only PR and confirm the shard jobs skip while the fan-ins report green with the skip note
- [ ] Compare wall time of this PR's matrix against a recent pre-change run
- [ ] Re-run a lane once to confirm the browser cache hits (the install step should skip the download)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added parallelized browser testing across multiple shards for faster validation.
  * Added automatic browser setup, caching, and failure-evidence uploads.
  * Added change detection to skip browser checks for documentation-only and other non-impacting changes.
  * Preserved clear browser check results through consolidated success or failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->