### PR TITLE
fix(storage): close the transaction opening gate atomically

### DIFF
--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -2156,6 +2156,12 @@ class FileTableStore {
   private readonly txContext = new AsyncLocalStorage<FileTransactionContext>();
   private transactionQueue: Promise<void> = Promise.resolve();
   private activeTransactionCount = 0;
+  // Transactions that have taken their queue slot but not yet incremented
+  // activeTransactionCount (they are awaiting the previous transaction or an
+  // in-flight flush). The plain-write gate honors this too (#5631): a write
+  // passing the gate in that window could apply after the transaction's
+  // first-mutation snapshot and be silently erased by a rollback.
+  private pendingTransactionCount = 0;
   private transactionIdleWaiters = new Set<() => void>();
   private pendingTransactionFlush = false;
   private quarantinedTables: QuarantinedStorageTable[] = [];
@@ -2713,8 +2719,19 @@ class FileTableStore {
     this.transactionQueue = new Promise<void>((resolve) => {
       releaseTransaction = resolve;
     });
-    await previousTransaction;
-    if (this.activeFlush) await this.activeFlush;
+    // Close the plain-write gate atomically with queue admission (#5631):
+    // without the pending count, a write could pass waitForWritableTurn
+    // during the awaits below (activeTransactionCount still 0), apply after
+    // this transaction's first-mutation snapshot, and vanish on rollback.
+    this.pendingTransactionCount++;
+    try {
+      await previousTransaction;
+      if (this.activeFlush) await this.activeFlush;
+    } catch (err) {
+      this.pendingTransactionCount--;
+      releaseTransaction();
+      throw err;
+    }
 
     const ctx: FileTransactionContext = {
       snapshots: new Map<string, Row[]>(),
@@ -2729,7 +2746,10 @@ class FileTableStore {
     // Deep copy — a shallow one would let in-transaction writes mutate the
     // snapshot's Sets and corrupt the rollback state (#4708).
     const dirtyShardsSnapshot = new Map([...this.dirtyShards].map(([table, keys]) => [table, new Set(keys)]));
+    // Handoff is synchronous, so the combined gate count never dips to zero
+    // between reservation and activation.
     this.activeTransactionCount++;
+    this.pendingTransactionCount--;
 
     try {
       const result = await this.txContext.run(ctx, () => fn(tx));
@@ -2819,8 +2839,18 @@ class FileTableStore {
 
   private async waitForWritableTurn(): Promise<void> {
     this.assertWritable();
-    if (this.activeTransactionCount > 0 && !this.txContext.getStore()) {
-      await this.waitForTransactions();
+    if (this.txContext.getStore()) return;
+    // Loop: a wake at activeTransactionCount === 0 can still land inside
+    // another transaction's reservation window (#5631), so re-check both
+    // counters after every wait. The idle waiters only fire on active-count
+    // transitions, so the pending-only case waits on the transaction queue
+    // instead (resolved when the queued transaction fully finishes).
+    while (this.activeTransactionCount > 0 || this.pendingTransactionCount > 0) {
+      if (this.activeTransactionCount > 0) {
+        await this.waitForTransactions();
+      } else {
+        await this.transactionQueue;
+      }
     }
   }
 

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -2724,32 +2724,36 @@ class FileTableStore {
     // during the awaits below (activeTransactionCount still 0), apply after
     // this transaction's first-mutation snapshot, and vanish on rollback.
     this.pendingTransactionCount++;
+    let ctx!: FileTransactionContext;
+    let dirtySnapshot!: boolean;
+    let dirtyTablesSnapshot!: Set<string>;
+    let dirtyShardsSnapshot!: Map<string, Set<string>>;
     try {
       await previousTransaction;
       if (this.activeFlush) await this.activeFlush;
+      ctx = {
+        snapshots: new Map<string, Row[]>(),
+        dirtyTables: new Set<string>(),
+        dirtyShards: new Map<string, Set<string>>(),
+        loadHealDirtyShards: new Map<string, Set<string>>(),
+        loadHealDirtyTables: new Set<string>(),
+        flushed: false,
+      };
+      dirtySnapshot = this.dirty;
+      dirtyTablesSnapshot = new Set(this.dirtyTables);
+      // Deep copy — a shallow one would let in-transaction writes mutate the
+      // snapshot's Sets and corrupt the rollback state (#4708).
+      dirtyShardsSnapshot = new Map([...this.dirtyShards].map(([table, keys]) => [table, new Set(keys)]));
+      // Handoff is synchronous, so the combined gate count never dips to zero
+      // between reservation and activation. Nothing after the increment can
+      // throw inside this try, so the reservation can never leak.
+      this.activeTransactionCount++;
+      this.pendingTransactionCount--;
     } catch (err) {
       this.pendingTransactionCount--;
       releaseTransaction();
       throw err;
     }
-
-    const ctx: FileTransactionContext = {
-      snapshots: new Map<string, Row[]>(),
-      dirtyTables: new Set<string>(),
-      dirtyShards: new Map<string, Set<string>>(),
-      loadHealDirtyShards: new Map<string, Set<string>>(),
-      loadHealDirtyTables: new Set<string>(),
-      flushed: false,
-    };
-    const dirtySnapshot = this.dirty;
-    const dirtyTablesSnapshot = new Set(this.dirtyTables);
-    // Deep copy — a shallow one would let in-transaction writes mutate the
-    // snapshot's Sets and corrupt the rollback state (#4708).
-    const dirtyShardsSnapshot = new Map([...this.dirtyShards].map(([table, keys]) => [table, new Set(keys)]));
-    // Handoff is synchronous, so the combined gate count never dips to zero
-    // between reservation and activation.
-    this.activeTransactionCount++;
-    this.pendingTransactionCount--;
 
     try {
       const result = await this.txContext.run(ctx, () => fn(tx));

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -231,6 +231,14 @@ export type FileNativeStoreTestHooks = {
   beforeTableWrite?: (table: string, serializedRows: string) => Promise<void> | void;
   writerLeaseScopeId?: string;
   writerLeaseBootId?: string;
+  /**
+   * Regression seam (#5631): runs after a plain (non-transaction) write has
+   * cleared the write gate, before its mutation applies. Lets a regression
+   * place the apply at a chosen point relative to a transaction's lifecycle
+   * — the one-tick scheduling freedom the gate race exposed, made
+   * deterministic. Never invoked for transaction-context writes.
+   */
+  afterWritableTurn?: () => Promise<void> | void;
 };
 
 type SelectFromBuilder<TProjection extends Projection | undefined> = {
@@ -2856,6 +2864,7 @@ class FileTableStore {
         await this.transactionQueue;
       }
     }
+    await this.testHooks?.afterWritableTurn?.();
   }
 
   private assertWritable() {

--- a/scripts/regressions/tx-gate-window.regression.ts
+++ b/scripts/regressions/tx-gate-window.regression.ts
@@ -1,0 +1,149 @@
+// #5631: a transaction's opening gate must close atomically.
+//   transaction() takes its queue slot, then AWAITS the previous transaction
+//   and any in-flight flush before incrementing activeTransactionCount. A
+//   plain write that passed waitForWritableTurn inside that window (count
+//   still 0) could apply AFTER the transaction's first-mutation table
+//   snapshot — and a rollback then restored the snapshot, silently erasing
+//   the write its caller had already seen succeed. Worse, when the write
+//   targeted a lazily-loaded unit, the load's rows were erased too while the
+//   unit stayed marked loaded, making persisted rows invisible in memory.
+//
+//   Pinned here by staging the exact interleaving: transaction A occupies the
+//   queue so transaction B parks in its opening awaits; a plain insert into a
+//   NON-resident unit fires while B is parked (its unit load is the async gap
+//   between gate and apply); B mutates the same table, then throws. With the
+//   pending-count gate the insert waits out B entirely; without it, the
+//   insert and the loaded unit vanish on B's rollback.
+//
+// Project imports are DYNAMIC, after the env assignments (see the gallery
+// suites for why).
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (process.env.MARINARA_EAGER_STORAGE === "1" || process.env.MARINARA_EAGER_STORAGE === "true") {
+  // The staged interleaving relies on the lazy unit load as the async gap
+  // between the write gate and the row apply.
+  console.log("Transaction gate-window regression skipped: MARINARA_EAGER_STORAGE is set.");
+  process.exit(0);
+}
+
+const dataDir = mkdtempSync(join(tmpdir(), "marinara-tx-gate-window-"));
+const storeDir = join(dataDir, "storage");
+process.env.DATA_DIR = dataDir;
+process.env.FILE_STORAGE_DIR = storeDir;
+
+const { createFileNativeDB, encodeShardKey } = await import("../../packages/server/src/db/file-backed-store.js");
+const { createChatsStorage } = await import("../../packages/server/src/services/storage/chats.storage.js");
+const { eq } = await import("../../packages/server/src/db/file-query.js");
+const { messages } = await import("../../packages/server/src/db/schema/index.js");
+
+const chatRow = (id: string) => ({ id, name: id, mode: "conversation" });
+const messageRow = (id: string, chatId: string, content: string) => ({
+  id,
+  chatId,
+  role: "assistant",
+  content,
+  activeSwipeIndex: 0,
+  createdAt: `2026-08-28T10:00:00.000Z`,
+});
+
+const shardPath = (table: string, key: string) => join(storeDir, "tables", table, `${encodeShardKey(key)}.json`);
+const writeShard = (table: string, key: string, rows: unknown[]) => {
+  mkdirSync(join(storeDir, "tables", table), { recursive: true });
+  writeFileSync(shardPath(table, key), JSON.stringify(rows));
+};
+
+// c1 stays NON-resident (never touched before the race); c2 is warmed below.
+writeShard("chats", "c1", [chatRow("c1")]);
+writeShard("messages", "c1", [messageRow("m1", "c1", "persisted before the race")]);
+writeShard("chats", "c2", [chatRow("c2")]);
+writeShard("messages", "c2", [messageRow("m2", "c2", "pre-transaction text")]);
+
+const db = await createFileNativeDB();
+const storage = createChatsStorage(db);
+const settle = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+try {
+  // Warm c2 only: B's in-transaction mutation must be synchronous (resident
+  // unit) so its first-mutation snapshot lands before the raced insert can.
+  await storage.getMessage("m2");
+
+  let releaseA!: () => void;
+  const aGate = new Promise<void>((resolve) => {
+    releaseA = resolve;
+  });
+  let releaseB!: () => void;
+  const bGate = new Promise<void>((resolve) => {
+    releaseB = resolve;
+  });
+
+  // A occupies the transaction queue so B parks in its opening awaits.
+  const txA = db.transaction(async () => {
+    await aGate;
+  });
+  await settle(30);
+
+  const forced = new Error("forced rollback (#5631)");
+  const txB = db
+    .transaction(async () => {
+      await db.update(messages).set({ content: "uncommitted tx edit" }).where(eq(messages.id, "m2"));
+      await bGate;
+      throw forced;
+    })
+    .catch((error: unknown) => error);
+  await settle(30);
+
+  // The raced plain write: insert into the non-resident c1 unit. Pre-fix its
+  // gate check passes the moment A finishes (B not yet counted), and the unit
+  // load defers the apply until after B's snapshot.
+  let insertSettled = false;
+  const pInsert = (async () => {
+    await db.insert(messages).values(messageRow("p-new", "c1", "raced insert"));
+  })();
+  void pInsert.then(() => {
+    insertSettled = true;
+  });
+  await settle(30);
+
+  // A finishes: its finally wakes the gate waiters BEFORE releasing the
+  // queue, so the raced insert's continuation runs ahead of B's.
+  releaseA();
+  await txA;
+
+  // Give the interleaving time to develop, then let B throw. Pre-fix the
+  // insert has applied mid-transaction (the race completes in milliseconds);
+  // post-fix it is parked at the gate, so the timer path releases B.
+  await Promise.race([pInsert, settle(300)]);
+  const insertAppliedDuringTransaction = insertSettled;
+  releaseB();
+
+  const txBResult = await txB;
+  assert.equal(txBResult, forced, "transaction B rejects with its forced error");
+  await pInsert;
+
+  assert.equal(
+    insertAppliedDuringTransaction,
+    false,
+    "a plain write racing the transaction's opening gate must wait for the transaction instead of applying inside it",
+  );
+
+  const raced = await storage.getMessage("p-new");
+  assert.equal(raced?.content, "raced insert", "the raced insert survives the rollback");
+
+  const persisted = await storage.getMessage("m1");
+  assert.equal(
+    persisted?.content,
+    "persisted before the race",
+    "the lazily-loaded unit's persisted rows survive the rollback (marked-loaded rows must not be erased)",
+  );
+
+  const rolledBack = await storage.getMessage("m2");
+  assert.equal(rolledBack?.content, "pre-transaction text", "the transaction's own mutation rolled back");
+} finally {
+  await db._fileStore.close();
+  rmSync(dataDir, { recursive: true, force: true });
+}
+
+console.log("Transaction gate-window regression passed.");

--- a/scripts/regressions/tx-gate-window.regression.ts
+++ b/scripts/regressions/tx-gate-window.regression.ts
@@ -65,14 +65,6 @@ writeShard("messages", "c1", [messageRow("m1", "c1", "persisted before the race"
 writeShard("chats", "c2", [chatRow("c2")]);
 writeShard("messages", "c2", [messageRow("m2", "c2", "pre-transaction text")]);
 
-const db = await createFileNativeDB();
-const storage = createChatsStorage(db);
-const settle = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const fileStore = (db as any)._fileStore;
-const originalGate = fileStore.waitForWritableTurn;
-
 let releaseA!: () => void;
 const aGate = new Promise<void>((resolve) => {
   releaseA = resolve;
@@ -86,17 +78,21 @@ const applyPause = new Promise<void>((resolve) => {
   releaseApplyPause = resolve;
 });
 let applyPauseArmed = false;
+let applyPauseTaken = false;
 
 // The injected pause between gate-pass and apply — the scheduling freedom the
-// one-tick hazard window exposes, made deterministic. Transaction-context
-// calls (exempt from the gate by design) never take it.
-fileStore.waitForWritableTurn = async function patchedGate(this: unknown) {
-  await originalGate.call(fileStore);
-  if (applyPauseArmed && !fileStore.txContext.getStore()) {
+// one-tick hazard window exposes, made deterministic. The hook only fires for
+// plain writes; transaction-context writes never reach it.
+const db = await createFileNativeDB({
+  afterWritableTurn: async () => {
+    if (!applyPauseArmed) return;
     applyPauseArmed = false;
+    applyPauseTaken = true;
     await applyPause;
-  }
-};
+  },
+});
+const storage = createChatsStorage(db);
+const settle = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 let insertError: unknown = null;
 try {
@@ -175,13 +171,16 @@ try {
 
   const rolledBack = await storage.getMessage("m2");
   assert.equal(rolledBack?.content, "pre-transaction text", "the transaction's own mutation rolled back");
+
+  // Anti-vacuity: the staged pause must actually have engaged, or the pin
+  // proved nothing about the apply's placement.
+  assert.equal(applyPauseTaken, true, "the raced insert took the staged gate-to-apply pause");
 } finally {
   // Never leave a gate parked: an assertion mid-block must not wedge the
   // store's close (which waits out the transaction queue) or the runner.
   releaseA();
   releaseB();
   releaseApplyPause();
-  fileStore.waitForWritableTurn = originalGate;
   await db._fileStore.close();
   rmSync(dataDir, { recursive: true, force: true });
 }

--- a/scripts/regressions/tx-gate-window.regression.ts
+++ b/scripts/regressions/tx-gate-window.regression.ts
@@ -8,12 +8,17 @@
 //   targeted a lazily-loaded unit, the load's rows were erased too while the
 //   unit stayed marked loaded, making persisted rows invisible in memory.
 //
-//   Pinned here by staging the exact interleaving: transaction A occupies the
-//   queue so transaction B parks in its opening awaits; a plain insert into a
-//   NON-resident unit fires while B is parked (its unit load is the async gap
-//   between gate and apply); B mutates the same table, then throws. With the
-//   pending-count gate the insert waits out B entirely; without it, the
-//   insert and the loaded unit vanish on B's rollback.
+//   The write's post-gate body is fully synchronous (lazy unit loads read
+//   shard files synchronously), so the real-world hazard is the scheduler
+//   placing the gate-resume microtask after the transaction's snapshot — a
+//   one-tick window no natural staging hits reliably. Pinned here with the
+//   hook technique: waitForWritableTurn is wrapped so the ONE raced insert
+//   (never transaction-context calls) takes a test-held pause between
+//   gate-pass and apply. The unfixed gate passes while the transaction is
+//   still in its opening awaits, so the paused apply lands after the
+//   snapshot and vanishes on rollback; the fixed gate parks INSIDE the real
+//   wait until the transaction fully finishes, so the pause is moot and the
+//   write survives.
 //
 // Project imports are DYNAMIC, after the env assignments (see the gallery
 // suites for why).
@@ -23,8 +28,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 if (process.env.MARINARA_EAGER_STORAGE === "1" || process.env.MARINARA_EAGER_STORAGE === "true") {
-  // The staged interleaving relies on the lazy unit load as the async gap
-  // between the write gate and the row apply.
+  // The lazy-unit erasure half of the pin has no meaning under eager storage.
   console.log("Transaction gate-window regression skipped: MARINARA_EAGER_STORAGE is set.");
   process.exit(0);
 }
@@ -65,21 +69,43 @@ const db = await createFileNativeDB();
 const storage = createChatsStorage(db);
 const settle = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const fileStore = (db as any)._fileStore;
+const originalGate = fileStore.waitForWritableTurn;
+
+let releaseA!: () => void;
+const aGate = new Promise<void>((resolve) => {
+  releaseA = resolve;
+});
+let releaseB!: () => void;
+const bGate = new Promise<void>((resolve) => {
+  releaseB = resolve;
+});
+let releaseApplyPause!: () => void;
+const applyPause = new Promise<void>((resolve) => {
+  releaseApplyPause = resolve;
+});
+let applyPauseArmed = false;
+
+// The injected pause between gate-pass and apply — the scheduling freedom the
+// one-tick hazard window exposes, made deterministic. Transaction-context
+// calls (exempt from the gate by design) never take it.
+fileStore.waitForWritableTurn = async function patchedGate(this: unknown) {
+  await originalGate.call(fileStore);
+  if (applyPauseArmed && !fileStore.txContext.getStore()) {
+    applyPauseArmed = false;
+    await applyPause;
+  }
+};
+
+let insertError: unknown = null;
 try {
   // Warm c2 only: B's in-transaction mutation must be synchronous (resident
-  // unit) so its first-mutation snapshot lands before the raced insert can.
+  // unit) so its first-mutation snapshot lands before the paused apply.
   await storage.getMessage("m2");
 
-  let releaseA!: () => void;
-  const aGate = new Promise<void>((resolve) => {
-    releaseA = resolve;
-  });
-  let releaseB!: () => void;
-  const bGate = new Promise<void>((resolve) => {
-    releaseB = resolve;
-  });
-
-  // A occupies the transaction queue so B parks in its opening awaits.
+  // A occupies the transaction queue so B parks in its opening awaits — the
+  // exact reservation window under test.
   const txA = db.transaction(async () => {
     await aGate;
   });
@@ -95,33 +121,41 @@ try {
     .catch((error: unknown) => error);
   await settle(30);
 
-  // The raced plain write: insert into the non-resident c1 unit. Pre-fix its
-  // gate check passes the moment A finishes (B not yet counted), and the unit
-  // load defers the apply until after B's snapshot.
+  // The raced plain write, fired while B sits in its opening awaits. The
+  // unfixed gate sees only A (active) and returns the moment A finishes; the
+  // fixed gate also sees B's reservation and parks until B fully finishes.
+  applyPauseArmed = true;
   let insertSettled = false;
   const pInsert = (async () => {
     await db.insert(messages).values(messageRow("p-new", "c1", "raced insert"));
   })();
-  void pInsert.then(() => {
-    insertSettled = true;
-  });
+  void pInsert.then(
+    () => {
+      insertSettled = true;
+    },
+    (error: unknown) => {
+      insertError = error;
+    },
+  );
   await settle(30);
 
-  // A finishes: its finally wakes the gate waiters BEFORE releasing the
-  // queue, so the raced insert's continuation runs ahead of B's.
   releaseA();
   await txA;
+  // Let B activate and take its first-mutation snapshot.
+  await settle(60);
 
-  // Give the interleaving time to develop, then let B throw. Pre-fix the
-  // insert has applied mid-transaction (the race completes in milliseconds);
-  // post-fix it is parked at the gate, so the timer path releases B.
-  await Promise.race([pInsert, settle(300)]);
+  // Release the paused apply. Pre-fix it lands here — after B's snapshot,
+  // inside the open transaction. Post-fix the insert is still parked inside
+  // the real gate, so this release is consumed only after B finishes.
+  releaseApplyPause();
+  await settle(60);
   const insertAppliedDuringTransaction = insertSettled;
-  releaseB();
 
+  releaseB();
   const txBResult = await txB;
   assert.equal(txBResult, forced, "transaction B rejects with its forced error");
   await pInsert;
+  assert.equal(insertError, null, "the raced insert itself never errors");
 
   assert.equal(
     insertAppliedDuringTransaction,
@@ -142,6 +176,12 @@ try {
   const rolledBack = await storage.getMessage("m2");
   assert.equal(rolledBack?.content, "pre-transaction text", "the transaction's own mutation rolled back");
 } finally {
+  // Never leave a gate parked: an assertion mid-block must not wedge the
+  // store's close (which waits out the transaction queue) or the runner.
+  releaseA();
+  releaseB();
+  releaseApplyPause();
+  fileStore.waitForWritableTurn = originalGate;
   await db._fileStore.close();
   rmSync(dataDir, { recursive: true, force: true });
 }


### PR DESCRIPTION
Closes #5631

## Why

The file store's transaction rollback could silently revert a concurrent plain write. `transaction()` took its queue slot, then *awaited* the previous transaction and any in-flight flush before incrementing `activeTransactionCount` — and `waitForWritableTurn` honored only the active count. A plain write passing the gate inside that window could apply **after** the transaction took its first-mutation table snapshot; a rollback then restored the snapshot and the write vanished from memory with no error surfaced to its caller.

The nastier variant, which the regression pins explicitly: when the raced write targets a lazily-loaded chat unit, the rollback erases the freshly *loaded* rows too, while the unit stays marked loaded — rows that are safely on disk become invisible in memory for the rest of the session.

Found by the #5599/#5600 adversarial verification pass; it predates those fixes, but message edits now run in a transaction, so the window has more traffic near it.

## The fix

A `pendingTransactionCount`, incremented **synchronously with queue admission**, closes the gate atomically:

- `waitForWritableTurn` loops over both counters: while a transaction is *active* it waits on the idle waiters as before; in a *pending-only* window it waits on the transaction queue (the idle waiters only fire on active-count transitions, which a pending-only window never produces), re-checking after every wake.
- The pending→active handoff is synchronous, so the combined count never dips to zero mid-reservation; the whole reservation-to-activation span sits in one try whose catch releases the count and the queue slot — which incidentally fixes a pre-existing theoretical hang (pre-fix, a rejecting in-flight-flush await left the queue slot taken forever).
- Deliberately untouched: flush parking still waits only on *active* transactions, and the eviction guard is unchanged (eviction during a pending window is equivalent to eviction before the transaction was called). No new lock-ordering edge: the pending count is part of tx-slot acquisition, covered by the documented message-queue → tx-slot invariant exactly as before.

## The regression, and how it earned its determinism

The write path is **fully synchronous after its gate** (lazy unit loads read shard files synchronously), so the real-world hazard is a one-tick scheduler placement no natural staging hits reliably — the first two drafts of this pin were provably vacuous, caught in review and by instrumented runs (the second draft paused a method on the `_fileStore` facade that the store never calls). The store now exposes `afterWritableTurn` in its existing test-hooks surface (the `beforeTableWrite` seam family): it runs after a plain write clears the gate and before its mutation applies, never for transaction-context writes. The regression arms it for the one raced insert and **asserts the pause actually engaged**, so the pin cannot silently go vacuous again.

A/B against "pre-fix store + seam only", two runs: with all assertions on it fails at the gate-ordering assert; with the ordering assert neutralized it fails at **"the raced insert survives the rollback"** — the silent erasure itself, observed. With the fix: green, including the seam-engagement assert.

## Verification

- 3-reviewer adversarial pass (deadlock/livelock audit, secondary count-consumer semantics, regression determinism). Verdicts: no deadlock cycle (every release path covered, flush I/O never takes the gate); the two behavioral costs are bounded and deliberate (theoretical writer starvation only under sustained overlapping transaction storms this codebase doesn't produce; plain writes now absorb flush latency when a transaction queues mid-flush); the reservation-leak and vacuous-pin findings were fixed in follow-up commits.
- The same pass surfaced two **pre-existing** store defects, verified unchanged by this fix and filed separately per the atomic-PR discipline: #5651 (rollback erases rows lazily loaded by a concurrent *read*, unit stays marked loaded) and #5652 (check-once `activeFlush` await lets a second flush run concurrently with a transaction and persist uncommitted rows).
- Full node regression suite: 164/165 locally — the sole failure is `launcher/format-guard.regression.mjs`, which dies with `node: command not found` from a spawned POSIX shell: a PATH problem in this Windows box's environment, unrelated (the guard doesn't import the store and is untouched here). CI's `complete-node-regressions` lane runs it on ubuntu.
- `pnpm check` green.
- Manual verification is not practical for a microtask-window race; the staged regression is the verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction handling to prevent plain writes from racing with transactions.
  * Ensured writes wait appropriately during transaction activity and remain intact after transaction rollbacks.
  * Preserved access to lazily loaded persisted data during concurrent database operations.

* **Tests**
  * Added regression coverage for transaction timing, concurrent writes, rollback behavior, and lazy-loaded data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->