### PR TITLE
fix(client): keep keyboard focus through TTS voice-picker refetches; settle flaky geometry measurements

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -6368,26 +6368,38 @@ test("desktop Tracker scales into either Roleplay gutter without shifting chat",
       );
     });
 
-    const [mainBox, chatColumnAfter, chatScrollAfter, trackerBox] = await Promise.all([
-      main.boundingBox(),
-      chatColumn.boundingBox(),
-      chatScroll.boundingBox(),
-      tracker.boundingBox(),
-    ]);
-    expect(mainBox).not.toBeNull();
-    expect(chatColumnAfter).not.toBeNull();
-    expect(chatScrollAfter).not.toBeNull();
-    expect(trackerBox).not.toBeNull();
-    expect(Math.abs(chatColumnAfter!.x - chatColumnBefore!.x)).toBeLessThanOrEqual(1);
-    expect(Math.abs(chatColumnAfter!.width - chatColumnBefore!.width)).toBeLessThanOrEqual(1);
-    expect(Math.abs(chatScrollAfter!.x - chatScrollBefore!.x)).toBeLessThanOrEqual(1);
-    expect(Math.abs(chatScrollAfter!.width - chatScrollBefore!.width)).toBeLessThanOrEqual(1);
+    // The tracker opens with a width transition that can still be pending
+    // when the animation registry above is queried (a transition scheduled
+    // but not yet started reports no animations), so a one-shot measurement
+    // can catch mid-transition geometry — CI saw the width ~5px short of
+    // final (#5642). Re-measure until the layout is stable.
+    let expectedWidth = 0;
+    let mainBox: { x: number; y: number; width: number; height: number } | null = null;
+    let trackerBox: { x: number; y: number; width: number; height: number } | null = null;
+    await expect(async () => {
+      const [mainBoxNow, chatColumnAfter, chatScrollAfter, trackerBoxNow] = await Promise.all([
+        main.boundingBox(),
+        chatColumn.boundingBox(),
+        chatScroll.boundingBox(),
+        tracker.boundingBox(),
+      ]);
+      expect(mainBoxNow).not.toBeNull();
+      expect(chatColumnAfter).not.toBeNull();
+      expect(chatScrollAfter).not.toBeNull();
+      expect(trackerBoxNow).not.toBeNull();
+      expect(Math.abs(chatColumnAfter!.x - chatColumnBefore!.x)).toBeLessThanOrEqual(1);
+      expect(Math.abs(chatColumnAfter!.width - chatColumnBefore!.width)).toBeLessThanOrEqual(1);
+      expect(Math.abs(chatScrollAfter!.x - chatScrollBefore!.x)).toBeLessThanOrEqual(1);
+      expect(Math.abs(chatScrollAfter!.width - chatScrollBefore!.width)).toBeLessThanOrEqual(1);
 
-    const expectedWidth = Math.max(0, Math.min(420, Math.floor(chatColumnAfter!.x - mainBox!.x - 8)));
-    expect(Math.abs(trackerBox!.width - expectedWidth)).toBeLessThanOrEqual(1);
-    expect(trackerBox!.x).toBeGreaterThanOrEqual(mainBox!.x - 1);
-    expect(trackerBox!.x).toBeLessThanOrEqual(mainBox!.x + 1);
-    expect(trackerBox!.x + trackerBox!.width).toBeLessThanOrEqual(chatColumnAfter!.x - 7);
+      expectedWidth = Math.max(0, Math.min(420, Math.floor(chatColumnAfter!.x - mainBoxNow!.x - 8)));
+      expect(Math.abs(trackerBoxNow!.width - expectedWidth)).toBeLessThanOrEqual(1);
+      expect(trackerBoxNow!.x).toBeGreaterThanOrEqual(mainBoxNow!.x - 1);
+      expect(trackerBoxNow!.x).toBeLessThanOrEqual(mainBoxNow!.x + 1);
+      expect(trackerBoxNow!.x + trackerBoxNow!.width).toBeLessThanOrEqual(chatColumnAfter!.x - 7);
+      mainBox = mainBoxNow;
+      trackerBox = trackerBoxNow;
+    }).toPass({ timeout: 10_000 });
 
     const trackerContent = tracker.locator(".mari-tracker-panel-scroll");
     const expectedScale = expectedWidth === 0 ? 1 : Math.max(0.65, expectedWidth / 420);
