### PR TITLE
fix(client): stop DraftNumberInput dropping an edit made during a commit round trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Numeric settings fields no longer silently lose an edit typed while a previous change in the same field was still saving: the echo of the earlier save could overwrite the value mid-typing, and a panel re-rendering at the wrong moment could discard the edit without saving anything. In-progress typing is now protected and a pending edit is committed even when its input is torn down — this covers every numeric field built on the shared draft input (agent run intervals, connection and preset editors, game sheets, and the rest) (#5636).
 - Profile preview uploads now remain available until they are imported, cancelled, or the server stops instead of expiring after 30 minutes and forcing another upload (#5624).
 - Profile imports now upload and scan the selected JSON or ZIP only once, reusing the reviewed server-side preview when import is confirmed; an unsupported or corrupt individual asset is skipped and reported as a warning while the rest of the valid profile continues restoring (#5624).
 - Profile ZIP import and export no longer impose archive, individual-asset, or restored-total byte ceilings, and native character, persona, PNG card, and CharX imports no longer reject otherwise valid image galleries by byte size; paths, media contents, and archive structure remain validated, while profile executable content stays quarantined (#5624).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -13662,12 +13662,37 @@ test("Secret Plot run interval stays editable across repeated commits", async ({
     await expect.poll(readRunInterval).toBe(3);
     await expect(intervalInput).toHaveValue("3");
 
+    // #5636: start the next edit while the previous commit's round trip is
+    // still in flight, and only blur after it has fully landed. The commit's
+    // async echo used to clobber the in-progress draft, so blur silently
+    // re-committed the previous value. Holding the PATCH until the next edit
+    // has begun guarantees the echo lands mid-edit on every runner, instead
+    // of only on ones slow enough to lose the race.
+    let releaseMetadataPatch: (() => void) | undefined;
+    const heldMetadataPatch = new Promise<void>((resolve) => {
+      releaseMetadataPatch = resolve;
+    });
+    await page.route(
+      `**/api/chats/${chat.id}/metadata`,
+      async (route) => {
+        if (route.request().method() !== "PATCH") return route.fallback();
+        await heldMetadataPatch;
+        await route.continue();
+      },
+      { times: 1 },
+    );
+    const metadataPatched = page.waitForResponse(
+      (response) =>
+        response.url().includes(`/api/chats/${chat.id}/metadata`) && response.request().method() === "PATCH",
+    );
     await intervalInput.fill("11");
     await intervalInput.press("Enter");
-    await expect.poll(readRunInterval).toBe(11);
-    await expect(intervalInput).toHaveValue("11");
-
     await intervalInput.fill("0");
+    releaseMetadataPatch!();
+    await metadataPatched;
+    await expect.poll(readRunInterval).toBe(11);
+    // The draft must survive the echo of the 11-commit landing mid-edit.
+    await expect(intervalInput).toHaveValue("0");
     await intervalInput.blur();
     await expect.poll(readRunInterval).toBe(1);
     await expect(intervalInput).toHaveValue("1");

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -13662,36 +13662,55 @@ test("Secret Plot run interval stays editable across repeated commits", async ({
     await expect.poll(readRunInterval).toBe(3);
     await expect(intervalInput).toHaveValue("3");
 
-    // #5636: start the next edit while the previous commit's round trip is
-    // still in flight, and only blur after it has fully landed. The commit's
-    // async echo used to clobber the in-progress draft, so blur silently
-    // re-committed the previous value. Holding the PATCH until the next edit
-    // has begun guarantees the echo lands mid-edit on every runner, instead
-    // of only on ones slow enough to lose the race.
-    let releaseMetadataPatch: (() => void) | undefined;
-    const heldMetadataPatch = new Promise<void>((resolve) => {
-      releaseMetadataPatch = resolve;
+    // #5636: an async echo of a previous commit landing while the next value
+    // is being typed must not clobber the in-progress draft. Merely delaying
+    // the PATCH echo cannot pin this — the optimistic cache update means the
+    // echo carries the number the input already shows, so the resync is
+    // invisible. Instead, forward the commit to the server immediately but
+    // hold its RESPONSE until the next edit has begun, and forge the echoed
+    // interval to a value (12) the client never displayed: the metadata
+    // version guard accepts it (same mutation version), so the unfixed
+    // component resynced the draft to "12" mid-edit and blur then committed
+    // 12 instead of the typed 0. Note this URL only ever receives PATCHes
+    // (api.patch in use-chats.ts is its sole caller), and { times: 1 } is
+    // consumed by ANY matching request regardless of method, so a method
+    // filter here would be a silent-vacuity trap, not a safeguard.
+    let releaseMetadataEcho: (() => void) | undefined;
+    const heldMetadataEcho = new Promise<void>((resolve) => {
+      releaseMetadataEcho = resolve;
     });
     await page.route(
       `**/api/chats/${chat.id}/metadata`,
       async (route) => {
-        if (route.request().method() !== "PATCH") return route.fallback();
-        await heldMetadataPatch;
-        await route.continue();
+        const response = await route.fetch();
+        const body = (await response.json()) as { metadata?: unknown };
+        const metadata =
+          typeof body.metadata === "string"
+            ? (JSON.parse(body.metadata) as Record<string, unknown>)
+            : ((body.metadata ?? {}) as Record<string, unknown>);
+        metadata.narrativeDirectorSecretPlotRunInterval = 12;
+        body.metadata = typeof body.metadata === "string" ? JSON.stringify(metadata) : metadata;
+        await heldMetadataEcho;
+        await route.fulfill({ response, json: body });
       },
       { times: 1 },
     );
-    const metadataPatched = page.waitForResponse(
+    const metadataEchoDelivered = page.waitForResponse(
       (response) =>
-        response.url().includes(`/api/chats/${chat.id}/metadata`) && response.request().method() === "PATCH",
+        response.url().includes(`/api/chats/${chat.id}/metadata`) &&
+        response.request().postDataJSON()?.narrativeDirectorSecretPlotRunInterval === 11,
     );
     await intervalInput.fill("11");
     await intervalInput.press("Enter");
-    await intervalInput.fill("0");
-    releaseMetadataPatch!();
-    await metadataPatched;
+    // route.fetch() has already forwarded the commit, so the server settles
+    // to 11 while the forged echo is still held.
     await expect.poll(readRunInterval).toBe(11);
-    // The draft must survive the echo of the 11-commit landing mid-edit.
+    await intervalInput.fill("0");
+    releaseMetadataEcho!();
+    await metadataEchoDelivered;
+    // Let the client consume the echo and paint before asserting.
+    await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+    // The draft must survive the forged echo landing mid-edit.
     await expect(intervalInput).toHaveValue("0");
     await intervalInput.blur();
     await expect.poll(readRunInterval).toBe(1);

--- a/packages/client/src/components/game/GameCharacterSheet.tsx
+++ b/packages/client/src/components/game/GameCharacterSheet.tsx
@@ -525,7 +525,15 @@ export function GameCharacterSheet({
             ) : (
               onSave && (
                 <button
-                  onClick={() => setIsEditing(true)}
+                  onClick={() => {
+                    // Reseed on entry: the parked draft can hold residue from
+                    // an edit session torn down mid-typing (the number inputs
+                    // flush pending edits on unmount, and their index-captured
+                    // commits land in whatever draft is current by then).
+                    // Editing must always start from the live card.
+                    setDraft(createDraft(card.gameCard));
+                    setIsEditing(true);
+                  }}
                   disabled={isRegenerating}
                   className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-button-bg)] p-0 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--foreground)] disabled:opacity-60 sm:h-auto sm:w-auto sm:min-w-0 sm:gap-1.5 sm:px-3 sm:py-1.5"
                   title={localizeUi("ui.game.gamecharactersheet.editSheet")}

--- a/packages/client/src/components/ui/DraftNumberInput.tsx
+++ b/packages/client/src/components/ui/DraftNumberInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface DraftNumberInputProps {
   value: number;
@@ -32,8 +32,16 @@ export function DraftNumberInput({
   id,
 }: DraftNumberInputProps) {
   const [draft, setDraft] = useState(String(value));
+  const focusedRef = useRef(false);
 
   useEffect(() => {
+    // While the user is editing, the draft belongs to them: a value-prop
+    // update arriving mid-edit is usually the ASYNC ECHO of the previous
+    // commit (mutate → invalidate → refetch), and syncing it here wiped the
+    // in-progress draft so blur re-committed the OLD value — a silently
+    // dropped edit (#5636). External updates still sync any time the field
+    // is not focused.
+    if (focusedRef.current) return;
     setDraft(String(value));
   }, [value]);
 
@@ -70,6 +78,22 @@ export function DraftNumberInput({
     setDraft(String(value));
   };
 
+  const commitRef = useRef(commit);
+  commitRef.current = commit;
+
+  useEffect(() => {
+    return () => {
+      // React fires no blur for a node that unmounts, so an edit in progress
+      // when the surrounding tree is torn down (a parent re-keys or a
+      // condition flips, the drawer closes) was silently dropped (#5636).
+      // Flush it the same way blur would have.
+      if (focusedRef.current) {
+        focusedRef.current = false;
+        commitRef.current();
+      }
+    };
+  }, []);
+
   return (
     <input
       type="text"
@@ -81,6 +105,7 @@ export function DraftNumberInput({
       title={title}
       disabled={disabled}
       onFocus={(e) => {
+        focusedRef.current = true;
         if (selectOnFocus) e.target.select();
       }}
       onChange={(e) => {
@@ -91,7 +116,10 @@ export function DraftNumberInput({
           if (parsed !== null) onCommit(clampValue(parsed));
         }
       }}
-      onBlur={commit}
+      onBlur={() => {
+        focusedRef.current = false;
+        commit();
+      }}
       onKeyDown={(e) => {
         if (e.key === "Enter") {
           e.currentTarget.blur();

--- a/packages/client/src/components/ui/DraftNumberInput.tsx
+++ b/packages/client/src/components/ui/DraftNumberInput.tsx
@@ -90,9 +90,16 @@ export function DraftNumberInput({
     // The browser fires no blur when a focused input becomes disabled, which
     // would leave the editing latch stuck and suppress prop syncs for the
     // rest of the mount. Drop the latch without committing — disabling
-    // mid-edit means the pending draft was not confirmed.
-    if (disabled) focusedRef.current = false;
-  }, [disabled]);
+    // mid-edit means the pending draft was not confirmed — and resync the
+    // abandoned draft, since the value-sync effect already ran (and skipped)
+    // for a value that arrived in this same render. The resync is gated on
+    // the latch: after a blur-commit flips `disabled` via isPending, the
+    // latch is already clear and the just-committed draft must stay visible
+    // rather than flashing back to the not-yet-echoed prop.
+    if (!disabled || !focusedRef.current) return;
+    focusedRef.current = false;
+    setDraft(String(value));
+  }, [disabled, value]);
 
   useEffect(() => {
     return () => {

--- a/packages/client/src/components/ui/DraftNumberInput.tsx
+++ b/packages/client/src/components/ui/DraftNumberInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 interface DraftNumberInputProps {
   value: number;
@@ -79,7 +79,20 @@ export function DraftNumberInput({
   };
 
   const commitRef = useRef(commit);
-  commitRef.current = commit;
+  useLayoutEffect(() => {
+    // Assigned post-commit rather than during render so an abandoned
+    // concurrent render can never leave the ref pointing at a closure whose
+    // state was never current.
+    commitRef.current = commit;
+  });
+
+  useEffect(() => {
+    // The browser fires no blur when a focused input becomes disabled, which
+    // would leave the editing latch stuck and suppress prop syncs for the
+    // rest of the mount. Drop the latch without committing — disabling
+    // mid-edit means the pending draft was not confirmed.
+    if (disabled) focusedRef.current = false;
+  }, [disabled]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
﻿Closes #5636

## Why

#5636: the Secret Plot "Run Interval" field silently dropped an edit — CI caught a run where a value typed right after a previous Enter-commit never reached the server (fill `0`, blur, server stayed at the previous `11` for a full 10-second poll, and **no third PATCH request appeared in the trace at all**). A real user hits the same window by typing a value, pressing Enter, then immediately correcting it and clicking away: the correction vanishes with no error.

The defect is not specific to that field — it lives in the shared `DraftNumberInput` component, which backs ~35 numeric settings fields across the connection editor, preset editor, settings panel, drawer, wizards, and game sheets.

## What was wrong

Two independent mechanisms could discard a typed-but-not-yet-blurred draft:

1. **Prop echo wipes the draft.** The `useEffect([value])` sync re-seeded the draft unconditionally. The async echo of a *previous* commit (mutate → invalidate → refetch) landing mid-edit replaced the in-progress draft with the old value, so blur re-committed the old value.
2. **Unmount drops the edit.** React fires no blur for a node that unmounts. If the surrounding tree is torn down mid-edit (a parent re-keys, a gate condition flips, the drawer closes), the pending draft died with the node — no commit at all. This is the only mechanism consistent with the CI trace showing **no** third PATCH (a draft wipe would still have PATCHed *something* on blur; a focus steal would have fired blur and committed the typed value).

## The fix (both in `DraftNumberInput`)

1. The prop→draft sync now yields while the input is focused (`focusedRef`). External updates still sync any time the field is not focused, and blur still reconciles through `commit()`.
2. A cleanup effect flushes the pending draft on unmount if the input was still focused — the same commit blur would have performed. This also fixes the adjacent case where closing the drawer mid-edit silently dropped the edit.

## Test hardening

The Secret Plot e2e step now forwards the previous commit's PATCH to the server immediately but holds its **response** until the next edit has begun, and forges the echoed interval to a value the client never displayed (`12`) — the metadata version guard accepts it, so the unfixed component resyncs the draft to "12" mid-edit and blur commits 12 instead of the typed 0. (Merely *delaying* the echo cannot pin the bug: the optimistic cache update means the echo carries the number the input already shows, so the resync is invisible.) A/B verified: **red on the pre-fix component** (`Expected: "0", Received: "12"` at the mid-edit assertion) and **green 3/3 with the fix**.

Verification round (second commit): an adversarial review pass over the first commit found and fixed three things — (1) the original held-PATCH test choreography was vacuous *and* could have flaked against the fixed component, hence the forged-echo redesign above; (2) the unmount flush turned `GameCharacterSheet`'s torn-down mid-edit case from a silent drop into a latent misdirected write (index-captured commits landing in a reseeded draft), so the Edit button now reseeds the draft from the live card on entry; (3) two robustness gaps in the new component code (`commitRef` now assigned in a layout effect; the editing latch drops when the input is disabled mid-edit, since the browser fires no blur for that). The same pass exonerated the drawer-internal tree as a remount source, refuted the whole-drawer-remount theory, and confirmed a real *field* remount vector in unguarded chat-cache writers — filed separately as #5641 (this PR's unmount flush absorbs its symptom).

## Validation

- `pnpm check` — passing (full build).
- `desktop-chromium -g "Secret Plot"` — deterministic A/B: red pre-fix, green 3/3 post-fix (`--retries=0`).
- StrictMode double-mount, all three `commitOnValidChange` sites, popover/drawer dismiss paths, and slider-pair concerns were checked against consumer code and verified safe (no spurious or double commits).
- Manually verify in browser: Roleplay chat → Chat Settings → Agents → Narrative Director → type an interval, press Enter, immediately type another value and click away; reopen and confirm the second value survived.
- Manually verify a `commitOnValidChange` field (Settings → the auto-commit numeric fields) still commits while typing and clamps on blur.
- Manually verify a game character sheet: edit a pool value, save, re-enter Edit — values start from the live card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved in-progress number edits when asynchronous updates arrive during editing.
  * Ensured focused edits are committed when leaving a field or navigating away.
  * Refreshed values when reopening edit mode to prevent stale drafts.
  * Improved reliability when making consecutive edits during delayed saves.

* **Tests**
  * Added end-to-end coverage for editing while an earlier save is still processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
