### PR TITLE
fix(storage): serialize message deletes against edits and make the edit's mirror write atomic

### DIFF
--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -68,6 +68,17 @@ const metadataPatchQueues = new Map<string, Promise<void>>();
 const messageExtraPatchQueues = new Map<string, Promise<void>>();
 const swipeExtraPatchQueues = new Map<string, Promise<void>>();
 
+/**
+ * LOCK ORDER (#5599/#5600): the message patch queue is always acquired
+ * BEFORE the store's transaction slot — updateMessageContent takes the queue
+ * and then opens db.transaction, and the delete paths hold the queue across
+ * plain writes that wait out active transactions. A db.transaction callback
+ * must therefore NEVER call a queue-taking message API (updateMessageContent,
+ * updateMessageExtra, add/remove/setActiveSwipe, removeMessage(s), ...) —
+ * that is the reverse order and deadlocks the whole store with no timeout.
+ * Same discipline as the experience-lock → metadata-queue order documented
+ * further down. The queues are not reentrant either.
+ */
 async function withPatchQueue<T>(
   queues: Map<string, Promise<void>>,
   key: string,

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -90,6 +90,37 @@ async function withPatchQueue<T>(
   }
 }
 
+/**
+ * Serialize one operation against MANY keys' queues at once (#5599: a bulk
+ * delete must be ordered against every affected message's in-flight edits).
+ * The shared gate is installed on every key synchronously before any await,
+ * so two concurrent multi-acquires order themselves strictly — the second
+ * finds the first's gate among its predecessors — and a cycle cannot form.
+ */
+async function withPatchQueues<T>(
+  queues: Map<string, Promise<void>>,
+  keys: string[],
+  operation: () => Promise<T>,
+): Promise<T> {
+  const uniqueKeys = [...new Set(keys)];
+  const previous = uniqueKeys.map((key) => queues.get(key) ?? Promise.resolve());
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  for (const key of uniqueKeys) queues.set(key, gate);
+
+  try {
+    await Promise.all(previous.map((tail) => tail.catch(() => undefined)));
+    return await operation();
+  } finally {
+    release();
+    for (const key of uniqueKeys) {
+      if (queues.get(key) === gate) queues.delete(key);
+    }
+  }
+}
+
 export async function withChatMetadataPatchQueue<T>(chatId: string, operation: () => Promise<T>): Promise<T> {
   return withPatchQueue(metadataPatchQueues, chatId, operation);
 }