@@ -6452,26 +6464,32 @@ test("desktop Tracker scales into either Roleplay gutter without shifting chat",
         element.getAnimations({ subtree: true }).map((animation) => animation.finished.catch(() => undefined)),
       );
     });
-    const [rightChatColumn, rightChatScroll, rightTrackerBox] = await Promise.all([
-      chatColumn.boundingBox(),
-      chatScroll.boundingBox(),
-      rightTracker.boundingBox(),
-    ]);
-    expect(rightChatColumn).not.toBeNull();
-    expect(rightChatScroll).not.toBeNull();
-    expect(rightTrackerBox).not.toBeNull();
-    expect(Math.abs(rightChatColumn!.x - chatColumnBefore!.x)).toBeLessThanOrEqual(1);
-    expect(Math.abs(rightChatColumn!.width - chatColumnBefore!.width)).toBeLessThanOrEqual(1);
-    expect(Math.abs(rightChatScroll!.x - chatScrollBefore!.x)).toBeLessThanOrEqual(1);
-    expect(Math.abs(rightChatScroll!.width - chatScrollBefore!.width)).toBeLessThanOrEqual(1);
+    // Same mid-transition hazard as the left side: re-measure until stable.
+    let expectedRightWidth = 0;
+    let rightTrackerBox: { x: number; y: number; width: number; height: number } | null = null;
+    await expect(async () => {
+      const [rightChatColumn, rightChatScroll, rightTrackerBoxNow] = await Promise.all([
+        chatColumn.boundingBox(),
+        chatScroll.boundingBox(),
+        rightTracker.boundingBox(),
+      ]);
+      expect(rightChatColumn).not.toBeNull();
+      expect(rightChatScroll).not.toBeNull();
+      expect(rightTrackerBoxNow).not.toBeNull();
+      expect(Math.abs(rightChatColumn!.x - chatColumnBefore!.x)).toBeLessThanOrEqual(1);
+      expect(Math.abs(rightChatColumn!.width - chatColumnBefore!.width)).toBeLessThanOrEqual(1);
+      expect(Math.abs(rightChatScroll!.x - chatScrollBefore!.x)).toBeLessThanOrEqual(1);
+      expect(Math.abs(rightChatScroll!.width - chatScrollBefore!.width)).toBeLessThanOrEqual(1);
 
-    const expectedRightWidth = Math.max(
-      0,
-      Math.min(420, Math.floor(mainBox!.x + mainBox!.width - (rightChatColumn!.x + rightChatColumn!.width) - 8)),
-    );
-    expect(Math.abs(rightTrackerBox!.width - expectedRightWidth)).toBeLessThanOrEqual(1);
-    expect(rightTrackerBox!.x).toBeGreaterThanOrEqual(rightChatColumn!.x + rightChatColumn!.width + 7);
-    expect(rightTrackerBox!.x + rightTrackerBox!.width).toBeLessThanOrEqual(mainBox!.x + mainBox!.width + 1);
+      expectedRightWidth = Math.max(
+        0,
+        Math.min(420, Math.floor(mainBox!.x + mainBox!.width - (rightChatColumn!.x + rightChatColumn!.width) - 8)),
+      );
+      expect(Math.abs(rightTrackerBoxNow!.width - expectedRightWidth)).toBeLessThanOrEqual(1);
+      expect(rightTrackerBoxNow!.x).toBeGreaterThanOrEqual(rightChatColumn!.x + rightChatColumn!.width + 7);
+      expect(rightTrackerBoxNow!.x + rightTrackerBoxNow!.width).toBeLessThanOrEqual(mainBox!.x + mainBox!.width + 1);
+      rightTrackerBox = rightTrackerBoxNow;
+    }).toPass({ timeout: 10_000 });
 
     const rightTrackerContent = rightTracker.locator(".mari-tracker-panel-scroll");
     const expectedRightScale = expectedRightWidth === 0 ? 1 : Math.max(0.65, expectedRightWidth / 420);
