### PR TITLE
fix(agents): preserve mandatory GLM reasoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- JSON agents now preserve mandatory reasoning for GLM 5.3 Flash on OpenRouter and NanoGPT instead of sending a reasoning-disable request that those providers reject (#5582).
+
 - Illustrator image downloads in the installed iPhone app now open the dismissible iOS share sheet instead of stranding the user in WebKit's full-screen file preview; choosing Save Image writes to Photos and returns to the still-open Marinara lightbox (#5681).
 - Firefox on Android no longer shows the empty band above the system navigation bar on the surfaces the earlier shell fix did not cover — full-screen mobile modals, the chat settings and gallery drawers, the setup wizards, game overlays (character sheet, inventory, narration, readables), the selection action bar, the browser hub, and the floating call/launcher buttons: every remaining bottom safe-area consumer now honors the engine-specific override that zeroes Gecko's misreported inset (#5667).
 

--- a/packages/server/src/services/llm/providers/glm-request-compat.ts
+++ b/packages/server/src/services/llm/providers/glm-request-compat.ts
@@ -14,6 +14,10 @@ export function isGlm52Model(model: string): boolean {
   return /(?:^|\/)glm-5\.2(?:$|[-:])/u.test(model.toLowerCase());
 }
 
+export function isGlm53FlashMandatoryReasoningModel(model: string): boolean {
+  return /(?:^|\/)glm-5\.3-flash(?:$|[-:])/u.test(model.toLowerCase());
+}
+
 export function isNativeGlmEndpoint(baseUrl: string): boolean {
   try {
     const hostname = new URL(baseUrl).hostname.toLowerCase();
@@ -50,6 +54,7 @@ export function applyGlmThinkingParameters(body: Record<string, unknown>, option
     return true;
   }
 
-  body.enable_thinking = thinkingEnabled;
+  body.enable_thinking =
+    options.providerKind === "nanogpt" && isGlm53FlashMandatoryReasoningModel(options.model) ? true : thinkingEnabled;
   return true;
 }

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -25,7 +25,7 @@ import {
 } from "@marinara-engine/shared";
 import { logger } from "../../../lib/logger.js";
 import { isLoopbackIp, isNonRoutableNetworkIp } from "../../../middleware/ip-allowlist.js";
-import { applyGlmThinkingParameters } from "./glm-request-compat.js";
+import { applyGlmThinkingParameters, isGlm53FlashMandatoryReasoningModel } from "./glm-request-compat.js";
 
 /**
  * Models that ONLY support the Responses API (`/responses`) and not Chat Completions.
@@ -786,7 +786,7 @@ export class OpenAIProvider extends BaseLLMProvider {
     return (
       this.supportsOpenAIReasoningDisable(normalized) ||
       this.supportsXAIReasoningDisable(normalized) ||
-      normalized.startsWith("z-ai/glm-") ||
+      (normalized.startsWith("z-ai/glm-") && !isGlm53FlashMandatoryReasoningModel(normalized)) ||
       normalized.startsWith("thudm/glm-") ||
       /^google\/gemini-2\.5-flash(?:-lite)?(?:$|-preview|-latest|:)/u.test(normalized) ||
       /^anthropic\/claude-(?:opus|sonnet)-5(?:$|[-.])/u.test(normalized)

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -8,6 +8,7 @@ import {
 } from "../../packages/shared/src/constants/model-lists.js";
 import {
   applyGlmThinkingParameters,
+  isGlm53FlashMandatoryReasoningModel,
   isNativeGlmEndpoint,
 } from "../../packages/server/src/services/llm/providers/glm-request-compat.js";
 import {
@@ -1115,6 +1116,21 @@ try {
     false,
     "known reasoning-mandatory OpenRouter models must keep their provider default",
   );
+
+  openRouterRequestBody = null;
+  await collectProviderOutput(provider, {
+    model: "z-ai/glm-5.3-flash",
+    stream: false,
+    reasoningEffort: "none",
+    enabledParameters: { reasoningEffort: true },
+  });
+  const mandatoryGlmOpenRouterBody = openRouterRequestBody as Record<string, unknown>;
+  assert.ok(mandatoryGlmOpenRouterBody);
+  assert.equal(
+    "reasoning" in mandatoryGlmOpenRouterBody,
+    false,
+    "GLM 5.3 Flash must keep OpenRouter's mandatory reasoning default",
+  );
 } finally {
   await new Promise<void>((resolve, reject) => openRouterServer.close((error) => (error ? reject(error) : resolve())));
 }
@@ -1200,6 +1216,36 @@ applyGlmThinkingParameters(glm52DisabledBody, {
   reasoningEffort: "none",
 });
 assert.deepEqual(glm52DisabledBody, { thinking: { type: "disabled" } });
+
+assert.equal(isGlm53FlashMandatoryReasoningModel("z-ai/glm-5.3-flash"), true);
+assert.equal(isGlm53FlashMandatoryReasoningModel("z-ai/glm-5.3-flash:free"), true);
+assert.equal(isGlm53FlashMandatoryReasoningModel("z-ai/glm-5.2"), false);
+
+const nanogptMandatoryGlmBody: Record<string, unknown> = {};
+applyGlmThinkingParameters(nanogptMandatoryGlmBody, {
+  model: "glm-5.3-flash",
+  baseUrl: "https://nano-gpt.com/api/v1",
+  providerKind: "nanogpt",
+  reasoningEffort: "none",
+});
+assert.deepEqual(
+  nanogptMandatoryGlmBody,
+  { enable_thinking: true },
+  "NanoGPT mandatory-reasoning GLM models must not receive a disable request",
+);
+
+const nativeGlm53DisabledBody: Record<string, unknown> = {};
+applyGlmThinkingParameters(nativeGlm53DisabledBody, {
+  model: "glm-5.3-flash",
+  baseUrl: "https://api.z.ai/api/paas/v4/",
+  providerKind: "custom",
+  reasoningEffort: "none",
+});
+assert.deepEqual(
+  nativeGlm53DisabledBody,
+  { enable_thinking: false },
+  "Native GLM endpoints must preserve their explicit reasoning setting",
+);
 
 const legacyGlmBody: Record<string, unknown> = {};
 applyGlmThinkingParameters(legacyGlmBody, {


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #5582

## Why this change

- JSON agents explicitly disable reasoning to protect their structured output budget. GLM 5.3 Flash requires reasoning on OpenRouter and NanoGPT, so those providers rejected agent requests before generation started.

## What changed

- Keep OpenRouter's provider-default reasoning for GLM 5.3 Flash instead of sending `reasoning.effort: none`.
- Keep NanoGPT reasoning enabled for GLM 5.3 Flash while preserving explicit reasoning controls on native GLM endpoints.
- Add request-shaping regressions for OpenRouter, NanoGPT, native GLM endpoints, and model ID suffixes.
- Add the user-facing fix to the Unreleased changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated request-body proof: `pnpm regression:node --filter provider-compat`
- Agent override proof: `pnpm regression:node --filter agent-runtime`
- Repository validation: `pnpm check`
- Installer artifact guard: `pnpm guard:installer-artifacts`
- Live OpenRouter and NanoGPT calls still need maintainer verification with configured provider credentials.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable. This change only updates server-side provider request shaping.

## Proof

- OpenRouter GLM 5.3 Flash requests omit explicit reasoning-disable fields.
- NanoGPT GLM 5.3 Flash requests send `enable_thinking: true`.
- Native GLM requests preserve explicit reasoning-off behavior.
- The targeted provider and agent regressions pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GLM 5.3 Flash requests through OpenRouter and NanoGPT to preserve required reasoning settings.
  * Prevented unsupported reasoning-disable parameters from being sent, avoiding rejected requests.
  * Retained explicit reasoning controls for compatible native GLM endpoints.
* **Reliability**
  * Added coverage for GLM 5.3 Flash behavior across supported providers and model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->