@@ -1779,36 +1810,43 @@ export function createChatsStorage(db: DB) {
         if (clearCommandContent) {
           messagePatch.extra = JSON.stringify({ ...existingExtra, conversationCommandContent: null });
         }
-        await db.update(messages).set(messagePatch).where(eq(messages.id, id));
-        if (existing) {
-          await invalidateMemoryChunksFrom(db, existing.chatId, existing.createdAt);
-        }
-        // Also sync the edit to the active swipe row so it persists across swipe switches.
-        const msg = await this.getMessage(id);
-        if (msg) {
-          const swipes = await this.getSwipes(id);
-          const activeSwipe = swipes.find((s: any) => s.index === msg.activeSwipeIndex);
-          if (activeSwipe) {
-            const swipePatch: Record<string, unknown> = { content };
-            if (clearCommandContent) {
-              const swipeExtra = parseExtraRecord(activeSwipe.extra);
-              // Clear only a raw copy this swipe itself carries, and never a
-              // command-only carrier's.
-              if (
-                typeof swipeExtra.conversationCommandContent === "string" &&
-                swipeExtra.conversationCommandContent.trim() !== "" &&
-                swipeExtra.commandOnly !== true
-              ) {
-                swipePatch.extra = JSON.stringify({ ...swipeExtra, conversationCommandContent: null });
-              }
-            }
-            await db
-              .update(messageSwipes)
-              .set(swipePatch)
-              .where(and(eq(messageSwipes.messageId, id), eq(messageSwipes.id, activeSwipe.id)));
+        // One transaction around the messages row and its swipe mirror
+        // (#5600): the store defers flushes while a transaction is active, so
+        // a crash or badly timed flush can no longer persist the edit on the
+        // message while the active swipe still holds the pre-edit text — the
+        // tear that used to surface only in exports and branched chats.
+        return db.transaction(async () => {
+          await db.update(messages).set(messagePatch).where(eq(messages.id, id));
+          if (existing) {
+            await invalidateMemoryChunksFrom(db, existing.chatId, existing.createdAt);
           }
-        }
-        return msg;
+          // Also sync the edit to the active swipe row so it persists across swipe switches.
+          const msg = await this.getMessage(id);
+          if (msg) {
+            const swipes = await this.getSwipes(id);
+            const activeSwipe = swipes.find((s: any) => s.index === msg.activeSwipeIndex);
+            if (activeSwipe) {
+              const swipePatch: Record<string, unknown> = { content };
+              if (clearCommandContent) {
+                const swipeExtra = parseExtraRecord(activeSwipe.extra);
+                // Clear only a raw copy this swipe itself carries, and never a
+                // command-only carrier's.
+                if (
+                  typeof swipeExtra.conversationCommandContent === "string" &&
+                  swipeExtra.conversationCommandContent.trim() !== "" &&
+                  swipeExtra.commandOnly !== true
+                ) {
+                  swipePatch.extra = JSON.stringify({ ...swipeExtra, conversationCommandContent: null });
+                }
+              }
+              await db
+                .update(messageSwipes)
+                .set(swipePatch)
+                .where(and(eq(messageSwipes.messageId, id), eq(messageSwipes.id, activeSwipe.id)));
+            }
+          }
+          return msg;
+        });
       });
     },
 
