### PR TITLE
fix(client): route all bottom safe-area consumers through the Gecko-aware override hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+### Fixed
+
+- Firefox on Android no longer shows the empty band above the system navigation bar on the surfaces the earlier shell fix did not cover — full-screen mobile modals, the chat settings and gallery drawers, the setup wizards, game overlays (character sheet, inventory, narration, readables), the selection action bar, the browser hub, and the floating call/launcher buttons: every remaining bottom safe-area consumer now honors the engine-specific override that zeroes Gecko's misreported inset (#5667).
+
 ## [2.4.5]
 
 ### Added

--- a/packages/client/src/components/chat/ChatCommonOverlays.tsx
+++ b/packages/client/src/components/chat/ChatCommonOverlays.tsx
@@ -155,7 +155,7 @@ function MultiSelectBar({
       data-component="MessageMultiSelectBar"
       className={cn(
         NEUTRAL_PANEL_SHELL,
-        "mari-chrome-token-scope fixed bottom-[max(1rem,env(safe-area-inset-bottom))] left-1/2 z-50 flex w-[min(30rem,calc(100vw-1.5rem))] -translate-x-1/2 flex-col gap-2 p-3",
+        "mari-chrome-token-scope fixed bottom-[max(1rem,var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))] left-1/2 z-50 flex w-[min(30rem,calc(100vw-1.5rem))] -translate-x-1/2 flex-col gap-2 p-3",
       )}
     >
       <span className="text-center text-xs font-medium text-[var(--marinara-chat-chrome-panel-muted)]">
@@ -228,7 +228,7 @@ function ChatSettingsLoadingFallback({ anchor }: { anchor: ChatFloatingPanelAnch
   return (
     <div
       data-chat-floating-panel
-      className="mari-chrome-token-scope fixed bottom-3 right-[calc(var(--mari-chat-ui-inset-right,0px)+0.75rem)] top-14 z-[70] flex w-[min(34rem,calc(100vw-var(--mari-chat-ui-inset-left,0px)-var(--mari-chat-ui-inset-right,0px)-1.5rem))] flex-col overflow-hidden rounded-xl border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] text-[var(--marinara-chat-chrome-panel-text)] shadow-2xl shadow-black/40 backdrop-blur-md max-md:inset-x-2 max-md:bottom-[calc(0.75rem+env(safe-area-inset-bottom))] max-md:top-[calc(3.5rem+env(safe-area-inset-top))] max-md:w-auto"
+      className="mari-chrome-token-scope fixed bottom-3 right-[calc(var(--mari-chat-ui-inset-right,0px)+0.75rem)] top-14 z-[70] flex w-[min(34rem,calc(100vw-var(--mari-chat-ui-inset-left,0px)-var(--mari-chat-ui-inset-right,0px)-1.5rem))] flex-col overflow-hidden rounded-xl border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] text-[var(--marinara-chat-chrome-panel-text)] shadow-2xl shadow-black/40 backdrop-blur-md max-md:inset-x-2 max-md:bottom-[calc(0.75rem+var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))] max-md:top-[calc(3.5rem+env(safe-area-inset-top))] max-md:w-auto"
       style={panelStyle}
     >
       <div className="mari-chrome-text-strong flex shrink-0 items-center gap-2 border-b border-[var(--marinara-chat-chrome-panel-divider)] px-4 py-3 text-sm font-semibold">

--- a/packages/client/src/components/chat/ChatGalleryDrawer.tsx
+++ b/packages/client/src/components/chat/ChatGalleryDrawer.tsx
@@ -154,7 +154,7 @@ export function ChatGalleryDrawer({
         data-chat-floating-panel
         className={cn(
           NEUTRAL_PANEL_SHELL,
-          "mari-chat-gallery-drawer fixed bottom-3 z-[70] flex w-[min(44rem,calc(100vw-var(--mari-chat-ui-inset-left,0px)-var(--mari-chat-ui-inset-right,0px)-1.5rem))] flex-col overflow-hidden max-md:inset-x-2 max-md:bottom-[calc(0.75rem+env(safe-area-inset-bottom))] max-md:top-[calc(3.5rem+env(safe-area-inset-top))] max-md:w-auto",
+          "mari-chat-gallery-drawer fixed bottom-3 z-[70] flex w-[min(44rem,calc(100vw-var(--mari-chat-ui-inset-left,0px)-var(--mari-chat-ui-inset-right,0px)-1.5rem))] flex-col overflow-hidden max-md:inset-x-2 max-md:bottom-[calc(0.75rem+var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))] max-md:top-[calc(3.5rem+env(safe-area-inset-top))] max-md:w-auto",
           anchor ? "" : "right-[calc(var(--mari-chat-ui-inset-right,0px)+0.75rem)] top-14",
         )}
         style={panelStyle}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -4654,7 +4654,7 @@ export function ChatSettingsDrawer({
       ? {
           bottom: "auto",
           left: "auto",
-          maxHeight: `min(42rem, calc(100dvh - ${anchor.top}px - 0.75rem - env(safe-area-inset-bottom)))`,
+          maxHeight: `min(42rem, calc(100dvh - ${anchor.top}px - 0.75rem - var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom))))`,
           right: `${anchor.right}px`,
           top: `${anchor.top}px`,
           width: `min(34rem, calc(100vw - ${anchor.right}px - 0.75rem))`,
@@ -4675,7 +4675,7 @@ export function ChatSettingsDrawer({
           NEUTRAL_PANEL_SHELL,
           "mari-chat-settings-popover",
           "mari-chat-settings-drawer",
-          "fixed bottom-3 z-[70] flex min-h-0 w-[min(34rem,calc(100vw-var(--mari-chat-ui-inset-left,0px)-var(--mari-chat-ui-inset-right,0px)-1.5rem))] flex-col overflow-hidden max-md:inset-x-2 max-md:bottom-[calc(0.75rem+env(safe-area-inset-bottom))] max-md:top-[calc(3.5rem+env(safe-area-inset-top))] max-md:w-auto",
+          "fixed bottom-3 z-[70] flex min-h-0 w-[min(34rem,calc(100vw-var(--mari-chat-ui-inset-left,0px)-var(--mari-chat-ui-inset-right,0px)-1.5rem))] flex-col overflow-hidden max-md:inset-x-2 max-md:bottom-[calc(0.75rem+var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))] max-md:top-[calc(3.5rem+env(safe-area-inset-top))] max-md:w-auto",
           anchor ? "" : "right-[calc(var(--mari-chat-ui-inset-right,0px)+0.75rem)] top-14",
         )}
         style={panelStyle}
@@ -4705,7 +4705,7 @@ export function ChatSettingsDrawer({
         <div
           className={cn(
             NEUTRAL_PANEL_SCROLL_AREA,
-            "flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain pb-[calc(1rem+env(safe-area-inset-bottom))]",
+            "flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain pb-[calc(1rem+var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))]",
           )}
         >
           {/* Settings profile bar — hidden in Game Mode. Scene chats keep it, but scene instructions stay chat-owned. */}

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -469,7 +469,7 @@ function SetupWizardShell({
 }) {
   const { t: localizeUi } = useUiTranslation();
   return (
-    <div className="absolute inset-0 z-50 flex items-center justify-center p-3 pointer-events-none max-md:pt-[max(0.75rem,env(safe-area-inset-top))] max-md:pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:p-4">
+    <div className="absolute inset-0 z-50 flex items-center justify-center p-3 pointer-events-none max-md:pt-[max(0.75rem,env(safe-area-inset-top))] max-md:pb-[max(0.75rem,var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))] sm:p-4">
       <AnimatePresence mode="wait">
         <motion.div
           key={animationKey}

--- a/packages/client/src/components/chat/HomeBrowserHub.tsx
+++ b/packages/client/src/components/chat/HomeBrowserHub.tsx
@@ -1287,7 +1287,7 @@ function FloatingProfessorMari({
         }}
         aria-label={t("home.assistant.navigate")}
         title={t("home.assistant.navigate")}
-        className="mari-chrome-accent-frame mari-chrome-accent-panel mari-accent-animated mari-home-professor-recall absolute bottom-[max(0.65rem,env(safe-area-inset-bottom))] right-[max(0.75rem,env(safe-area-inset-right))] z-[30] flex h-14 w-14 items-end justify-center overflow-hidden rounded-full border p-0.5 transition-[transform,box-shadow,background-color] hover:-translate-y-0.5 hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)] active:scale-95 motion-reduce:transition-none sm:bottom-4 sm:right-4"
+        className="mari-chrome-accent-frame mari-chrome-accent-panel mari-accent-animated mari-home-professor-recall absolute bottom-[max(0.65rem,var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))] right-[max(0.75rem,env(safe-area-inset-right))] z-[30] flex h-14 w-14 items-end justify-center overflow-hidden rounded-full border p-0.5 transition-[transform,box-shadow,background-color] hover:-translate-y-0.5 hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)] active:scale-95 motion-reduce:transition-none sm:bottom-4 sm:right-4"
       >
         <img
           src={MARI_ASSISTANT_IDLE}
@@ -1342,7 +1342,7 @@ function FloatingProfessorMari({
         "mari-home-professor-popup pointer-events-none absolute z-[30]",
         desktopDragEnabled
           ? "inset-0"
-          : "bottom-[max(0rem,env(safe-area-inset-bottom))] left-2 right-2 flex items-end justify-end sm:left-5 sm:right-5",
+          : "bottom-[max(0rem,var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))] left-2 right-2 flex items-end justify-end sm:left-5 sm:right-5",
       )}
       aria-label={t("home.assistant.landmark")}
       data-dragging={dragging ? "true" : "false"}

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -5477,7 +5477,7 @@ export function HomeProfessorMariChat({
                 "flex min-h-0 items-stretch justify-center",
                 embeddedTab
                   ? "relative z-auto h-full w-full bg-transparent p-0"
-                  : "fixed inset-x-0 bottom-0 top-[calc(env(safe-area-inset-top)_+_3rem)] z-[80] bg-[var(--background)] pb-[env(safe-area-inset-bottom)] sm:static sm:z-auto sm:h-full sm:max-h-none sm:w-full sm:flex-1 sm:bg-transparent sm:p-0",
+                  : "fixed inset-x-0 bottom-0 top-[calc(env(safe-area-inset-top)_+_3rem)] z-[80] bg-[var(--background)] pb-[var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom))] sm:static sm:z-auto sm:h-full sm:max-h-none sm:w-full sm:flex-1 sm:bg-transparent sm:p-0",
               )}
             >
               <div className={cn("h-full min-h-0 w-full", embeddedTab ? "max-w-none" : "max-w-none sm:max-w-5xl")}>

--- a/packages/client/src/components/chat/NewChatConnectionGate.tsx
+++ b/packages/client/src/components/chat/NewChatConnectionGate.tsx
@@ -107,7 +107,7 @@ export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGatePr
       <div className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[3px]" onClick={onClose} />
       <div
         data-new-chat-connection-gate={mode}
-        className="mari-chrome-token-scope mari-chrome-text-accent-scope fixed inset-0 z-50 flex items-center justify-center p-3 max-md:pt-[max(0.75rem,env(safe-area-inset-top))] max-md:pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:p-4"
+        className="mari-chrome-token-scope mari-chrome-text-accent-scope fixed inset-0 z-50 flex items-center justify-center p-3 max-md:pt-[max(0.75rem,env(safe-area-inset-top))] max-md:pb-[max(0.75rem,var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))] sm:p-4"
       >
         <div className="flex max-h-[calc(100dvh-1.5rem)] w-full max-w-sm flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl sm:max-h-[min(90dvh,38rem)]">
           <div className="flex shrink-0 items-center justify-between border-b border-[var(--border)] px-4 py-3">

--- a/packages/client/src/components/game-assets/AudioPlayerModal.tsx
+++ b/packages/client/src/components/game-assets/AudioPlayerModal.tsx
@@ -36,7 +36,7 @@ export function AudioPlayerModal({ path, name, onClose }: { path: string; name: 
       role="dialog"
       aria-modal="true"
       aria-label={localizeUi("ui.gameAssets.audioplayermodal.audioPlayerValue1", { value1: name })}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-3 pb-[max(var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4"
       onClick={onClose}
     >
       <div

--- a/packages/client/src/components/game-assets/FileEditorModal.tsx
+++ b/packages/client/src/components/game-assets/FileEditorModal.tsx
@@ -111,7 +111,7 @@ export function FileEditorModal({ node, onClose, initialMode = "edit" }: FileEdi
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-3 pb-[max(var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4"
       onClick={handleRequestClose}
     >
       <div

--- a/packages/client/src/components/game-assets/ImagePreviewModal.tsx
+++ b/packages/client/src/components/game-assets/ImagePreviewModal.tsx
@@ -35,7 +35,7 @@ export function ImagePreviewModal({ node, onClose }: { node: TreeNode; onClose: 
       role="dialog"
       aria-modal="true"
       aria-label={localizeUi("ui.gameAssets.imagepreviewmodal.imagePreviewValue1", { value1: node.name })}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-3 pb-[max(var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4"
       onClick={onClose}
     >
       <div className="relative flex max-h-[90vh] max-w-[90vw] supports-[height:100dvh]:max-h-[90dvh]">

--- a/packages/client/src/components/game/GameCharacterSheet.tsx
+++ b/packages/client/src/components/game/GameCharacterSheet.tsx
@@ -461,7 +461,7 @@ export function GameCharacterSheet({
   return (
     <div
       data-game-skip-bg-nav="true"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-3 pb-[max(var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4"
       onClick={onClose}
     >
       <div

--- a/packages/client/src/components/game/GameInventory.tsx
+++ b/packages/client/src/components/game/GameInventory.tsx
@@ -200,7 +200,7 @@ export function GameInventory({
 
   return (
     <div
-      className="fixed inset-y-0 z-[80] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4"
+      className="fixed inset-y-0 z-[80] flex items-center justify-center bg-black/70 p-3 pb-[max(var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4"
       style={{
         left: "var(--mari-chat-ui-inset-left, 0px)",
         right: "var(--mari-chat-ui-inset-right, 0px)",

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -4532,7 +4532,7 @@ export function GameNarration({
   };
 
   return (
-    <div className="relative flex min-h-0 flex-1 items-end px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-20 md:pt-24 sm:px-6 md:pb-4">
+    <div className="relative flex min-h-0 flex-1 items-end px-3 pb-[max(0.75rem,var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))] pt-20 md:pt-24 sm:px-6 md:pb-4">
       {/* Readability scrim. It darkens the whole scene, not just the panel, so it has to fade
           out with the panel — otherwise collapsing hides the text but keeps the art dimmed. */}
       <div

--- a/packages/client/src/components/game/GameReadableDisplay.tsx
+++ b/packages/client/src/components/game/GameReadableDisplay.tsx
@@ -148,7 +148,7 @@ export function GameReadableDisplay({ type, content, onClose }: GameReadableDisp
 
   return (
     <div
-      className="fixed inset-y-0 z-[90] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-md sm:p-4"
+      className="fixed inset-y-0 z-[90] flex items-center justify-center bg-black/70 p-3 pb-[max(var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-md sm:p-4"
       style={{
         left: "var(--mari-chat-ui-inset-left, 0px)",
         right: "var(--mari-chat-ui-inset-right, 0px)",

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -1343,7 +1343,7 @@ export function GameSetupWizard({
         className="fixed inset-0 z-[10000] bg-black/45 backdrop-blur-[2px]"
         onClick={isLoading ? undefined : onCancel}
       />
-      <div className="fixed inset-0 z-[10001] flex items-center justify-center p-3 pointer-events-none max-md:pt-[max(0.75rem,env(safe-area-inset-top))] max-md:pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:p-4">
+      <div className="fixed inset-0 z-[10001] flex items-center justify-center p-3 pointer-events-none max-md:pt-[max(0.75rem,env(safe-area-inset-top))] max-md:pb-[max(0.75rem,var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))] sm:p-4">
         <AnimatePresence mode="wait">
           <motion.div
             key={currentStep.key}

--- a/packages/client/src/components/game/NewGameExperienceChooser.tsx
+++ b/packages/client/src/components/game/NewGameExperienceChooser.tsx
@@ -238,7 +238,7 @@ export function NewGameExperienceChooser({
         className="fixed inset-0 z-[10000] bg-black/45 backdrop-blur-[2px]"
         onClick={launching ? undefined : onCancelSetup}
       />
-      <div className="fixed inset-0 z-[10001] flex items-center justify-center p-3 pointer-events-none max-md:pt-[max(0.75rem,env(safe-area-inset-top))] max-md:pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:p-4">
+      <div className="fixed inset-0 z-[10001] flex items-center justify-center p-3 pointer-events-none max-md:pt-[max(0.75rem,env(safe-area-inset-top))] max-md:pb-[max(0.75rem,var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))] sm:p-4">
         {/* NEUTRAL_PANEL_SHELL remaps the theme tokens to the chrome palette inside the panel, the same
             way the built-in wizard does. Without it the package's setup comes out tinted. */}
         <motion.div

--- a/packages/client/src/components/modals/AboutMeViewerModal.tsx
+++ b/packages/client/src/components/modals/AboutMeViewerModal.tsx
@@ -345,7 +345,7 @@ export function AboutMeViewerModal({
         className={cn(
           "mari-about-me-popout mari-modal-panel border border-[var(--border)] bg-[var(--card)] shadow-2xl",
           isMobile
-            ? "absolute inset-x-0 bottom-0 top-16 flex flex-col overflow-hidden rounded-t-2xl pb-[env(safe-area-inset-bottom)]"
+            ? "absolute inset-x-0 bottom-0 top-16 flex flex-col overflow-hidden rounded-t-2xl pb-[var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom))]"
             : "absolute w-80 max-w-[calc(100vw-1rem)] rounded-2xl",
         )}
         style={

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -3201,7 +3201,7 @@ function ExpandedEditorModal({
     <PresetModalPortal>
       <div
         data-chat-floating-panel
-        className="fixed inset-0 z-50 flex items-center justify-center p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-[max(0.75rem,env(safe-area-inset-top))] sm:p-6"
+        className="fixed inset-0 z-50 flex items-center justify-center p-3 pb-[max(0.75rem,var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))] pt-[max(0.75rem,env(safe-area-inset-top))] sm:p-6"
       >
         <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleClose} />
         <div className="mari-editor-shell mari-editor-legacy-bridge relative flex h-[80vh] max-h-[calc(100vh-1.5rem)] w-full max-w-3xl flex-col rounded-2xl border border-[var(--marinara-editor-border)] bg-[var(--marinara-editor-surface-bg)] shadow-2xl shadow-black/50 supports-[height:100dvh]:h-[80dvh] supports-[height:100dvh]:max-h-[calc(100dvh-1.5rem)]">

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -134,7 +134,7 @@ function ExpandedMacroEditor({
         data-component="ExpandedMacroEditor"
         data-macro-modal="true"
         className={cn(
-          "fixed inset-0 z-[10050] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4",
+          "fixed inset-0 z-[10050] flex items-center justify-center bg-black/70 p-3 pb-[max(var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4",
           EDITOR_MODAL_SURFACE_VARIABLES,
         )}
       >
@@ -210,7 +210,7 @@ function MacrosReferenceModal({ open, onClose }: MacrosReferenceModalProps) {
         data-component="MacroReference"
         data-macro-modal="true"
         className={cn(
-          "fixed inset-0 z-[10050] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4",
+          "fixed inset-0 z-[10050] flex items-center justify-center bg-black/70 p-3 pb-[max(var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4",
           EDITOR_MODAL_SURFACE_VARIABLES,
         )}
       >

--- a/packages/client/src/components/ui/Modal.tsx
+++ b/packages/client/src/components/ui/Modal.tsx
@@ -150,7 +150,7 @@ export function Modal({
       className={`mari-modal fixed inset-0 z-[10000] flex items-center justify-center ${dragThrough ? "pointer-events-none" : ""} ${
         mobileFullscreen
           ? "p-0 sm:p-4"
-          : "p-3 max-md:pt-[max(0.75rem,env(safe-area-inset-top))] max-md:pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:p-4"
+          : "p-3 max-md:pt-[max(0.75rem,env(safe-area-inset-top))] max-md:pb-[max(0.75rem,var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))] sm:p-4"
       }`}
       style={{
         opacity: isEntering ? 1 : 0,
@@ -175,7 +175,7 @@ export function Modal({
         tabIndex={-1}
         className={`mari-modal-panel ${NEUTRAL_PANEL_SHELL} relative flex w-full flex-col ${dragThrough ? "pointer-events-auto" : ""} ${width} max-h-[calc(100dvh-1.5rem)] sm:max-h-[min(90dvh,52rem)]${
           mobileFullscreen
-            ? " max-sm:h-full max-sm:max-h-none max-sm:max-w-none max-sm:rounded-none max-sm:border-0 max-sm:pt-[env(safe-area-inset-top)] max-sm:pb-[env(safe-area-inset-bottom)]"
+            ? " max-sm:h-full max-sm:max-h-none max-sm:max-w-none max-sm:rounded-none max-sm:border-0 max-sm:pt-[env(safe-area-inset-top)] max-sm:pb-[var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom))]"
             : ""
         } ${panelClassName ?? ""}`}
         style={{

--- a/packages/client/src/components/ui/SelectionActionBar.tsx
+++ b/packages/client/src/components/ui/SelectionActionBar.tsx
@@ -36,7 +36,7 @@ export function SelectionActionBar({
     <div
       className={cn(
         isPanelFooter
-          ? "mari-selection-action-bar fixed bottom-0 right-0 z-[60] w-[min(var(--mari-right-panel-width,20rem),100vw)] px-3 pb-[calc(0.625rem+env(safe-area-inset-bottom))] pt-2.5"
+          ? "mari-selection-action-bar fixed bottom-0 right-0 z-[60] w-[min(var(--mari-right-panel-width,20rem),100vw)] px-3 pb-[calc(0.625rem+var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))] pt-2.5"
           : "mari-selection-action-bar sticky bottom-0 z-20 -mx-3 mt-auto px-3 py-2.5",
         className,
       )}
@@ -74,7 +74,10 @@ export function SelectionActionBar({
   if (isPanelFooter) {
     return (
       <>
-        <div aria-hidden="true" className="h-[calc(6rem+env(safe-area-inset-bottom))] shrink-0" />
+        <div
+          aria-hidden="true"
+          className="h-[calc(6rem+var(--mari-safe-area-inset-bottom,env(safe-area-inset-bottom)))] shrink-0"
+        />
         {actionBar}
       </>
     );

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -7251,24 +7251,24 @@ strong {
 }
 
 .mari-conversation-call-mini {
-  bottom: max(env(safe-area-inset-bottom), 0.75rem);
+  bottom: max(var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom)), 0.75rem);
   left: max(env(safe-area-inset-left), 0.75rem);
   transition: bottom 220ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 :root[data-professor-mari-floating="true"] .mari-conversation-call-mini {
-  bottom: calc(max(env(safe-area-inset-bottom), 0.75rem) + min(32rem, calc(100vh - 5rem)) + 0.75rem);
+  bottom: calc(max(var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom)), 0.75rem) + min(32rem, calc(100vh - 5rem)) + 0.75rem);
 }
 
 @supports (height: 100dvh) {
   :root[data-professor-mari-floating="true"] .mari-conversation-call-mini {
-    bottom: calc(max(env(safe-area-inset-bottom), 0.75rem) + min(32rem, calc(100dvh - 5rem)) + 0.75rem);
+    bottom: calc(max(var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom)), 0.75rem) + min(32rem, calc(100dvh - 5rem)) + 0.75rem);
   }
 }
 
 @media (max-width: 639px) {
   :root[data-professor-mari-floating="true"] .mari-conversation-call-mini {
-    bottom: calc(max(env(safe-area-inset-bottom), 0.75rem) + 4rem);
+    bottom: calc(max(var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom)), 0.75rem) + 4rem);
   }
 }
 

--- a/scripts/regressions/mobile-safe-area-inset.regression.ts
+++ b/scripts/regressions/mobile-safe-area-inset.regression.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -42,6 +42,30 @@ assert.match(
   appShellSource,
   /MOBILE_SHELL_PANEL_BOTTOM_PADDING_CLASS\s*=\s*\n?\s*"pb-\[min\(max\(var\(--mari-safe-area-inset-bottom,env\(safe-area-inset-bottom\)\),0\.5rem\),3rem\)\]"/u,
   "Mobile shell panels must prefer the safe-area override hook over env()",
+);
+
+// Issue #5667: every client consumer of the bottom safe-area inset must route
+// through the override hook so the Gecko zero-override (and any future
+// shell-published inset) applies uniformly. A raw env(safe-area-inset-bottom)
+// reintroduces the Android Firefox dead band on that surface.
+const clientSourceRoot = join(repositoryRoot, "packages/client/src");
+const overrideHookPattern = /var\(--mari-safe-area-inset-bottom,\s*env\(safe-area-inset-bottom\)\)/gu;
+const cssCommentPattern = /\/\*[\s\S]*?\*\//gu;
+const rawConsumers: string[] = [];
+for (const entry of readdirSync(clientSourceRoot, { recursive: true, withFileTypes: true })) {
+  if (!entry.isFile() || !/\.(?:tsx?|css)$/u.test(entry.name)) continue;
+  const filePath = join(entry.parentPath, entry.name);
+  const stripped = readFileSync(filePath, "utf8")
+    .replace(overrideHookPattern, "")
+    .replace(cssCommentPattern, "");
+  if (stripped.includes("env(safe-area-inset-bottom")) {
+    rawConsumers.push(filePath.slice(repositoryRoot.length + 1));
+  }
+}
+assert.deepEqual(
+  rawConsumers,
+  [],
+  "Client code must consume the bottom safe-area inset via var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom)), never raw env() (#5667)",
 );
 
 console.info("Mobile safe-area inset regressions passed.");


### PR DESCRIPTION
## Linked issue

Closes #5667

## Why this change

#5666 fixed the Android Firefox dead band above the system navigation bar, but only for the mobile shell panels and the chat composer — the two surfaces #5665 reported. Gecko's Android build reports `env(safe-area-inset-bottom)` as the navigation-bar height even though its layout viewport already stops above the bar, so any raw `env()` consumer double-compensates into an empty band that clips content. Roughly two dozen other client call sites still consumed the inset raw: full-screen mobile modals, the chat settings and gallery drawers, the setup wizards, the game overlays (character sheet, inventory, narration, readables), the selection action bar, the browser hub, and the floating launcher/call buttons all still showed the band on Android Firefox.

## What changed

- Wrapped every remaining raw `env(safe-area-inset-bottom)` in the override hook #5666 introduced — `var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom))` — across 21 client components and the four floating-launcher rules in `globals.css` (32 call sites total). The hook is zeroed for Gecko via the existing single `@supports (-moz-appearance: none)` block; no new `@supports` block is introduced. Non-Gecko engines are unchanged because the var falls back to `env()` wherever the override is not set, including the sites that use the inset as a `max()` floor inside modal centering. Top/left/right insets are untouched.
- Extended `scripts/regressions/mobile-safe-area-inset.regression.ts` with a sweep over `packages/client/src` that fails if any raw `env(safe-area-inset-bottom)` consumer reappears outside the override-hook fallback, so new surfaces can't silently reintroduce the band.
- Added a CHANGELOG entry under Unreleased.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passes locally; `node ./scripts/run-regressions.mjs --filter mobile-safe-area-inset` and `--filter roleplay-streaming` both pass (the latter guards the single-Gecko-`@supports`-block invariant this change must not break).
- Verified against the production client bundle that Tailwind generated every new arbitrary-value utility: the built CSS contains 19 `var(--mari-safe-area-inset-bottom, …)` occurrences (identical class strings dedupe) and zero `env(safe-area-inset-bottom)` outside the fallback position.
- Negative control: the regression sweep run against the pre-fix tree flags the raw consumers, so it genuinely pins this migration.
- The mechanical wrap preserves each site's existing expression shape (`max()` floors, `calc()` offsets), so iOS/Chromium resolve to byte-identical values. Remaining to eyeball on devices: a full-screen modal and the chat settings drawer on Android Firefox (band gone, flush with the fixed shell panels) and once on iOS Safari (home-indicator clearance unchanged).

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

See the screenshots on #5665 for the band's appearance; the affected surfaces here show the same artifact until this change and match the fixed shell panels after it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile spacing across chat panels, game screens, modals, drawers, and action bars.
  * Corrected bottom safe-area handling on Firefox for Android to help prevent content from being obscured by navigation controls.
  * Improved interaction behavior for the Game Setup Wizard overlay.
* **Tests**
  * Added regression coverage to detect mobile safe-area handling issues throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->