@@ -9542,11 +9560,20 @@ test("ElevenLabs keeps models visible and exposes scrollable account voices in e
     await expect(characterList).toBeVisible();
     await expect(characterList).toHaveCSS("overflow-y", "scroll");
     await expect(characterList.locator("xpath=../..")).toHaveCSS("position", "fixed");
+    const savesBeforeAssignment = saveCount;
+    const fetchesBeforeAssignment = voiceFetchCount;
     await characterList.getByRole("option", { name: characterName, exact: true }).click();
     await expect(characterPicker).toBeFocused();
     await characterPicker.click();
     await page.keyboard.press("Escape");
     await expect(characterPicker).toBeFocused();
+
+    // Drain the debounced autosave from the assignment edit — and the voices
+    // refetch its invalidation triggers — before opening the voice picker: a
+    // refetch landing mid-open flips the trigger disabled, which force-closes
+    // the panel out from under the measurements below (#5642).
+    await expect.poll(() => saveCount, { timeout: 5_000 }).toBeGreaterThan(savesBeforeAssignment);
+    await expect.poll(() => voiceFetchCount, { timeout: 5_000 }).toBeGreaterThan(fetchesBeforeAssignment);
 
     const characterVoicePicker = ttsCard.getByRole("button", { name: /^Voice for / });
     const characterVoiceTriggerBox = await characterVoicePicker.boundingBox();
@@ -17134,27 +17161,37 @@ test("home browser hub scales cleanly and opens FAQ as a bookmark window", async
     await page.locator('[data-tour="panel-settings"]').click();
     const feed = page.locator('[data-component="HomeBrowserHub.Feed"]');
     await expect(feed).toBeVisible();
-    const widthUsage = await feed.evaluate((element) => {
-      const contentElement = element.closest('[data-component="HomeBrowserHub.Content"]');
-      return contentElement ? element.getBoundingClientRect().width / contentElement.getBoundingClientRect().width : 0;
-    });
-    expect(widthUsage).toBeGreaterThan(0.94);
-    expect(await content.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBeTruthy();
-    const partialWidgetWidths = await Promise.all(
-      ["professor", "whats-new", "learn", "community", "clock", "achievements"].map((id) =>
-        page.locator(`[data-home-widget-id="${id}"]`).evaluate((element) => element.getBoundingClientRect().width),
-      ),
-    );
-    expect(Math.max(...partialWidgetWidths) - Math.min(...partialWidgetWidths)).toBeLessThanOrEqual(2);
-    const partialWidgetHeights = await Promise.all(
-      ["professor", "whats-new", "discovery", "character", "learn", "community", "clock", "achievements"].map((id) =>
-        page.locator(`[data-home-widget-id="${id}"]`).evaluate((element) => element.getBoundingClientRect().height),
-      ),
-    );
-    expect(Math.max(...partialWidgetHeights) - Math.min(...partialWidgetHeights)).toBeLessThanOrEqual(2);
+    // The settings panel just closed, which resizes the hub content and
+    // reflows the widget grid over a few frames — one-shot measurements can
+    // sample different frames of that transition (CI saw a ~77px spread,
+    // #5642). The retried unit below is what rides out the reflow; the
+    // column-count assertion only pins that the grid is in its 4-column
+    // regime at this viewport before geometry is compared.
     await expect(feed).toHaveAttribute("data-home-grid-columns", "4");
+    await expect(async () => {
+      const widthUsage = await feed.evaluate((element) => {
+        const contentElement = element.closest('[data-component="HomeBrowserHub.Content"]');
+        return contentElement
+          ? element.getBoundingClientRect().width / contentElement.getBoundingClientRect().width
+          : 0;
+      });
+      expect(widthUsage).toBeGreaterThan(0.94);
+      expect(await content.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBeTruthy();
+      const partialWidgetWidths = await Promise.all(
+        ["professor", "whats-new", "learn", "community", "clock", "achievements"].map((id) =>
+          page.locator(`[data-home-widget-id="${id}"]`).evaluate((element) => element.getBoundingClientRect().width),
+        ),
+      );
+      expect(Math.max(...partialWidgetWidths) - Math.min(...partialWidgetWidths)).toBeLessThanOrEqual(2);
+      const partialWidgetHeights = await Promise.all(
+        ["professor", "whats-new", "discovery", "character", "learn", "community", "clock", "achievements"].map((id) =>
+          page.locator(`[data-home-widget-id="${id}"]`).evaluate((element) => element.getBoundingClientRect().height),
+        ),
+      );
+      expect(Math.max(...partialWidgetHeights) - Math.min(...partialWidgetHeights)).toBeLessThanOrEqual(2);
+      expect(await content.evaluate((element) => element.scrollHeight <= element.clientHeight + 2)).toBeTruthy();
+    }).toPass({ timeout: 10_000 });
     await expect(feed.locator("[data-home-empty-slot]")).toHaveCount(0);
-    expect(await content.evaluate((element) => element.scrollHeight <= element.clientHeight + 2)).toBeTruthy();
 
     await page.getByRole("tab", { name: "Professor", exact: true }).click();
     await expect(page.locator('[data-component="HomeBrowserHub.Address"]')).toContainText("marinara/professor");

--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -453,17 +453,44 @@ function TtsSearchableSelect({
   const filteredOptions = normalizedSearch
     ? options.filter((option) => option.searchText.toLowerCase().includes(normalizedSearch))
     : options;
-  const closePanel = useCallback((restoreFocus = true) => {
-    setOpen(false);
-    setSearch("");
-    if (restoreFocus) {
-      // Deferred one frame: focusing synchronously races the panel unmount
-      // and any concurrent re-render of the trigger row — the focus call can
-      // land on a node that detaches a beat later, dropping focus to <body>
-      // (#5633). After the frame, the ref points at whatever node survived.
-      requestAnimationFrame(() => triggerRef.current?.focus());
-    }
+  const restoreFrameRef = useRef(0);
+  const restoreFocusToTrigger = useCallback(() => {
+    // Deferred one frame: focusing synchronously races the panel unmount and
+    // any concurrent re-render of the trigger row — the focus call can land
+    // on a node that detaches a beat later, dropping focus to <body> (#5633).
+    // Retried across frames: focus() on a disabled button is a silent no-op,
+    // and the trigger is transiently disabled whenever a voices refetch flips
+    // `fetchingVoices` — a single-frame restore landing in that window
+    // stranded keyboard focus on <body> for good (#5642). Bounded so an
+    // indefinitely disabled trigger cannot leak a perpetual rAF loop.
+    const startedAt = performance.now();
+    cancelAnimationFrame(restoreFrameRef.current);
+    const attempt = () => {
+      const trigger = triggerRef.current;
+      // If focus has legitimately landed somewhere else in the meantime
+      // (the user tabbed on), the restore is stale — never steal from them.
+      const active = document.activeElement;
+      if (active && active !== document.body && active !== trigger && !panelRef.current?.contains(active)) return;
+      if (trigger && !trigger.disabled) {
+        trigger.focus();
+        if (document.activeElement === trigger) return;
+      }
+      if (performance.now() - startedAt > 2000) return;
+      restoreFrameRef.current = requestAnimationFrame(attempt);
+    };
+    restoreFrameRef.current = requestAnimationFrame(attempt);
   }, []);
+
+  useEffect(() => () => cancelAnimationFrame(restoreFrameRef.current), []);
+
+  const closePanel = useCallback(
+    (restoreFocus = true) => {
+      setOpen(false);
+      setSearch("");
+      if (restoreFocus) restoreFocusToTrigger();
+    },
+    [restoreFocusToTrigger],
+  );
 
   useEffect(() => {
     if (!open) return;
@@ -541,10 +568,27 @@ function TtsSearchableSelect({
   }, [compact, open]);
 
   useEffect(() => {
-    if (!disabled) return;
+    if (!disabled || !open) return;
+    // Force-closing because the control became disabled unmounts the panel —
+    // and with it the autofocused search input — so without a restore,
+    // keyboard focus silently falls to <body> (#5642). Only restore when the
+    // user's focus was actually inside this control. Focus already sitting on
+    // <body> counts as inside: with few options no search input renders, so
+    // focus stays on the trigger, and the browser drops it to <body>
+    // synchronously when the trigger's disabled attribute lands — before this
+    // effect can observe it. An outside pointerdown closes the panel through
+    // closePanel(false) before focus could legitimately be elsewhere, and the
+    // restore's own guard aborts if any real element takes focus meanwhile.
+    const active = document.activeElement;
+    const focusWasInside =
+      !active ||
+      active === document.body ||
+      active === triggerRef.current ||
+      panelRef.current?.contains(active) === true;
     setOpen(false);
     setSearch("");
-  }, [disabled]);
+    if (focusWasInside) restoreFocusToTrigger();
+  }, [disabled, open, restoreFocusToTrigger]);
 
   return (
     <div ref={rootRef} className="relative min-w-0 flex-1">


### PR DESCRIPTION
Closes #5642

## Why

Three desktop-chromium tests were failing intermittently on unrelated PRs (evidence in #5642: the same suite content flip-flopping between pass and fail across PR #5640's three matrix runs). One of them turned out to be a real accessibility bug, not test noise.

## The ElevenLabs focus flake is an app bug — fixed in `TTSConfigCard`

The adversarial verification pass traced the full mechanism: every edit in the TTS card schedules a debounced autosave; its `onSuccess` invalidates the voices query; the refetch flips `fetchingVoices`, which disables every voice-picker trigger for a beat. Two ways that strands keyboard focus on `<body>`:

- The searchable-select's disabled effect force-closes an open panel **without restoring focus** — the autofocused search input unmounts and focus silently dies. With few options (no search input), it's worse: the browser drops focus to `<body>` synchronously the moment the focused trigger's `disabled` attribute lands.
- Even the Escape path's focus restore was a single `requestAnimationFrame` — and `focus()` on a disabled button is a **silent no-op**, never retried. A restore landing in the transient disabled window lost focus permanently.

That is exactly CI's `toBeFocused` → `inactive` (full 10s) at `core-flows.e2e.ts:9560`, and why it never reproduces locally (the mocked refetch closes the window in ~ms; 30/30 local baseline was green).

Fix: a bounded retrying restore (`restoreFocusToTrigger`) — retries across frames until the trigger accepts focus, 2s deadline, canceled on unmount, and **aborts the moment focus legitimately lands on any real element** so it can never steal from a user who moved on. The disabled-close path now restores too, when focus was inside the control (body counts, per the synchronous-drop behavior above). This is a real keyboard-user fix: previously any voices refetch while browsing a voice list dumped focus to `<body>`.

The test also gained a drain step: it now waits out the debounced autosave (and its voices refetch) before opening the per-character picker, closing the sibling window where the refetch could force-close the panel mid-measurement.

## The two geometry flakes are measurement races — fixed in the tests

- **Tracker gutter** (`:6387`, width 5.47px short): the `getAnimations({subtree: true})` settle can see an empty registry for a transition that is scheduled but not started, so the one-shot measurement catches mid-transition geometry. The post-toggle measurements are now one retried unit (`expect(...).toPass()`), re-reading all boxes per attempt; the right-side re-anchor block got the same treatment (identical structure, CI just hadn't hit it yet). All assertions still compare against pre-toggle baselines, so a *real* layout regression fails terminally — verified in review that the retry cannot convert a genuine failure into a pass.
- **Home hub widget grid** (`:17148`, ~77px spread): the measurements run right after the settings panel closes, and the six sequential width reads can sample different frames of the resize transition. Now anchored on the 4-column regime and wrapped in a retried unit; the later duplicate width check after the tab round-trip still provides the long-settled comparison.

## Validation

- Local baseline (pre-fix): 30/30 green — these flakes need CI-slow runners, so mechanism-level review was the main line of defense.
- Post-fix: 30/30 green ×2 rounds (`--repeat-each=10`, `--retries=0`); final round includes every review-pass amendment.
- `pnpm check` — passing.
- Adversarial verification workflow (3 reviewers) confirmed the ElevenLabs mechanism end-to-end, verified the retried units cannot mask persistent regressions, and caught one real gap mid-review (a variable-scope error in the first tracker rework, plus the no-search-input focus variant) — both fixed before this PR.
- Manually verify in browser: Settings → Connections → Text to Speech (ElevenLabs source) → open a voice picker, press Escape — focus returns to the picker button; repeat while a voices refresh is in flight.

## Notes

- Found in passing: the e2e specs are never type-checked by any lane (the root tsconfig includes them but nothing runs `tsc` on it) — that's how a scope error survived `pnpm check`. Left as a separate follow-up task rather than folding a large tsconfig effort into this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus restoration when closing the voice selection menu.
  * Automatically closes the voice selection menu when disabled, while preserving focus appropriately.
  * Improved reliability during animated layout changes and delayed data updates.

* **Tests**
  * Expanded end-to-end coverage for layout stability, autosave completion, voice loading, and responsive grid behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->