### PR TITLE
fix(client): honor theme colors in message counts and preset feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Mobile Roleplay and Game message numbers now follow Chat Chrome Text Color, and Marinara preset import and save/export feedback follows the active accent instead of fixed theme-independent colors (#5679).
 - Mobile Roleplay now clears Trackers, Echo Chamber, and other agent windows while the composer is active; the app-owned composer chrome is shorter above the software keyboard; and Conversation and Roleplay message editors leave enough trailing scroll space to reach their final lines without first changing the text (#5672).
 - Roleplay context usage now follows the configured chat chroma text color; mobile message editing temporarily clears agent overlays while keeping message controls available; and the Characters and Personas libraries now use concise search copy, full-width sorting fields, and a consistent action layout (#5648).
 - Firefox on Android no longer shows a large empty band above the system navigation bar that obscured the bottom of the Agents, Connections, Presets, and chats panels and pushed the chat composer up: Gecko reports the navigation-bar height as a bottom safe-area inset even though its viewport already stops above the bar, so the app now zeroes its bottom safe-area padding on that engine instead of double-compensating (#5665).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -114,6 +114,17 @@ async function readCssVariableColor(page: Page, variableName: string) {
   }, variableName);
 }
 
+async function readScopedCssVariableColor(scope: Locator, variableName: string) {
+  return scope.evaluate((element, name) => {
+    const probe = document.createElement("span");
+    probe.style.color = `var(${name})`;
+    element.append(probe);
+    const color = getComputedStyle(probe).color;
+    probe.remove();
+    return color;
+  }, variableName);
+}
+
 async function openEditorSection(editor: Locator, label: string) {
   const compactMenuButton = editor.getByRole("button", { name: "Editor sections" });
   const navigation = editor.getByRole("navigation", { name: "Editor sections" });
@@ -2083,6 +2094,51 @@ test("Conversation transcript dates and message numbers follow Chat Chrome Text 
     await assertChromeText("#3b82f6");
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
+  }
+});
+
+test("mobile Roleplay message numbers follow Chat Chrome Text Color", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("mobile"), "Mobile Roleplay message-number regression.");
+
+  const chatResponse = await page.request.post("/api/chats", {
+    data: { name: "Roleplay Message Number Chroma Smoke", mode: "roleplay", characterIds: [] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+  const messageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
+    data: { role: "user", content: "Roleplay message-number chroma probe." },
+  });
+  expect(messageResponse.ok()).toBeTruthy();
+  const message = (await messageResponse.json()) as { id: string };
+
+  try {
+    await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
+    await page.goto("/");
+    await page.evaluate(async () => {
+      const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
+        useUIStore: {
+          getState: () => {
+            setChatChromeTextColor: (value: string) => void;
+            setShowMessageNumbers: (value: boolean) => void;
+          };
+        };
+      };
+      const ui = useUIStore.getState();
+      ui.setChatChromeTextColor("#3b82f6");
+      ui.setShowMessageNumbers(true);
+    });
+    await setAppAccentColor(page, "#ec4899");
+
+    const messageNumber = page.locator(`[data-message-id="${message.id}"]`).getByText(/^#1$/u);
+    await expect(messageNumber).toBeVisible();
+    const expectedColor = await readCssVariableColor(page, "--marinara-chat-chrome-text");
+    await expect(messageNumber).toHaveCSS("color", expectedColor);
+    await testInfo.attach(`mobile-roleplay-message-number-${testInfo.project.name}.png`, {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+  } finally {
+    await bestEffortDelete(page.request, `/api/chats/${chat.id}?force=true`);
   }
 });
 
@@ -8039,6 +8095,90 @@ test("message search stays before Chat Settings and jumps to unloaded history", 
     }
   } finally {
     await Promise.allSettled(chats.map((chat) => request.delete(`/api/chats/${chat.id}`)));
+  }
+});
+
+test("preset import and save-export feedback follow the active accent", async ({ page, request }, testInfo) => {
+  const suffix = `${testInfo.project.name}-${Date.now().toString(36)}`;
+  const presetResponse = await request.post("/api/prompts", {
+    data: { name: `Theme Feedback Preset ${suffix}`, description: "Theme feedback regression fixture." },
+  });
+  expect(presetResponse.ok()).toBeTruthy();
+  const preset = (await presetResponse.json()) as { id: string };
+
+  await page.route(/\/api\/import\/st-preset$/u, async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ success: true }) });
+  });
+
+  try {
+    await page.goto("/");
+    await setAppAccentColor(page, "#14b8a6");
+    await page.evaluate(async () => {
+      const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
+        useUIStore: { getState: () => { openModal: (type: string) => void } };
+      };
+      useUIStore.getState().openModal("import-preset");
+    });
+
+    const importDialog = page.getByRole("dialog", { name: "Import Preset", exact: true });
+    await expect(importDialog).toBeVisible();
+    await importDialog.locator('input[type="file"]').setInputFiles({
+      name: "theme-aware-preset.json",
+      mimeType: "application/json",
+      buffer: Buffer.from(JSON.stringify({ name: "Theme-aware import" })),
+    });
+
+    const importSummary = importDialog.getByText(/1\s+succeeded,?\s+0\s+failed/u);
+    await expect(importSummary).toBeVisible();
+    const expectedModalAccent = await readScopedCssVariableColor(importSummary, "--primary");
+    await expect(importSummary).toHaveCSS("color", expectedModalAccent);
+    await expect(importDialog.locator('svg[class*="lucide-circle-check"]').last()).toHaveCSS(
+      "color",
+      expectedModalAccent,
+    );
+    await testInfo.attach(`preset-import-accent-${testInfo.project.name}.png`, {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+
+    await importDialog.getByRole("button", { name: "Close", exact: true }).click();
+    await expect(importDialog).toBeHidden();
+    await page.evaluate(async (presetId) => {
+      const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
+        useUIStore: { getState: () => { openPresetDetail: (id: string) => void } };
+      };
+      useUIStore.getState().openPresetDetail(presetId);
+    }, preset.id);
+
+    const editor = page.locator(".mari-editor-shell");
+    const titleInput = editor.locator(".mari-editor-title-input");
+    await expect(titleInput).toBeVisible();
+    await titleInput.fill(`Theme Feedback Export ${suffix}`);
+    await editor.getByTitle("Save current edits before exporting", { exact: true }).click();
+    const exportDialog = page.getByRole("dialog", { name: /Save before exporting/u });
+    await expect(exportDialog).toBeVisible();
+    await exportDialog.getByRole("button", { name: "Save and export", exact: true }).click();
+
+    const expectedEditorAccent = await readScopedCssVariableColor(editor, "--marinara-editor-accent");
+    const savedFeedback = editor.getByText("Changes saved", { exact: true });
+    await expect(savedFeedback).toBeVisible();
+    await expect(savedFeedback).toHaveCSS("color", expectedEditorAccent);
+    await testInfo.attach(`preset-save-export-accent-${testInfo.project.name}.png`, {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+
+    await titleInput.fill(`Unsaved Theme Feedback ${suffix}`);
+    await editor.locator(".mari-editor-header-main > button").first().click();
+    const unsavedFeedback = editor.getByText("You have unsaved changes.", { exact: true }).locator("..");
+    await expect(unsavedFeedback).toBeVisible();
+    await expect(unsavedFeedback).toHaveCSS("color", expectedEditorAccent);
+    await testInfo.attach(`preset-unsaved-accent-${testInfo.project.name}.png`, {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+  } finally {
+    await bestEffortDelete(request, `/api/prompts/${preset.id}`);
   }
 });
 

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -3255,7 +3255,7 @@ export const ChatMessage = memo(function ChatMessage({
                 </div>
               )}
               {(showActions || showMessageNumbers) && messageIndex != null && (
-                <span className="mt-1 text-[0.5625rem] font-medium text-[var(--muted-foreground)] select-none">
+                <span className="mt-1 text-[0.5625rem] font-medium text-[var(--marinara-chat-chrome-text)] select-none">
                   #{messageIndex}
                 </span>
               )}
@@ -3301,7 +3301,9 @@ export const ChatMessage = memo(function ChatMessage({
                 {(showRoleplayAvatarPanel || hideRoleplayAvatars) &&
                   (showActions || showMessageNumbers) &&
                   messageIndex != null && (
-                    <span className="text-[0.5625rem] font-medium text-white/25 select-none">#{messageIndex}</span>
+                    <span className="text-[0.5625rem] font-medium text-[var(--marinara-chat-chrome-text)] select-none">
+                      #{messageIndex}
+                    </span>
                   )}
               </div>
             )}
@@ -3804,7 +3806,7 @@ export const ChatMessage = memo(function ChatMessage({
               </div>
             )}
             {(showActions || showMessageNumbers) && messageIndex != null && (
-              <span className="mt-0.5 text-[0.5rem] font-medium text-[var(--muted-foreground)] select-none">
+              <span className="mt-0.5 text-[0.5rem] font-medium text-[var(--marinara-chat-chrome-text)] select-none">
                 #{messageIndex}
               </span>
             )}

--- a/packages/client/src/components/modals/ImportPresetModal.tsx
+++ b/packages/client/src/components/modals/ImportPresetModal.tsx
@@ -158,7 +158,7 @@ export function ImportPresetModal({ open, onClose }: Props) {
             <div
               className={`flex items-center gap-2 rounded-lg p-3 text-xs ${
                 results.some((result) => result.success)
-                  ? "bg-emerald-500/10 text-emerald-400"
+                  ? "bg-[var(--primary)]/10 text-[var(--primary)]"
                   : "bg-[var(--destructive)]/10 text-[var(--destructive)]"
               }`}
             >
@@ -174,7 +174,7 @@ export function ImportPresetModal({ open, onClose }: Props) {
                   className="flex items-start gap-2 border-b border-[var(--border)] px-3 py-2 text-xs last:border-b-0"
                 >
                   {result.success ? (
-                    <CheckCircle size="0.8125rem" className="mt-0.5 shrink-0 text-emerald-400" />
+                    <CheckCircle size="0.8125rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
                   ) : (
                     <XCircle size="0.8125rem" className="mt-0.5 shrink-0 text-[var(--destructive)]" />
                   )}

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -608,14 +608,14 @@ export function PresetEditor() {
 
       {/* Saved toast */}
       {showSaved && (
-        <div className="absolute left-1/2 top-14 z-50 -translate-x-1/2 animate-fade-in-up rounded-lg border border-emerald-500/30 bg-emerald-500/15 px-3 py-1.5 text-xs font-medium text-emerald-400 shadow-lg backdrop-blur-sm">
+        <div className="absolute left-1/2 top-14 z-50 -translate-x-1/2 animate-fade-in-up rounded-lg border border-[var(--marinara-editor-accent)]/30 bg-[var(--marinara-editor-accent)]/15 px-3 py-1.5 text-xs font-medium text-[var(--marinara-editor-accent)] shadow-lg backdrop-blur-sm">
           {localizeUi("ui.presets.preseteditor.changesSaved")}
         </div>
       )}
 
       {/* Unsaved warning */}
       {showUnsavedWarning && (
-        <div className="flex items-center justify-between bg-[var(--warning)]/10 px-4 py-2 text-xs text-[var(--warning)]">
+        <div className="flex items-center justify-between bg-[var(--marinara-editor-accent)]/10 px-4 py-2 text-xs text-[var(--marinara-editor-accent)]">
           <span>{localizeUi("ui.presets.preseteditor.youHaveUnsavedChanges")}</span>
           <div className="flex gap-2">
             <button


### PR DESCRIPTION
## Linked issue

Closes #5679

## Why this change

- Mobile Roleplay and Game message counts bypass Chat Chrome Text Color, while Marinara preset transfer feedback uses fixed green and amber styling instead of the selected theme.

## What changed

- Route every shared Roleplay/Game message-number variant through the existing chat chrome text token.
- Route successful preset imports and preset save/export feedback through existing accent tokens.
- Keep actual import failures on the destructive token and preserve their icon/text distinction.
- Add desktop Chromium, mobile Chromium, and mobile WebKit regression coverage plus an Unreleased changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated browser proof: `pnpm exec playwright test -c playwright.config.ts e2e/core-flows.e2e.ts --grep "mobile Roleplay message numbers|preset import and save-export feedback"`
- Verify a custom Chat Chrome Text Color on a mobile Roleplay message number.
- Verify a custom accent on preset import success, Save and export feedback, and the unsaved warning on desktop and mobile.
- Verify a failed preset import remains destructive rather than looking successful.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence

- The focused Playwright regression attaches screenshots for the mobile message number and every preset feedback state on desktop Chromium, mobile Chromium, and mobile WebKit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mobile Roleplay and Game message numbers to use the configured theme colors.
  * Updated preset import success indicators to match the active theme.
  * Updated preset editor saved and unsaved-change feedback to use the configured editor accent color.
* **Tests**
  * Added end-to-end coverage for theme-aware colors across mobile chat and preset workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->