### PR TITLE
Fix iOS chat shell scrolling and Roleplay visual retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- iPhone chat fields no longer let software-keyboard focus pan and transform the entire app shell; Roleplay also releases its inactive full-resolution background after each crossfade and avoids unused full-viewport compositor hints, reducing persistent WebKit visual memory (#5710, #5711).
 - Character library and omnibar searches now share a generation-aware in-memory character catalog, so list views do not repeatedly scan and transfer complete character cards.
 - Fixed character identity prompt previews, imports, gallery participant handling, and quick-menu scrolling and bounds.
 - Fixed character identity profile routing, prompt macro resolution, sprite subjects, memory naming, and lorebook scan context.

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -19114,13 +19114,67 @@ test("mobile chat composer follows the visual viewport above the software keyboa
       element.style.setProperty("--mari-safe-area-inset-bottom", "34px");
     });
     await expect(page.getByText(/^Keyboard viewport history line 18\./)).toBeVisible();
-    await textarea.focus();
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const htmlStyle = getComputedStyle(document.documentElement);
+          const bodyStyle = getComputedStyle(document.body);
+          const rootStyle = getComputedStyle(document.getElementById("root")!);
+          return {
+            htmlHeight: htmlStyle.height,
+            htmlOverflow: htmlStyle.overflow,
+            bodyPosition: bodyStyle.position,
+            bodyInset: [bodyStyle.top, bodyStyle.right, bodyStyle.bottom, bodyStyle.left],
+            bodyHeight: bodyStyle.height,
+            bodyOverflow: bodyStyle.overflow,
+            rootHeight: rootStyle.height,
+            rootOverflow: rootStyle.overflow,
+          };
+        }),
+      )
+      .toEqual({
+        htmlHeight: `${await page.evaluate(() => window.innerHeight)}px`,
+        htmlOverflow: "hidden",
+        bodyPosition: "fixed",
+        bodyInset: ["0px", "0px", "0px", "0px"],
+        bodyHeight: `${await page.evaluate(() => window.innerHeight)}px`,
+        bodyOverflow: "hidden",
+        rootHeight: `${await page.evaluate(() => window.innerHeight)}px`,
+        rootOverflow: "hidden",
+      });
+    await page.evaluate(() => {
+      const probeWindow = window as typeof window & {
+        __mariOriginalScrollIntoView: typeof Element.prototype.scrollIntoView;
+        __mariScrollIntoViewCalls: number;
+      };
+      probeWindow.__mariOriginalScrollIntoView = Element.prototype.scrollIntoView;
+      probeWindow.__mariScrollIntoViewCalls = 0;
+      Element.prototype.scrollIntoView = function () {
+        probeWindow.__mariScrollIntoViewCalls += 1;
+      };
+    });
     await page.evaluate(() => {
       (
         window as typeof window & {
           __setMarinaraVisualViewport: (height: number, offsetTop: number) => void;
         }
-      ).__setMarinaraVisualViewport(360, 72);
+      ).__setMarinaraVisualViewport(360, 340);
+    });
+    await textarea.focus();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as typeof window & { __mariScrollIntoViewCalls: number }).__mariScrollIntoViewCalls,
+        ),
+      )
+      .toBe(0);
+    await page.evaluate(() => {
+      const probeWindow = window as typeof window & {
+        __mariOriginalScrollIntoView: typeof Element.prototype.scrollIntoView;
+        __mariScrollIntoViewCalls?: number;
+      };
+      Element.prototype.scrollIntoView = probeWindow.__mariOriginalScrollIntoView;
+      delete probeWindow.__mariScrollIntoViewCalls;
     });
 
     await expect
@@ -19209,10 +19263,8 @@ test("mobile chat composer follows the visual viewport above the software keyboa
           getComputedStyle(document.documentElement).getPropertyValue("--mari-app-scroll-compensate").trim(),
         ),
       )