@@ -2011,13 +2049,19 @@ export function createChatsStorage(db: DB) {
     },
 
     async removeMessage(id: string) {
-      const existing = await this.getMessage(id);
-      if (existing) await deleteGameStateForMessages([id], [existing.chatId]);
-      await db.delete(messages).where(eq(messages.id, id));
-      if (existing) {
-        await invalidateMemoryChunksFrom(db, existing.chatId, existing.createdAt);
-        await refreshChatLastMessageAt(existing.chatId);
-      }
+      // Serialized on the same per-message queue as every other message
+      // mutation (#5599): an in-flight edit either completes before the
+      // delete or starts after it and sees a consistent world, instead of
+      // having its writes silently vanish mid-flight into a 404.
+      return withPatchQueue(messageExtraPatchQueues, id, async () => {
+        const existing = await this.getMessage(id);
+        if (existing) await deleteGameStateForMessages([id], [existing.chatId]);
+        await db.delete(messages).where(eq(messages.id, id));
+        if (existing) {
+          await invalidateMemoryChunksFrom(db, existing.chatId, existing.createdAt);
+          await refreshChatLastMessageAt(existing.chatId);
+        }
+      });
     },
 
     async removeMessages(ids: string[], chatId?: string) {
@@ -2026,22 +2070,27 @@ export function createChatsStorage(db: DB) {
       const CHUNK = 500;
       for (let i = 0; i < ids.length; i += CHUNK) {
         const chunk = ids.slice(i, i + CHUNK);
-        const condition = chatId
-          ? and(inArray(messages.id, chunk), eq(messages.chatId, chatId))
-          : inArray(messages.id, chunk);
-        const existingRows = await db
-          .select({ id: messages.id, chatId: messages.chatId, createdAt: messages.createdAt })
-          .from(messages)
-          .where(condition);
-        for (const row of existingRows) {
-          const current = earliestByChat.get(row.chatId);
-          if (!current || row.createdAt < current) earliestByChat.set(row.chatId, row.createdAt);
-        }
-        await deleteGameStateForMessages(
-          existingRows.map((row) => row.id),
-          existingRows.map((row) => row.chatId),
-        );
-        await db.delete(messages).where(condition);
+        // Per-chunk queue acquisition (#5599): each message's delete is
+        // ordered against its in-flight edits; cross-chunk atomicity was
+        // never promised by this bulk path.
+        await withPatchQueues(messageExtraPatchQueues, chunk, async () => {
+          const condition = chatId
+            ? and(inArray(messages.id, chunk), eq(messages.chatId, chatId))
+            : inArray(messages.id, chunk);
+          const existingRows = await db
+            .select({ id: messages.id, chatId: messages.chatId, createdAt: messages.createdAt })
+            .from(messages)
+            .where(condition);
+          for (const row of existingRows) {
+            const current = earliestByChat.get(row.chatId);
+            if (!current || row.createdAt < current) earliestByChat.set(row.chatId, row.createdAt);
+          }
+          await deleteGameStateForMessages(
+            existingRows.map((row) => row.id),
+            existingRows.map((row) => row.chatId),
+          );
+          await db.delete(messages).where(condition);
+        });
       }
       for (const [affectedChatId, createdAt] of earliestByChat) {
         await invalidateMemoryChunksFrom(db, affectedChatId, createdAt);

--- a/scripts/regressions/message-edit-delete-races.regression.ts
+++ b/scripts/regressions/message-edit-delete-races.regression.ts
@@ -1,0 +1,165 @@
+// #5599/#5600: message edit/delete concurrency.
+//   - #5599: removeMessage/removeMessages were the only per-message mutations
+//     NOT serialized on the per-message patch queue, so a delete could land
+//     inside an in-flight edit's await gaps and silently drop the edit into a
+//     404. Pinned here by holding the queue and proving a delete now waits.
+//   - #5600: the edit wrote the messages row and its active-swipe mirror with
+//     awaited gaps between them and no transaction, so a flush (or crash) in
+//     the window persisted the edit on the message while the swipe kept the
+//     pre-edit text — surfacing in exports and branches. Pinned here by
+//     flushing mid-edit and reading the shard files: the store defers flushes
+//     while a transaction is active, so the flush must now produce a
+//     consistent pair on disk.
+//
+// Project imports are DYNAMIC, after the env assignments (see the gallery
+// suites for why).
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (process.env.MARINARA_EAGER_STORAGE === "1" || process.env.MARINARA_EAGER_STORAGE === "true") {
+  // The queue and transaction semantics under test are storage-mode
+  // independent, but the shard-file assertions below read the lazy layout.
+  console.log("Message edit/delete race regressions skipped: MARINARA_EAGER_STORAGE is set.");
+  process.exit(0);
+}
+
+const dataDir = mkdtempSync(join(tmpdir(), "marinara-edit-delete-races-"));
+const storeDir = join(dataDir, "storage");
+process.env.DATA_DIR = dataDir;
+process.env.FILE_STORAGE_DIR = storeDir;
+
+const { createFileNativeDB, encodeShardKey } = await import("../../packages/server/src/db/file-backed-store.js");
+const { createChatsStorage, withMessageExtraPatchQueue } = await import(
+  "../../packages/server/src/services/storage/chats.storage.js"
+);
+
+const chatRow = (id: string) => ({ id, name: id, mode: "conversation" });
+const messageRow = (id: string, chatId: string, content: string) => ({
+  id,
+  chatId,
+  role: "assistant",
+  content,
+  activeSwipeIndex: 0,
+  createdAt: `2026-08-28T10:00:00.000Z`,
+});
+const swipeRow = (id: string, messageId: string, content: string) => ({ id, messageId, index: 0, content });
+
+const shardPath = (table: string, key: string) => join(storeDir, "tables", table, `${encodeShardKey(key)}.json`);
+const writeShard = (table: string, key: string, rows: unknown[]) => {
+  mkdirSync(join(storeDir, "tables", table), { recursive: true });
+  writeFileSync(shardPath(table, key), JSON.stringify(rows));
+};
+
+writeShard("chats", "c1", [chatRow("c1")]);
+writeShard("messages", "c1", [
+  messageRow("m-hold", "c1", "hold me"),
+  messageRow("m-bulk", "c1", "bulk me"),
+  messageRow("m-race", "c1", "race me"),
+  messageRow("m-tear", "c1", "old text"),
+]);
+writeShard("message_swipes", "c1", [
+  swipeRow("s-race", "m-race", "race me"),
+  swipeRow("s-tear", "m-tear", "old text"),
+]);
+
+const db = await createFileNativeDB();
+const storage = createChatsStorage(db);
+const settle = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+try {
+  // ── #5599: a delete waits for the per-message queue ──
+  {
+    let release!: () => void;
+    const hold = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const held = withMessageExtraPatchQueue("m-hold", () => hold);
+    const deletion = storage.removeMessage("m-hold");
+    await settle(150);
+    assert.notEqual(
+      await storage.getMessage("m-hold"),
+      null,
+      "removeMessage waits for the message's patch queue instead of racing past an in-flight mutation",
+    );
+    release();
+    await held;
+    await deletion;
+    assert.equal(await storage.getMessage("m-hold"), null, "the queued delete completes once the queue frees");
+  }
+
+  // ── #5599: the bulk delete waits for every affected message's queue ──
+  {
+    let release!: () => void;
+    const hold = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const held = withMessageExtraPatchQueue("m-bulk", () => hold);
+    const deletion = storage.removeMessages(["m-bulk"], "c1");
+    await settle(150);
+    assert.notEqual(
+      await storage.getMessage("m-bulk"),
+      null,
+      "removeMessages waits for each affected message's patch queue",
+    );
+    release();
+    await held;
+    await deletion;
+    assert.equal(await storage.getMessage("m-bulk"), null, "the queued bulk delete completes once the queue frees");
+  }
+
+  // ── #5599: edit-then-delete resolves in queue order — the edit wins ──
+  {
+    const edit = storage.updateMessageContent("m-race", "edited before deletion");
+    const deletion = storage.removeMessage("m-race");
+    const edited = await edit;
+    await deletion;
+    assert.equal(
+      edited?.content,
+      "edited before deletion",
+      "an edit enqueued before a delete completes with its result instead of a silent null",
+    );
+    assert.equal(await storage.getMessage("m-race"), null, "the delete still lands afterward");
+  }
+
+  // ── #5600: a flush initiated mid-edit cannot persist a torn pair ──
+  {
+    const gen0 = db._fileStore.getTableWriteGeneration("messages");
+    const edit = storage.updateMessageContent("m-tear", "EDITED TEXT");
+    // Wait for the edit's FIRST write (the messages row) to be marked, then
+    // flush. Pre-fix the flush wrote the messages shard while the swipe
+    // mirror was still unwritten — the exact crash-persisted state. With the
+    // edit inside a transaction, the flush blocks until commit and writes a
+    // consistent pair.
+    let waited = 0;
+    while (db._fileStore.getTableWriteGeneration("messages") === gen0 && waited < 4000) {
+      await new Promise((resolve) => setImmediate(resolve));
+      waited += 1;
+    }
+    assert.notEqual(waited, 4000, "the edit's first write was observed");
+    await db._fileStore.flush();
+    const messagesShard = readFileSync(shardPath("messages", "c1"), "utf8");
+    const swipesShard = readFileSync(shardPath("message_swipes", "c1"), "utf8");
+    const messageEdited = messagesShard.includes("EDITED TEXT");
+    const swipeEdited = swipesShard.includes("EDITED TEXT");
+    assert.equal(
+      messageEdited,
+      swipeEdited,
+      `the on-disk pair must be consistent after a mid-edit flush (message edited: ${messageEdited}, swipe edited: ${swipeEdited})`,
+    );
+    const edited = await edit;
+    assert.equal(edited?.content, "EDITED TEXT", "the edit completes normally");
+    await db._fileStore.flush();
+    assert.equal(
+      readFileSync(shardPath("message_swipes", "c1"), "utf8").includes("EDITED TEXT"),
+      true,
+      "the swipe mirror carries the edit after the final flush",
+    );
+  }
+} finally {
+  await db._fileStore.close();
+  rmSync(dataDir, { recursive: true, force: true });
+}
+
+console.log("Message edit/delete race regressions passed.");

--- a/scripts/regressions/message-edit-delete-races.regression.ts
+++ b/scripts/regressions/message-edit-delete-races.regression.ts
@@ -31,9 +31,8 @@ process.env.DATA_DIR = dataDir;
 process.env.FILE_STORAGE_DIR = storeDir;
 
 const { createFileNativeDB, encodeShardKey } = await import("../../packages/server/src/db/file-backed-store.js");
-const { createChatsStorage, withMessageExtraPatchQueue } = await import(
-  "../../packages/server/src/services/storage/chats.storage.js"
-);
+const { createChatsStorage, withMessageExtraPatchQueue } =
+  await import("../../packages/server/src/services/storage/chats.storage.js");
 
 const chatRow = (id: string) => ({ id, name: id, mode: "conversation" });
 const messageRow = (id: string, chatId: string, content: string) => ({
@@ -59,16 +58,17 @@ writeShard("messages", "c1", [
   messageRow("m-race", "c1", "race me"),
   messageRow("m-tear", "c1", "old text"),
 ]);
-writeShard("message_swipes", "c1", [
-  swipeRow("s-race", "m-race", "race me"),
-  swipeRow("s-tear", "m-tear", "old text"),
-]);
+writeShard("message_swipes", "c1", [swipeRow("s-race", "m-race", "race me"), swipeRow("s-tear", "m-tear", "old text")]);
 
 const db = await createFileNativeDB();
 const storage = createChatsStorage(db);
 const settle = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 try {
+  // Warm-up: load the chat unit before any timed block, so the sleeps below
+  // budget for in-memory work only, never the first lazy shard load.
+  await storage.getMessage("m-hold");
+
   // ── #5599: a delete waits for the per-message queue ──
   {
     let release!: () => void;
@@ -109,46 +109,96 @@ try {
     assert.equal(await storage.getMessage("m-bulk"), null, "the queued bulk delete completes once the queue frees");
   }
 
-  // ── #5599: edit-then-delete resolves in queue order — the edit wins ──
+  // ── #5599: a delete landing mid-edit no longer nulls the edit out ──
+  // Deterministic injection: the edit's SECOND getMessage call (its post-write
+  // re-read) fires the delete and gives it time to run. Pre-fix the delete is
+  // unqueued, completes inside the gap, and the edit's re-read returns null —
+  // the silent-404 symptom. Post-fix the delete waits on the queue, the edit
+  // completes with its result, and the delete lands after.
   {
-    const edit = storage.updateMessageContent("m-race", "edited before deletion");
-    const deletion = storage.removeMessage("m-race");
-    const edited = await edit;
-    await deletion;
+    const originalGetMessage = storage.getMessage.bind(storage);
+    let editReads = 0;
+    let injectedDeletion: Promise<void> | null = null;
+    storage.getMessage = (async (id: string) => {
+      if (id === "m-race") {
+        editReads += 1;
+        if (editReads === 2) {
+          storage.getMessage = originalGetMessage;
+          injectedDeletion = storage.removeMessage("m-race");
+          await settle(200);
+        }
+      }
+      return originalGetMessage(id);
+    }) as typeof storage.getMessage;
+    const edited = await storage.updateMessageContent("m-race", "edited before deletion");
+    storage.getMessage = originalGetMessage;
+    assert.notEqual(injectedDeletion, null, "the injection point was reached");
+    await injectedDeletion;
     assert.equal(
       edited?.content,
       "edited before deletion",
-      "an edit enqueued before a delete completes with its result instead of a silent null",
+      "an in-flight edit completes with its result instead of a silent null when a delete lands mid-edit",
     );
     assert.equal(await storage.getMessage("m-race"), null, "the delete still lands afterward");
   }
 
   // ── #5600: a flush initiated mid-edit cannot persist a torn pair ──
+  // Deterministic injection: the edit's getSwipes call marks the exact window
+  // between the messages-row write and the swipe-mirror write. A flush is
+  // fired from the OUTER (non-transaction) context inside that window and
+  // given time to finish. Pre-fix it wrote the messages shard while the swipe
+  // shard kept the old text — the crash-persisted tear. With the edit inside
+  // a transaction, the store parks that flush until commit, so the on-disk
+  // pair can never be torn.
   {
-    const gen0 = db._fileStore.getTableWriteGeneration("messages");
-    const edit = storage.updateMessageContent("m-tear", "EDITED TEXT");
-    // Wait for the edit's FIRST write (the messages row) to be marked, then
-    // flush. Pre-fix the flush wrote the messages shard while the swipe
-    // mirror was still unwritten — the exact crash-persisted state. With the
-    // edit inside a transaction, the flush blocks until commit and writes a
-    // consistent pair.
-    let waited = 0;
-    while (db._fileStore.getTableWriteGeneration("messages") === gen0 && waited < 4000) {
-      await new Promise((resolve) => setImmediate(resolve));
-      waited += 1;
-    }
-    assert.notEqual(waited, 4000, "the edit's first write was observed");
-    await db._fileStore.flush();
-    const messagesShard = readFileSync(shardPath("messages", "c1"), "utf8");
-    const swipesShard = readFileSync(shardPath("message_swipes", "c1"), "utf8");
-    const messageEdited = messagesShard.includes("EDITED TEXT");
-    const swipeEdited = swipesShard.includes("EDITED TEXT");
+    const originalGetSwipes = storage.getSwipes.bind(storage);
+    let midEditSnapshot: { messageEdited: boolean; swipeEdited: boolean } | null = null;
+    storage.getSwipes = (async (messageId: string) => {
+      if (messageId === "m-tear") {
+        storage.getSwipes = originalGetSwipes;
+        // Escape the ambient transaction context: a flush from inside it
+        // returns without writing, which would prove nothing. setImmediate
+        // callbacks run outside the AsyncLocalStorage transaction scope only
+        // if scheduled from outside — so signal a pre-armed outer waiter.
+        armFlush();
+        await flushWindowDone;
+      }
+      return originalGetSwipes(messageId);
+    }) as typeof storage.getSwipes;
+
+    let armFlush!: () => void;
+    const flushArmed = new Promise<void>((resolve) => {
+      armFlush = resolve;
+    });
+    let finishWindow!: () => void;
+    const flushWindowDone = new Promise<void>((resolve) => {
+      finishWindow = resolve;
+    });
+    const outerFlushDriver = (async () => {
+      await flushArmed;
+      const flushAttempt = db._fileStore.flush();
+      // Give a pre-fix flush ample time to write the torn pair to disk; the
+      // post-fix flush is parked by the store until the transaction commits.
+      await Promise.race([flushAttempt, settle(400)]);
+      midEditSnapshot = {
+        messageEdited: readFileSync(shardPath("messages", "c1"), "utf8").includes("EDITED TEXT"),
+        swipeEdited: readFileSync(shardPath("message_swipes", "c1"), "utf8").includes("EDITED TEXT"),
+      };
+      finishWindow();
+      await flushAttempt;
+    })();
+
+    const edited = await storage.updateMessageContent("m-tear", "EDITED TEXT");
+    storage.getSwipes = originalGetSwipes;
+    await outerFlushDriver;
+    assert.notEqual(midEditSnapshot, null, "the mid-edit flush window was exercised");
+    const snapshot = midEditSnapshot!;
     assert.equal(
-      messageEdited,
-      swipeEdited,
-      `the on-disk pair must be consistent after a mid-edit flush (message edited: ${messageEdited}, swipe edited: ${swipeEdited})`,
+      snapshot.messageEdited && !snapshot.swipeEdited,
+      false,
+      `a mid-edit flush must not persist the edit on the message while the swipe keeps the old text ` +
+        `(message edited: ${snapshot.messageEdited}, swipe edited: ${snapshot.swipeEdited})`,
     );
-    const edited = await edit;
     assert.equal(edited?.content, "EDITED TEXT", "the edit completes normally");
     await db._fileStore.flush();
     assert.equal(


### PR DESCRIPTION
Closes #5599. Closes #5600. The two concurrency findings from the #5592 Phase 2 review, fixed together — same file, same family.

## #5599 — deletes now take the per-message patch queue

`removeMessage` and `removeMessages` were the only per-message mutations not serialized on the per-message patch queue, so a delete landing inside an in-flight edit's await gaps silently dropped the edit into a `404 Message not found`. Both now take the queue. The bulk path gets a new `withPatchQueues` multi-acquire: one shared gate is installed on every affected id's queue **synchronously before any await**, so two concurrent multi-acquires order themselves strictly and a cycle cannot form (each 500-id chunk acquires and releases independently — cross-chunk atomicity was never promised).

## #5600 — the edit's two writes are now one transaction

`updateMessageContent` wrote the messages row and its active-swipe mirror with awaited gaps between them and no transaction, so a crash — or just the 750 ms debounce flush landing in the window — persisted the edit on the message while the swipe kept the pre-edit text. Invisible in the live chat (the UI reads the message row, and swipe switching heals the pair), but the stale text survived into **exports and branched chats**. The messages-row write, memory-chunk invalidation, and swipe-mirror write now run inside one `db.transaction`; the store defers flushes while a transaction is active, so a mid-edit flush produces a consistent pair on disk. The store's transaction is ambient (AsyncLocalStorage), joins nested transactions, and `messages`/`message_swipes` are not durable-on-commit tables — so no extra synchronous disk flush lands on the hot edit path.

## Adversarial verification (two independent reviewers ran before this PR opened)

They confirmed the fixes sound — reentrancy ruled out for every call path, the multi-acquire cycle-free, rollback restoring all three tables with the #5606 load-heal pairing intact — and caught three things that materially improved this PR:

1. **My original #5600 regression block was vacuous** (it passed against the pre-fix code: the poll's macrotask yield drained the whole edit before the flush ran). Rebuilt with deterministic injection at the edit's own internal reads: a flush fired from the outer context in the exact window between the two writes, shard files snapshotted. Verified red pre-fix (the torn pair on disk), green post-fix (the store parks the flush until commit). The edit-vs-delete ordering block got the same treatment.
2. **A latent lock-order hazard, proven by experiment**: this PR establishes "message queue → transaction slot" ordering, so a future `db.transaction` callback that calls a queue-taking message API would deadlock the store (no live path exists today — they checked all 21 transaction call sites). Mitigated the way the repo already handles its metadata-queue ordering: the lock order is now documented on `withPatchQueue`, and it's stated here for reviewers.
3. **A pre-existing store-level gate window** (a plain write racing a transaction's opening can be silently reverted by that transaction's rollback) — not introduced here, filed as #5631.

One reviewer concern analyzed and accepted with a correction: "edits now stall behind long transactions like profile imports." Pre-change, every message *write* already waited out active transactions at the store's writable gate — the stall is not new; what's new is only that short edit-transactions serialize among themselves, which is negligible.

## Validation done

- New regression lane `message-edit-delete-races` — four blocks (queue-hold for single and bulk delete, mid-edit delete injection, mid-edit flush tear), each A/B-verified red against pre-fix code
- Adjacent lanes green: `lazy-chat-units`, `message-sharding` (lazy + eager), `autonomous-check-storage`, `open-issues`
- Server typecheck and prettier clean

## Manually verify

- [ ] Edit a message and immediately delete it from another tab/device — the edit should either apply-then-delete or the delete wins cleanly, never a spurious 404 mid-save
- [ ] Edit a message, then export the chat and branch it — both must carry the edited text
- [ ] Normal editing/swiping feels unchanged (the transaction adds no synchronous flush)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message editing and deletion reliability during concurrent operations.
  * Ensured message edits and swipe content remain synchronized when saved together.
  * Prevented deletions from overriding or invalidating in-progress edits.
  * Preserved consistency during bulk message updates and deletions.

* **Tests**
  * Added regression coverage for message edit/delete race conditions and transactional persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->