### PR TITLE
ci: boot only each shard's server pair and give webkit a fourth shard

### DIFF
--- a/.github/actions/playwright-shard/action.yml
+++ b/.github/actions/playwright-shard/action.yml
@@ -18,6 +18,9 @@ inputs:
   total-shards:
     description: Total shard count
     required: true
+  server-project:
+    description: Which app-server pair the tests talk to (desktop or mobile) — the other pair is not booted (#5637)
+    required: true
 runs:
   using: composite
   steps:
@@ -61,6 +64,8 @@ runs:
       # order, so tests never run concurrently against the shard's servers —
       # the property fullyParallel:false exists to protect.
       shell: bash
+      env:
+        PLAYWRIGHT_ONLY_PROJECT: ${{ inputs.server-project }}
       run: >-
         pnpm exec playwright test -c playwright.config.ts
         --project=${{ inputs.project }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -128,6 +128,7 @@ jobs:
           browser: chromium
           shard: ${{ matrix.shard }}
           total-shards: 3
+          server-project: desktop
 
       - name: Upload failure evidence
         if: failure()
@@ -166,6 +167,7 @@ jobs:
           browser: chromium
           shard: ${{ matrix.shard }}
           total-shards: 3
+          server-project: mobile
 
       - name: Upload failure evidence
         if: failure()
@@ -177,7 +179,9 @@ jobs:
           retention-days: 7
 
   mobile-webkit-shards:
-    name: mobile-webkit ${{ matrix.shard }}/3
+    # Four shards for webkit alone (#5637): WebKit-on-Linux is the slowest
+    # lane, and matrix wall time is the slowest single shard.
+    name: mobile-webkit ${{ matrix.shard }}/4
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: changes
@@ -189,7 +193,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4]
 
     steps:
       - name: Checkout
@@ -203,7 +207,8 @@ jobs:
           project: mobile-webkit
           browser: webkit
           shard: ${{ matrix.shard }}
-          total-shards: 3
+          total-shards: 4
+          server-project: mobile
 
       - name: Upload failure evidence
         if: failure()

--- a/e2e/start-servers.mjs
+++ b/e2e/start-servers.mjs
@@ -108,12 +108,23 @@ async function waitForUrl(url) {
 process.on("SIGINT", () => stopChildren("SIGINT"));
 process.on("SIGTERM", () => stopChildren("SIGTERM"));
 
+// CI shards set PLAYWRIGHT_ONLY_PROJECT to boot just the server pair their
+// Playwright project talks to (#5637) — no test reaches across to the other
+// pair's ports. Unset (local runs) keeps the boot-both behavior.
+const onlyProject = ["desktop", "mobile"].includes(process.env.PLAYWRIGHT_ONLY_PROJECT?.trim())
+  ? process.env.PLAYWRIGHT_ONLY_PROJECT.trim()
+  : null;
+
 try {
   resetPlaywrightData();
   await runPnpm(["--filter", "@marinara-engine/shared", "build:preserve"]);
-  startProject("mobile", mobileClientPort, mobileServerPort);
-  await waitForUrl(`http://127.0.0.1:${mobileClientPort}`);
-  startProject("desktop", desktopClientPort, desktopServerPort);
+  if (onlyProject !== "desktop") {
+    startProject("mobile", mobileClientPort, mobileServerPort);
+    await waitForUrl(`http://127.0.0.1:${mobileClientPort}`);
+  }
+  if (onlyProject !== "mobile") {
+    startProject("desktop", desktopClientPort, desktopServerPort);
+  }
 } catch (error) {
   stopChildren();
   console.error(error instanceof Error ? error.message : error);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -48,7 +48,10 @@ export default defineConfig({
       ? undefined
       : {
           command: "node ./e2e/start-servers.mjs",
-          url: baseURL,
+          // The readiness check must target a server that actually boots:
+          // when a CI shard gates the boot to one project pair (#5637), the
+          // desktop URL would never come up on a mobile-only shard.
+          url: process.env.PLAYWRIGHT_ONLY_PROJECT?.trim() === "mobile" ? mobileBaseURL : baseURL,
           reuseExistingServer: false,
           timeout: 180_000,
           gracefulShutdown: { signal: "SIGTERM", timeout: 10_000 },


### PR DESCRIPTION
Closes #5637. The two approved follow-ups to #5622's sharding; the node_modules/apt-caching idea is deferred per maintainer decision and not included.

## What changed

**1. Each shard boots only the server pair its tests talk to.** `start-servers.mjs` booted both the desktop (5178/7971) and mobile (5179/7972) client/server pairs in every shard, though each Playwright project only ever uses one — verified by grep that no test reaches across to the other pair's ports. CI shards now set `PLAYWRIGHT_ONLY_PROJECT` (plumbed through a new composite-action input), `start-servers.mjs` boots just that pair, and the Playwright `webServer` readiness URL follows the same variable — required, since a mobile-only shard would otherwise wait forever on the desktop URL. Unset keeps the boot-both behavior byte-for-byte, so local runs are untouched. Saves roughly 30–60 s of boot per shard plus runner memory.

**2. Mobile-webkit gets a fourth shard.** The matrix wall time is the slowest single shard, and WebKit-on-Linux is consistently the slowest lane. Its matrix goes to 4 shards (distribution verified: 50/49/49/49) while both chromium lanes stay at 3. Shard-job names change (`mobile-webkit 1/4`, …); the `mobile-webkit` fan-in keeps its exact name for branch protection, unchanged.

Expected result: webkit wall time from ~10 min toward ~7, chromium lanes shave their boot time.

## Validation done

- YAML parse-validated; webkit `--shard=k/4` distribution checked
- Both gating modes exercised locally with real tests: a desktop test under `PLAYWRIGHT_ONLY_PROJECT=desktop` and a mobile-executing test under `=mobile`, both green (the mobile pair's readiness URL switch is what the second one proves)
- Ungated local behavior unchanged (same code path as before when the variable is unset)
- This PR's own CI run exercises all 10 shard jobs with the gating live

## Manually verify (for the human contributor)

- [ ] Compare this PR's `mobile-webkit` wall time against a recent 3-shard run
- [ ] Confirm plain local `pnpm regression:ui` still boots both pairs and passes as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test execution by selecting the appropriate desktop or mobile test server.
  * Increased mobile WebKit test coverage by adding a fourth parallel test shard.
  * Improved readiness checks for mobile test runs.
* **Chores**
  * Updated automated test workflows to support explicit desktop and mobile configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->