### PR TITLE
fix(termux): prevent GitHub credential prompts during updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Termux startup no longer prompts for GitHub credentials during public update checks; failed checks now continue with the installed version.
 - Mobile Roleplay now keeps its full composer controls visible while scrolling through chat history instead of replacing them with a simplified text field (#5685).
 - Available app updates now wait for an explicit refresh instead of silently reloading active sessions, and Roleplay avatars no longer request persistent compositor layers, reducing iPhone WebKit memory pressure (#5686).
 - JSON agents now preserve mandatory reasoning for GLM 5.3 Flash on OpenRouter and NanoGPT instead of sending a reasoning-disable request that those providers reject (#5582).

--- a/scripts/regressions/launcher/update.regression.mjs
+++ b/scripts/regressions/launcher/update.regression.mjs
@@ -265,6 +265,13 @@ function assertPosixReminderRouting(launcherName) {
 assertPosixReminderRouting("start.sh");
 assertPosixReminderRouting("start-termux.sh");
 
+const termuxLauncherSource = readFileSync(join(repositoryRoot, "start-termux.sh"), "utf8");
+assert.match(
+  termuxLauncherSource,
+  /cd "\$\(dirname "\$0"\)"[\s\S]*?export GIT_TERMINAL_PROMPT=0/u,
+  "The Termux launcher must disable interactive Git credential prompts before update checks",
+);
+
 const windowsLauncherSource = readFileSync(join(repositoryRoot, "start.bat"), "utf8");
 assert.match(windowsLauncherSource, /check-launcher-update\.mjs/u);
 assert.match(

--- a/start-termux.sh
+++ b/start-termux.sh
@@ -37,6 +37,9 @@ echo ""
 # Navigate to script directory
 cd "$(dirname "$0")"
 
+# Public update checks must never pause for GitHub credentials.
+export GIT_TERMINAL_PROMPT=0
+
 # APK-managed installs provision a per-install secret in Termux-private
 # storage. The server uses it to keep unrelated Android apps from inheriting
 # loopback trust; manual Termux installs simply continue without this setting.


### PR DESCRIPTION
## Linked issue

Closes #5693

## Why this change

- A Termux user saw a GitHub username/password prompt after `Checking for updates...`, even though the official Marinara repository is public and the same remote fetched successfully without credentials.
- Startup must never block on an interactive credential request for a public update check.

## What changed

- Export `GIT_TERMINAL_PROMPT=0` before any Git operation in `start-termux.sh`.
- Add a launcher regression guard for the export and its placement before update checks.
- Add an Unreleased changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated verification completed: `pnpm check` and `pnpm regression:launcher-update` pass.
- Manual Android/Termux verification remains for the maintainer or contributor with an Android device.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable.