### PR TITLE
feat(agents): let an operator correct Beholder's physical state

### DIFF
--- a/packages/server/src/middleware/rate-limit.ts
+++ b/packages/server/src/middleware/rate-limit.ts
@@ -39,6 +39,17 @@ export const ADMIN_RESTART_RATE_LIMIT = {
   timeWindow: 60_000,
 } as const satisfies MarinaraRouteRateLimit;
 
+/**
+ * Operator corrections to Beholder's physical state.
+ *
+ * A person fixing slots clicks Apply a handful of times a minute; this is far above
+ * that and still bounds an authorized write to the state the next prompt is built from.
+ */
+export const BEHOLDER_STATE_RATE_LIMIT = {
+  max: 60,
+  timeWindow: 60_000,
+} as const satisfies MarinaraRouteRateLimit;
+
 export const BACKUP_RATE_LIMIT = {
   max: 60,
   timeWindow: 60_000,

--- a/packages/server/src/routes/agents.routes.ts
+++ b/packages/server/src/routes/agents.routes.ts
@@ -24,6 +24,7 @@ import {
   type CustomAgentCapability,
 } from "@marinara-engine/shared";
 import { requirePrivilegedAccess } from "../middleware/privileged-gate.js";
+import { BEHOLDER_STATE_RATE_LIMIT } from "../middleware/rate-limit.js";
 import {
   getCustomAgentImportPolicy,
   setCustomAgentImportsEnabled,
@@ -286,21 +287,25 @@ export async function agentsRoutes(app: FastifyInstance) {
    * The body is normalized before it is stored, so a malformed correction is refused
    * rather than written into the state the prompt is built from.
    */
-  app.put<{ Params: { chatId: string } }>("/beholder-state/:chatId", async (req, reply) => {
-    // Guarded like the other write routes in this file: this rewrites the state the
-    // next prompt is built from, for any chat id the caller names.
-    if (!requirePrivilegedAccess(req, reply, { feature: "Beholder state correction" })) return;
-    const body = req.body as { state?: unknown } | undefined;
-    const state = normalizeBeholderState(body?.state);
-    if (!state) return reply.status(400).send({ error: "Invalid Beholder state" });
-    const run = await storage.getLastSuccessfulRunByType("beholder", req.params.chatId);
-    if (!run) return reply.status(404).send({ error: "No Beholder run to correct yet" });
-    // The run can be deleted between the lookup and the write. Reporting success then
-    // would tell the operator their correction was saved when it was discarded.
-    const updated = await storage.updateRunResultData(run.id, state, req.params.chatId);
-    if (!updated) return reply.status(409).send({ error: "The Beholder run changed while saving; try again" });
-    return { state, messageId: run.messageId ?? null, createdAt: run.createdAt ?? null };
-  });
+  app.put<{ Params: { chatId: string } }>(
+    "/beholder-state/:chatId",
+    { config: { rateLimit: BEHOLDER_STATE_RATE_LIMIT } },
+    async (req, reply) => {
+      // Guarded like the other write routes in this file: this rewrites the state the
+      // next prompt is built from, for any chat id the caller names.
+      if (!requirePrivilegedAccess(req, reply, { feature: "Beholder state correction" })) return;
+      const body = req.body as { state?: unknown } | undefined;
+      const state = normalizeBeholderState(body?.state);
+      if (!state) return reply.status(400).send({ error: "Invalid Beholder state" });
+      const run = await storage.getLastSuccessfulRunByType("beholder", req.params.chatId);
+      if (!run) return reply.status(404).send({ error: "No Beholder run to correct yet" });
+      // The run can be deleted between the lookup and the write. Reporting success then
+      // would tell the operator their correction was saved when it was discarded.
+      const updated = await storage.updateRunResultData(run.id, state, req.params.chatId);
+      if (!updated) return reply.status(409).send({ error: "The Beholder run changed while saving; try again" });
+      return { state, messageId: run.messageId ?? null, createdAt: run.createdAt ?? null };
+    },
+  );
 
   /** Get the latest validated Beholder physical-state snapshot for a roleplay chat. */
   app.get<{ Params: { chatId: string } }>("/beholder-state/:chatId", async (req) => {

--- a/packages/server/src/routes/agents.routes.ts
+++ b/packages/server/src/routes/agents.routes.ts
@@ -275,6 +275,27 @@ export async function agentsRoutes(app: FastifyInstance) {
     return storage.listCustomRunsForChat(req.params.chatId, parsedLimit);
   });
 
+  /**
+   * Persist an operator correction to the Beholder physical state.
+   *
+   * The state a chat carries forward is the result of the agent's last successful
+   * run, which is also what the next prompt is built from — so a correction has to
+   * land there to mean anything. Without this, a hand-set slot would look right on
+   * screen and be narrated away on the next turn.
+   *
+   * The body is normalized before it is stored, so a malformed correction is refused
+   * rather than written into the state the prompt is built from.
+   */
+  app.put<{ Params: { chatId: string } }>("/beholder-state/:chatId", async (req, reply) => {
+    const body = req.body as { state?: unknown } | undefined;
+    const state = normalizeBeholderState(body?.state);
+    if (!state) return reply.status(400).send({ error: "Invalid Beholder state" });
+    const run = await storage.getLastSuccessfulRunByType("beholder", req.params.chatId);
+    if (!run) return reply.status(404).send({ error: "No Beholder run to correct yet" });
+    await storage.updateRunResultData(run.id, state, req.params.chatId);
+    return { state, messageId: run.messageId ?? null, createdAt: run.createdAt ?? null };
+  });
+
   /** Get the latest validated Beholder physical-state snapshot for a roleplay chat. */
   app.get<{ Params: { chatId: string } }>("/beholder-state/:chatId", async (req) => {
     const run = await storage.getLastSuccessfulRunByType("beholder", req.params.chatId);

--- a/packages/server/src/routes/agents.routes.ts
+++ b/packages/server/src/routes/agents.routes.ts
@@ -287,12 +287,18 @@ export async function agentsRoutes(app: FastifyInstance) {
    * rather than written into the state the prompt is built from.
    */
   app.put<{ Params: { chatId: string } }>("/beholder-state/:chatId", async (req, reply) => {
+    // Guarded like the other write routes in this file: this rewrites the state the
+    // next prompt is built from, for any chat id the caller names.
+    if (!requirePrivilegedAccess(req, reply, { feature: "Beholder state correction" })) return;
     const body = req.body as { state?: unknown } | undefined;
     const state = normalizeBeholderState(body?.state);
     if (!state) return reply.status(400).send({ error: "Invalid Beholder state" });
     const run = await storage.getLastSuccessfulRunByType("beholder", req.params.chatId);
     if (!run) return reply.status(404).send({ error: "No Beholder run to correct yet" });
-    await storage.updateRunResultData(run.id, state, req.params.chatId);
+    // The run can be deleted between the lookup and the write. Reporting success then
+    // would tell the operator their correction was saved when it was discarded.
+    const updated = await storage.updateRunResultData(run.id, state, req.params.chatId);
+    if (!updated) return reply.status(409).send({ error: "The Beholder run changed while saving; try again" });
     return { state, messageId: run.messageId ?? null, createdAt: run.createdAt ?? null };
   });
 


### PR DESCRIPTION
# Pull request

## Linked issue

Closes #

## Why this change

Beholder shows what the extractor believes about each character. When it is wrong there is currently no way to fix it.

The state a chat carries forward is the `resultData` of the agent's last successful run, and `loadPriorBeholderState` builds the next prompt from that same record. So a correction has to land there or it means nothing — anything stored elsewhere would look right in the panel and then be narrated away on the following turn.

The existing `PATCH /runs/:runId` cannot serve this. Both the listing and the patch reach runs through an inner join on `agentConfigs`, which a package agent's runs do not satisfy, so the client cannot discover the run id in the first place. Verified against a running Engine: `GET /runs/:chatId/custom` returns zero rows for a chat with Beholder state.

## What changed

One route, beside the `GET` that already reads this state:

- `PUT /api/agents/beholder-state/:chatId` — normalizes the submitted state, refuses it with 400 if it does not survive normalization, 404s when there is no run to correct yet, and otherwise updates the last successful Beholder run's `resultData`.

Nothing else is touched, and nothing outside the Beholder agent's own area of the routes file.

## Package and security impact

- Affected package IDs: `beholder`
- Engine compatibility impact: additive route; no schema or contract change
- New or changed permissions/entrypoints: none
- Restart, storage, update, or uninstall impact: none. It writes the same record the agent already writes, through the same storage call the existing run-patch route uses.

The body is normalized with `normalizeBeholderState` before storage, so a malformed or hostile payload is rejected rather than written into the state the prompt is built from.

## Validation

- [x] `tsc --noEmit -p packages/server/tsconfig.json` clean
- [x] Exercised against a running Engine: `PUT` returns 200 and the following `GET` reflects the change
- [x] Driven end to end from the package UI — 29/29 UI checks pass, including "the edit is written to the stored state" and the edited garment then appearing in the panel
- [ ] Installed or updated the affected package through Marinara Engine
- [ ] Checked supported modes, restart behavior, and uninstall cleanup

### Manual verification notes

Tested by pointing an isolated Engine (own port, own DATA_DIR) at a build of this branch with the Beholder package installed, then driving the panel in a browser: open a slot, edit it, Apply, and confirm both that `GET /beholder-state/:chatId` returns the edit and that the panel redraws with it. Also confirmed the 400 path by submitting a state that does not normalize.

## Documentation impact

- [x] No documentation changes needed

## UI evidence (if applicable)

The consuming UI ships in the Beholder package, not the Engine; screenshots belong with that change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a privileged endpoint for operators to update a conversation’s Beholder state.
  * Validates and normalizes submitted state before applying changes.
  * Requires a latest successful Beholder run and returns the corrected state with run metadata.
  * Applies rate limiting to state updates.
  * Provides clear errors for invalid state, missing runs, or conflicting updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->