### PR TITLE
feat(tooling): type-check the Playwright e2e specs in pnpm check

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -85,7 +85,7 @@ async function prepareOnboardingReplay(page: Page) {
 
 async function setAppAccentColor(page: Page, color: string) {
   await page.evaluate(async (nextColor) => {
-    const { useUIStore } = (await import("/src/stores/ui.store.ts")) as {
+    const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
       useUIStore: {
         getState: () => {
           setAppAccentColor: (value: string) => void;
@@ -872,7 +872,7 @@ test("Chat Settings adds a formatted greeting after the setup wizard is skipped"
       document.documentElement.style.setProperty("--marinara-chat-chrome-panel-text", "rgb(12, 34, 56)");
     });
     await page.evaluate(async () => {
-      const { useChatStore } = (await import("/src/stores/chat.store.ts")) as {
+      const { useChatStore } = (await import("/src/stores/chat.store.ts" as string)) as {
         useChatStore: {
           getState: () => {
             setShouldOpenSettings: (open: boolean) => void;
@@ -1332,7 +1332,7 @@ test("Author's Notes keeps its expand and full macro guide inside the field", as
     await expect(macroReference.getByText(negationSyntax, { exact: true })).toBeVisible();
     await expect(macroReference.getByText(/"is not", "not contains", and "not includes"/u)).toBeVisible();
     const macroHelp = await page.evaluate(async () => {
-      const { matchSlashCommand } = (await import("/src/lib/slash-commands.ts")) as {
+      const { matchSlashCommand } = (await import("/src/lib/slash-commands.ts" as string)) as {
         matchSlashCommand: (input: string) => {
           command: { execute: (args: string, context: never) => Promise<{ feedback?: string }> };
         } | null;
@@ -1594,7 +1594,7 @@ test("message deletion uses unified chroma controls and selection states", async
     const messages = (await Promise.all(messageResponses.map((response) => response.json()))) as Array<{
       id: string;
     }>;
-    const targetMessage = messages[1];
+    const targetMessage = messages[1]!;
     const assistantMessageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
       data: { role: "assistant", content: "First assistant swipe." },
     });
@@ -1756,7 +1756,7 @@ test("Conversation transcript dates and message numbers follow Chat Chrome Text 
     await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
     await page.goto("/");
     await page.evaluate(async () => {
-      const { useUIStore } = (await import("/src/stores/ui.store.ts")) as {
+      const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
         useUIStore: { getState: () => { setShowMessageNumbers: (value: boolean) => void } };
       };
       useUIStore.getState().setShowMessageNumbers(true);
@@ -1773,7 +1773,7 @@ test("Conversation transcript dates and message numbers follow Chat Chrome Text 
     const transcriptLabels = page.locator(".mari-conversation-transcript-chrome-text");
     const assertChromeText = async (color: string) => {
       await page.evaluate(async (nextColor) => {
-        const { useUIStore } = (await import("/src/stores/ui.store.ts")) as {
+        const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
           useUIStore: { getState: () => { setChatChromeTextColor: (value: string) => void } };
         };
         useUIStore.getState().setChatChromeTextColor(nextColor);
@@ -1816,7 +1816,7 @@ test("Conversation message actions follow their messages on desktop and mobile",
     await page.goto("/");
     await setAppAccentColor(page, "#ec4899");
     await page.evaluate(async () => {
-      const { useUIStore } = (await import("/src/stores/ui.store.ts")) as {
+      const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
         useUIStore: { getState: () => { setChatChromeTextColor: (value: string) => void } };
       };
       useUIStore.getState().setChatChromeTextColor("#14b8a6");
@@ -1827,7 +1827,7 @@ test("Conversation message actions follow their messages on desktop and mobile",
 
     for (const style of ["classic", "bubble"] as const) {
       await page.evaluate(async (messageStyle) => {
-        const { useUIStore } = (await import("/src/stores/ui.store.ts")) as {
+        const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
           useUIStore: {
             getState: () => { setConversationMessageStyle: (value: "classic" | "bubble") => void };
           };
@@ -2165,7 +2165,7 @@ test("destructive confirmation actions use the shared accent button treatment", 
   });
 
   await page.evaluate(async () => {
-    const { showConfirmDialog } = (await import("/src/lib/app-dialogs.ts")) as {
+    const { showConfirmDialog } = (await import("/src/lib/app-dialogs.ts" as string)) as {
       showConfirmDialog: (options: {
         title: string;
         message: string;
@@ -2189,7 +2189,7 @@ test("destructive confirmation actions use the shared accent button treatment", 
   await confirmDialog.getByRole("button", { name: "Cancel" }).click();
 
   await page.evaluate(async () => {
-    const { showChoiceDialog } = (await import("/src/lib/app-dialogs.ts")) as {
+    const { showChoiceDialog } = (await import("/src/lib/app-dialogs.ts" as string)) as {
       showChoiceDialog: (options: {
         title: string;
         message: string;
@@ -2214,7 +2214,7 @@ test("destructive confirmation actions use the shared accent button treatment", 
 test("modal backdrops ignore drag releases but still close on a fresh outside click", async ({ page }) => {
   await page.goto("/");
   await page.evaluate(async () => {
-    const { showConfirmDialog } = (await import("/src/lib/app-dialogs.ts")) as {
+    const { showConfirmDialog } = (await import("/src/lib/app-dialogs.ts" as string)) as {
       showConfirmDialog: (options: { title: string; message: string; confirmLabel: string }) => Promise<boolean>;
     };
     void showConfirmDialog({
@@ -2266,7 +2266,7 @@ test("connection model fetch errors inherit the configured editor accent", async
     });
     await page.goto("/");
     await page.evaluate(async (accent) => {
-      const { useUIStore } = (await import("/src/stores/ui.store.ts")) as {
+      const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
         useUIStore: {
           getState: () => {
             setAppAccentColor: (color: string) => void;
@@ -2345,7 +2345,7 @@ test("connection test-message errors inherit the configured editor accent", asyn
     });
     await page.goto("/");
     await page.evaluate(async (accent) => {
-      const { useUIStore } = (await import("/src/stores/ui.store.ts")) as {
+      const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
         useUIStore: {
           getState: () => {
             setAppAccentColor: (color: string) => void;
@@ -2532,7 +2532,7 @@ test("NovelAI generation defaults survive save and editor navigation", async ({ 
     await expect
       .poll(() =>
         page.evaluate(async () => {
-          const { useUIStore } = await import("/src/stores/ui.store.ts");
+          const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
           return useUIStore.getState().personaDetailId;
         }),
       )
@@ -2845,7 +2845,7 @@ test("Characters can be dragged from the right panel into the active chat", asyn
   try {
     await page.goto("/");
     await page.evaluate(async (chatId) => {
-      const module = await import("/src/stores/chat.store.ts");
+      const module = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
       module.useChatStore.getState().setActiveChatId(chatId);
     }, chat.id);
     const dropSurface = page.locator("[data-chat-resource-drop-surface]");
@@ -2893,7 +2893,7 @@ test("Character row actions can add a resource to the active chat without draggi
   try {
     await page.goto("/");
     await page.evaluate(async (chatId) => {
-      const module = await import("/src/stores/chat.store.ts");
+      const module = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
       module.useChatStore.getState().setActiveChatId(chatId);
     }, chat.id);
     await expect(page.locator("[data-chat-resource-drop-surface]")).toBeVisible();
@@ -2965,7 +2965,7 @@ test("Dropping a persona confirms before replacing the active chat persona", asy
   try {
     await page.goto("/");
     await page.evaluate(async (chatId) => {
-      const module = await import("/src/stores/chat.store.ts");
+      const module = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
       module.useChatStore.getState().setActiveChatId(chatId);
     }, chat.id);
     await expect(page.locator("[data-chat-resource-drop-surface]")).toBeVisible();
@@ -3029,7 +3029,7 @@ test("Character Chat actions reuse mode selection and seed the chosen setup wiza
 
   const readActiveChatId = () =>
     page.evaluate(async () => {
-      const module = await import("/src/stores/chat.store.ts");
+      const module = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
       return module.useChatStore.getState().activeChatId;
     });
   const readButtonTypography = (button: Locator) =>
@@ -3159,7 +3159,7 @@ test("Character Chat actions reuse mode selection and seed the chosen setup wiza
     expect(copiedNameBox).not.toBeNull();
     expect(copiedTagsBox).not.toBeNull();
     const orderedRowBoxes = [originalRowBox!, copiedRowBox!].sort((left, right) => left.y - right.y);
-    expect(orderedRowBoxes[0].y + orderedRowBoxes[0].height).toBeLessThanOrEqual(orderedRowBoxes[1].y);
+    expect(orderedRowBoxes[0]!.y + orderedRowBoxes[0]!.height).toBeLessThanOrEqual(orderedRowBoxes[1]!.y);
     expect(originalNameBox!.y + originalNameBox!.height).toBeLessThanOrEqual(originalTagsBox!.y);
     expect(copiedNameBox!.y + copiedNameBox!.height).toBeLessThanOrEqual(copiedTagsBox!.y);
     expect(originalTagsBox!.y + originalTagsBox!.height).toBeLessThanOrEqual(
@@ -3486,7 +3486,7 @@ test("Character and Persona avatar actions stay separated and visually balanced"
         }),
       );
       for (let index = 1; index < compactTabBoxes.length; index += 1) {
-        expect(compactTabBoxes[index].left - compactTabBoxes[index - 1].right).toBeGreaterThanOrEqual(-0.5);
+        expect(compactTabBoxes[index]!.left - compactTabBoxes[index - 1]!.right).toBeGreaterThanOrEqual(-0.5);
       }
       await expect(header.evaluate((element) => element.scrollWidth <= element.clientWidth)).resolves.toBe(true);
 
@@ -3511,8 +3511,8 @@ test("Character and Persona avatar actions stay separated and visually balanced"
         expect(navigationBox.width).toBeLessThan(headerBox.width * 0.65);
       }
       for (let index = 1; index < tabBoxes.length; index += 1) {
-        expect(tabBoxes[index].left - tabBoxes[index - 1].right).toBeGreaterThanOrEqual(-0.5);
-        expect(tabBoxes[index].left - tabBoxes[index - 1].right).toBeLessThanOrEqual(5);
+        expect(tabBoxes[index]!.left - tabBoxes[index - 1]!.right).toBeGreaterThanOrEqual(-0.5);
+        expect(tabBoxes[index]!.left - tabBoxes[index - 1]!.right).toBeLessThanOrEqual(5);
       }
       if (firstActionBox) {
         for (const tabBox of tabBoxes) expect(Math.abs(tabBox.height - firstActionBox.height)).toBeLessThanOrEqual(1);
@@ -4188,7 +4188,7 @@ test("expanded character editors keep native keyboard and quote caret behavior",
     await expect(fields.getByRole("button", { name: "AI Write sources", exact: true })).toHaveCount(0);
     await expect(fields.locator("select")).toHaveCount(1);
 
-    await aboutMe.evaluate((textarea) => {
+    await aboutMe.evaluate((textarea: HTMLTextAreaElement) => {
       textarea.focus();
       textarea.setSelectionRange(0, textarea.value.length);
     });
@@ -4201,20 +4201,20 @@ test("expanded character editors keep native keyboard and quote caret behavior",
     const expandedEditor = page.locator('[data-component="ExpandedMacroEditor"] textarea');
     await expect(expandedEditor).toHaveValue("alpha\nbeta");
 
-    await expandedEditor.evaluate((textarea) => {
+    await expandedEditor.evaluate((textarea: HTMLTextAreaElement) => {
       textarea.focus();
       textarea.setSelectionRange(2, 2);
     });
     await page.keyboard.type("X");
     await page.waitForTimeout(40);
-    await expect.poll(() => expandedEditor.evaluate((textarea) => textarea.selectionStart)).toBe(3);
+    await expect.poll(() => expandedEditor.evaluate((textarea: HTMLTextAreaElement) => textarea.selectionStart)).toBe(3);
     await page.keyboard.type("Y");
     await expect(expandedEditor).toHaveValue("alXYpha\nbeta");
     await page.keyboard.press(`${process.platform === "darwin" ? "Meta" : "Control"}+z`);
     await page.keyboard.press(`${process.platform === "darwin" ? "Meta" : "Control"}+z`);
     await expect(expandedEditor).toHaveValue("alpha\nbeta");
 
-    await expandedEditor.evaluate((textarea) => {
+    await expandedEditor.evaluate((textarea: HTMLTextAreaElement) => {
       textarea.focus();
       textarea.setSelectionRange(0, textarea.value.length);
     });
@@ -4223,7 +4223,7 @@ test("expanded character editors keep native keyboard and quote caret behavior",
     await page.keyboard.press(`${process.platform === "darwin" ? "Meta" : "Control"}+z`);
     await expect(expandedEditor).toHaveValue("alpha\nbeta");
 
-    await expandedEditor.evaluate((textarea) => {
+    await expandedEditor.evaluate((textarea: HTMLTextAreaElement) => {
       textarea.focus();
       textarea.setSelectionRange(0, textarea.value.length);
     });
@@ -4251,7 +4251,7 @@ test("expanded character editors keep native keyboard and quote caret behavior",
     ] as const) {
       await quoteEditor.fill("alpha beta");
       await waitForDelayedSelectionRestores();
-      await quoteEditor.evaluate((textarea) => {
+      await quoteEditor.evaluate((textarea: HTMLTextAreaElement) => {
         textarea.focus();
         textarea.setSelectionRange(6, 6);
       });
@@ -4261,7 +4261,7 @@ test("expanded character editors keep native keyboard and quote caret behavior",
       await expect(quoteEditor).toHaveValue(expected);
       await expect
         .poll(() =>
-          quoteEditor.evaluate((textarea) => ({
+          quoteEditor.evaluate((textarea: HTMLTextAreaElement) => ({
             start: textarea.selectionStart,
             end: textarea.selectionEnd,
           })),
@@ -4474,7 +4474,7 @@ test("character schedules export the live draft and import safely", async ({ pag
     await expect(page.getByText("Schedule imported as an unsaved draft.", { exact: true })).toBeVisible();
     await expect(activity).toHaveValue("Imported current format");
     await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
-    await expect.poll(async () => (await storedSchedule()).days.Monday[0]?.activity).toBe("Original research");
+    await expect.poll(async () => (await storedSchedule())!.days.Monday![0]?.activity).toBe("Original research");
 
     dialog = await openScheduleEditor();
     activity = await expandMonday(dialog);
@@ -4494,8 +4494,8 @@ test("character schedules export the live draft and import safely", async ({ pag
     });
     await expect(activity).toHaveValue("Imported legacy format");
     await dialog.getByRole("button", { name: "Save schedule", exact: true }).click();
-    await expect.poll(async () => (await storedSchedule()).days.Monday[0]?.activity).toBe("Imported legacy format");
-    expect((await storedSchedule()).talkativeness).toBe(90);
+    await expect.poll(async () => (await storedSchedule())!.days.Monday![0]?.activity).toBe("Imported legacy format");
+    expect((await storedSchedule())!.talkativeness).toBe(90);
   } finally {
     await Promise.allSettled([
       request.delete(`/api/chats/${chat.id}`),
@@ -5228,8 +5228,8 @@ test("typographic quotes do not pull the Roleplay caret behind later text", asyn
     await waitForDelayedSelectionRestores();
 
     await expect(input).toHaveValue("wasn’t");
-    await expect.poll(() => input.evaluate((element) => element.selectionStart)).toBe(6);
-    await expect.poll(() => input.evaluate((element) => element.selectionEnd)).toBe(6);
+    await expect.poll(() => input.evaluate((element: HTMLTextAreaElement) => element.selectionStart)).toBe(6);
+    await expect.poll(() => input.evaluate((element: HTMLTextAreaElement) => element.selectionEnd)).toBe(6);
 
     await input.fill("");
     await input.focus();
@@ -5237,8 +5237,8 @@ test("typographic quotes do not pull the Roleplay caret behind later text", asyn
     await waitForDelayedSelectionRestores();
 
     await expect(input).toHaveValue("“t");
-    await expect.poll(() => input.evaluate((element) => element.selectionStart)).toBe(2);
-    await expect.poll(() => input.evaluate((element) => element.selectionEnd)).toBe(2);
+    await expect.poll(() => input.evaluate((element: HTMLTextAreaElement) => element.selectionStart)).toBe(2);
+    await expect.poll(() => input.evaluate((element: HTMLTextAreaElement) => element.selectionEnd)).toBe(2);
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`);
   }
@@ -5293,7 +5293,7 @@ test("desktop Roleplay composition keeps ambient work off the input path and gro
       element.style.width = "240px";
       return element.clientHeight;
     });
-    await input.evaluate((element) => {
+    await input.evaluate((element: HTMLTextAreaElement) => {
       const value =
         "A long Roleplay sentence should wrap onto another line without briefly hiding the newly typed text.";
       element.value = value;
@@ -5454,7 +5454,7 @@ test("mobile Roleplay composition avoids draft rewrites and pauses ambient rende
     await page.goto("/");
 
     const input = page.locator("textarea.mari-chat-input-textarea");
-    await input.evaluate((element) => {
+    await input.evaluate((element: HTMLTextAreaElement) => {
       element.value = 'She said "';
       element.dispatchEvent(
         new InputEvent("input", {
@@ -5826,7 +5826,7 @@ test("Roleplay can show streaming reasoning inline and control automatic collaps
     await page.goto("/");
     await setAppAccentColor(page, "#ec4899");
     await page.evaluate(async () => {
-      const { useUIStore } = (await import("/src/stores/ui.store.ts")) as {
+      const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
         useUIStore: { getState: () => { setChatChromeTextColor: (value: string) => void } };
       };
       useUIStore.getState().setChatChromeTextColor("#14b8a6");
@@ -5855,7 +5855,7 @@ test("Roleplay can show streaming reasoning inline and control automatic collaps
     await expect(savedThinkingButton).toHaveCSS("color", chromeTextColor);
     await expect(savedThinking).not.toContainText("Saved inline reasoning.");
     await expect(savedRow.getByRole("button", { name: "View model thoughts" })).toHaveCount(0);
-    const expandedLayoutSamples = await savedThinkingButton.evaluate(async (button) => {
+    const expandedLayoutSamples = await savedThinkingButton.evaluate(async (button: HTMLElement) => {
       const output = button.closest("[data-message-id]")?.querySelector<HTMLElement>(".mari-message-content");
       if (!output) return [];
       button.click();
@@ -7238,7 +7238,7 @@ test("chat toolbar panels close when their trigger is clicked again across modes
 
     const setActiveChat = async (chatId: string) => {
       await page.evaluate(async (nextChatId) => {
-        const module = await import("/src/stores/chat.store.ts");
+        const module = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
         module.useChatStore.getState().setActiveChatId(nextChatId);
       }, chatId);
     };
@@ -7303,7 +7303,7 @@ test("chat Help overlay labels visible controls in every mode", async ({ page, r
 
     const setActiveChat = async (chatId: string) => {
       await page.evaluate(async (nextChatId) => {
-        const module = await import("/src/stores/chat.store.ts");
+        const module = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
         module.useChatStore.getState().setActiveChatId(nextChatId);
       }, chatId);
     };
@@ -7583,7 +7583,7 @@ test("the first conversation opens Help once after setup", async ({ page, reques
     await page.goto("/");
     await expect(page.locator('[data-chat-mode="conversation"]')).toBeVisible();
     await page.evaluate(async () => {
-      const module = await import("/src/stores/ui.store.ts");
+      const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
       module.useUIStore.setState({ chatHelpSeenModes: ["roleplay", "game"] });
     });
     const overlay = page.locator('[data-chat-help-overlay="conversation"]');
@@ -7607,7 +7607,7 @@ test("the first conversation opens Help once after setup", async ({ page, reques
     await expect
       .poll(() =>
         page.evaluate(async () => {
-          const module = await import("/src/stores/ui.store.ts");
+          const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
           return module.useUIStore.getState().chatHelpSeenModes.includes("conversation");
         }),
       )
@@ -8740,7 +8740,7 @@ test("Game widget editing and log deletion follow Chroma while weather effects r
     await page.goto("/");
     await setAppAccentColor(page, "#ec4899");
     await page.evaluate(async () => {
-      const { useUIStore } = (await import("/src/stores/ui.store.ts")) as {
+      const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
         useUIStore: { getState: () => { setChatChromeTextColor: (value: string) => void } };
       };
       useUIStore.getState().setChatChromeTextColor("#14b8a6");
@@ -8781,7 +8781,7 @@ test("Game combat sheet helpers preserve ability types, card matches, and zero H
 
   await page.goto("/");
   const result = await page.evaluate(async () => {
-    const module = (await import("/src/components/game/GameSurface.tsx")) as unknown as {
+    const module = (await import("/src/components/game/GameSurface.tsx" as string)) as unknown as {
       combatSkillsFromSheet(value: unknown): Array<{ name: string; type: string; description?: string }> | undefined;
       findGameCombatCard(cards: Array<{ name?: string }>, targetName: string): { name?: string } | undefined;
       generatedPartyMemberToCombatant(
@@ -9796,7 +9796,7 @@ test("home shell and primary topbar panels open without client errors", async ({
   expect(surfaceLightness(darkAddressSurfaces.addressRow)).toBeLessThan(surfaceLightness(darkAddressSurfaces.chrome));
 
   await page.evaluate(async () => {
-    const module = await import("/src/stores/ui.store.ts");
+    const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
     module.useUIStore.getState().setTheme("light");
   });
   await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
@@ -9810,7 +9810,7 @@ test("home shell and primary topbar panels open without client errors", async ({
   }
   expect(surfaceLightness(lightAddressSurfaces.addressRow)).toBeLessThan(surfaceLightness(lightAddressSurfaces.chrome));
   await page.evaluate(async () => {
-    const module = await import("/src/stores/ui.store.ts");
+    const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
     module.useUIStore.getState().setTheme("dark");
   });
 
@@ -9842,7 +9842,7 @@ test("home shell and primary topbar panels open without client errors", async ({
         })
         .filter((center): center is number => center !== null),
     );
-    const spacings = iconCenters.slice(1).map((center, index) => center - iconCenters[index]);
+    const spacings = iconCenters.slice(1).map((center, index) => center - iconCenters[index]!);
     expect(iconCenters.length).toBeGreaterThan(2);
     expect(Math.max(...spacings) - Math.min(...spacings)).toBeLessThanOrEqual(2);
   }
@@ -10426,7 +10426,7 @@ test("Professor Mari visibly arrives on Home and navigates without AI", async ({
   const chat = (await chatResponse.json()) as { id: string };
   try {
     await page.evaluate(async (chatId) => {
-      const module = await import("/src/stores/chat.store.ts");
+      const module = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
       module.useChatStore.getState().setActiveChatId(chatId);
     }, chat.id);
     await expect(page.locator('[data-component="HomeBrowserHub"]')).toHaveCount(0);
@@ -10461,7 +10461,7 @@ test("Professor Mari opens a named character directly in its editor", async ({ p
     const assistant = page.locator('aside[aria-label="Professor Mari assistant"]');
     await expect(assistant).toBeVisible({ timeout: 6_000 });
     await page.evaluate(async () => {
-      const module = await import("/src/stores/ui.store.ts");
+      const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
       module.useUIStore.getState().setReduceAmbientEffects(true);
     });
     await expect
@@ -10589,7 +10589,7 @@ test("settings search divider stays aligned with editor headers across text scal
 
   await page.goto("/");
   await page.evaluate(async () => {
-    const module = await import("/src/stores/ui.store.ts");
+    const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
     module.useUIStore.getState().openAgentDetail("__new__");
   });
   await expect(page.locator(".mari-editor-header")).toBeVisible();
@@ -10629,7 +10629,7 @@ test("settings search divider stays aligned with editor headers across text scal
 test("custom Agent prompts preview the selected result format", async ({ page }) => {
   await page.goto("/");
   await page.evaluate(async () => {
-    const module = await import("/src/stores/ui.store.ts");
+    const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
     module.useUIStore.getState().openAgentDetail("__new__");
   });
 
@@ -10670,8 +10670,8 @@ test("custom Agent character cards are created only after approval", async ({ pa
     await page.goto("/");
     await page.evaluate(async (characterName) => {
       const [{ useAgentStore }, { useUIStore }] = await Promise.all([
-        import("/src/stores/agent.store.ts"),
-        import("/src/stores/ui.store.ts"),
+        import("/src/stores/agent.store.ts" as string) as Promise<PageAgentStoreModule>,
+        import("/src/stores/ui.store.ts" as string) as Promise<PageUiStoreModule>,
       ]);
       useAgentStore.getState().enqueuePendingAgentWriteApproval({
         id: `card-create-${Date.now()}`,
@@ -10800,7 +10800,7 @@ test("Storyboard Agent settings stay organized and contained at phone widths", a
   try {
     await page.goto("/");
     await page.evaluate(async () => {
-      const module = await import("/src/stores/ui.store.ts");
+      const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
       module.useUIStore.getState().openAgentDetail("storyboard");
     });
 
@@ -11096,7 +11096,7 @@ test("UI language selection loads locale files and persists across reloads", asy
   await expect
     .poll(() =>
       page.evaluate(async () => {
-        const { translate } = (await import("/src/localization/i18n.ts")) as {
+        const { translate } = (await import("/src/localization/i18n.ts" as string)) as {
           translate: (key: string, options?: Record<string, unknown>) => string;
         };
         return {
@@ -11134,7 +11134,7 @@ test("UI language selection loads locale files and persists across reloads", asy
   await expect
     .poll(() =>
       page.evaluate(async () => {
-        const { translate } = (await import("/src/localization/i18n.ts")) as {
+        const { translate } = (await import("/src/localization/i18n.ts" as string)) as {
           translate: (key: string, options?: Record<string, unknown>) => string;
         };
         return {
@@ -11235,7 +11235,7 @@ test("Character and Persona panels launch card downloads and their local librari
   });
   await page.goto("/");
   await page.evaluate(async () => {
-    const module = await import("/src/stores/ui.store.ts");
+    const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
     module.useUIStore.getState().setSidebarOpen(true);
   });
 
@@ -11453,7 +11453,7 @@ test("Downloaded cards use Marinara destination and lorebook choices", async ({ 
     leakedProperty: "",
   });
   const normalizedLink = await page.evaluate(async () => {
-    const { sanitizeChatHtml } = (await import("/src/lib/chat-html.ts")) as {
+    const { sanitizeChatHtml } = (await import("/src/lib/chat-html.ts" as string)) as {
       sanitizeChatHtml: (html: string) => string;
     };
     const host = document.createElement("div");
@@ -12145,7 +12145,7 @@ test("Music Player stays unavailable until Music DJ is installed", async ({ page
   };
   await page.goto("/");
   await page.evaluate(async () => {
-    const { useUIStore } = await import("/src/stores/ui.store.ts");
+    const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
     useUIStore.getState().setMusicPlayerSource("spotify");
   });
   const musicPlayer = page.locator('[data-component^="SpotifyMiniPlayer."]');
@@ -13366,7 +13366,7 @@ test("Roleplay Chat Summaries persists semantic retrieval without overflowing it
     panel = await openSummary();
     await expect(panel.getByRole("checkbox", { name: "Semantic retrieval", exact: true })).toBeChecked();
     await page.evaluate(async () => {
-      const module = await import("/src/stores/ui.store.ts");
+      const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
       module.useUIStore.getState().setTheme("light");
     });
     await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
@@ -14803,7 +14803,7 @@ test("Professor Mari follows an open conversation across chats and mobile naviga
     }
 
     await page.evaluate(async (chatId) => {
-      const { useChatStore } = await import("/src/stores/chat.store.ts");
+      const { useChatStore } = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
       useChatStore.getState().setActiveChatId(chatId);
     }, chat.id);
 
@@ -14867,8 +14867,8 @@ test("Professor Mari suggestions stay visible after chat history loads", async (
     await page.goto("/");
     await page.evaluate(async () => {
       const [{ useAgentStore }, { useUIStore }] = await Promise.all([
-        import("/src/stores/agent.store.ts"),
-        import("/src/stores/ui.store.ts"),
+        import("/src/stores/agent.store.ts" as string) as Promise<PageAgentStoreModule>,
+        import("/src/stores/ui.store.ts" as string) as Promise<PageUiStoreModule>,
       ]);
       useAgentStore.getState().clearMariChips();
       useAgentStore.getState().clearMariPlan();
@@ -14963,7 +14963,7 @@ test("Professor Mari shows the latest context budget when token usage is enabled
 
     await page.goto("/");
     await page.evaluate(async () => {
-      const { useUIStore } = (await import("/src/stores/ui.store.ts")) as {
+      const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
         useUIStore: {
           getState: () => {
             setChatChromeTextColor: (value: string) => void;
@@ -16249,10 +16249,10 @@ test("Settings profile import reuses its preview upload and skips one invalid as
     await expect(status).toContainText("Profile import complete with warnings");
     await expect(status).toContainText("game-assets/sprites/.native");
     await expect.poll(() => importRequests.length).toBe(2);
-    expect(importRequests[0].bodyBytes).toBeGreaterThan(0);
-    expect(importRequests[0].previewToken).toBeUndefined();
-    expect(importRequests[1].bodyBytes).toBe(0);
-    expect(importRequests[1].previewToken).toBeTruthy();
+    expect(importRequests[0]!.bodyBytes).toBeGreaterThan(0);
+    expect(importRequests[0]!.previewToken).toBeUndefined();
+    expect(importRequests[1]!.bodyBytes).toBe(0);
+    expect(importRequests[1]!.previewToken).toBeTruthy();
 
     const restoredAsset = await page.request.get(`/api/game-assets/file/sprites/${validAssetName}`);
     expect(restoredAsset.ok()).toBeTruthy();
@@ -16384,7 +16384,7 @@ test("Home Community and clock widgets are useful, timezone-aware, and optional"
 
   const timeZone = "America/Los_Angeles";
   await page.evaluate(async (nextTimeZone) => {
-    const module = await import("/src/stores/ui.store.ts");
+    const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
     module.useUIStore.getState().setConversationTimeZone(nextTimeZone);
   }, timeZone);
   const clock = page.locator('[data-component="HomeClockCalendar"]');
@@ -16582,6 +16582,9 @@ test("enabling Recent Chats anchors its 2 by 2 footprint and repacks smaller wid
   } else {
     await expect(page.locator('[data-component="HomeBrowserHub.Feed"]')).toHaveAttribute("data-home-grid-columns", "4");
     const [firstRowLeft, firstRowRight, secondRowLeft, secondRowRight] = smallBounds;
+    if (!firstRowLeft || !firstRowRight || !secondRowLeft || !secondRowRight) {
+      throw new Error(`expected four small-widget bounds, got ${smallBounds.length}`);
+    }
     expect(recentBounds!.x + recentBounds!.width).toBeLessThanOrEqual(firstRowLeft.x + 1);
     expect(Math.abs(recentBounds!.y - firstRowLeft.y)).toBeLessThanOrEqual(2);
     expect(Math.abs(firstRowLeft.y - firstRowRight.y)).toBeLessThanOrEqual(2);
@@ -16681,7 +16684,7 @@ test("Home achievements preview the latest unlock and nearest measurable goal", 
   );
   await page.goto("/");
   await page.evaluate(async () => {
-    const module = await import("/src/stores/ui.store.ts");
+    const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
     module.useUIStore.getState().setHasCompletedOnboarding(true);
     module.useUIStore.getState().setProfessorMariNavigationEnabled(false);
   });
@@ -17116,7 +17119,7 @@ test("home browser hub scales cleanly and opens FAQ as a bookmark window", async
 
     await page.setViewportSize({ width: 2560, height: 1440 });
     await page.evaluate(async () => {
-      const module = await import("/src/stores/ui.store.ts");
+      const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
       module.useUIStore.getState().setProfessorMariNavigationEnabled(false);
     });
     await expect(page.locator('aside[aria-label="Professor Mari assistant"]')).toBeHidden();
@@ -17125,7 +17128,7 @@ test("home browser hub scales cleanly and opens FAQ as a bookmark window", async
     await page.waitForTimeout(1_300);
     await expect(page.locator('aside[aria-label="Professor Mari assistant"]')).toBeHidden();
     await page.evaluate(async () => {
-      const module = await import("/src/stores/ui.store.ts");
+      const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
       module.useUIStore.getState().setReduceAmbientEffects(true);
       module.useUIStore.getState().setProfessorMariNavigationEnabled(true);
     });
@@ -17134,7 +17137,7 @@ test("home browser hub scales cleanly and opens FAQ as a bookmark window", async
     await expect(restoredAssistant.locator(".mari-home-professor-popup__idle-stage--active")).toBeVisible();
     await expect(restoredAssistant.locator(".mari-home-professor-popup__arrival-frame")).toHaveCSS("opacity", "0");
     await page.evaluate(async () => {
-      const module = await import("/src/stores/ui.store.ts");
+      const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
       module.useUIStore.getState().setReduceAmbientEffects(false);
     });
     await page.locator('[data-tour="panel-settings"]').click();
@@ -17261,7 +17264,7 @@ test("Professor Mari navigation can be repositioned within Home on desktop", asy
   await page.goto("/");
   await expect(page.getByRole("heading", { name: "What shall we cook tonight?" })).toBeVisible({ timeout: 30_000 });
   await page.evaluate(async () => {
-    const module = await import("/src/stores/ui.store.ts");
+    const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
     module.useUIStore.getState().setHasCompletedOnboarding(true);
     module.useUIStore.getState().setProfessorMariNavigationEnabled(true);
   });
@@ -17428,12 +17431,12 @@ test("Professor Mari navigation can be repositioned within Home on desktop", asy
   expect(Math.abs(restoredPosition!.y - droppedPosition!.y)).toBeLessThanOrEqual(8);
 
   await page.evaluate(async () => {
-    const module = await import("/src/stores/ui.store.ts");
+    const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
     module.useUIStore.getState().setProfessorMariNavigationEnabled(false);
   });
   await expect(sprite).toBeHidden();
   await page.evaluate(async () => {
-    const module = await import("/src/stores/ui.store.ts");
+    const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
     module.useUIStore.getState().setProfessorMariNavigationEnabled(true);
   });
   await expect(sprite).toBeVisible({ timeout: 1_000 });
@@ -17655,12 +17658,12 @@ test("Home lifecycle stays bounded across repeated tab and chat navigation", asy
     const cycleHomeMount = async (count: number) => {
       for (let index = 0; index < count; index += 1) {
         await page.evaluate(async (chatId) => {
-          const module = await import("/src/stores/chat.store.ts");
+          const module = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
           module.useChatStore.getState().setActiveChatId(chatId);
         }, auditChat.id);
         await expect(page.locator('[data-component="HomeBrowserHub.HomePage"]')).toHaveCount(0);
         await page.evaluate(async () => {
-          const module = await import("/src/stores/chat.store.ts");
+          const module = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
           module.useChatStore.getState().setActiveChatId(null);
         });
         await expect(page.locator('[data-component="HomeBrowserHub.HomePage"]')).toBeVisible();
@@ -17878,7 +17881,7 @@ test("new-chat connection gates follow Chat Chrome Text Color and close before o
 
   await page.goto("/");
   await page.evaluate(async () => {
-    const { useUIStore } = (await import("/src/stores/ui.store.ts")) as {
+    const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
       useUIStore: {
         getState: () => {
           setAppAccentColor: (value: string) => void;
@@ -18966,7 +18969,7 @@ test("mobile topbar remains reachable while sidebars switch", async ({ page }, t
   );
   await page.goto("/");
   await page.evaluate(async () => {
-    const { DEFAULT_MOBILE_MUSIC_WIDGET_POSITION, useUIStore } = await import("/src/stores/ui.store.ts");
+    const { DEFAULT_MOBILE_MUSIC_WIDGET_POSITION, useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
     const state = useUIStore.getState();
     state.setMusicPlayerSource("spotify");
     state.setSpotifyMobileWidgetCollapsed(true);
@@ -19026,7 +19029,7 @@ test("mobile topbar remains reachable while sidebars switch", async ({ page }, t
     initialMusicDjBounds!.y + initialMusicDjBounds!.height > bookmarksBounds!.y;
   expect(musicDjOverlapsBookmarks).toBe(false);
   const initialMusicDjPosition = await page.evaluate(async () => {
-    const { useUIStore } = await import("/src/stores/ui.store.ts");
+    const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
     return useUIStore.getState().spotifyMobileWidgetPosition;
   });
   await musicDjWidget.dispatchEvent("pointerdown", {
@@ -19050,7 +19053,7 @@ test("mobile topbar remains reachable while sidebars switch", async ({ page }, t
   await expect
     .poll(() =>
       page.evaluate(async () => {
-        const { useUIStore } = await import("/src/stores/ui.store.ts");
+        const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
         return useUIStore.getState().spotifyMobileWidgetPosition.x;
       }),
     )
@@ -20099,7 +20102,7 @@ test("background prompt review preserves edits through rerenders and resumes the
     await promptEditor.fill(editedPrompt);
 
     await page.evaluate(async (chatId) => {
-      const { useAgentStore } = (await import("/src/stores/agent.store.ts")) as {
+      const { useAgentStore } = (await import("/src/stores/agent.store.ts" as string)) as {
         useAgentStore: {
           getState: () => {
             setProcessing: (processing: boolean, activeChatId?: string | null) => void;

--- a/e2e/page-context-modules.d.ts
+++ b/e2e/page-context-modules.d.ts
@@ -1,0 +1,38 @@
+// Typing for BROWSER-context dynamic imports used inside page.evaluate
+// callbacks (e.g. `await import("/src/stores/ui.store.ts")`). tsc cannot
+// resolve these dev-server URLs — and, because rooted specifiers are
+// classified as relative, ambient `declare module` blocks can never match
+// them either. The working pattern, applied at every call site:
+//
+//   const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
+//
+// `as string` widens the specifier so tsc skips resolution (it is erased at
+// transpile time — the browser receives the literal unchanged), and the cast
+// types the result via the aliases below, which type-query the REAL client
+// sources so drift surfaces as a type error instead of at runtime.
+//
+// This file is a global script (no top-level import/export), so the aliases
+// are visible in every spec without importing. When a type-query would drag
+// too much of the client program into this project (React component trees,
+// vite-specific typing), keep the call site's own structural cast instead —
+// the GameSurface.tsx import in core-flows.e2e.ts is the example.
+
+// Minimal vite ImportMeta surface for the client sources type-queried below
+// (locale-loader uses import.meta.env / import.meta.glob). The client's own
+// build types these via "vite/client", which is not resolvable from the root
+// project; this merge declares only what those sources touch.
+interface ImportMeta {
+  readonly env?: Record<string, string | boolean | undefined>;
+  glob<T = unknown>(
+    pattern: string,
+    options?: { import?: string; query?: string; eager?: boolean },
+  ): Record<string, () => Promise<T>>;
+}
+
+type PageUiStoreModule = typeof import("../packages/client/src/stores/ui.store");
+type PageChatStoreModule = typeof import("../packages/client/src/stores/chat.store");
+type PageAgentStoreModule = typeof import("../packages/client/src/stores/agent.store");
+type PageAppDialogsModule = typeof import("../packages/client/src/lib/app-dialogs");
+type PageI18nModule = typeof import("../packages/client/src/localization/i18n");
+type PageChatHtmlModule = typeof import("../packages/client/src/lib/chat-html");
+type PageSlashCommandsModule = typeof import("../packages/client/src/lib/slash-commands");

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:shared": "pnpm --filter @marinara-engine/shared build",
     "build:server": "pnpm --filter @marinara-engine/server build",
     "build:client": "pnpm build:shared && pnpm --filter @marinara-engine/client build",
-    "check": "pnpm clean:stale-client && pnpm impeccable:check && pnpm localization:check && pnpm format:check && pnpm lint && pnpm build",
+    "check": "pnpm clean:stale-client && pnpm impeccable:check && pnpm localization:check && pnpm format:check && pnpm lint && pnpm check:e2e-types && pnpm build",
     "start": "node packages/server/dist/index.js",
     "mari": "node scripts/run-mari.mjs",
     "format": "prettier --write \"packages/**/*.{ts,tsx}\"",
@@ -31,6 +31,7 @@
     "localization:check": "node ./scripts/check-locales.mjs && pnpm localization:ui-check",
     "localization:ui-check": "node ./scripts/migrate-static-jsx-localization.mjs --check --notices packages/client/src",
     "lint": "pnpm -r run lint",
+    "check:e2e-types": "tsc --noEmit -p tsconfig.json",
     "regression": "pnpm regression:node",
     "regression:node": "pnpm build:shared && node ./scripts/run-regressions.mjs",
     "regression:ui": "playwright test -c playwright.config.ts",
@@ -64,7 +65,8 @@
     "@types/node": "^24.12.2",
     "adm-zip": "^0.6.0",
     "esbuild": "^0.28.1",
-    "prettier": "^3.8.3"
+    "prettier": "^3.8.3",
+    "typescript": "^5.9.3"
   },
   "pnpm": {
     "overrides": {

--- a/packages/client/src/lib/slash-commands.ts
+++ b/packages/client/src/lib/slash-commands.ts
@@ -302,7 +302,7 @@ function parseImpersonatePromptArg(args: string): string {
   let prompt = args.trim();
   if (!prompt) return "";
 
-  const quote = prompt[0];
+  const quote = prompt[0] ?? "";
   const closeQuote = quote === "\u201c" ? "\u201d" : quote === "\u2018" ? "\u2019" : quote;
   if (quote === '"' || quote === "'" || quote === "\u201c" || quote === "\u2018") {
     prompt = prompt.slice(1);

--- a/packages/client/src/localization/locale-loader.ts
+++ b/packages/client/src/localization/locale-loader.ts
@@ -34,8 +34,8 @@ function canonicalizeLocale(value: string): string | null {
 }
 
 function localeFromModulePath(path: string): string | null {
-  const match = /\/([^/]+)\.json$/u.exec(path);
-  return match ? canonicalizeLocale(match[1]) : null;
+  const captured = /\/([^/]+)\.json$/u.exec(path)?.[1];
+  return captured ? canonicalizeLocale(captured) : null;
 }
 
 for (const [path, loader] of Object.entries(localeAssets)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   packages/client:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,26 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "types": ["node"],
     "typeRoots": ["./node_modules/@types", "./packages/server/node_modules/@types"],
     "noEmit": true,
     "declaration": false,
     "declarationMap": false,
     "noUnusedLocals": false,
-    "noUnusedParameters": false
+    "noUnusedParameters": false,
+    // The page-context aliases in e2e/page-context-modules.d.ts type-query
+    // real client/shared sources so the specs type-check against the actual
+    // app APIs; these mappings let those sources resolve their own imports
+    // without building anything first (lib is ES2023 to match the client
+    // project those sources normally compile under). Note: Playwright's own
+    // transpiler also honors these paths when it resolves NODE-side imports
+    // in spec files, so keep them pointing at import-compatible sources —
+    // today only a type-only import uses a mapped specifier.
+    "paths": {
+      "@marinara-engine/shared": ["./packages/shared/src/index.ts"],
+      "@/*": ["./packages/client/src/*"]
+    }
   },
   "include": ["e2e/**/*.ts", "playwright.config.ts"]
 }


### PR DESCRIPTION
## Why

The root tsconfig has always included `e2e/**/*.ts`, but no check lane ever ran tsc on it — `pnpm check` runs only the three package lints. That let a plain runtime `ReferenceError` (a variable moved into a closure while still referenced outside it) pass `pnpm check` untouched and only surface when the test executed, during the #5642 work. This PR makes the specs type-checkable and wires the check into `pnpm check`, so that class of bug dies in CI.

Note: there is no linked issue for this — it came out of a follow-up task spun off from the #5642 investigation.

## The interesting part: typing browser-context imports

The specs import app modules *inside `page.evaluate` callbacks* through dev-server URLs (`import("/src/stores/ui.store.ts")`). tsc cannot resolve those — and because rooted (`/`-prefixed) specifiers are classified as **relative**, ambient `declare module` blocks can never match them either (tried first; silently ignored). The working pattern, applied at all 58 call sites:

```ts
const module = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
```

`as string` widens the specifier so tsc skips resolution — it's erased at transpile, so the browser receives the literal unchanged (the repo already had TS casts inside evaluate callbacks passing CI, proving Playwright transpiles the callbacks before serializing them). The `Page*Module` aliases live in a new global `e2e/page-context-modules.d.ts` and **type-query the real client sources**, so the specs type-check against the actual app APIs and drift surfaces as a type error instead of at runtime. The one `.tsx` page import (GameSurface) keeps its existing structural cast rather than dragging the component tree into the program.

## What the lane immediately caught

~50 genuine strictness misses, all fixed: wrong element types on `evaluate` callbacks (textarea/input selection APIs on `HTMLElement | SVGElement`), unchecked indexed access across measurement arrays, and a missing four-bounds guard in the home-hub layout assertions (now a real assertion with a useful message). The `storedSchedule()` chains use `!` rather than `?.` deliberately, preserving the exact throw-on-missing poll semantics of the untyped code (`expect.poll` fails immediately on a throw but soft-times-out on `undefined`).

Two client sources that the type queries pull into the root program were hardened one line each (`slash-commands.ts`, `locale-loader.ts`) for `noUncheckedIndexedAccess`, which the root project enables and the client project doesn't. A minimal `ImportMeta` interface merge covers the vite-specific `import.meta.env/glob` those sources use.

## Wiring

- `check:e2e-types` = `tsc --noEmit -p tsconfig.json`, with `typescript@^5.9.3` (matching the workspaces) as a root devDependency.
- Runs inside `pnpm check` between lint and build — verified build-independent (`--traceResolution` shows every `@marinara-engine/shared` import resolving to `packages/shared/src`, never `dist`), so it works on a fresh clone before anything is built.
- The existing pull-request-checks workflow picks it up with **zero CI changes**; the lane adds ~3s.
- Root `lib` bumped ES2022 → ES2023 to match the client project the type-queried sources normally compile under.

## Validation

- `check:e2e-types` exit 0; full `pnpm check` green.
- A/B: reintroducing the motivating bug class (an out-of-scope variable reference) fails the lane with TS2304.
- 11-test runtime sanity pass across every edit class — including the Korean-localization and GameSurface-combat tests as canaries for non-ASCII string literals — all green, `--retries=0`.
- 3-reviewer adversarial pass verified: all 58 conversion sites well-formed, every retained structural cast checked against the real module exports, the vite `/src` ↔ `packages/client/src` correspondence exact, no behavior change in any "type-only" edit, and lockfile drift limited to the one devDependency. The same pass caught an encoding corruption in an intermediate version of this branch (PowerShell mojibake across the spec's non-ASCII literals) — the final commit was rebuilt byte-exactly via Node and the canary tests above prove it.
- Manually verify: run `pnpm check` on a fresh checkout of this branch; optionally re-add a bogus `void someUndeclaredName;` line to `e2e/core-flows.e2e.ts` and confirm `pnpm check:e2e-types` rejects it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when parsing empty slash-command arguments.
  - Preserved locale detection behavior across supported and unsupported paths.
  - Added clearer validation errors when widget layout bounds are missing.

- **Tests**
  - Strengthened end-to-end coverage for selections, undo, imports, state, and widget layouts.
  - Added type checking for browser-context test modules and editor textareas.

- **Chores**
  - Integrated end-to-end type checking into the standard validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->