### PR TITLE
feat(server): detect host freezes and surface the Termux wake-lock outcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- The server now detects when the host operating system suspended it (the Android/Termux background freeze that shows as an endless "Opening chat…" until Termux is foregrounded) and logs the suspension length on thaw, so session logs carry positive proof of a freeze instead of nothing (#5655).
+- The Termux launcher reports its Android wake-lock outcome to the server, and both the health endpoint and Copy Support Diagnostics now include the wake-lock status and the most recent detected freeze; a failed or unavailable wake lock is announced with a prominent launcher warning that names the fix (`pkg install termux-tools`, battery set to Unrestricted) (#5656).
+
 - File-native storage format advances to version 6, pairing `STORAGE_VERSION` and `storage-format.json` so the launcher downgrade guard correctly rejects rollbacks to builds that do not understand the new sharded layout and writer-lease ownership model.
 - Chat connection switchers can now show the latest measured context usage in their popup and around the connection button, with Game usage available under Chat Settings > Connection. The display is enabled by default and can be controlled in Advanced settings (#5577).
 - Character card sprites can now be renamed after upload without replacing the image (#5575).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
-- The server now detects when the host operating system suspended it (the Android/Termux background freeze that shows as an endless "Opening chat…" until Termux is foregrounded) and logs the suspension length on thaw, so session logs carry positive proof of a freeze instead of nothing (#5655).
+- The server now notices when it stopped running for a stretch — consistent with the host suspending it (the Android/Termux background freeze that shows as an endless "Opening chat…" until Termux is foregrounded, or a laptop sleeping) or with a severe internal stall — and logs the estimated length on thaw, so session logs carry positive evidence instead of nothing (#5655).
 - The Termux launcher reports its Android wake-lock outcome to the server, and both the health endpoint and Copy Support Diagnostics now include the wake-lock status and the most recent detected freeze; a failed or unavailable wake lock is announced with a prominent launcher warning that names the fix (`pkg install termux-tools`, battery set to Unrestricted) (#5656).
 
 - File-native storage format advances to version 6, pairing `STORAGE_VERSION` and `storage-format.json` so the launcher downgrade guard correctly rejects rollbacks to builds that do not understand the new sharded layout and writer-lease ownership model.

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -7706,7 +7706,9 @@ function AdvancedSettings() {
   const activeConnection = activeChat?.connectionId
     ? (connections.find((connection) => connection.id === activeChat.connectionId) ?? null)
     : (connections.find((connection) => connection.isDefault) ?? null);
-  const supportDiagnosticsPending = isConnectionsLoading || (!!activeChatId && isActiveChatLoading);
+  // Health is included so a copy taken before the query settles cannot label
+  // pending wake-lock/freeze telemetry as genuinely absent (#5656 review).
+  const supportDiagnosticsPending = isConnectionsLoading || (!!activeChatId && isActiveChatLoading) || health.isPending;
 
   const handleCopySupportDiagnostics = useCallback(async () => {
     const copied = await copyToClipboard(

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -7695,6 +7695,8 @@ function AdvancedSettings() {
       heapLimitMiB: number;
       rssMiB: number;
     };
+    wakeLock?: string | null;
+    lastFreeze?: { detectedAt: string; gapMs: number; suspendedMs: number } | null;
   }>({
     queryKey: ["health"],
     queryFn: () => api.get("/health"),
@@ -7714,6 +7716,8 @@ function AdvancedSettings() {
         commit: health.data?.commit ?? null,
         serverOs: health.data?.serverOs ?? "Unavailable",
         serverMemory: health.data?.memory,
+        wakeLock: health.data?.wakeLock ?? null,
+        lastFreeze: health.data?.lastFreeze ?? null,
         clientOs: resolveClientOs(navigator.userAgent, navigator.platform, navigator.maxTouchPoints),
         browser: navigator.userAgent,
         gpu: detectBrowserGpu(),

--- a/packages/client/src/lib/support-diagnostics.ts
+++ b/packages/client/src/lib/support-diagnostics.ts
@@ -14,6 +14,10 @@ export interface SupportDiagnostics {
   connectionName: string | null;
   connectionProvider: string | null;
   model: string | null;
+  /** Launcher-reported Android wake-lock outcome; null when not reported. */
+  wakeLock?: string | null;
+  /** Most recent host suspension the server's freeze detector observed. */
+  lastFreeze?: { detectedAt: string; gapMs: number; suspendedMs: number } | null;
 }
 
 export function resolveClientOs(userAgent: string, platform: string, maxTouchPoints = 0): string {
@@ -54,6 +58,7 @@ function available(value: string | null | undefined): string {
 
 export function formatSupportDiagnostics(diagnostics: SupportDiagnostics): string {
   const memory = diagnostics.serverMemory;
+  const freeze = diagnostics.lastFreeze;
   return [
     "Marinara Engine diagnostics",
     `Version: ${available(diagnostics.version)}`,
@@ -61,6 +66,8 @@ export function formatSupportDiagnostics(diagnostics: SupportDiagnostics): strin
     `Commit: ${available(diagnostics.commit)}`,
     `Server OS: ${available(diagnostics.serverOs)}`,
     `Server memory: ${memory ? `heap ${memory.heapUsedMiB} / ${memory.heapLimitMiB} MiB; RSS ${memory.rssMiB} MiB` : "Unavailable"}`,
+    `Background wake lock: ${diagnostics.wakeLock ?? "not reported"}`,
+    `Last detected freeze: ${freeze ? `~${Math.round(freeze.suspendedMs / 1000)}s suspension, thawed at ${freeze.detectedAt}` : "none detected"}`,
     `Client OS: ${available(diagnostics.clientOs)}`,
     `Browser / app shell: ${available(diagnostics.browser)}`,
     `GPU: ${available(diagnostics.gpu)}`,

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -54,6 +54,7 @@ import { androidLocalAuthHook, androidLocalLoginRoute } from "./middleware/andro
 import { arch, platform, release } from "node:os";
 import { execFileSync } from "node:child_process";
 import { getRuntimeMemorySnapshot } from "./utils/runtime-memory.js";
+import { getLastFreeze } from "./lib/freeze-detector.js";
 
 const isLite = process.env.MARINARA_LITE === "true" || process.env.MARINARA_LITE === "1";
 const MAX_UPLOAD_BYTES = 256 * 1024 * 1024;
@@ -320,6 +321,11 @@ export async function buildApp(https?: { cert: Buffer; key: Buffer }) {
       build: getBuildLabel(),
       serverOs: SERVER_OS,
       memory: getRuntimeMemorySnapshot(),
+      // Termux background-reliability telemetry (#5655/#5656): the launcher
+      // exports its wake-lock outcome, and the freeze detector records the
+      // most recent host-suspension it observed. Null on non-Termux hosts.
+      wakeLock: process.env.MARINARA_WAKE_LOCK_STATUS || null,
+      lastFreeze: getLastFreeze(),
       timestamp: new Date().toISOString(),
       capabilityPackages: {
         status: capabilityPackages

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "url";
 import { buildApp } from "./app.js";
 import { StorageWriterLeaseError } from "./db/file-backed-store.js";
 import { logger } from "./lib/logger.js";
+import { startFreezeDetector, stopFreezeDetector } from "./lib/freeze-detector.js";
 import { getHost, getPort, getServerProtocol, loadTlsOptions, logStorageDiagnostics } from "./config/runtime-config.js";
 import { logCsrfTrustSummary } from "./middleware/csrf-protection.js";
 import { startEnvWatcher } from "./config/env-watcher.js";
@@ -87,6 +88,7 @@ async function main() {
     try {
       envWatcher.stop();
       stopRuntimeMemoryMonitor();
+      stopFreezeDetector();
       await app.close();
       logger.info("Shutdown complete");
       process.exit(0);
@@ -106,6 +108,7 @@ async function main() {
   try {
     await app.listen({ port, host });
     logger.info(`Marinara Engine server listening on ${protocol}://${host}:${port}`);
+    startFreezeDetector();
     stopRuntimeMemoryMonitor = startRuntimeMemoryMonitor();
     logCsrfTrustSummary();
     scheduleTaskbarShortcutMigration();

--- a/packages/server/src/lib/freeze-detector.ts
+++ b/packages/server/src/lib/freeze-detector.ts
@@ -1,0 +1,81 @@
+// ──────────────────────────────────────────────
+// Freeze detector (#5655)
+// ──────────────────────────────────────────────
+// When Android freezes a backgrounded Termux process (cached-app freezer,
+// vendor app-sleep), every timer simply stops and resumes later — an idle
+// server at the default log level records nothing, so support threads cannot
+// distinguish "host froze the server" from "server crashed" from "network
+// problem". This detector turns a freeze into positive, timestamped log
+// evidence: an unref'd tick measures its own lateness, and a tick arriving
+// far beyond its interval means the process stopped running — usually an OS
+// suspension (Android freezer, laptop sleep), though a severe app-internal
+// stall (a minutes-long synchronous flush under GC thrash, the #4730
+// pathology) reads the same way, which is why the warning hedges and points
+// at the memory figures. The same pattern already proved itself at watchdog
+// scale in the extension sandbox (shouldGrantSandboxResumeGrace).
+
+import { logger } from "./logger.js";
+
+export const FREEZE_DETECTOR_INTERVAL_MS = 60_000;
+/** A tick this many times later than scheduled counts as a suspension. */
+export const FREEZE_GAP_FACTOR = 2;
+
+export type FreezeRecord = {
+  /** When the post-freeze tick ran (i.e. when the process thawed). */
+  detectedAt: string;
+  /** Total gap between consecutive ticks, in milliseconds. */
+  gapMs: number;
+  /** Estimated suspension length (gap minus the scheduled interval). */
+  suspendedMs: number;
+};
+
+/**
+ * Pure classifier so regressions can pin the threshold without timers:
+ * returns the estimated suspension when the gap crosses the threshold,
+ * null for an on-time tick.
+ */
+export function classifyTickGap(
+  now: number,
+  lastTickAt: number,
+  intervalMs: number = FREEZE_DETECTOR_INTERVAL_MS,
+): number | null {
+  const gap = now - lastTickAt;
+  if (gap <= intervalMs * FREEZE_GAP_FACTOR) return null;
+  return gap - intervalMs;
+}
+
+let timer: NodeJS.Timeout | null = null;
+let lastTickAt = 0;
+let lastFreeze: FreezeRecord | null = null;
+
+export function startFreezeDetector(intervalMs: number = FREEZE_DETECTOR_INTERVAL_MS) {
+  if (timer) return;
+  lastTickAt = Date.now();
+  timer = setInterval(() => {
+    const now = Date.now();
+    const suspendedMs = classifyTickGap(now, lastTickAt, intervalMs);
+    if (suspendedMs !== null) {
+      lastFreeze = { detectedAt: new Date(now).toISOString(), gapMs: now - lastTickAt, suspendedMs };
+      logger.warn(
+        "Process was suspended for ~%d s (timer gap %d ms). Either the host OS froze or slept the server, or the server itself stalled that long — on Android/Termux check the wake lock and battery exemptions, and compare the memory figures in /api/health.",
+        Math.round(suspendedMs / 1000),
+        now - lastTickAt,
+      );
+    }
+    lastTickAt = now;
+  }, intervalMs);
+  // The detector must never keep the process alive on its own.
+  timer.unref();
+}
+
+export function stopFreezeDetector() {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}
+
+/** Most recent detected suspension, for /health and support diagnostics. */
+export function getLastFreeze(): FreezeRecord | null {
+  return lastFreeze;
+}

--- a/scripts/regressions/freeze-detector.regression.ts
+++ b/scripts/regressions/freeze-detector.regression.ts
@@ -1,0 +1,50 @@
+// #5655: the freeze detector must turn a process suspension into positive,
+// recorded evidence. The classifier is pinned pure; the wired detector is
+// pinned by genuinely blocking the event loop past the gap threshold — the
+// same thing an OS freeze does to timers — and asserting the recorded
+// suspension. Intervals are sized so scheduler jitter on a loaded CI runner
+// cannot false-positive the on-time assertion (200ms interval tolerates
+// 200ms of lateness before the 2x threshold).
+import assert from "node:assert/strict";
+
+const { classifyTickGap, startFreezeDetector, stopFreezeDetector, getLastFreeze } =
+  await import("../../packages/server/src/lib/freeze-detector.js");
+
+// Classifier: on-time and slightly-late ticks are not freezes.
+assert.equal(classifyTickGap(60_000, 0, 60_000), null, "an exact-interval tick is not a freeze");
+assert.equal(classifyTickGap(119_999, 0, 60_000), null, "a tick inside 2x interval is not a freeze");
+// Past 2x interval, the estimated suspension is the gap minus the interval.
+assert.equal(classifyTickGap(180_000, 0, 60_000), 120_000, "a 3x-late tick reports gap minus interval");
+
+const settle = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+startFreezeDetector(200);
+try {
+  await settle(250);
+  // A loaded CI runner can genuinely stall this process >400ms, which the
+  // detector must record — that would be a true positive, not a bug. Only a
+  // record WITHOUT a genuinely late tick is a detector false positive.
+  const onTimePhase = getLastFreeze();
+  if (onTimePhase !== null) {
+    assert.equal(
+      onTimePhase.gapMs >= 400,
+      true,
+      `a freeze recorded during the on-time phase must reflect a genuinely late tick (got ${onTimePhase.gapMs}ms)`,
+    );
+  }
+
+  // Synchronously freeze the event loop well past the 2x threshold.
+  const sab = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(sab, 0, 0, 900);
+  await settle(300);
+
+  const freeze = getLastFreeze();
+  assert.notEqual(freeze, null, "a blocked event loop is recorded as a suspension");
+  assert.equal(freeze!.gapMs >= 900, true, `the recorded gap covers the blocked window (got ${freeze!.gapMs}ms)`);
+  assert.equal(freeze!.suspendedMs, freeze!.gapMs - 200, "the estimated suspension subtracts the scheduled interval");
+  assert.equal(typeof freeze!.detectedAt, "string", "the thaw moment is timestamped");
+} finally {
+  stopFreezeDetector();
+}
+
+console.log("Freeze detector regression passed.");

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -689,6 +689,8 @@ for (const expectedLine of [
   "Commit: abcdef123456",
   "Server OS: Linux 6.8.0 (x64)",
   "Server memory: heap 768 / 1536 MiB; RSS 1024 MiB",
+  "Background wake lock: not reported",
+  "Last detected freeze: none detected",
   "Client OS: macOS 15.6",
   "Browser / app shell: Marinara test shell",
   "GPU: Test GPU",

--- a/start-termux.sh
+++ b/start-termux.sh
@@ -669,12 +669,35 @@ trap release_termux_wake_lock EXIT
 if command -v termux-wake-lock &> /dev/null && command -v termux-wake-unlock &> /dev/null; then
     if termux-wake-lock >/dev/null 2>&1; then
         TERMUX_WAKE_LOCK_ACQUIRED=1
+        export MARINARA_WAKE_LOCK_STATUS=acquired
         echo "  [OK] Android wake lock acquired for background reliability"
     else
+        export MARINARA_WAKE_LOCK_STATUS=failed
         echo "  [WARN] Could not acquire an Android wake lock; background execution may pause."
     fi
 else
+    export MARINARA_WAKE_LOCK_STATUS=unavailable
     echo "  [WARN] Termux wake-lock commands are unavailable; background execution may pause."
+fi
+
+# A missing wake lock is the #1 background-reliability signal (#5656): repeat
+# it prominently right before the server starts so it cannot scroll away
+# unnoticed, and tell the user what to do about it.
+if [ "$MARINARA_WAKE_LOCK_STATUS" != "acquired" ]; then
+    echo ""
+    echo "  ============================================================"
+    echo "  [WARN] NO ANDROID WAKE LOCK ($MARINARA_WAKE_LOCK_STATUS)."
+    echo "         Android may FREEZE the server whenever Termux is in"
+    echo "         the background: the app will hang until you bring"
+    echo "         Termux back to the foreground."
+    if [ "$MARINARA_WAKE_LOCK_STATUS" = "unavailable" ]; then
+        echo "         termux-wake-lock ships with the core termux-tools"
+        echo "         package: run 'pkg install termux-tools' and restart."
+    fi
+    echo "         Also set Termux's battery usage to Unrestricted in"
+    echo "         Android settings."
+    echo "  ============================================================"
+    echo ""
 fi
 
 # Start server


### PR DESCRIPTION
Closes #5655
Closes #5656

## Why

The Termux background-freeze triage (see #4956 and the #5655/#5656 issue family) hit an observability wall: when Android freezes the backgrounded server, **nothing a user can paste shows it happened**. An idle server logs nothing, every timer silently stops and resumes, and the one decisive fact — whether the launcher's wake lock engaged — existed only as one scroll-away line at launch. Diagnosing this week's report required asking the user to dig the session log's first lines out of `~/.marinara-engine/logs/`.

## What this adds

**Freeze detector (#5655).** An `unref()`'d 60-second tick (`packages/server/src/lib/freeze-detector.ts`) measures its own lateness; a tick beyond 2× its interval records the suspension (`{detectedAt, gapMs, suspendedMs}`) and logs a warning with the estimated length. Design decisions, each deliberate:

- **Wall-clock, not monotonic**: `CLOCK_MONOTONIC` does not advance through an OS suspension — a monotonic detector would miss exactly the freezes this exists to catch. The cost (a forward clock-step fabricates a record; a backward step is silently absorbed) is acceptable for evidence-gathering.
- **Hedged attribution**: a severe app-internal stall (a minutes-long synchronous flush under GC thrash — the #4730 pathology) reads identically to an OS freeze, so the warning says "the host OS froze or slept the server, or the server itself stalled that long" and points at the memory figures in `/api/health` for disambiguation, instead of steering every thread toward battery settings.
- **Desktop laptop-sleep fires it too** — a true statement that explains "it hung overnight" reports there as well; the Termux guidance in the message is conditionally worded.
- The timer never keeps the process alive (`unref`), and shutdown stops it explicitly.

**Wake-lock surfacing (#5656).** `start-termux.sh` exports `MARINARA_WAKE_LOCK_STATUS=acquired|failed|unavailable` from its existing branches and, when the lock is *not* held, prints a prominent boxed warning immediately before the server starts — including the corrected guidance that `termux-wake-lock` ships in core `termux-tools` (the Termux:API claim in the docs is wrong; that correction is #5659). `/api/health` now returns `wakeLock` and `lastFreeze`, and **Copy Support Diagnostics renders both**:

```
Background wake lock: acquired
Last detected freeze: ~143s suspension, thawed at 2026-08-30T…
```

Those two lines are exactly what the next freeze report will need.

## Validation

- New regression `freeze-detector.regression.ts`: pins the pure gap classifier, then the wired detector by *genuinely blocking the event loop* with `Atomics.wait(900ms)` against a 200ms interval. The on-time phase tolerates real CI stalls honestly: a freeze recorded there must itself reflect a genuinely late tick, distinguishing environment stalls from detector false positives. Green locally.
- The support-diagnostics pin list in `open-issues.regression.ts` now covers the two new lines' default rendering.
- Adversarial review (2 lenses) verified: every format-guard launcher pin still passes against the edited `start-termux.sh` (ran the guard), env inheritance into the server launch, `/health` consumers are all additive-safe (keep-alive, `checkVersion`, e2e, auth middlewares — no strict shape validation anywhere), unref/shutdown hygiene, and module-singleton safety. Its findings (attribution hedge, on-time-phase tolerance, empty-string env normalization, formatter pins) are all applied.
- `pnpm check` green; `bash -n start-termux.sh` clean.
- Manually verify on a Termux device: launch via `start-termux.sh`, confirm the wake-lock line appears in Copy Support Diagnostics; background Termux long enough to trigger a freeze, foreground, and confirm the session log shows the suspension warning and diagnostics show the freeze record.

Related follow-ups filed separately: #5657 (client unreachable-state UX), #5658 (checkVersion fetch leak), #5659 (TROUBLESHOOTING corrections).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Android/Termux host-suspension detection with freeze-duration logging.
  * Health and support diagnostics now report wake-lock status and the latest detected freeze.
  * Launcher warnings provide installation and battery-optimization guidance when wake locks are unavailable or fail.

* **Bug Fixes**
  * Improved visibility into background suspension and wake-lock issues affecting server availability.

* **Tests**
  * Added regression coverage for freeze detection and diagnostic reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->