### PR TITLE
fix(agents): recover the removal a compound take-off loses

### DIFF
--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -1088,6 +1088,15 @@ async function executeBeholderLanePasses(args: {
       const repairMessages = prepareAgentProviderMessages(
         buildBeholderMessages(config, lanePrompts.worn, context, takeoffClause),
       );
+      // Through the debug path like every other provider call. This one is easy to
+      // miss precisely because it is conditional, and it is the call you most want to
+      // see when a removal did not come back.
+      emitAgentDebug(context, {
+        stage: "request",
+        ...agentDebugBase(config, model, temperature, maxTokens),
+        messageCount: repairMessages.length,
+        messages: debugMessages(repairMessages),
+      });
       const repair = await provider.chatComplete(repairMessages, {
         model,
         temperature,

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -47,6 +47,9 @@ import { normalizeCyoaChoiceOutput } from "./cyoa-choice-normalization.js";
 import { getAssetManifest } from "../game/asset-manifest.service.js";
 import { normalizeBeholderProse } from "./beholder-normalizer.js";
 import {
+  beholderDeltaLacksRemoval,
+  beholderTakeoffClause,
+  mergeBeholderWornRemovals,
   BEHOLDER_PASS_LANES,
   buildBeholderUserMessage,
   formatBeholderRequestContext,
@@ -1067,6 +1070,50 @@ async function executeBeholderLanePasses(args: {
   }
 
   const merged = mergeBeholderLaneDeltas(laneResponses);
+
+  // Compound take-off repair. When one sentence both removes a garment and adds
+  // another, the extractor reports the addition and drops the removal — and the
+  // garment it failed to take off stays in state and is fed back into every later
+  // turn, so a single miss compounds for the rest of the scene. Re-asking the worn
+  // lane with just the take-off clause recovers it, because removal-only prose is
+  // what the model handles reliably. Only worn_remove is taken from the answer.
+  //
+  // Costs one extra call, and only on a turn that shows something coming off and
+  // reported no removal — an ordinary turn pays nothing.
+  const takeoffClause = beholderDeltaLacksRemoval(merged.delta)
+    ? beholderTakeoffClause(beholderNarration(config, context))
+    : null;
+  if (takeoffClause) {
+    try {
+      const repairMessages = prepareAgentProviderMessages(
+        buildBeholderMessages(config, lanePrompts.worn, context, takeoffClause),
+      );
+      const repair = await provider.chatComplete(repairMessages, {
+        model,
+        temperature,
+        maxTokens,
+        enableCaching: config.enableCaching,
+        anthropicExtendedCacheTtl: config.anthropicExtendedCacheTtl,
+        cachingAtDepth: config.cachingAtDepth,
+        customParameters: args.customParameters,
+        enabledParameters: config.enabledParameters,
+        suppressModelParameters: config.suppressModelParameters,
+        stream: false,
+        signal: agentCallSignal(context.signal),
+      });
+      totalTokens += repair.usage?.totalTokens ?? 0;
+      const repairData = parseAgentResponse(config, (repair.content ?? "").trim()).data;
+      if (isBeholderLaneResponse(repairData) && isRecord(repairData) && repairData.changed === true) {
+        mergeBeholderWornRemovals(merged.delta, repairData.delta);
+        merged.changed = true;
+        logger.info(`[agent] ${config.type} take-off repair recovered a removal`);
+      }
+    } catch (error) {
+      // The repair is an improvement on the turn, never a reason to lose it.
+      logger.warn("[agent] %s take-off repair failed: %s", config.type, extractErrorMessage(error));
+    }
+  }
+
   logger.info(
     `[agent] ${config.type} done (${laneResponses.length}/${BEHOLDER_PASS_LANES.length} passes, changed=${merged.changed}, ${Date.now() - startTime}ms)`,
   );
@@ -2067,13 +2114,22 @@ function buildCustomAgentCapabilityBlock(config: AgentExecConfig, context: Agent
  * history is background, but here the message IS the thing being extracted from, so
  * cutting it silently hides whatever state the rest of it described.
  */
-function buildBeholderMessages(config: AgentExecConfig, template: string, context: AgentContext): ChatMessage[] {
+function beholderNarration(config: AgentExecConfig, context: AgentContext): string {
   const contextSize = normalizeAgentContextSize(config.settings.contextSize);
   const recent = contextSize > 0 ? context.recentMessages.slice(-contextSize) : [];
-  const narration = recent
+  return recent
     .map((message) => normalizeBeholderProse(message.content))
     .filter((text) => text.length > 0)
     .join("\n");
+}
+
+function buildBeholderMessages(
+  config: AgentExecConfig,
+  template: string,
+  context: AgentContext,
+  narrationOverride?: string,
+): ChatMessage[] {
+  const narration = narrationOverride ?? beholderNarration(config, context);
   const user = buildBeholderUserMessage(context.memory._beholderState, context.persona?.name ?? null, narration);
   return [
     { role: "system", content: template },

--- a/packages/server/src/services/agents/beholder-state.ts
+++ b/packages/server/src/services/agents/beholder-state.ts
@@ -553,6 +553,73 @@ export function formatBeholderRequestContext(state: unknown, personaName: string
  * Resolve either the benchmarked delta response or the legacy full snapshot
  * into the full normalized shape used by storage and the Beholder drawer.
  */
+/**
+ * The clause of a sentence that shows a garment coming off, or null when there is
+ * nothing to repair.
+ *
+ * The extractor loses the removal when ONE sentence both takes a garment off and puts
+ * another on: measured against the held-out set it emits the removal 2 times in 8 on
+ * compound prose, against 3 in 3 when the take-off stands alone. Re-asking the same
+ * compound sentence with removal-only framing recovers none of it — the compound
+ * sentence itself is what blinds the model — so the repair has to hand it prose of the
+ * shape it handles, which means splitting the sentence and keeping the take-off half.
+ */
+export function beholderTakeoffClause(prose: string): string | null {
+  const text = typeof prose === "string" ? prose : "";
+  if (!TAKEOFF_CUE.test(text)) return null;
+  const clauses = text.split(/,?\s+\band\b\s+/u);
+  if (clauses.length < 2) return null; // not compound; the lane already handles it
+  const index = clauses.findIndex((clause) => TAKEOFF_CUE.test(clause));
+  if (index === -1) return null;
+  let clause = clauses[index]!.trim();
+  // A trailing clause ("and takes off her boots") has lost its subject; carry the
+  // first clause's opening word so the lane still knows who is acting.
+  if (index > 0 && !/^[A-Z]/u.test(clause)) {
+    const subject = clauses[0]!.trim().split(/\s+/u)[0];
+    if (subject) clause = `${subject} ${clause}`;
+  }
+  return /[.!?]$/u.test(clause) ? clause : `${clause}.`;
+}
+
+/** Verbs that show something coming off. Narrow on purpose: a false positive costs one
+ *  extra call on a turn that did not need it, a false negative costs the removal. */
+const TAKEOFF_CUE =
+  /\b(takes?|took|pulls?|pulled|peels?|peeled|kicks?|kicked|strips?|stripped|shrugs?|shrugged|slips?|slipped)\b[^.]{0,24}\b(off|out of)\b|\b(unbuckles?|unbuttons?|unzips?|removes?|removed|discards?|drops?|dropped|hangs?|hung|sheds?|doffs?)\b/iu;
+
+/** True when no slot anywhere in the delta carries a worn_remove. */
+export function beholderDeltaLacksRemoval(delta: unknown): boolean {
+  if (!isRecord(delta)) return true;
+  for (const characterDelta of Object.values(delta)) {
+    if (!isRecord(characterDelta) || !isRecord(characterDelta.body)) continue;
+    for (const slotState of Object.values(characterDelta.body)) {
+      if (isRecord(slotState) && Array.isArray(slotState.worn_remove) && slotState.worn_remove.length > 0) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+/** Merge ONLY worn_remove entries from a repair pass into a delta. Never additions:
+ *  the repair exists to recover a lost removal, not to re-open the whole reply. */
+export function mergeBeholderWornRemovals(delta: Record<string, unknown>, repair: unknown): Record<string, unknown> {
+  if (!isRecord(repair)) return delta;
+  for (const [name, characterDelta] of Object.entries(repair)) {
+    if (!isRecord(characterDelta) || !isRecord(characterDelta.body)) continue;
+    for (const [slotName, slotState] of Object.entries(characterDelta.body)) {
+      if (!isRecord(slotState)) continue;
+      const removals = slotState.worn_remove;
+      if (!Array.isArray(removals) || removals.length === 0) continue;
+      const target = (isRecord(delta[name]) ? delta[name] : (delta[name] = {})) as Record<string, unknown>;
+      const body = (isRecord(target.body) ? target.body : (target.body = {})) as Record<string, unknown>;
+      const slot = (isRecord(body[slotName]) ? body[slotName] : (body[slotName] = {})) as Record<string, unknown>;
+      const existing = Array.isArray(slot.worn_remove) ? (slot.worn_remove as unknown[]) : [];
+      slot.worn_remove = [...new Set([...existing, ...removals])];
+    }
+  }
+  return delta;
+}
+
 export function resolveBeholderStateResponse(
   value: unknown,
   priorValue: unknown,

--- a/packages/server/src/services/agents/beholder-state.ts
+++ b/packages/server/src/services/agents/beholder-state.ts
@@ -567,7 +567,17 @@ export function formatBeholderRequestContext(state: unknown, personaName: string
 export function beholderTakeoffClause(prose: string): string | null {
   const text = typeof prose === "string" ? prose : "";
   if (!TAKEOFF_CUE.test(text)) return null;
-  const clauses = text.split(/,?\s+\band\b\s+/u);
+  // Work inside the sentence that shows the take-off. beholderNarration can join
+  // several messages, and taking the subject from the first clause of all of them
+  // attributed the removal to whoever happened to act first: "Tim waits. Maggie ties
+  // a scarf and takes off her boots." produced "Tim takes off her boots.", which then
+  // removed Tim's garment. The last matching sentence is the most recent action.
+  const sentences = text
+    .split(/(?<=[.!?])\s+|\n+/u)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean);
+  const sentence = sentences.filter((candidate) => TAKEOFF_CUE.test(candidate)).pop() ?? text;
+  const clauses = sentence.split(/,?\s+\band\b\s+/u);
   if (clauses.length < 2) return null; // not compound; the lane already handles it
   const index = clauses.findIndex((clause) => TAKEOFF_CUE.test(clause));
   if (index === -1) return null;

--- a/scripts/regressions/beholder-takeoff-repair.regression.ts
+++ b/scripts/regressions/beholder-takeoff-repair.regression.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import {
+  beholderDeltaLacksRemoval,
+  beholderTakeoffClause,
+  mergeBeholderWornRemovals,
+} from "../../packages/server/src/services/agents/beholder-state.js";
+
+// When one sentence both takes a garment off and puts another on, the extractor
+// reports the addition and drops the removal — 2 in 8 against 3 in 3 when the
+// take-off stands alone. The garment it failed to remove then stays in state and is
+// fed back into every later turn, so one miss compounds for the rest of the scene.
+//
+// The repair splits the sentence and re-asks the worn lane on the take-off half,
+// because removal-only prose is the shape the model handles. These pin the parts that
+// decide WHEN it fires and WHAT it asks; firing too eagerly costs a call on every
+// turn, not firing at all costs the removal.
+
+// Splits a compound take-off down to the half that shows the garment coming off.
+assert.equal(
+  beholderTakeoffClause("Maggie hangs the green cloak on a hook by the door and pulls on a pair of black boots."),
+  "Maggie hangs the green cloak on a hook by the door.",
+);
+assert.equal(
+  beholderTakeoffClause("She peels off her muddy gloves and ties a wool scarf around her neck."),
+  "She peels off her muddy gloves.",
+);
+assert.equal(
+  beholderTakeoffClause("He unbuckles the leather belt and shrugs a heavy coat over his shoulders."),
+  "He unbuckles the leather belt.",
+);
+
+// A trailing take-off keeps the subject, or the lane cannot tell who is acting.
+{
+  const clause = beholderTakeoffClause("Maggie ties a scarf around her neck and takes off her boots.");
+  assert.ok(clause?.startsWith("Maggie"), `expected the subject to be carried, got ${clause}`);
+  assert.ok(clause?.includes("takes off"), clause ?? "");
+}
+
+// Stays out of the way when there is nothing to repair, so an ordinary turn pays nothing.
+assert.equal(beholderTakeoffClause("Maggie pulls on a pair of black boots."), null, "an addition alone");
+assert.equal(beholderTakeoffClause("She wears a long red dress."), null, "a description");
+assert.equal(beholderTakeoffClause("Tim kicks off his boots."), null, "a take-off the lane already handles");
+assert.equal(beholderTakeoffClause(""), null);
+assert.equal(beholderTakeoffClause(undefined as unknown as string), null);
+
+// Always a terminated sentence.
+assert.ok(/[.!?]$/u.test(beholderTakeoffClause("Maggie hangs the cloak on a hook and pulls on boots") ?? ""));
+
+// The repair only runs when the reply carried no removal at all.
+assert.equal(beholderDeltaLacksRemoval({ Tim: { body: { chest: { worn: [{ item: "coat" }] } } } }), true);
+assert.equal(beholderDeltaLacksRemoval({ Tim: { body: { chest: { worn_remove: ["cloak"] } } } }), false);
+assert.equal(beholderDeltaLacksRemoval({ Tim: { body: { chest: { worn_remove: [] } } } }), true, "an empty list is no removal");
+assert.equal(beholderDeltaLacksRemoval(null), true);
+
+// Only worn_remove is taken from the repair answer — never additions, or the second
+// call could re-open the whole reply instead of recovering one lost removal.
+{
+  const delta: Record<string, unknown> = { Tim: { body: { left_foot: { worn: [{ item: "sandal" }] } } } };
+  mergeBeholderWornRemovals(delta, {
+    Tim: {
+      body: {
+        left_foot: { worn_remove: ["boot"], worn: [{ item: "SHOULD NOT APPEAR" }] },
+        right_foot: { worn_remove: ["boot"] },
+      },
+    },
+  });
+  const tim = delta.Tim as { body: Record<string, { worn?: unknown[]; worn_remove?: unknown[] }> };
+  assert.deepEqual(tim.body.left_foot?.worn_remove, ["boot"]);
+  assert.deepEqual(tim.body.left_foot?.worn, [{ item: "sandal" }], "the repair must not add or replace worn items");
+  assert.deepEqual(tim.body.right_foot?.worn_remove, ["boot"], "a slot the reply did not mention is created");
+}
+
+// Merging is additive and does not duplicate.
+{
+  const delta: Record<string, unknown> = { Tim: { body: { chest: { worn_remove: ["cloak"] } } } };
+  mergeBeholderWornRemovals(delta, { Tim: { body: { chest: { worn_remove: ["cloak", "scarf"] } } } });
+  const tim = delta.Tim as { body: Record<string, { worn_remove?: unknown[] }> };
+  assert.deepEqual([...(tim.body.chest?.worn_remove ?? [])].sort(), ["cloak", "scarf"]);
+}
+
+console.log("beholder take-off repair regression passed.");

--- a/scripts/regressions/beholder-takeoff-repair.regression.ts
+++ b/scripts/regressions/beholder-takeoff-repair.regression.ts
@@ -49,7 +49,11 @@ assert.ok(/[.!?]$/u.test(beholderTakeoffClause("Maggie hangs the cloak on a hook
 // The repair only runs when the reply carried no removal at all.
 assert.equal(beholderDeltaLacksRemoval({ Tim: { body: { chest: { worn: [{ item: "coat" }] } } } }), true);
 assert.equal(beholderDeltaLacksRemoval({ Tim: { body: { chest: { worn_remove: ["cloak"] } } } }), false);
-assert.equal(beholderDeltaLacksRemoval({ Tim: { body: { chest: { worn_remove: [] } } } }), true, "an empty list is no removal");
+assert.equal(
+  beholderDeltaLacksRemoval({ Tim: { body: { chest: { worn_remove: [] } } } }),
+  true,
+  "an empty list is no removal",
+);
 assert.equal(beholderDeltaLacksRemoval(null), true);
 
 // Only worn_remove is taken from the repair answer — never additions, or the second
@@ -79,3 +83,21 @@ assert.equal(beholderDeltaLacksRemoval(null), true);
 }
 
 console.log("beholder take-off repair regression passed.");
+
+// The narration handed to the lane can span several messages. Taking the subject from
+// the first clause of all of them bound the removal to whoever acted first, and the
+// repair then stripped that character's garment instead.
+{
+  const joined = "Tim waits.\nMaggie ties a scarf and takes off her boots.";
+  const clause = beholderTakeoffClause(joined);
+  assert.ok(clause, "a compound take-off in a later sentence is still recovered");
+  assert.match(clause, /^Maggie\b/u, "the subject must come from the take-off's own sentence, not the first one");
+  assert.ok(!/^Tim\b/u.test(clause), "binding the removal to the wrong character strips the wrong garment");
+  assert.match(clause, /takes off her boots/u);
+}
+
+{
+  // Same shape, separated by sentences rather than a newline.
+  const clause = beholderTakeoffClause("Tim waits. Maggie ties a scarf and takes off her boots.");
+  assert.ok(clause && /^Maggie\b/u.test(clause), "sentence-separated narration must behave the same");
+}


### PR DESCRIPTION
# Pull request

## Linked issue

Closes #

## Why this change

When one sentence both takes a garment off and puts another on, the extractor reports the addition and drops the removal. Measured against the held-out set:

| prose | removal emitted |
|---|---|
| take-off alone — *"hangs the cloak on a hook"* | **3/3** |
| compound — *"hangs the cloak on a hook **and** pulls on black boots"* | **2/8** |

The garment it failed to remove stays in state and is fed back into every later turn, so one miss compounds for the rest of the scene. This reproduces on ordinary prose, not just constructed cases — a six-turn scene hit it on *"trades the ruined sweater for a clean linen shirt… and pulls the coat back on"*.

## What changed

- `beholder-state.ts` gains three pure helpers: `beholderTakeoffClause` (split a compound sentence down to the take-off half), `beholderDeltaLacksRemoval`, and `mergeBeholderWornRemovals`.
- `agent-executor.ts` runs one extra worn-lane call after the five passes **only** when the reply carried no removal, the prose shows something coming off, and the sentence is compound. Only `worn_remove` is merged from the answer — it never adds or replaces a garment. A failed repair is logged and dropped rather than losing the turn.
- `buildBeholderMessages` takes an optional narration override; the narration derivation moved to `beholderNarration` so both callers share it.

**The route matters.** Re-asking the *same compound sentence* with removal-only framing recovers **0 of 6** — it is the compound sentence itself that blinds the model, not the framing. That is why this splits the input rather than rewording the prompt. Five prompt variants were measured first (an explicit rule, a worked example, clause-splitting instructions, a terse imperative, and reordering the existing bullet); every one left the number at 2/8.

## Package and security impact

- Affected package IDs: `beholder` (agent behaviour only; no manifest or catalog change)
- Engine compatibility impact: none — no schema, route or contract change
- New or changed permissions/entrypoints: none
- Restart, storage, update, or uninstall impact: none. Cost is one extra provider call on turns that show a garment coming off and reported no removal; ordinary turns are unaffected.

## Validation

- [x] `scripts/regressions/beholder-takeoff-repair.regression.ts` passes
- [x] All pre-existing `beholder-*` regressions still pass
- [x] `tsc --noEmit -p packages/server/tsconfig.json` clean
- [ ] Installed or updated the affected package through Marinara Engine
- [ ] Checked supported modes, restart behavior, and uninstall cleanup

### Manual verification notes

Measured end to end through these helpers against the trained extractor (koboldcpp, Beholder-Q8_0):

| group | before | after | extra calls |
|---|---|---|---|
| compound | 2/8 | **8/8** | 5 |
| removal only | 3/3 | 3/3 | 0 |
| addition only | 4/4 | 4/4 | 0 |

The two unticked boxes are honest: this is server-side behaviour with no package payload, so there is nothing to install, and it was verified through the regression harness and a live-model run rather than a chat session.

The unit regression pins what decides *when* it fires and *what* it asks — firing too eagerly costs a call on every turn, not firing costs the removal — plus that the merge takes only `worn_remove` and never duplicates.

## Documentation impact

- [x] No documentation changes needed

## UI evidence (if applicable)

None — no UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clothing removal detection for compound narration.
  * Corrected cases where worn-item removals were missed during scene updates.
  * Prevented duplicate removals and unrelated item changes from being applied.
  * Improved handling of take-off actions spanning multiple clauses or sentences.

* **Tests**
  * Added regression coverage for compound take-off actions, subject preservation, no-op scenarios, and repaired removal results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->