### PR TITLE
fix: support NanoGPT embeddings and reasoning controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Character library and omnibar searches now share a generation-aware in-memory character catalog, so list views do not repeatedly scan and transfer complete character cards.
 - Fixed character identity prompt previews, imports, gallery participant handling, and quick-menu scrolling and bounds.
 - Fixed character identity profile routing, prompt macro resolution, sprite subjects, memory naming, and lorebook scan context.
+- Fixed NanoGPT lorebook vectorization by sending the authentication header required by its embedding endpoint (#5688).
+- Fixed NanoGPT agent requests so an explicit reasoning-off setting sends `reasoning_effort: "none"`, while preserving mandatory reasoning for GLM 5.3 Flash (#5582).
 - Preserved historical user names and portraits across identity switches.
 - Termux startup no longer prompts for GitHub credentials during public update checks; failed checks now continue with the installed version.
 - Mobile Roleplay now keeps its full composer controls visible while scrolling through chat history instead of replacing them with a simplified text field (#5685).

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -806,10 +806,7 @@ export abstract class BaseLLMProvider {
   async embed(texts: string[], model: string, signal?: AbortSignal): Promise<number[][]> {
     const timeoutMs = getEmbeddingRequestTimeoutMs();
     const timeoutSignal = AbortSignal.timeout(timeoutMs);
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${this.apiKey}`,
-    };
+    const headers = this.embeddingHeaders();
     const res = await llmFetch(resolveEmbeddingEndpointUrl(this.baseUrl), {
       method: "POST",
       headers,
@@ -824,6 +821,13 @@ export abstract class BaseLLMProvider {
     }
     const json = await res.json();
     return parseEmbeddingResponse(json);
+  }
+
+  protected embeddingHeaders(): Record<string, string> {
+    return {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${this.apiKey}`,
+    };
   }
 }
 

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -558,6 +558,12 @@ export class OpenAIProvider extends BaseLLMProvider {
     return h;
   }
 
+  protected override embeddingHeaders(): Record<string, string> {
+    const headers = this.buildHeaders();
+    if (this.providerKind === "nanogpt" && this.apiKey.trim()) headers["x-api-key"] = this.apiKey.trim();
+    return headers;
+  }
+
   private isGenericCustomProvider(): boolean {
     return this.providerKind === "custom";
   }
@@ -874,6 +880,15 @@ export class OpenAIProvider extends BaseLLMProvider {
       } else if (this.shouldSendReasoningEffort(options.model, options.reasoningEffort)) {
         body.reasoning_effort = options.reasoningEffort;
       }
+      return;
+    }
+
+    if (
+      this.providerKind === "nanogpt" &&
+      this.hasExplicitReasoningDisable(options.reasoningEffort) &&
+      !isGlm53FlashMandatoryReasoningModel(options.model)
+    ) {
+      body.reasoning_effort = "none";
       return;
     }
 

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -149,6 +149,75 @@ const gatewaySseBody = [
   "data: [DONE]",
 ].join("\n");
 
+const embeddingRequests: Array<{ headers: Record<string, string>; body: Record<string, unknown> }> = [];
+const embeddingServer = createServer(async (request, response) => {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  embeddingRequests.push({
+    headers: request.headers as Record<string, string>,
+    body: JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>,
+  });
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify({ data: [{ embedding: [0.1, 0.2], index: 0 }] }));
+});
+await new Promise<void>((resolve) => embeddingServer.listen(0, "127.0.0.1", resolve));
+try {
+  const address = embeddingServer.address();
+  assert.ok(address && typeof address === "object");
+  const nanoGpt = new OpenAIProvider(`http://localhost:${address.port}/v1`, "nano-key", undefined, undefined, undefined, "nanogpt");
+  await nanoGpt.embed(["test"], "text-embedding-model");
+  assert.equal(embeddingRequests[0]?.headers.authorization, "Bearer nano-key");
+  assert.equal(embeddingRequests[0]?.headers["x-api-key"], "nano-key");
+
+  const openAi = new OpenAIProvider(`http://localhost:${address.port}/v1`, "openai-key");
+  await openAi.embed(["test"], "text-embedding-model");
+  assert.equal(embeddingRequests[1]?.headers.authorization, "Bearer openai-key");
+  assert.equal(embeddingRequests[1]?.headers["x-api-key"], undefined);
+} finally {
+  await new Promise<void>((resolve, reject) => embeddingServer.close((error) => (error ? reject(error) : resolve())));
+}
+
+let nanoGptRequestBody: Record<string, unknown> | null = null;
+const nanoGptServer = createServer(async (request, response) => {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  nanoGptRequestBody = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify({ choices: [{ message: { content: "nano response" }, finish_reason: "stop" }] }));
+});
+await new Promise<void>((resolve) => nanoGptServer.listen(0, "127.0.0.1", resolve));
+try {
+  const address = nanoGptServer.address();
+  assert.ok(address && typeof address === "object");
+  const provider = new OpenAIProvider(
+    `http://127.0.0.1:${address.port}/v1`,
+    "nano-key",
+    undefined,
+    undefined,
+    undefined,
+    "nanogpt",
+  );
+  await collectProviderOutput(provider, {
+    model: "some-model",
+    stream: false,
+    reasoningEffort: "none",
+    enabledParameters: { reasoningEffort: true },
+  });
+  assert.equal(nanoGptRequestBody?.reasoning_effort, "none");
+
+  nanoGptRequestBody = null;
+  await collectProviderOutput(provider, {
+    model: "glm-5.3-flash",
+    stream: false,
+    reasoningEffort: "none",
+    enabledParameters: { reasoningEffort: true },
+  });
+  assert.equal("reasoning_effort" in (nanoGptRequestBody ?? {}), false);
+  assert.equal(nanoGptRequestBody?.enable_thinking, true);
+} finally {
+  await new Promise<void>((resolve, reject) => nanoGptServer.close((error) => (error ? reject(error) : resolve())));
+}
+
 assert.equal(resolveNovelAiStyleReferenceSecondaryStrength(1), 0);
 assert.equal(resolveNovelAiStyleReferenceSecondaryStrength(0.75), 0.25);
 assert.equal(resolveNovelAiStyleReferenceSecondaryStrength(0), 1);


