### PR TITLE
fix(client): give avatar crop handles a mobile-sized touch target

### DIFF
--- a/packages/client/src/components/ui/AvatarCropWidget.tsx
+++ b/packages/client/src/components/ui/AvatarCropWidget.tsx
@@ -40,6 +40,10 @@ export interface AvatarCropWidgetProps {
 }
 
 const MIN_CROP_PX = 24;
+/** Drawn size of a corner handle. */
+const HANDLE_VISUAL_PX = 14;
+/** Touch target around it — the usual 44px mobile minimum. */
+const HANDLE_TOUCH_PX = 44;
 const MAX_DISPLAY_W = 360;
 const MAX_DISPLAY_H = 360;
 
@@ -369,24 +373,39 @@ function CornerHandle({
   onPointerMove: (e: React.PointerEvent) => void;
   onPointerUp: () => void;
 }) {
-  const base: React.CSSProperties = {
-    position: "absolute",
-    width: 14,
-    height: 14,
-    background: "white",
-    border: "1px solid black",
-    borderRadius: 2,
-  };
+  // The visible square stays small, but a 14px target is roughly 3.5mm on a phone
+  // and misses far more often than it hits. Wrap it in a 44px transparent target
+  // (the standard mobile minimum) that reaches mostly *outward* from the crop
+  // corner: it intrudes only `HANDLE_VISUAL_PX / 2` into the crop box, so the
+  // four corners cannot swallow the pan area even at `MIN_CROP_PX`.
+  const inset = HANDLE_TOUCH_PX - HANDLE_VISUAL_PX / 2;
   const cursorByPos = { tl: "nwse-resize", tr: "nesw-resize", bl: "nesw-resize", br: "nwse-resize" } as const;
-  const positionByPos: Record<typeof pos, React.CSSProperties> = {
-    tl: { top: -8, left: -8 },
-    tr: { top: -8, right: -8 },
-    bl: { bottom: -8, left: -8 },
-    br: { bottom: -8, right: -8 },
+  const targetByPos: Record<typeof pos, React.CSSProperties> = {
+    tl: { top: -inset, left: -inset },
+    tr: { top: -inset, right: -inset },
+    bl: { bottom: -inset, left: -inset },
+    br: { bottom: -inset, right: -inset },
+  };
+  // Pin the visible square to the target's crop-facing corner, so it lands where
+  // it has always been drawn.
+  const squareByPos: Record<typeof pos, React.CSSProperties> = {
+    tl: { bottom: 0, right: 0 },
+    tr: { bottom: 0, left: 0 },
+    bl: { top: 0, right: 0 },
+    br: { top: 0, left: 0 },
   };
   return (
     <div
-      style={{ ...base, ...positionByPos[pos], cursor: cursorByPos[pos] }}
+      style={{
+        position: "absolute",
+        width: HANDLE_TOUCH_PX,
+        height: HANDLE_TOUCH_PX,
+        // Without this the WebView can claim the gesture as a scroll before the
+        // pointer capture in `onPointerDown` takes effect.
+        touchAction: "none",
+        ...targetByPos[pos],
+        cursor: cursorByPos[pos],
+      }}
       onPointerDown={(e) => {
         e.stopPropagation();
         onPointerDown(e);
@@ -394,7 +413,19 @@ function CornerHandle({
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}
-    />
+    >
+      <div
+        style={{
+          position: "absolute",
+          width: HANDLE_VISUAL_PX,
+          height: HANDLE_VISUAL_PX,
+          background: "white",
+          border: "1px solid black",
+          borderRadius: 2,
+          ...squareByPos[pos],
+        }}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
Closes #5705

## Why

The avatar crop corner handles are 14×14 CSS px, which is roughly 3.5mm on a phone — well under the ~44px mobile minimum. The reporter's video shows repeated missed taps ("I only tap the drag handles by luck").

Two things made it worse than the size alone suggests:

- The handle element had no `touch-action`. The crop box sets `touch-none`, but `touch-action` is not inherited, so a drag starting on a handle could be claimed by the WebView as a scroll before `setPointerCapture` in `onPointerDown` took effect.
- The visible square *is* the hit target, so there was no margin for error at all.

## What

The visible 14px square is unchanged and still drawn exactly where it was. It is now wrapped in a 44px transparent touch target with `touch-action: none`.

The target reaches mostly **outward** from the crop corner — it intrudes only `HANDLE_VISUAL_PX / 2` (7px) into the crop box. That matters because `MIN_CROP_PX` is 24: centred 44px targets would have covered a minimum-size crop entirely and made panning unreachable on touch. Reaching outward keeps the pan area usable at every crop size and stops the four corners overlapping each other.

`AvatarCropWidget` is shared by `CharacterEditor` and `PersonaEditor`, so this covers the persona crop the reporter suspected was also affected.

## Test plan

- [ ] `pnpm check`
- [ ] `node scripts/run-regressions.mjs`
- [ ] Manually crop a character avatar on a touch device and confirm the corner handles are reliably grabbable
- [ ] Manually confirm the same for a persona avatar
- [ ] Manually shrink the crop to its minimum and confirm panning by dragging the middle still works
- [ ] Manually confirm the handles look unchanged on desktop and still resize with the mouse
- [ ] Manually confirm a drag that starts on a handle does not scroll the page on mobile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar crop corner handles for more reliable touch interaction.
  * Preserved more of the crop area for panning, especially when using the minimum crop size.
  * Maintained clear, visible corner indicators while expanding their touch targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->