-      .toBe("64px");
-    await expect
-      .poll(() => page.evaluate(() => getComputedStyle(document.querySelector<HTMLElement>(".mari-app")!).transform))
-      .toContain("64");
+      .toBe("");
+    await expect.poll(() => shell.evaluate((element) => getComputedStyle(element).transform)).toBe("none");
 
     await page.evaluate(async () => {
       const storePath = "/src/stores/ui.store.ts";
@@ -19246,6 +19298,54 @@ test("mobile chat composer follows the visual viewport above the software keyboa
     }, chat.id);
     await expect(shell).not.toHaveAttribute("data-chat-surface-active");
     await expect.poll(() => shell.evaluate((element) => getComputedStyle(element).transform)).toBe("none");
+  } finally {
+    await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
+  }
+});
+
+test("mobile Roleplay releases its inactive background after a crossfade", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("webkit"), "Decoded-background retention is covered in mobile WebKit.");
+
+  const response = await page.request.post("/api/chats", {
+    data: {
+      name: "Roleplay background retention smoke",
+      mode: "roleplay",
+      characterIds: [],
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const chat = (await response.json()) as { id: string };
+
+  await page.addInitScript((chatId) => {
+    localStorage.setItem("marinara-active-chat-id", chatId);
+  }, chat.id);
+
+  try {
+    await page.goto("/");
+    await expect(page.locator('[data-chat-mode="roleplay"]')).toBeVisible();
+    const backgrounds = page.locator("img.mari-background[src]");
+    const makeBackground = (color: string) =>
+      `data:image/svg+xml,${encodeURIComponent(`<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><rect width="32" height="32" fill="${color}"/></svg>`)}`;
+
+    const setBackground = async (url: string) => {
+      await page.evaluate(async (backgroundUrl) => {
+        const storePath = "/src/stores/ui.store.ts";
+        const { useUIStore } = (await import(/* @vite-ignore */ storePath)) as {
+          useUIStore: {
+            getState: () => {
+              setChatBackground: (url: string | null) => void;
+            };
+          };
+        };
+        useUIStore.getState().setChatBackground(backgroundUrl);
+      }, url);
+    };
+
+    await setBackground(makeBackground("#512da8"));
+    await expect.poll(() => backgrounds.count()).toBeGreaterThan(0);
+    await setBackground(makeBackground("#00897b"));
+    await expect(backgrounds).toHaveCount(2);
+    await expect.poll(() => backgrounds.count(), { timeout: 2_000 }).toBe(1);
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
   }

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -56,7 +56,7 @@ import { translateDraftText } from "../../lib/draft-translation";
 import { prepareImageAttachment } from "../../lib/chat-attachment-images";
 import { CARD_ASSET_INSERT_EVENT, type CardAssetInsertDetail } from "../../lib/card-asset-links";
 import { isFileDrag } from "../../lib/chat-resource-drag";
-import { isGenerationSendBlocked } from "../../lib/generation-stream-policy";
+import { isGenerationSendBlocked, isIosWebKitBrowser } from "../../lib/generation-stream-policy";
 import { requestChatScrollToBottom } from "../../lib/chat-scroll-events";
 import { EmojiPicker } from "../ui/EmojiPicker";
 import { SpeechToTextButton } from "../ui/SpeechToTextButton";
@@ -1778,6 +1778,7 @@ export const ChatInput = memo(function ChatInput({
 
   const ensureInputVisible = useCallback(() => {
     if (typeof window === "undefined" || !window.matchMedia("(max-width: 767px)").matches) return;
+    if (isIosWebKitBrowser(navigator.userAgent, navigator.platform, navigator.maxTouchPoints)) return;
     const scroll = () => {
       const inputBar = inputBarRef.current;
       const viewport = window.visualViewport;

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -153,6 +153,7 @@ const ActiveLorebookEntriesContent = lazy(async () => {
 const roleplayNotificationSeenKeys = new Set<string>();
 const MAX_ROLEPLAY_NOTIFICATION_SEEN_KEYS = 5_000;
 const MOBILE_FLOATING_PANEL_PADDING = 8;
+const BACKGROUND_CROSSFADE_MS = 700;
 
 type MobileFloatingPanelFrame = {
   top: number;
@@ -230,6 +231,7 @@ function CrossfadeBackground({
   const [bgB, setBgB] = useState<string | null>(null);
   const [aActive, setAActive] = useState(true);
   const activeSlot = useRef<"a" | "b">("a");
+  const cleanupTimerRef = useRef<number | null>(null);
   const backgroundBlurStyle = getBackgroundBlurStyle(blurPx);
 
   useEffect(() => {
@@ -259,17 +261,33 @@ function CrossfadeBackground({
     };
 
     function applyUrl(nextUrl: string | null) {
+      if (cleanupTimerRef.current !== null) window.clearTimeout(cleanupTimerRef.current);
       if (activeSlot.current === "a") {
         setBgB(nextUrl);
         setAActive(false);
         activeSlot.current = "b";
+        cleanupTimerRef.current = window.setTimeout(() => {
+          cleanupTimerRef.current = null;
+          setBgA(null);
+        }, BACKGROUND_CROSSFADE_MS);
       } else {
         setBgA(nextUrl);
         setAActive(true);
         activeSlot.current = "a";
+        cleanupTimerRef.current = window.setTimeout(() => {
+          cleanupTimerRef.current = null;
+          setBgB(null);
+        }, BACKGROUND_CROSSFADE_MS);
       }
     }
   }, [bgA, bgB, url]);
+
+  useEffect(
+    () => () => {
+      if (cleanupTimerRef.current !== null) window.clearTimeout(cleanupTimerRef.current);
+    },
+    [],
+  );
 
   return (
     <>
@@ -283,7 +301,7 @@ function CrossfadeBackground({
         )}
         style={{
           opacity: aActive && bgA ? 1 : 0,
-          transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
+          transition: `opacity ${BACKGROUND_CROSSFADE_MS}ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out`,
           ...backgroundBlurStyle,
         }}
       />
@@ -297,7 +315,7 @@ function CrossfadeBackground({
         )}
         style={{
           opacity: !aActive && bgB ? 1 : 0,
-          transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
+          transition: `opacity ${BACKGROUND_CROSSFADE_MS}ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out`,
           ...backgroundBlurStyle,
         }}
       />

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -46,7 +46,7 @@ import { translateDraftText } from "../../lib/draft-translation";
 import { prepareImageAttachment } from "../../lib/chat-attachment-images";
 import { isFileDrag } from "../../lib/chat-resource-drag";
 import { CARD_ASSET_INSERT_EVENT, type CardAssetInsertDetail } from "../../lib/card-asset-links";
-import { isGenerationSendBlocked } from "../../lib/generation-stream-policy";
+import { isGenerationSendBlocked, isIosWebKitBrowser } from "../../lib/generation-stream-policy";
 import { requestChatScrollToBottom } from "../../lib/chat-scroll-events";
 import { searchStandardEmojiShortcodes, type StandardEmojiShortcode } from "../../lib/emoji-shortcodes";
 import { QuickConnectionSwitcher } from "./QuickConnectionSwitcher";
@@ -1895,6 +1895,7 @@ export function ConversationInput({
 
   const ensureInputVisible = useCallback(() => {
     if (typeof window === "undefined" || !window.matchMedia("(max-width: 767px)").matches) return;
+    if (isIosWebKitBrowser(navigator.userAgent, navigator.platform, navigator.maxTouchPoints)) return;
     const scroll = () => {
       const inputBar = inputBarRef.current;
       const viewport = window.visualViewport;

--- a/packages/client/src/components/chat/WeatherEffects.tsx
+++ b/packages/client/src/components/chat/WeatherEffects.tsx
@@ -315,7 +315,7 @@ export function WeatherEffects({ weather, timeOfDay, showCelestial = true, pause
     <canvas
       key={`${weather ?? ""}:${timeOfDay ?? ""}:${showCelestial ? "celestial" : "particles"}:${workerFailed ? "fallback" : "worker"}`}
       ref={canvasRef}
-      className="pointer-events-none absolute inset-0 z-0 h-full w-full transform-gpu [contain:strict] [will-change:transform]"
+      className="pointer-events-none absolute inset-0 z-0 h-full w-full [contain:strict]"
     />
   );
 }

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -252,11 +252,6 @@ export function AppShell() {
     const isIOSWebKit =
       /iP(?:ad|hone|od)/i.test(navigator.userAgent) ||
       (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
-    // iOS doesn't track the keyboard's visualViewport.offsetTop/height
-    // reliably, so we force offsetTop to 0 and instead counter the scroll
-    // drift iOS applies with a `transform: translateY()` (a GPU compositor
-    // update, unlike window.scrollTo() it doesn't fight WebKit's own
-    // animation).
     const updateVisualViewportGeometry = () => {
       if (frame) cancelAnimationFrame(frame);
       frame = requestAnimationFrame(() => {
@@ -272,9 +267,6 @@ export function AppShell() {
         largestViewportHeight = Math.max(largestViewportHeight, height);
         root.style.setProperty("--mari-visual-viewport-height", `${Math.max(0, Math.round(height))}px`);
         root.style.setProperty("--mari-visual-viewport-offset-top", `${Math.round(offsetTop)}px`);
-        if (isIOSWebKit) {
-          root.style.setProperty("--mari-app-scroll-compensate", `${Math.round(window.scrollY)}px`);
-        }
         const keyboardOpen = supportsVirtualKeyboard && largestViewportHeight - height >= 80;
         root.toggleAttribute("data-mari-software-keyboard-open", keyboardOpen);
         dispatchChatVisualViewportChange({
@@ -327,7 +319,6 @@ export function AppShell() {
       document.removeEventListener("focusout", refreshAfterFocusChange);
       root.style.removeProperty("--mari-visual-viewport-height");
       root.style.removeProperty("--mari-visual-viewport-offset-top");
-      root.style.removeProperty("--mari-app-scroll-compensate");
       root.removeAttribute("data-mari-software-keyboard-open");
     };
   }, []);

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -7277,18 +7277,12 @@ strong {
 }
 
 :root[data-professor-mari-floating="true"] .mari-conversation-call-mini {
-  bottom: calc(
-    max(var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom)), 0.75rem) + min(32rem, calc(100vh - 5rem)) +
-      0.75rem
-  );
+  bottom: calc(max(var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom)), 0.75rem) + min(32rem, calc(100vh - 5rem)) + 0.75rem);
 }
 
 @supports (height: 100dvh) {
   :root[data-professor-mari-floating="true"] .mari-conversation-call-mini {
-    bottom: calc(
-      max(var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom)), 0.75rem) + min(32rem, calc(100dvh - 5rem)) +
-        0.75rem
-    );
+    bottom: calc(max(var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom)), 0.75rem) + min(32rem, calc(100dvh - 5rem)) + 0.75rem);
   }
 }
 

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -5991,14 +5991,29 @@ strong {
    * the literal and WKWebView cannot resolve variables → shows black instead.
    */
   html {
-    min-height: 100dvh;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
     overflow: hidden;
+    overscroll-behavior: none;
   }
 
   body {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    overscroll-behavior: none;
     /* Safe-area insets handled by AppShell — only apply sides here */
     padding-left: env(safe-area-inset-left);
     padding-right: env(safe-area-inset-right);
+  }
+
+  #root {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
   }
 
   /* Scoped to conversation/roleplay/game (each sets data-chat-mode on its
@@ -6009,8 +6024,6 @@ strong {
     bottom: auto;
     height: var(--mari-visual-viewport-height, 100dvh);
     min-height: 0;
-    /* Counters the iOS scroll-drag bug described in AppShell.tsx. */
-    transform: translateY(var(--mari-app-scroll-compensate, 0px)) translateZ(0);
   }
 
   .app-sidebar-mobile {
@@ -7264,12 +7277,18 @@ strong {
 }
 
 :root[data-professor-mari-floating="true"] .mari-conversation-call-mini {
-  bottom: calc(max(var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom)), 0.75rem) + min(32rem, calc(100vh - 5rem)) + 0.75rem);
+  bottom: calc(
+    max(var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom)), 0.75rem) + min(32rem, calc(100vh - 5rem)) +
+      0.75rem
+  );
 }
 
 @supports (height: 100dvh) {
   :root[data-professor-mari-floating="true"] .mari-conversation-call-mini {
-    bottom: calc(max(var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom)), 0.75rem) + min(32rem, calc(100dvh - 5rem)) + 0.75rem);
+    bottom: calc(
+      max(var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom)), 0.75rem) + min(32rem, calc(100dvh - 5rem)) +
+        0.75rem
+    );
   }
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5710
Closes #5711

## Why this change

- Real-device testing confirms the prior iPhone keyboard and black-screen fixes were incomplete on the current staging Docker image.
- Composer focus can pan the iOS document, after which Marinara transforms its fixed full-screen shell by that scroll amount.
- Roleplay retains an inactive decoded background and requests compositor layers that do not contribute to the rendered result.

## What changed

- Lock the mobile document/root to the viewport and remove full-shell scroll-transform compensation.
- Keep Android's focus assistance while preventing iOS composer focus from invoking document-scrolling `scrollIntoView()`.
- Release the inactive Roleplay background after its crossfade and remove the unused weather-canvas compositor hint.
- Add iPhone-sized WebKit regression coverage for document locking, stable edit scrolling, and visual-layer cleanup.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Automated verification notes

- `pnpm check` passed, including localization, formatting, lint, E2E type-checking, and the production build.
- Focused mobile WebKit coverage passed for Roleplay editing, visual-viewport keyboard geometry, iOS focus without `scrollIntoView()`, and inactive-background release.
- Every mobile-adjacent failure from the broad local matrix passed three repeated isolated runs on its original engine: 15/15 mobile WebKit and 15/15 mobile Chromium.
- The broad local `pnpm smoke:ui` run finished with 394 passed and 216 skipped. Eight first-pass failures were isolated; seven mobile failures passed all repeated runs. One unrelated desktop group-awareness provider fixture remains reproducibly broken locally because it receives no provider request.
- The local Docker client is present, but its daemon is unavailable. The PR's hosted `container-build-test` remains the container gate.

### Manual verification notes

- Physical-iPhone confirmation remains required for the intermittent WebKit black-screen termination.
- Manually verify composer focus, message editing, keyboard dismissal, transcript scrolling, and sustained Roleplay reading in the installed iPhone PWA.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

A user-focused `CHANGELOG.md` entry is included. No documentation or release metadata changes are needed.

## UI evidence (if applicable)

The reporter supplied a physical-iPhone before screenshot showing the displaced app shell above the keyboard. The regression suite now checks the corresponding fixed geometry and layer lifecycle; after-state hardware evidence remains part of the manual iPhone gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iPhone chat input behavior by preventing the on-screen keyboard from shifting or transforming the app layout.
  * Stabilized mobile viewport scrolling and prevented unintended input auto-scrolling.
  * Improved mobile layout stability during keyboard interactions.
  * Improved Roleplay background transitions by releasing inactive images after crossfades, reducing visual memory usage.
  * Reduced unnecessary compositor overhead for weather effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->