### PR DESCRIPTION
$## Summary\n\nFixes NanoGPT lorebook vectorization and agent reasoning controls.\n\n## Why\n\nNanoGPT embedding requests require `x-api-key`, while the shared embedding path sent only a Bearer header. Agent requests also need an explicit `reasoning_effort: "none"` when reasoning is disabled. GLM 5.3 Flash remains an exception because NanoGPT requires reasoning for that model.\n\n## Changes\n\n- Send `x-api-key` on NanoGPT embedding requests.\n- Send `reasoning_effort: "none"` for explicit NanoGPT reasoning-off requests.\n- Preserve `enable_thinking: true` for NanoGPT GLM 5.3 Flash.\n- Add provider regression coverage.\n\nFixes #5688\nFixes #5582\n\n## Verification\n\n- `pnpm install`\n- `pnpm format:check`\n- `pnpm build:shared && node ./scripts/run-regressions.mjs --filter scripts/regressions/provider-compat.regression.ts`\n- `pnpm check`\n\n## Manual verification\n\n- Manually verify lorebook vectorization with a NanoGPT embedding model.\n- Manually verify an agent with a NanoGPT non-reasoning model.\n- Manually verify NanoGPT GLM 5.3 Flash still sends mandatory reasoning.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed NanoGPT lorebook vectorization requests so authentication headers are sent correctly.
  * Fixed NanoGPT requests with reasoning disabled to explicitly disable reasoning.
  * Preserved mandatory reasoning behavior for GLM 5.3 Flash models.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->