### PR TITLE
fix(settings): deep-link the Generations Download Illustrator button to the Illustrator agent

### DIFF
--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -5880,7 +5880,7 @@ function GenerationsSettings() {
   );
   const openDownloadAgents = useCallback(() => {
     openRightPanel("agents");
-    openAgentCatalog();
+    openAgentCatalog("illustrator");
   }, [openAgentCatalog, openRightPanel]);
 
   return (


### PR DESCRIPTION
## Linked issue

Closes #5663

## Why this change

- Clicking **Download Illustrator** in Settings -> Generations (the empty state shown when the Illustrator agent is not installed) opened the agent catalog on the wrong agent. The button called `openAgentCatalog()` without a package id, so `AgentCatalogView` fell back to auto-selecting the first catalog entry instead of the Illustrator agent (reported on 2.4.4, builds `9e806cc8b59c` and `1a299369ac70`).

## What changed

- `packages/client/src/components/panels/SettingsPanel.tsx`: the Generations empty-state button now calls `openAgentCatalog("illustrator")`, using the same `agentCatalogInitialPackageId` deep-link path the home-browser agent recommendations already use, so the catalog opens with the Illustrator agent selected (and jumps straight to its detail view on mobile).

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- With the Illustrator agent uninstalled, open Settings -> Generations and click **Download Illustrator**: the agent catalog should open with the Illustrator agent selected (on mobile it should land directly on the Illustrator detail view).
- Confirm the general **Download Agents** entry points (Agents panel, setup wizards) still open the catalog with no forced selection.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Reporter's screenshot of the wrong-agent behavior is attached to #5663.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The Illustrator download shortcut now opens the Agent Catalog filtered to the Illustrator agent for faster access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->