### PR TITLE
docs(i18n): commit the translation glossaries to the branch they govern

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,18 @@ single tag, so translations add zero checkout size.
 
 ## Updating a pack
 
-1. Edit or add files under `<lang>/`, keeping paths identical to `docs/` on
+1. Read the language's conventions in `glossaries/glossary-<lang>.md` first —
+   register, terminology, typography, and UI-label rules are per-language and
+   deliberate. (The `glossaries/` folder is contributor documentation only; it
+   is outside every pack directory and never downloaded by the app.)
+2. Edit or add files under `<lang>/`, keeping paths identical to `docs/` on
    `staging`. Translate prose, headings, and link text only — code blocks,
    paths, URLs, and link targets (including `#fragments`) stay byte-identical.
-2. From an Engine checkout, run:
+3. From an Engine checkout, run:
    - `node scripts/docs-i18n/build-manifest.mjs <path-to>/<lang> --source-commit <engine-sha>`
    - `node scripts/docs-i18n/validate-pack.mjs <path-to>/<lang>`
-3. Commit content and manifest together.
+4. Commit content and manifest together — and if the change sets a new
+   terminology or style precedent, update the glossary in the same commit.
 
 See `CONTRIBUTING.md § Translated documentation` on `staging` for the full
 rules, including the per-file English fallback that makes partial packs safe.

--- a/glossaries/README.md
+++ b/glossaries/README.md
@@ -1,0 +1,37 @@
+# Translation glossaries
+
+One working glossary per language pack: the register, terminology, typography,
+UI-label, and QA conventions each pack shipped with. These are contributor
+documents for whoever edits a pack next — human or agent — so a small mirror
+change doesn't have to reverse-engineer a language's rules from 125 files.
+
+They live on this branch deliberately. The first-generation glossaries were
+working files in a temporary workspace and were destroyed twice by machine
+cleanup — the second loss unrecoverable. Committing them next to the packs they
+govern ends that failure mode. Nothing here is downloaded by the app: packs are
+fetched per `<lang>/manifest.json`, and this folder is outside every pack
+directory.
+
+## Ground rules
+
+- **The pack is the ground truth.** Each glossary documents the conventions as
+  shipped, verified against the pack; where a pack is internally inconsistent,
+  the glossary says so ("known pack residuals") instead of pretending.
+- **Update the glossary in the same PR as the pack change** whenever an edit
+  sets a new precedent (a new term, a new label-gloss ruling, a typography
+  call). A glossary that lags its pack is worse than none.
+- **Provenance:** these are second-generation documents, re-derived 2026-09-01
+  from three sources — the shipped packs, each pack's original PR decision
+  write-up, and the terminology notes of the 2026-09-01 mirror cycle — after
+  the original working glossaries were lost. Rules carried from the originals
+  that the pack itself cannot evidence are marked as recorded rulings.
+
+## Files
+
+`glossary-<code>.md` for each shipped pack: es, de, fr, pt-br, pl, ru, ja, ko,
+zh-hans, hi.
+
+`glossary-ar-draft.md` is different: Arabic has **no pack yet** (the cycle is
+held pending an explicit maintainer go-ahead). The draft preserves the Arabic
+conventions worked out during the RTL viewer scoping so the eventual cycle
+doesn't start from zero. It prescribes; it cannot yet cite a pack.

--- a/glossaries/glossary-ar-draft.md
+++ b/glossaries/glossary-ar-draft.md
@@ -1,0 +1,69 @@
+# Arabic (ar) — conventions draft
+
+**Status: DRAFT — no Arabic pack exists.** The ar cycle is held pending an
+explicit maintainer go-ahead. This file preserves the Arabic conventions worked
+out during the RTL viewer scoping (2026-08-02) and hardened by the RTL viewer
+PR (#4489, shipped), so the eventual translation cycle doesn't start from zero.
+Unlike the other glossaries, nothing here can cite pack evidence yet; every
+rule is a recorded scoping ruling, to be confirmed or amended when the pack is
+actually built.
+
+## Language & register
+
+- **Undiacritized Modern Standard Arabic.** No dialect, no tashkeel outside
+  genuinely ambiguous single words.
+- Orthography is part of searchability, not just correctness:
+  - **Hamza carriers are never folded** — أ / إ / آ are not ا.
+  - **ة is not ه**; **ي is not ى.** These two are NOT reliably
+    machine-checkable — native-reader QA is a standing stage from file 1, not
+    a final pass.
+  - **NFC mandate**, plus a grep for the presentation-forms ranges
+    (U+FB50–U+FDFF, U+FE70–U+FEFF), which must never appear.
+- Split-spelling audits (hamza variants, ة/ه, ي/ى) play the role the
+  ideographic-search runtime probes played for the CJK packs: search the
+  rendered pack for both spellings of sampled terms; the wrong spelling must
+  return zero results.
+
+## Typography & mechanics
+
+- **Zero tolerance for invisible characters**: no LRM/RLM, no tatweel (ـ), no
+  ZWJ/ZWNJ. Direction is handled by the viewer (per-doc `dir` keyed off
+  `doc.language`), never by embedded control characters.
+- **ASCII digits only.** A Devanagari-style exception does not exist here for
+  a hard technical reason: `١.` at the start of a list item silently degrades
+  to a paragraph — the markdown renderer's ordered-list regex matches `\d`
+  (ASCII) only.
+- **Quotes: «…»** for Arabic prose quoting; English UI strings inside them
+  stay byte-exact.
+- **Backtick mandate for direction-fragile inline literals**: `50%`, dates,
+  `8-bit`, and similar digit/Latin fragments visually reverse when set in RTL
+  prose — put them in inline code, which the viewer forces LTR. Also
+  `MARI_DATA_DIR`-style identifiers: outside code, the ASCII-`\w`
+  italic-lookaround in the renderer can eat the underscores.
+- **Arrow paths stay ALL-English with →** (Settings → General → …), with the
+  Arabic gloss outside the path, covering the whole path — never a mixed
+  half-translated path.
+
+## Viewer facts the pack can rely on (shipped in #4489)
+
+- The pack ships WITH its selector row: the ar entry in `DOCS_LANGUAGE_LABELS`
+  carries `direction: "rtl"`, plus the `DIR_LABELS_BY_DOCS_LANG` ar map and
+  SettingsPanel aliases, landing in the same PR as the pack so the selector
+  never offers a missing pack. A regression asserts the direction contract.
+- Per-doc direction is keyed off `doc.language`, so English-fallback docs in a
+  partial pack render LTR correctly.
+- Inline code and fences are forced LTR; `:---`/`---:` table alignment maps to
+  start/end; the docs-reader isolation class scopes RTL fixes away from chat.
+- Known open question from scoping §5 (maintainer): whether modal chrome keeps
+  mirroring under an ar UI locale (recommended) or pins LTR — re-raise at
+  cycle start.
+
+## Process notes for the eventual cycle
+
+- Native-reader QA from the first file, not the last (the ة/ه and ي/ى classes
+  make late QA unaffordable).
+- Glossary preview rows AR-1..AR-11 lived in the original scoping report
+  (§4), which was lost with the first-generation glossaries; the rules above
+  are the surviving substance. Term-table work (prompt, token, lorebook,
+  agent, …) starts fresh at cycle time and must follow the same
+  evidence-and-banned-alternates format as the shipped glossaries.

--- a/glossaries/glossary-de.md
+++ b/glossaries/glossary-de.md
@@ -1,0 +1,540 @@
+# German (de) — pack conventions
+
+**Provenance.** This is the *second-generation* German glossary, re-derived on
+2026-09-01 after the original working glossaries were lost to temp-directory
+cleanup. It was rebuilt from three surviving sources, in authority order:
+the **shipped `de/` pack itself** (125 docs — the ground truth), the **decision
+write-up of the pack's shipping PR** ([#4157](https://github.com/Pasta-Devs/Marinara-Engine/pull/4157)),
+and the **terminology notes from the 2026-09-01 mirror cycle**
+(`prd-notes-de.md`). Every prescriptive rule below is either verified against
+the pack as shipped — with a cited evidence file, and line numbers where they
+pin a single sentence — or explicitly marked as a **recorded ruling** carried
+forward from the original cycle (§7 collects all seven). Nothing here is
+invented to fill a gap: where the pack is inconsistent, this file says so in §8
+rather than pretending a rule exists.
+
+**Verification pass, 2026-09-01.** Every count and absence claim in §§1–6 was
+re-measured against the 125 shipped files with a Unicode-aware scanner, and
+every cited evidence line was opened. That pass corrected the register counts
+in §1, the navigation-separator rule in §3, the `endpoint` and `tool` rows in
+§4, and the NBSP claim in §5; it withdrew one residual as a false positive and
+added three new ones (7, 8, 9). Where a claim could not be checked from this
+branch — anything about `de.json`, `validate-pack.mjs` or `build-manifest.mjs`,
+none of which live here — it is now labelled as such at the point of use.
+
+German is language #3 of the FIGS(P) → CJK rollout, and it is the pack that
+**originated the anti-calque approach** later languages inherited. That is why
+§1's naturalness rule outranks every term row in §4: the terms are the floor,
+not the goal.
+
+---
+
+## 1. Register & address
+
+- **Informal, lowercase `du`.** Consistently, in every document class —
+  onboarding, reference tables, troubleshooting, and the developer docs under
+  `development/`. Evidence: `agents/custom-agents.md:3`
+  ("wie **du** in Marinara Engine einen eigenen Agenten baust"),
+  `CONFIGURATION.md:37`, `development/frontend.md:397` ("bevor **du** an dieser
+  Funktion etwas änderst").
+- **Lowercase in mid-sentence, always.** Never the courtesy `Du`/`Dein`/`Dir`
+  as a politeness marker. Note the counting trap: a naive
+  `\b(Du|Dein|Dir|Dich)\b` grep returns **174 hits**, and **173** of them are
+  ordinary sentence-initial capitalisation of the informal pronoun
+  ("Du findest sie unter …"), which is correct German. Exactly **one** capital
+  falls mid-sentence — `game/map-time-weather.md:30`, inside the gloss
+  `**You are here** (Du bist hier)`, where it renders an English UI label and
+  is likewise correct. So the rule is real but it is *not* mechanically
+  checkable by that grep; see §8 for the anchored version.
+- **No `Sie` addressing the reader.** Capitalised `Sie` appears **237** times
+  and every one is sentence-initial third person or the plural pronoun; the
+  lowercase `sie` adds **839**, `Ihre*` **13**, `Ihnen` **1**. Examples:
+  `home/professor-mari.md:79` ("## **Ihre** Änderungen prüfen" = *her* changes,
+  Professor Mari's) and `roleplay/getting-started.md:64` ("**Ihre**
+  Schaltflächen" = *its* buttons). A `Sie`/`Ihnen` that addresses the reader is
+  a defect; see §8 for the verb-anchored grep that finds only those.
+- **Imperatives address the reader directly** and are usually the short
+  (apocopated) `du`-imperative. `Klick auf …` is **307 occurrences**; counting
+  every imperative `Klick` it is ~351, and `Klick` in any function (including
+  the noun *ein Klick*, 110) is 461. **`Klicke` appears exactly zero times**
+  (`chats/messages.md`, `noodle/settings.md:59`). This one is absolute.
+- Other verbs are **mixed and that is accepted**: `Wähle` 123 / `Wähl` 50,
+  `Prüfe` 32 / `Prüf` 47, `Setze` 17 / `Setz` 21. Pick by rhythm; do not
+  "normalize" an existing file in either direction. `Öffne` (342 as the bare
+  imperative, 378 counting inflected `Öffnen`/`Öffnest`) and `Nimm` (60) are
+  the settled forms for those two verbs.
+- **Tone: warm, plain, second person.** 82 of the 125 files open with the exact
+  frame `In dieser Anleitung erfährst du, …` — reuse it verbatim when adding a
+  guide, and keep the sentence a promise about *what the reader will learn*,
+  never a summary of the feature.
+- **Gender-neutrality: soft, never typographic.** The pack uses no Gendersternchen
+  (`*innen`), no Binnen-I, no colon or underscore forms. Neutrality is achieved
+  lexically where it is natural — `die Erstellerin` in
+  `development/hierarchical-locations-prd-v3.md:126` reads as a role noun, not
+  a marked form — and otherwise the generic form stands. Do not retro-fit
+  gender markers into existing prose; introducing them would break the
+  hit-count search and the pack's plain register at once.
+- **Reformed orthography only:** `dass` 182 / `daß` 0, `muss` 122 / `muß` 0.
+  `ß` is used normally (Germany/Austria spelling, not Swiss `ss`).
+
+---
+
+## 2. Product, feature & mode names
+
+- **`Marinara Engine` and `Marinara` are frozen.** No article, no declension,
+  no hyphenated German plural. In compounds the product name hyphenates
+  normally: `Marinara-Versionen` (`TROUBLESHOOTING.md:260`),
+  `Marinara-Agents` (25×), `Marinara-Server`.
+- **The three chat modes stay English:** `Conversation`, `Roleplay`,
+  `Game Mode`. This matches the Engine-side change in PR #4157, which kept the
+  same three names in the German sidebar map so the docs and the UI agree.
+  Evidence: `integrations/discord-mirror.md:3` ("Das klappt in Conversation,
+  Roleplay und Game Mode."), `agents/hierarchical-maps.md:287`.
+- **Carrier-noun pattern for modes.** A mode name takes a German carrier noun
+  by hyphenated compound, never a translated mode name:
+  `Conversation-Chat` (63), `Roleplay-Chat(s)` (52), `Game-Chat(s)` (34),
+  `Chat-Modus`/`Chat-Modi` (36). Banned: `Rollenspiel-Modus`, `Spielmodus`,
+  `Unterhaltungsmodus` — all confirmed absent from the pack.
+- **Agent and feature names stay English, unglossed after first use:**
+  `Prose Guardian`, `Narrative Director`, `World State`, `Quest Tracker`,
+  `Memory Recall`, `Illustrator`, `Music DJ`, `World Maps`, `Noodle`,
+  `Professor Mari`, `Local Model`, `Agent Suite`, `Support Diagnostics`
+  (`agents/built-in-agents.md`, `TROUBLESHOOTING.md:330`).
+  They take German carrier nouns the same way: `Tracker-Agenten` (16),
+  `Storyboard-Agenten` (13).
+- **`Personal Extensions` is a frozen product name; `Erweiterung` is the
+  common noun.** Both live in the pack and they are not interchangeable:
+  the feature is `Personal Extensions` (`data/backup-and-restore.md:10`,
+  `development/frontend.md:393`), an individual instance in running prose is
+  `die Erweiterung` (`data/backup-and-restore.md:75`, "Jede wiederhergestellte
+  **Erweiterung** kommt deaktiviert an"). The first mention in a guide gets the
+  gloss `**Personal Extensions** (persönliche Erweiterungen)`
+  (`extending/personal-extensions.md:3`).
+- **`Engine` takes an article when it means the runtime**, not the product,
+  and it is **feminine — `die Engine`**: `die Engine` 13, `der Engine`
+  (gen./dat.) 19, `von der Engine` (`development/optional-agent-packages.md:62`,
+  "Die Sicherheitsregeln **der Engine** haben Vorrang", `:98`). `das/dem/den
+  Engine` are absent. The single `vom Engine` at `development/file-storage.md:35`
+  is a gender slip, not the pattern — see §8 residual 9.
+- **Articles for the frozen English loans** are listed in §4 and are
+  load-bearing — `der Prompt`, `das Token`, `das Lorebook`, `das Preset`,
+  `der Chat`, `die Persona`, `der Swipe`. Get the gender wrong and the
+  declension cascade goes with it.
+
+---
+
+## 3. UI labels & glosses
+
+The pack's single most distinctive convention, and the reason it reads the way
+it does: **instructions are written to be followed against the English
+interface.** The app ships an incomplete and uneven German UI locale, so the
+docs deliberately do *not* mirror it (see §8, tooling traps).
+
+1. **UI labels are byte-exact English in bold.** `**Save**`, `**Download Backup**`,
+   `**Max Output Tokens**`, `**Review Agent Outputs**`. Never translated,
+   never re-cased, never pluralized into German.
+2. **Navigational control labels get a one-time German gloss in parentheses,
+   lowercase-or-natural-case, on first use per document:**
+   `**Settings** (Einstellungen)`, `**Chat Settings** (Chat-Einstellungen)`,
+   `**Appearance** (Darstellung)`, `**Import Character** (Charakter importieren)`,
+   `**Extract Colors from Avatar** (Farben aus dem Avatar übernehmen)`
+   (`characters/colors-and-stats.md:19`), `**Delete This Branch Only**
+   (Nur diese Verzweigung löschen)` (`chats/managing-chats.md:64`). Subsequent
+   mentions in the same document drop the gloss.
+3. **App-rendered *status* and error strings are bold English with NO gloss.**
+   This is the split the mirror cycle re-confirmed: `**Untrusted request host**`
+   (`TROUBLESHOOTING.md:103`), `**Save blocked: missing CSRF header**` (L114),
+   `**Waiting for vector**` / `**Embedding unavailable**` (L163–164),
+   `**Server unreachable**` / `**Unreachable (request timed out)**` (L330),
+   `**No API connection configured for this chat**` (L128). A parenthetical
+   gloss on a string that already contains parentheses would also collide, so
+   the no-gloss rule is mechanical as well as stylistic.
+4. **Navigation paths use two co-existing separators, split by where the bold
+   starts and stops.** Both are productive; neither is a residual.
+   - `>` **between two separate bold spans**: `**Settings** > **Addons**`
+     (`data/backup-and-restore.md:75`, `TROUBLESHOOTING.md:129`) — **43**
+     occurrences across 7 files.
+   - `→` **inside a single bold span**, the usual form for multi-level
+     Settings paths: `**Settings → Advanced → Danger Zone**`
+     (`TROUBLESHOOTING.md:386`), `**Agents → Download Agents**`
+     (`CONFIGURATION.md:20`), `**Chat Settings → Agents → Tracker Agents**`
+     (`agents/built-in-agents.md:123`) — **66** occurrences across 21 files.
+
+   A further 21 `→` sit outside bold in unrelated senses (sort orders
+   `Name A→Z` at `lorebooks/entries.md:14`, place hierarchies at
+   `agents/hierarchical-maps.md:295`, mappings at `lorebooks/entries.md:377`);
+   87 arrows in total. Match the file you are editing rather than converting
+   between the two forms.
+5. **An in-app English string quoted as text (not as a control) goes in German
+   quotation marks:** `„Opening chat...“` (`TROUBLESHOOTING.md:330`),
+   `„This parameter is sent to the model“` (L129), and the panel heading
+   `## Das Panel „Cached prompt injections“`
+   (`agents/approvals-and-agent-suite.md:91`).
+6. **Untranslated-by-design UI text is never invented around.** If a label has
+   no German UI equivalent, it stays English; do not coin one.
+7. **Placeholders and literal file/env names stay in backticks and untouched:**
+   `` `MARINARA_MAX_RESIDENT_CHATS` ``, `` `~/.marinara-engine/logs/` ``,
+   `` `server-*.log` `` (`CONFIGURATION.md:155`, `TROUBLESHOOTING.md:324`).
+
+### The one-time definition pattern
+
+The pack teaches jargon inline, once, in a short appositive sentence right
+after first use — this is *why* the loanwords are safe to keep:
+
+> `Ein Token ist ein kleines Textstück, ungefähr ein paar Zeichen lang.`
+> — `lorebooks/token-budgets.md:5`
+
+> `Ein Lorebook ist eine Sammlung von Weltwissen, auf die die KI zurückgreifen kann.`
+> — `home/achievements.md:53`
+
+> `Ein Agent ist ein kleiner KI-Helfer, der automatisch neben der eigentlichen
+> Chat-Antwort mitläuft.` — `agents/built-in-agents.md:7`
+
+Each new guide re-defines the terms it uses, because guides are entered
+directly from search. The wording may vary slightly per document; **the
+headword must not.**
+
+---
+
+## 4. Core terminology
+
+One standardized term per concept — PR #4157's stated rationale is that the
+docs viewer's hit-count search only works if a concept has exactly one German
+spelling (R3). "Banned alternates" below are, unless the row says otherwise,
+either confirmed absent from the pack (count 0) or present only in a different,
+legitimate sense — which is noted inline.
+
+**Four rows are exceptions and say so**: `character`, `character card`,
+`endpoint` and `tool` point at §8 residuals, because the pack itself is
+inconsistent there. Where that happens this file states what the pack does and
+sends you to the residuals table for the counts, rather than prescribing a
+term the pack does not use. All counts below were re-measured against the
+shipped pack on 2026-09-01 with a Unicode-aware scanner.
+
+| English | This pack's term | Banned alternates | Evidence |
+|---|---|---|---|
+| prompt | **der Prompt** (m.) | `Eingabeaufforderung` (2, both reserved for the Windows *Command Prompt*, `installation/windows.md:66`, `:78`) | `agents/built-in-agents.md:11` |
+| token | **das Token** (n.), pl. **Tokens** | `Zeichen`, `Worteinheit` (0) | `lorebooks/token-budgets.md:5` |
+| token budget | **das Token-Budget** | `Token-Etat`, `Zeichenbudget` (0) | `agents/built-in-agents.md:200` |
+| preset | **das Preset** (n.) | `Voreinstellung` (0 in pack — but it *is* the app locale's word; see §8) | `prompts/presets.md:7` |
+| lorebook | **das Lorebook** (n.) | `Weltbuch`, `Wissensbuch` (both 0) | `lorebooks/overview.md:7` |
+| lorebook entry | **der Lorebook-Eintrag** (10), pl. `Lorebook-Einträge` (34), dat. `-Einträgen` (4) | `Lorebookeintrag` (closed compound, 0) | `characters/personas.md:101` |
+| character | **der Charakter** (1,275) | `Figur` (see §8 residual), `Kunstfigur` (0) | `characters/personas.md:7` |
+| character card | **die Charakterkarte** (91) | `Figurenkarte` (1 residual, §8), `Merkmalskarte` (0) | `agents/approvals-and-agent-suite.md:18` |
+| persona | **die Persona** (f.) | `Rollenprofil`, `Spielerprofil` (0) | `characters/personas.md:7` |
+| chat | **der Chat** (m.) | `Sitzung`, `Unterhaltung` as headword | `chats/messages.md:5` |
+| message | **die Nachricht** (f.) | `Mitteilung` (0) | `chats/messages.md:1` |
+| swipe (alt. reply) | **der Swipe**, glossed once as *(alternative Antworten)* | `Wischer`, `Variante` as headword | `chats/messages.md:56`, `chats/branches.md:23` |
+| branch (a chat) | **die Verzweigung** (99) | `Zweig` in this sense | `chats/branches.md`, `agents/hierarchical-maps.md:481` |
+| branch (macro / code) | **der Zweig** (11) — *distinct sense, keep separate* | `Verzweigung` in this sense | `prompts/conditional-prompts.md:23` (`{{else}}`-Zweig) |
+| agent | **der Agent** (n-declension: *dem/den Agenten*) | `Assistent`, `Bot` as headword | `agents/built-in-agents.md:7` |
+| AI | **die KI** (546 vs 71 `AI`, and the `AI` hits are all inside English UI labels) | `AI` in German prose | `agents/agents-overview.md:17` |
+| connection | **die Verbindung** (565; zero competing headwords) | `Anschluss` (1, = film continuity, `game/ltx-2-3-storyboards.md:193`) | `connections/connecting-to-a-provider.md:7` |
+| provider | **der Anbieter** | `Provider`, `Dienstleister` | `connections/providers-reference.md:11` |
+| launcher | **der Launcher** (52), incl. `Shell-Launcher`, `Termux-Launcher` | `Starter` in this sense (`Starter` = 31, all *conversation starters* / starter library) | `CONFIGURATION.md:88`, `TROUBLESHOOTING.md:22` |
+| update (noun) | **das Update** (210), pl. `Updates` | `Aktualisierung` as headword (21, secondary/verbal use only) | `TROUBLESHOOTING.md:92` |
+| apply (an update) | **einspielen** | `anwenden`, `applizieren` | `CONFIGURATION.md:238` ("das serverseitige **Einspielen** von Updates") |
+| apply (an editor change) | **übernehmen** — *distinct from updates* | `einspielen` in this sense | `development/hierarchical-locations-prd-v3.md:126` (`**Apply** (Übernehmen)`) |
+| release channel | **der Release-Kanal** / **Update-Kanal** | `Ausgabekanal`, `Zweig` | `CONFIGURATION.md:237`, `installation/windows.md:201` |
+| channel switch | **der Kanalwechsel** (4) | `Kanalumschaltung` (0) | `CONFIGURATION.md:238`, `installation/macos-linux.md:231` |
+| Discord channel | **der Discord-Kanal** | `Discord-Channel` | `integrations/discord-mirror.md:3` |
+| (development) checkout | **die Entwicklungs-Installation** | `Checkout`, `Arbeitskopie` (means an *editor draft* here — would mislead) | `CONFIGURATION.md:238` |
+| working copy (in an editor) | **die Arbeitskopie** | `Entwurf` as headword | `agents/hierarchical-maps.md:69`, `:117` |
+| check out (git, verb) | **auschecken** / **klonen** — attested as the participle `ausgecheckt` and as `klone`/`klonen`; the bare infinitive `auschecken` happens not to occur | — | `installation/containers.md:24` ("schon **ausgecheckt** hast … **klone** es zuerst"), `UPGRADING.md:33` |
+| wake lock | **der Wake-Lock** (hyphenated, capitalized; `Android-Wake-Lock`) | `Wachhaltesperre`, `Aktivsperre` (0) | `TROUBLESHOOTING.md:324`, `:330` |
+| battery optimization | **die Akkuoptimierung** | `Batterieoptimierung` (0) | `TROUBLESHOOTING.md:326`, `:332` |
+| background activity / run in background | **die Aktivität im Hintergrund** / **die Ausführung im Hintergrund** | `Hintergrundaktivität` (closed compound) | `TROUBLESHOOTING.md:326`, `:332` |
+| frozen (process) | **eingefroren** (bold when the EN is bold) | `blockiert`, `hängt` | `TROUBLESHOOTING.md:330` |
+| memory / RAM / in memory | **der Arbeitsspeicher** (18) — "im Arbeitsspeicher halten", "in den Arbeitsspeicher laden" | `Speicher` alone (ambiguous with disk), `Erinnerung` | `CONFIGURATION.md:155`, `TROUBLESHOOTING.md:182`, `development/file-storage.md:39` |
+| from disk | **von der Festplatte** | `vom Datenträger` | `CONFIGURATION.md:155`, `TROUBLESHOOTING.md:260`, `UPGRADING.md:186` |
+| evict (from memory) | **aus dem Arbeitsspeicher entfernen** | `verdrängen`, `räumen` (0) | `CONFIGURATION.md:155` |
+| least-recently-used | **der am längsten nicht genutzte …** (phrasal — no LRU noun exists in the pack) | `LRU`, `zuletzt-verwendet` | `CONFIGURATION.md:155` |
+| cache (noun) | **der Cache** (21), pl. `Caches` | `Zwischenspeicher` as headword | `TROUBLESHOOTING.md:80`, `data/clearing-data.md:50` |
+| cached (adj./verb) | **zwischengespeichert** / **zwischenspeichern** | `gecacht` | `agents/approvals-and-agent-suite.md:3`, `development/frontend.md:559` |
+| backup | **das Backup** (95) | `Sicherung` as headword (2, developer prose only) | `data/backup-and-restore.md:9` |
+| restore | **die Wiederherstellung** / **wiederherstellen** | `Rückspielen` | `data/backup-and-restore.md:20` |
+| snapshot (runtime / state) | **der Snapshot** (73) | `Abbild` | `agents/hierarchical-maps.md:234`, `development/architecture-map.md:95` |
+| snapshot (saved card version) | **die Momentaufnahme** (15) — *distinct sense* | `Snapshot` in this sense | `characters/creating-and-editing-characters.md:128`, `:141` |
+| extension (common noun) | **die Erweiterung** (126) | `Ergänzung`, `Add-on` as headword | `data/backup-and-restore.md:75` |
+| Personal Extensions (product) | **Personal Extensions** (English, frozen, 19) | `Persönliche Erweiterungen` as the name — 1 residual, the doc link title at `extending/personal-extensions.md:206`; the lowercase gloss `(persönliche Erweiterungen)` after the frozen name is correct and appears 4× | `development/frontend.md:393` |
+| NPC | **der NPC**, pl. **NPCs**, glossed once as *(Nicht-Spieler-Charaktere)* | `Nichtspielercharakter` (0), `NSC` (0) | `game/party-and-npcs.md:3`, `game/sessions-and-saves.md:70` |
+| sprite | **das Sprite** (n.) | `Figurenbild` | `characters/sprites.md:7`, `chats/slash-commands.md:90` |
+| theme | **das Theme** (n.), `Theme-Bibliothek` | `Erscheinungsbild` as headword | `home/professor-mari.md:27` |
+| tool (custom tool / function calling) | **das Tool** (n.) — but see §8 residual 8 | `Werkzeug` as the headword *for this sense* (`Werkzeugleiste` = *toolbar*, 37, different; `Werkzeug`/`Werkzeuge` for a generic piece of software — Tailscale, Git — is fine and common) | `extending/custom-tools.md:15`, `:153` |
+| webhook | **der Webhook** | `Web-Haken` | `integrations/discord-mirror.md:9` |
+| environment variable | **die Umgebungsvariable** | `Umgebungs-Variable` (hyphenated) | `CONFIGURATION.md:3`, `media/music.md:68` |
+| unset (env var) | **nicht gesetzt** — *keep distinct from* `leer` (empty) | `leer` for *unset* | `CONFIGURATION.md:238`, `:244` |
+| off / unlimited (defaults) | **aus** / **unbegrenzt** | `deaktiviert`, `unlimitiert` | `CONFIGURATION.md:155`, `:156` |
+| endpoint | **der Endpunkt** (27 across 12 files) — but see §8 residual 7 | `Endpoint` in German prose (6, five of them in one file) | `connections/providers-reference.md:66`, `development/frontend.md:456` ("## API-Endpunkte") |
+| port | **der Port**, glossed as *der nummerierte Kanal* | `Anschluss` | `connections/local-self-hosted.md:37` |
+| rate limit | **⚠ not standardized** — see §8. `Ratenlimit` is a false friend and the pack's only instance | `Ratenlimit` (the one occurrence is the defect) | `noodle/settings.md:200` |
+
+### Anti-calque quick list
+
+PR #4157 shipped the pack against an explicit anti-calque table. That table was
+lost with the first-generation glossary; what survives is its output, and the
+absence-checks above reconstruct the enforceable part of it. Confirmed absent
+from all 125 files, and to stay absent: `Voreinstellung`, `Weltbuch`,
+`Wissensbuch`, `Mitteilung`, `Kunstfigur`, `Merkmalskarte`, `Wachhaltesperre`,
+`Batterieoptimierung`, `Nichtspielercharakter`, `Rollenspiel-Modus`,
+`Spielmodus`, `Unterhaltungsmodus`, `Rate-Begrenzung`, `Beiwerk`,
+`Aktivsperre`, `Token-Etat`, `Zeichenbudget`, `Rollenprofil`, `Spielerprofil`,
+`Wischer`, `Figurenbild`, `Web-Haken`, `Kanalumschaltung`, `Dienstleister`,
+`Umgebungs-Variable`, `Datenträger`, `gecacht`, `Rückspielen`, `NSC`,
+`Lorebookeintrag`, `daß`, `muß` — all re-verified at 0 on 2026-09-01.
+
+Two words that an earlier draft of this list treated as absent are **not**
+absent and have been moved out of it: `Endpunkt` (27) and `Werkzeug` (97).
+Both are covered by §8 residuals 7 and 8.
+
+---
+
+## 5. Typography & punctuation
+
+- **Quotation marks are German `„…“`** (low-open, high-close) — 325 pairs,
+  balanced. Straight `"` never appears in German prose; its 928 occurrences are
+  all inside code fences, CSS, or quoted English JSON
+  (`agents/custom-agents.md:182`, `appearance/card-css-theming.md:290`).
+- **Dashes: en dash `–` for parenthetical and appositive breaks, spaced.**
+  806 en dashes against 4 em dashes. This is the settled rule.
+  Example: `Agenten kosten zusätzliche Tokens und zusätzliche Modellaufrufe –
+  ein Token ist ein kleines Textstück.` (`agents/agents-overview.md:55`).
+  Three of the four em dashes are residuals; the fourth is correct because it
+  sits inside an English code span (§8 residual 5).
+- **En dash also for numeric ranges, unspaced:** `128–16.384`, `1–20`, `1–100`
+  (`agents/built-in-agents.md:200`).
+- **Digits: German thousands separator is a period**, and it is applied to
+  four-digit-and-up numbers in prose: `16.384`, `2.048`, `1.000`
+  (`agents/built-in-agents.md:200`, `development/hierarchical-locations-prd-v3.md:356`).
+  **Numbers inside backticks, code fences, env-var defaults and file paths keep
+  their source form** — `` `4096` ``, `` `32768` `` — because they are literals
+  the reader types.
+- **Percent takes a space:** `5 %`, `200 %`, `40 %`, `80 %`
+  (`characters/sprites.md:154`, `game/map-time-weather.md:39`,
+  `prompts/macros.md:174`, `lorebooks/entries.md`) — DIN 5008. Be honest about
+  how thin this majority is: **15 spaced occurrences across 4 files against 16
+  unspaced across 2** (§8 residual 4). It is the right rule and it holds in
+  every file except two, but one non-conforming file alone outweighs all the
+  conforming ones by raw count, so do not cite "the pack does it" as
+  self-evident — cite the four conforming files.
+- **Units take a space:** `180 MB`, `350 MB` (`conversation/calls.md:69`),
+  `16–24 GB` (`game/ltx-2-3-storyboards.md:40`).
+- **Decimals take a comma:** `rund 5,4 GB`, `rund 7,5 GB`
+  (`connections/local-model.md:72`, `:77`) — never a decimal point in German
+  prose. Together with the thousands rule above this inverts the English
+  source's punctuation on both sides, so numbers are a per-file check, not a
+  copy-through.
+- **No NBSP — and the count is zero, not "a few".** A full character scan finds
+  **0 × U+00A0** across all 125 files, and 0 × U+3000, U+200B and U+200D as
+  well: the only non-ASCII spacing-class characters in the pack are none at
+  all. German docs here rely on normal spaces and the renderer. (An earlier
+  draft of this glossary reported "5 NBSP" in
+  `extending/personal-extensions.md:167–171`. Those 5 characters are **U+FE0F
+  variation selectors** on the ⚠️ emoji in that table, one per row — see §8
+  residual 6. Scan for the codepoint, not for "something wide-looking".)
+- **Emoji are rare and localized — do not spread them.** The whole pack holds
+  21: a ✅/⚠️/⛔ capability matrix in `extending/personal-extensions.md:167–171`,
+  🎲 in three dice/connection guides, 🔞 twice in `characters/bot-browser.md`,
+  and one ✦ in `appearance/card-css-theming.md`. Prose does not decorate
+  headings or bullets with them. The ⚠️ carries a U+FE0F variation selector,
+  which is why a careless character scan mistakes it for stray whitespace.
+- **LF-only line endings.** Zero CRLF across all 125 files — `validate-pack.mjs`
+  enforces this and the Windows checkout is the usual way to break it. This is
+  the one item in R6's structural gate that is mechanically checkable here, and
+  it passes.
+- **Sentence terminators:** ordinary `.`; no `!` in instructional prose.
+  Headings never take a terminator; question headings do take `?`
+  (`CONFIGURATION.md:5` "## Wann lohnt sich eine Konfiguration?").
+- **List mechanics:** bullets that are full sentences end with a period;
+  bullets that are noun phrases or table-like fragments do not. Both patterns
+  coexist within a file (`FAQ.md`) — match the surrounding list, do not
+  normalize.
+- **Bold-label list items** use `- **Label** (Glosse): Text` with a colon
+  (`agents/agents-overview.md:49`) or `- **Label**: Text`
+  (`agents/built-in-agents.md:115`). The spaced-en-dash form
+  `- **Label** — Text` exists only in the two em-dash residuals; prefer the colon.
+
+---
+
+## 6. Language-specific mechanics
+
+- **Compounds are hyphenated whenever an English loan or a proper name is a
+  member.** `Prompt-Preset`, `Token-Budget`, `Chat-Einstellungen`,
+  `Lorebook-Eintrag`, `Persona-Editor`, `Roleplay-Chat`, `Cached-App-Freezer`,
+  `Release-Kanal`, `Wake-Lock`, `Entwicklungs-Installation`. This is Duden-style
+  and it is what makes the loans declinable and searchable.
+- **Native-only compounds stay closed:** `Charakterkarte`, `Arbeitsspeicher`,
+  `Akkuoptimierung`, `Nachrichtenbox`, `Werkzeugleiste`, `Umgebungsvariable`,
+  `Kanalwechsel`, `Fertigkeitsprobe`. Never hyphenate these.
+- **Never a Deppenleerzeichen.** `Token Budget` (open compound) is wrong;
+  `Token-Budget` is right. The only space-separated capitalized sequences in
+  German prose are **UI labels inside `**…**`**, which are English by rule.
+- **Genders and declension of the loans** are fixed by §4 and cascade:
+  `der Prompt` → *dem Prompt, den Prompt, die Prompts*;
+  `das Token` → *dem Token, die Tokens*;
+  `das Lorebook` → *dem Lorebook, die Lorebooks*;
+  `der Chat` → *dem Chat, den Chat, die Chats*;
+  `die Persona` → *der Persona, die Personas*.
+  Loan plurals take **-s**, not German umlaut plurals.
+- **`Agent` is an n-declension noun**: *der Agent, **des/dem/den Agenten**, die
+  Agenten* — `agents/agents-overview.md:9` ("Auf einer Charakterkarte gibt es
+  keinen Schalter für **Agenten**"), `custom-agents.md:3` ("einen eigenen
+  **Agenten** baust"). `dem Agent` / `den Agent` are errors.
+- **Compounds built on frozen mode names keep the English member capitalized**:
+  `Game-Chat`, not `game-Chat`; `Conversation-Chat`, not `Konversations-Chat`.
+- **Verb-final subordinate clauses are welcome** — the pack does not chop
+  sentences into English-shaped fragments to stay "simple." Naturalness beats
+  parallelism with the English source: the German sentence may split, merge, or
+  re-order clauses freely as long as every fact survives.
+- **Headings are translated; anchor targets are not.** Heading text is German
+  (`# Server-Konfiguration – Referenz`) while link fragments keep the **English**
+  slug of the English source heading:
+  `[Schreibstrategie](entries.md#authoring-strategy-choosing-the-right-entry)`
+  (`lorebooks/overview.md:81`),
+  `](../characters/galleries.md#reuse-a-gallery-image-in-messages-and-greetings)`
+  (`chats/sending-and-streaming.md:56`). A "helpfully" translated fragment is a
+  dead link — the viewer resolves against the English structure. The pack has
+  only **9** fragment links in total, and **0** of them carry an umlaut in the
+  fragment, so the rule is currently unbroken — and cheap to keep that way.
+- **Section headings may keep an English feature name whole** when the section
+  *is* that feature: `### External Extensions` (`CONFIGURATION.md:57`).
+
+---
+
+## 7. Recorded rulings (no in-pack evidence possible)
+
+These are process and priority rulings preserved from the original cycle and
+from PR #4157's write-up. They govern how the pack is *authored*; the pack can
+show their consequences but cannot prove the rules themselves.
+
+- **R1 — Naturalness over calque is the top rule.** It outranks every term row
+  in §4. If a standardized term makes a sentence read like translated English,
+  restructure the sentence — do not swap the term. (PR #4157: "makes natural,
+  idiomatic phrasing the top rule (with an explicit anti-calque table)".)
+- **R2 — German originated the anti-calque approach**, in response to the
+  Spanish pack (#4100) reading too literally. Later packs inherited it. When
+  this glossary and a later language's glossary disagree on method, this one is
+  the ancestor, not the deviation.
+- **R3 — One standardized term per concept, because the docs viewer's
+  hit-count search depends on it.** The rationale, not just the practice.
+- **R4 — Known pack residuals are documented, not silently fixed.** Discovered
+  drift is recorded in §8 and left for a deliberate sweep, so a translation
+  edit never rides along inside an unrelated change. `Anbindung` and
+  `Ratenlimit` were both flagged in an earlier cycle under this rule.
+- **R5 — The `Ratenlimit` false friend and the `Anbindung` variants are
+  deferred to a future sweep**, not to the next content edit that happens to
+  touch those files.
+- **R6 — Structural verification is a gate, not a review step:** byte-identical
+  code fences and link targets, heading parity with the English source, LF-only,
+  no added images — plus an address-form and terminology sweep and an
+  independent language-QA panel. (PR #4157, "Translation approach".)
+- **R7 — A change that sets a new terminology or style precedent updates this
+  glossary in the same commit.** (Branch `README.md`, "Updating a pack", step 4.)
+
+---
+
+## 8. QA checks & known traps
+
+### Mechanical checks (run these on any changed `de/` file)
+
+```sh
+# 1. Formal address must not appear (should return nothing).
+grep -rnE '\b(Sie|Ihnen|Ihre[mnrs]?) (können|müssen|sollten|finden|klicken|öffnen|wählen|haben|brauchen)' de/
+
+# 1b. Courtesy-capital du-forms. NOTE: a bare \b(Du|Dein|Dir|Dich)\b grep is
+#     USELESS here — 173 of its 174 hits are correct sentence-initial
+#     capitals. Anchor to mid-sentence instead (expect exactly 1 hit, the
+#     "(Du bist hier)" UI gloss in game/map-time-weather.md:30).
+grep -rnE '[a-zäöüß,] (Du|Dein|Deine[mnrs]?|Dir|Dich)\b' de/
+
+# 2. Imperative: Klicke is always wrong here.
+grep -rn '\bKlicke\b' de/
+
+# 3. Typography.
+grep -rn '—' de/                       # em dash: 4 known (3 residual + 1 correct)
+grep -rnP '\x{00A0}' de/               # NBSP: must be ZERO (not 5 — see residual 6)
+grep -rnU $'\r' de/                    # CRLF: must be zero
+grep -rnE '[0-9]%' de/ | grep -v '`'   # unspaced percent in prose: 16 known
+
+# 4. Banned alternates (all must be zero).
+grep -rnE 'Voreinstellung|Weltbuch|Wissensbuch|Mitteilung|Kunstfigur|Merkmalskarte|Wachhaltesperre|Aktivsperre|Batterieoptimierung|Nichtspielercharakter|Rollenspiel-Modus|Spielmodus|Unterhaltungsmodus|Rate-Begrenzung|Beiwerk|Token-Etat|Zeichenbudget|Rollenprofil|Spielerprofil|Wischer|Figurenbild|Web-Haken|Kanalumschaltung|Dienstleister|Umgebungs-Variable|Datenträger|gecacht|Rückspielen|Lorebookeintrag|daß|muß' de/
+
+# 4b. NOT zero — known drift with a documented baseline. Investigate only a
+#     count that moved; see the residuals table for the current numbers.
+grep -rc 'Endpunkt' de/ | grep -v ':0'    # 27 across 12 files  (residual 7)
+grep -rc 'Werkzeug' de/ | grep -v ':0'    # 97 total, 28 of them tool-sense in
+                                          # integrations/home-assistant.md (residual 8)
+grep -rn 'Figur' de/ | grep -v 'table-games\|built-in-agents\|prd-v3'  # residual 3
+grep -rn 'Ratenlimit\|Anbindung\|vom Engine' de/          # residuals 1, 2, 9
+
+# 5. Declension traps.
+grep -rnE '\b(dem|den) Agent\b' de/    # must be Agenten
+grep -rnE 'Token Budget|Prompt Preset|Chat Einstellungen' de/   # Deppenleerzeichen
+
+# 6. Link fragments must stay English-slugged (9 links total, 0 offenders).
+grep -rnoE '\]\([^)]*#[a-zäöüß-]*[äöüß][a-zäöüß-]*\)' de/
+```
+
+A note for whoever ports these checks to a script: **do not reach for a
+JS-flavoured `\w` or `\b`.** In JavaScript `\w` is `[A-Za-z0-9_]`, so `\bPrüf\b`
+and `\bWähle\b` misfire on the umlaut and every count in §1 comes out wrong.
+Python's `re` is Unicode-aware by default and was used for every number in this
+file; GNU `grep -P` needs the `(*UCP)` verb or an explicit class. The same trap
+bites much harder on non-Latin packs — **it must stay documented for `ru`**,
+where a JS `\w` matches nothing at all in Cyrillic.
+
+### Tooling traps
+
+- **The app locale `de.json` is NOT a terminology source.** It uses
+  `Voreinstellungen` for presets, `Zweig` for a chat branch, and
+  `Persönliche Erweiterungen` as a product name — all of which contradict this
+  glossary — and it carries outright defects (`benutzergegonnene`, `Kopiiere`,
+  `Wissenquellen`, "lokale **Coden**"). The docs are written against the
+  **English** UI by design (§3). Consult `de.json` only to check whether a
+  German UI string exists at all, never for wording.
+  *(Carried forward from the original cycle. `de.json` lives in the Engine
+  repo, not on this branch, so the specific defect list could not be
+  re-verified during the 2026-09-01 re-derivation — treat it as a recorded
+  ruling, not a measured claim.)*
+- **Windows checkouts silently rewrite line endings.** `validate-pack.mjs`
+  fails on CRLF; `.gitattributes` on this branch is the guard — verified
+  present and reading `* text eol=lf`, with the comment "Never check out
+  CRLF" — but a copy through an editor or a scratch directory can defeat it.
+  Re-run the validator after any out-of-tree edit. The pack is currently clean
+  at **0 CRLF**.
+- **The manifest must be rebuilt in the same commit as content**
+  (`build-manifest.mjs`, then `validate-pack.mjs`) or the pack fails hash
+  verification at download time, and the user gets the English fallback with no
+  visible explanation.
+- **Renames and deletions must be mirrored from `docs/` on `staging`**, or the
+  file is orphaned — `validate-pack.mjs` catches orphans, but only for files
+  that exist; a *missing* translation degrades silently to the per-file English
+  fallback and is easy to miss in review.
+
+### Known pack residuals — documented, not fixed (see R4/R5)
+
+| # | Residual | Where | Why it is left |
+|---|---|---|---|
+| 1 | **`Anbindung`** used as the carrier noun in the "what is a connection" definition, against the plurality choice `Verknüpfung` | `agents/memory.md:36` ("Eine Verbindung ist eine gespeicherte **Anbindung** an einen KI-Anbieter."), `noodle/overview.md:16` (plus two unrelated-sense uses: `development/chat-resource-drag-drop-plan.md:237` "Anbindung der Panels", `development/code-cleanup-audit.md:239` "Anbindung an den Host") | Flagged in an earlier cycle; 4 files untouched since. The **headword** `Verbindung` is fully standardized (565 hits, no competing headword) — only the definitional carrier noun varies: `Verknüpfung` ×3 (`chats/chat-settings.md:28`, `chats/guided-and-impersonate.md:90`, `conversation/getting-started.md:29`), `Anbindung` ×2, `Setup` ×1 (`connections/connecting-to-a-provider.md:7`), `Verbindung` self-referentially ×1 (`media/illustrator-agent.md:15`). *Corrected 2026-09-01: an earlier draft listed `Eintrag` and `Konfiguration` here; neither is attested.* Low reader impact. |
+| 2 | **`Ratenlimit`** — false friend (`Rate` = *installment payment* in ordinary German) | `noodle/settings.md:200`, the pack's only rate-limit rendering | Flagged in an earlier cycle. Because there is no competing precedent anywhere in the pack, the correct term is an open decision (`Rate Limit` vs `Anfragelimit`) and is deliberately **not** resolved here. |
+| 3 | **`Figur` / `Figurenkarte` / `Figurenreihenfolge` / `Figuren-ID` / `Figurengalerie`** instead of `Charakter` / `Charakterkarte` | `characters/galleries.md` lines 73, 79, 81, 83, 85, 89, 91 — **13 occurrences**, plus **3** at `chats/sending-and-streaming.md:56` (`Figur`, `Figurengalerie`, `Figurengalerien`); **16 in the drifted sense** | *Discovered 2026-09-01; recount 2026-09-01 raised it from the 8 first reported to 13 in `galleries.md`.* Genuine terminology drift in one guide against 1,275 `Charakter` / 91 `Charakterkarte`, and `Figurenkarte` is the pack's only competing spelling of `Charakterkarte`. It breaks the hit-count search for the most searched noun in the pack. **Highest-priority residual.** Correct, leave alone: `Figuren` = *chess pieces* in `conversation/table-games.md:89–91` and `agents/built-in-agents.md:288`; `Figur`/`Figuren` in `development/hierarchical-locations-prd-v3.md:159/161/419/1041/1111` contrasts with `Charaktere` in the same sentences ("sichtbare Charaktere … die führende sichtbare Figur") and reads as deliberate. |
+| 4 | **Unspaced percent in prose** (`0%`, `100%`, `90%`) against the pack's `5 %` convention — **16 occurrences** | `appearance/appearance-settings.md:87, 90, 91, 97, 98` (15 occurrences on 5 lines), `agents/knowledge-sources.md:83` (1) | Cosmetic, and file-scoped to two files — but note it outnumbers the 15 conforming occurrences, so the convention is a 4-file majority rather than an overwhelming one. Percent inside code fences and CSS is correct as-is and must not be touched. |
+| 5 | **Em dash in German prose** (3 instances) against the 806:3 en-dash convention | `agents/custom-agents.md:113`, `:114`, `TROUBLESHOOTING.md:260` | Cosmetic. The fourth em dash (`lorebooks/entries.md:189`) is **correct** — it is inside a byte-identical English code span and must stay. |
+| 6 | ~~NBSP as table padding~~ — **withdrawn; there is no NBSP in the pack** | `extending/personal-extensions.md:167–171` | *Corrected 2026-09-01.* A full codepoint scan returns **0 × U+00A0**. The 5 characters on those lines are **U+FE0F variation selectors**, one per row, attached to the ⚠️ emoji in the capability matrix. Kept in the table so the next reviewer does not re-file the same false positive. Nothing to sweep. |
+| 7 | **`Endpoint` vs `Endpunkt`** — the pack's actual split, and the reverse of what an earlier draft of this glossary prescribed | `Endpunkt` **27** across 12 files (`development/frontend.md:456` "## API-Endpunkte", `connections/providers-reference.md:66`, `CONFIGURATION.md:132`, `media/image-providers.md:96`, …). `Endpoint` **11**: 5 inside English UI labels or code (`**Embedding Endpoint URL**`, `**Local / Custom Endpoint**`, `**RunPod Endpoint ID**`) which are correct by §3.1, and **6 in bare German prose — 5 of them in `connections/local-self-hosted.md:9, 55, 59`** plus `media/comfyui.md:20` | *Discovered 2026-09-01.* `Endpunkt` is the settled German headword by a wide margin; `connections/local-self-hosted.md` is a single drifted guide that also carries the concept's inline definition ("Ein **Endpoint** ist die Webadresse, unter der ein Server auf Anfragen wartet."), which is why an earlier pass mistook the minority for the rule. Fix as a terminology change in its own commit, and rewrite that definition sentence with it. Second-priority residual after 3. |
+| 8 | **`Werkzeug`/`Werkzeuge` as the headword for a custom tool**, against `das Tool` | `integrations/home-assistant.md` — **28 `Werkzeug*` against 7 `Tool`** in one guide (lines 11, 15, 80, 81, 92, 102, 104, 106, 111, 113, 115, 128, 143, 188, 190, 192, 204, 210, 220, 228, 232) | *Discovered 2026-09-01.* The canonical guide `extending/custom-tools.md` uses `Tool` **60×** and `Werkzeug` **0×**; `home-assistant.md` inverts that for the identical concept, and its line 11 makes the collision explicit: "Sie legt Smart-Home-**Werkzeuge** in Marinara an … Marinara nennt sie „custom tools“." One guide, one sweep. **Do not** mass-replace `Werkzeug` pack-wide: of the 97 bare `Werkzeug`/`Werkzeuge`/`Werkzeugen` in the pack, 27 are this guide's and the other **70** mean a generic piece of software (Tailscale at `FAQ.md:39` and `REMOTE_ACCESS.md:16`, Git at `UPGRADING.md:33`, `backgroundremover` at `TROUBLESHOOTING.md:197`) — those are correct, as are the 37 `Werkzeugleiste` = *toolbar*. |
+| 9 | **`vom Engine`** — wrong gender for `die Engine` | `development/file-storage.md:35` ("werden **vom Engine** nie gelöscht") | *Discovered 2026-09-01.* One slip against 32 correctly feminine article uses (`die Engine` 13, `der Engine` 19, `von der Engine` at `development/optional-agent-packages.md:62`). Should read `von der Engine`. Trivial, but it is a grammar defect rather than a style choice, so it does not need the same deliberation as a terminology sweep — fold it into the next edit that touches `file-storage.md`. |
+
+Residuals 1, 2, 4 and 5 are cosmetic or scoped; 6 is withdrawn and 9 is a
+one-word grammar fix. **Residuals 3, 7 and 8 are the ones worth dedicated
+sweeps** — each is a real terminology split that defeats the hit-count search
+(§4), each is confined to one or two guides, and each should be fixed as a
+terminology change with its own manifest rebuild rather than folded into
+unrelated content work. Priority order: **3** (`Figur`, 16 hits, the most
+searched noun in the pack), then **7** (`Endpoint`, 6 prose hits and a wrong
+inline definition), then **8** (`Werkzeug`, 28 hits in one guide).
+
+Per R5 the `Ratenlimit` and `Anbindung` scheduling ruling still stands and is
+untouched by this review; residuals 3, 7 and 8 are new findings from the
+2026-09-01 re-derivation and inherit R4's "document, do not silently fix"
+treatment rather than any earlier scheduling decision.

--- a/glossaries/glossary-es.md
+++ b/glossaries/glossary-es.md
@@ -1,0 +1,369 @@
+# Marinara Engine — Spanish (`es`) documentation-pack glossary
+
+## Provenance
+
+This is the **second-generation** `es` glossary, **re-derived 2026-09-01**. The original
+working glossaries from the pack-authoring cycle were lost to temp-directory cleanup, so
+nothing here is inherited text — every rule below was re-established from source.
+
+Sources, in authority order:
+
+1. **The shipped pack** (`docs-i18n` branch, `es/`, 125 `.md` guides plus `manifest.json` =
+   126 files) — **ground truth**. Every terminology row and prescriptive rule below cites a pack
+   file (and, where useful, a line) that demonstrates it. **Counts in this document are
+   occurrence counts over the 125 guides**, produced with accent-aware, case-insensitive-where-
+   noted matching (see § 7, "Counting traps").
+2. **The pack's shipping PR decision write-up** — PR
+   [#4100](https://github.com/Pasta-Devs/Marinara-Engine/pull/4100) ("Documentation Language
+   setting + first full translation: Spanish, 123 guides"). Its terminology paragraph is the
+   origin of the one-term-per-concept and loanword rulings.
+3. **The 2026-09-01 mirror-cycle notes** (`prd-notes-es.md`) — per-row, evidence-cited choices
+   made three hours before this glossary, covering the `#5604` / `#5720` / `#5718` deltas.
+4. **The app locale file** `packages/client/src/localization/locales/es.json` — consulted only
+   for UI-gloss reality checks (see § 5 and § 7; it is **not** an authority over the pack).
+
+**Descriptive, not aspirational.** The recorded maintainer ruling for `es` is that the pack
+**skews literal by history**, and that naturalness/anti-calque critiques were **deliberately
+deferred**. This glossary therefore documents the pack **as shipped**. If `es` is ever
+re-opened for a naturalness pass, the recorded ruling is that **the `de` glossary's anti-calque
+approach is the template** — but that is a future-work note, not a rule that governs edits
+today. *(Recorded maintainer ruling; not verifiable from pack content.)*
+
+---
+
+## 1. Register & address
+
+| Rule | Evidence |
+| --- | --- |
+| **Informal `tú` throughout.** Second-person singular, `tú` verb forms, `tu/tus` possessives. Never `usted`/`ustedes` for addressing the reader. `usted` has **zero** occurrences in the pack. | `es/agents/agents-overview.md:51` "abre un visor donde **puedes** leer"; `es/agents/approvals-and-agent-suite.md:18` "Siempre piden **tu** aprobación" |
+| **Never `vosotros`.** Zero occurrences of `podéis` / `vuestro`. Plural address, when unavoidable, goes through impersonal or `tú`-singular rephrasing. | pack-wide grep: 0 hits |
+| **Imperative for instructions**, `tú` form: `Haz clic`, `Abre`, `Escribe`, `Elige`, `Establece`, `Consulta`, `Revisa`. | `es/agents/approvals-and-agent-suite.md:65` "**Haz clic** en **Agent Suite**." |
+| **Neutral / pan-American lexicon**, not peninsular. `computadora` (106) — **never** `ordenador` (0) or `computador` (0); `archivo` (406) — never `fichero` (0); `video` (290) — never `vídeo` (0); `celular` (0) is not used, the phone is `teléfono` (85) with `móvil` (15) as adjective. | `es/INSTALLATION.md:43` "significa tu propia **computadora**"; `es/chats/messages.md:5` "en una **computadora**, o cuando tocas el mensaje en un **teléfono**" |
+| **`app`** is the default word for the application — the bare token `app` occurs 441× (`apps` 12×), of which `la app` is 325×, against `aplicación` 35× / `aplicaciones` 2×. `aplicación` survives mostly in platform prose and in `la aplicación de actualizaciones` (= *applying* updates, 2×). | `es/TROUBLESHOOTING.md:80` "guarda **la app** web en caché"; `es/CONFIGURATION.md:238` "la **aplicación** de actualizaciones" |
+| **Gender-neutral where natural**, achieved by rephrasing — `quienes crean personajes`, `quien colabora`, plural `personas`, agentless constructions. The pack leans on `se`-impersonal and second-person `tú` far more than on these relative-clause forms (each occurs once), so treat them as licensed rather than expected. | `es/appearance/card-css-theming.md:3` "muestra a **quienes crean** personajes y personas"; `es/development/localization.md:62` "Traduce un valor de la comunidad solo cuando **quien colabora** pueda aportar…" |
+| **Banned inclusive orthography**: `@`, `x`, or `-e` endings (`usuari@s`, `usuarixs`, `todes`). Zero occurrences; the pack solves gender by rewriting, not by glyph. | pack-wide grep: 0 hits |
+| **`la IA`** is the actor in prose (261 `la IA`, 197 `de IA`). Bare `AI` appears only inside byte-exact English UI labels (`**Create with AI**`, `**AI Edit**`). | `es/lorebooks/overview.md:7` "de la que **la IA** puede tomar datos"; `es/agents/hierarchical-maps.md:91` "**Create with AI**" |
+| **Click vs. tap**: `haz clic` (255) is the default; `pulsa` (30) is for **keys** and hardware-ish presses; `toca` (26, plus `doble toque` 5 and enclitic `tócala`) is the touch verb. Don't swap them. `doble clic` (10) and `doble toque` (5) are the paired mouse/touch forms. | `es/characters/library-organization.md:62` "haz **doble clic** en ella, **tócala dos veces**, o selecciónala y **pulsa** la tecla F2" |
+
+---
+
+## 2. Product, feature & mode names
+
+| Rule | Evidence |
+| --- | --- |
+| **Product names never translate**: `Marinara`, `Marinara Engine`, `Termux`, `Android`, `Node`, `Docker`, `GitHub`, `Discord`. The token `Marinara` occurs 1247× in all, of which 239 are the formal `Marinara Engine` and ~1008 the short form; keep whichever the English source used. | `es/development/localization.md:56` "Deja sin cambios los **nombres de producto** como Marinara Engine"; `es/CONFIGURATION.md:71` |
+| **UI-surfaced feature and panel names stay English**, styled as the English source styled them: `Local Model` (69), `Download Agents` (34), `Character Editor` (18), `World Info` (18), `Global Gallery` (11), `Apply Update` (11), `Release Channel` (3), `Agents Manager` (1), `Support Diagnostics` (1), `Professor Mari` (93), `Noodle` (167), `Card Browser` (24). | `es/lorebooks/overview.md:7` "También se le llama **World Info**"; `es/TROUBLESHOOTING.md:330` "la copia de **Support Diagnostics**" |
+| **A frozen English name takes a Spanish gloss the first time it is a *clickable label*** — see § 5. A frozen name used as a *proper noun of a subsystem* (e.g. `Support Diagnostics`, `Agents Manager`) is left bare and unglossed when the English source leaves it unbolded. | `es/TROUBLESHOOTING.md:330` — `Support Diagnostics` bare and unglossed in the same sentence where two bold labels **are** glossed |
+| **Mode names stay English behind a Spanish carrier noun**: `modo Conversation` (30), `modo Roleplay` (10), `modo Game` (7). `Game Mode` is itself a frozen two-word name and stays whole (235 occurrences) — do **not** rewrite it to `modo Game` when the English source said "Game Mode". | `es/appearance/card-css-theming.md:211` "En el **modo Conversation**"; `es/game/getting-started.md:1` "# **Game Mode**: primeros pasos" |
+| `modo de juego` (7) means *a game mode* generically, **not** the product's Game Mode. Keep the distinction. | `es/game/` prose vs. `es/game/getting-started.md:1` |
+| **Carrier-noun + English-name is the general pattern** for typed things: `el panel **Personas**`, `el botón **Apply Update**`, `el asistente New Game Setup`, `la pestaña **Advanced**`. Gender/article come from the Spanish carrier noun, never from the English name. | `es/characters/personas.md:19` "El **panel** **Personas** es tu biblioteca"; `es/UPGRADING.md:151` "El **botón** **Apply Update**" |
+| **Agent names stay English**: `Narrative Director`, `Character Tracker`, `Beholder`, `Illustrator`. Introduce them with the Spanish carrier `agente`. | `es/roleplay/narrative-director.md:7` "El **Narrative Director** es uno de estos **agentes**." |
+| **Headings translate**, sentence case, Spanish question marks where the English heading is a question. `Overview` → `Descripción general de <noun>`, and the **H1 headings are consistent about it** — all three that use the pattern say `Descripción general de …`. The competing forms (`Resumen de`, `Visión general de`, `Vista general de`, `Introducción a`) appear only in **link text**; do not import them into a heading. See § 7 residual 8. | `es/lorebooks/overview.md:1` "# Descripción general de los lorebooks"; `es/settings/settings-overview.md:1`; `es/chats/chat-settings.md:1`; `es/CONFIGURATION.md:5` "## ¿Cuándo configurarías Marinara?" |
+| **Titles may be recast as `Nombre: descripción`** where English used a bare noun phrase. | `es/agents/agents-overview.md:1` "# Agentes: ayudantes de IA para tus chats"; `es/noodle/overview.md:1` "# Noodle: la línea de tiempo social dentro de la app" |
+
+---
+
+## 3. Core terminology
+
+Column 2 is **the pack's term — use it**. Column 3 lists renderings that must **not** be
+introduced (either because the pack never uses them, or because the pack reserves them for a
+different concept). Evidence is one pack file that demonstrates the row.
+
+| English term | This pack's term | Banned alternates | Evidence |
+| --- | --- | --- | --- |
+| prompt | **prompt**, masculine — `el prompt` (105), `un prompt` (46), `los prompts` (53); 727 in all. First use in a guide takes the gloss `prompt (las instrucciones enviadas a la IA)`. | `la prompt` / `una prompt` (0 — the pack is uniformly masculine); `indicación` *(reserved — see the last row)*; `aviso` *(reserved: 64 uses for a browser/password prompt, an on-screen notice or a toast — `es/CONFIGURATION.md:124` "un **aviso** de contraseña")*; `mensaje del sistema`; `instrucción` as a standalone equivalent | `es/characters/personas.md:7` "en cada **prompt** (las instrucciones enviadas a la IA)"; `es/lorebooks/overview.md:9` (definition-sentence variant) |
+| token | **token**, masculine — `un token`, `los tokens`, `de tokens`, `recuentos de tokens`, `presupuesto de tokens` (129 in all). First use glossed `un token (un fragmento de texto)`. | `ficha` *(reserved — 13 uses, all UI chips/tiles: poker chips `es/conversation/table-games.md:112,114,122`, attachment chips `es/chats/sending-and-streaming.md:32`, emoji/sticker tiles `es/conversation/emoji-stickers-gifs.md:42,50,51,68`, recent-chat tiles `es/home/welcome.md:14`)*; `unidad léxica`; `símbolo` | `es/prompts/generation-parameters.md:31`; `es/lorebooks/token-budgets.md:1` "Presupuestos de **tokens**" |
+| preset | **preset**, masculine — `un preset` (37), `el preset`, `los presets` (231 in all). First use glossed `preset (ajuste guardado)`. | `preajuste`; `ajuste predefinido`; `plantilla` *(reserved — 103 uses for a genuine **template**: map templates, `Prompt Template`, storyboard templates; `es/agents/hierarchical-maps.md:31` "**plantillas** de mapa")* | `es/data/importing-from-sillytavern.md:17` "Un **preset** (ajuste guardado) es un paquete guardado de ajustes de generación." |
+| lorebook | **lorebook**, masculine — `un lorebook` (89), `los lorebooks` (605 in all). First use glossed `lorebook (libro de trasfondo)` — the gloss phrase `libro de trasfondo` occurs 19× across 19 files (once per file that introduces the term). Also announce the synonym `World Info`. | `libro de conocimiento`; `libro de lore`; `códice`; using `libro de trasfondo` as the standalone term | `es/lorebooks/overview.md:3,7`; `es/data/importing-from-sillytavern.md:17` |
+| character card | **tarjeta de personaje** (61 sg. / 27 pl.). The English `character card` appears only when the source is quoting the term itself. | `ficha de personaje`; `carta de personaje`; `perfil de personaje` as the term | `es/FAQ.md:101` "Una **character card** (tarjeta de personaje) es el perfil guardado…" |
+| chat | **chat**, masculine — `un chat` (329), `el chat` (209), `los chats` (100); the token `chat` occurs 1734× and `chats` 422×. Verb: `chatear` (10). | `conversación` as the term for a chat — but note it is **not** unused: 77 occurrences carry the ordinary sense "a conversation" (`es/chats/managing-chats.md:45` "no cambia la **conversación**") and the `Conversation` mode gloss. Reserve it for those; never make it the noun for a saved chat. Also banned: `charla` (1, `es/conversation/schedules.md`) | `es/chats/chat-settings.md:28`; `es/CONFIGURATION.md:155` "cuántos **chats** mantiene el servidor en memoria" |
+| message | **mensaje**, masculine — `el mensaje`, `los mensajes`, `un mensaje`. `barra de herramientas del mensaje`, `historial de mensajes`, `rama de mensajes`. | `entrada` for a chat message *(reserved for lorebook entries and log entries)*; `post` | `es/chats/messages.md:5`; `es/chats/branches.md:23` |
+| agent | **agente**, masculine — `el agente` (105), `los agentes` (73), `un agente` (62); 655 in all. Agent *names* stay English. | `asistente` as the term for an Engine agent — reserved, and heavily used (91): the assistant **chat role** (`mensajes del usuario y del **asistente**`), **setup wizards** (`el **asistente** New Game Setup`, `es/characters/choosing-your-persona.md:48`), Professor Mari (`es/FAQ.md:161`) and a generic outside `asistente de IA` (`es/appearance/card-css-theming.md:524`). `ayudante de IA` (32) is the pack's explanatory gloss for *agent*, not a second term. Also banned: `bot` | `es/roleplay/narrative-director.md:7`; `es/agents/agents-overview.md:1` |
+| connection | **conexión**, feminine — `una conexión` (163), `la conexión` (120), `las conexiones` (16); `conexión`/`conexiones` 569 in all. Panel label stays `**Connections** (Conexiones)`. | `enlace` as the term for a saved connection — reserved and common (124): a **hyperlink** (`es/INSTALLATION.md:27` "usa el **enlace** Descargar APK") and the network **gateway** `puerta de enlace` (`es/REMOTE_ACCESS.md:17`). It appears once in the *definition* of a connection (`un enlace guardado a un proveedor`) and must not be promoted from there. Also banned: `perfil de conexión` | `es/chats/chat-settings.md:28` "Una **conexión** es un enlace guardado a un proveedor de IA" |
+| provider | **proveedor** (286) / `proveedores` (56). English `provider` (78) survives only inside frozen labels, code, and URLs. | `suministrador`; `servicio` as the term | `es/chats/chat-settings.md:28` "qué **proveedor** de IA y qué modelo responden" |
+| launcher | **lanzador**, masculine — `el lanzador`, `los lanzadores`, `los lanzadores de shell`, `el lanzador de Termux` (91 in all). | `iniciador`; `arrancador`; leaving `launcher` in English (3 residual hits, all naming a script/binary) | `es/CONFIGURATION.md:71,88`; `es/TROUBLESHOOTING.md:324` |
+| update (noun/verb) | **actualización** (151) / **actualizar** (37). "Apply an update" → `aplicar la actualización`; the noun phrase for server-side apply is `la aplicación de actualizaciones` (2). The button itself stays `**Apply Update** (Aplicar actualización)`. | `parche` for a release update *(reserved: 7 uses in dev docs for a **patch** to state — "los **parches** del agente World State")*; `upgrade` (0); `actualizamiento` (0) | `es/UPGRADING.md:120,151`; `es/CONFIGURATION.md:238` |
+| channel (release/update) | **canal**, masculine (24 in all). The bare `canal` carries most of the load; the expanded phrase is rare and appears in **two forms** — `canal de versiones` 1× and `canal de versión` 1× — so match the neighbouring file rather than standardising. A channel switch is `un cambio de canal` (2). The label `**Release Channel**` is itself glossed **two different ways** — `(Canal de versiones)` and `(Canal de lanzamiento)`; see § 7 residual 10. | `rama` for a release channel *(reserved for message/git branches)*; `vía` *(reserved: 33 uses meaning "via/route")*; `flujo` *(reserved: 166 uses for a ComfyUI **workflow**, `flujo de trabajo`)* | label: `es/installation/windows.md:201`; `canal de versiones`: `es/installation/macos-linux.md:231`; `canal de versión`: `es/CONFIGURATION.md:237`; `cambio de canal`: `es/CONFIGURATION.md:238` |
+| channel (Discord) | **canal de Discord** — same noun, different qualifier. Never merge the two senses in one sentence without the qualifier. | `servidor de Discord` for a channel | `es/integrations/discord-mirror.md:3,7` |
+| checkout (git working tree) | **checkout**, masculine loanword (9) — `un checkout de desarrollo`, `un git checkout`. Kept English because it names the Git artifact. | `pago` *(reserved: 14 uses meaning payment)*; `pedido`; `descarga`; `copia de trabajo` **in the git sense** | `es/CONFIGURATION.md:238` "nunca pueda reescribir un **checkout** de desarrollo"; `es/UPGRADING.md:33,37`; `es/TROUBLESHOOTING.md:39` |
+| working copy (editor buffer) | **copia de trabajo** (12) — the *editor's* unsaved buffer, an unrelated concept from git checkout. | `checkout`; `borrador` *(reserved: 99 uses for an AI or extension **draft**, `un borrador de IA`)* | `es/agents/hierarchical-maps.md:69,98,117,146` |
+| wake lock | **wake lock**, masculine loanword — `solicita un wake lock de Android`, `Un wake lock por sí solo`. | `bloqueo de activación`; `bloqueo de suspensión`; `wakelock` (one word) | `es/TROUBLESHOOTING.md:324,330` |
+| battery optimization | **optimización de batería** (no article on `batería`). "Remove/exempt from it" → `quítale la optimización de batería` / `exime a Termux de la optimización de batería`. | `optimización de la batería`; `ahorro de batería`; `optimización energética` | `es/TROUBLESHOOTING.md:326,332` |
+| background (activity / running) | **en segundo plano** — `funcionar en segundo plano`, `la actividad en segundo plano`, `mensajes autónomos en segundo plano`, `un script en segundo plano`. | `en el fondo`; `de trasfondo` *(`trasfondo` is reserved for lore/backstory)*; `background` | `es/TROUBLESHOOTING.md:326,332,363`; `es/TROUBLESHOOTING.md:80` |
+| memory / in memory | **memoria** / **en memoria** — bare, articleless `en memoria` (8) is the *residency* sense: `mantiene el servidor en memoria`, `cargar cada chat en memoria`, `las filas en memoria`, `store de tablas en memoria`. Take the article only when the memory is **possessed or specified**: `en la memoria del servidor`, `la memoria de la página`, `la memoria de la GPU`, `la memoria del teléfono` (6 such). | `en la memoria` for the bare residency sense; `residente`; `memoria RAM` in prose | articleless: `es/CONFIGURATION.md:155,156`; `es/development/file-storage.md:39,43`; `es/development/architecture-map.md:95`. Possessed: `es/characters/bot-browser.md:116`; `es/media/comfyui.md:13` |
+| eviction / evict | **descarte** / **descartar(se)** — `se descarta de la memoria (nunca del disco)`, `desactiva el descarte`. | `desalojo`; `expulsión`; `desahucio`; `evicción` | `es/CONFIGURATION.md:155` |
+| least-recently-used | **el chat usado menos recientemente** (there is no `LRU` precedent in `es`; this follows the pack's `actividad menos reciente` pattern). | `LRU`; `menos usado recientemente`; `el más antiguo` | `es/CONFIGURATION.md:155`; pattern source `es/chats/managing-chats.md` |
+| cache | **caché**, feminine (41; `en caché` 24) — `la caché del navegador`, `una copia en caché`, `guarda la app web en caché`, `apps en caché`. Masculine `el caché` has **0** occurrences. | `memoria caché` in running prose (0); `cache` unaccented *(1 residual, inside the HTTP literal `no-cache` at `es/development/optional-agent-packages.md:28` — code, not prose)*; masculine `el caché` | `es/TROUBLESHOOTING.md:75,80,330`; `es/UPGRADING.md:192`; `es/media/tts-setup.md:142` |
+| backup | **copia de seguridad** (48 sg. / 17 pl.). Verb phrase: `haz una copia de seguridad`. `respaldo` (22) exists but as the *fallback / backing* sense (`el respaldo en tiempo de ejecución`, `nodos con respaldo de trasfondo`), **not** as a backup file. | `respaldo` for a backup archive; `backup` in Spanish prose — the English word does survive 26× but **only** inside frozen labels (`**Creating backup…**`, `**Download Backup**`, `**Existing backups**`), directory/file names (`backups/`, `marinara-automatic-backup.zip`), routes (`/api/backup`) and link targets; `salvaguarda` | `es/data/backup-and-restore.md:9,20,36`; frozen-label case `es/data/backup-and-restore.md:121`; contrast `es/development/localization.md:5` "la de **respaldo** en tiempo de ejecución" |
+| snapshot | **instantánea**, feminine (43) — `instantáneas de viaje`, `la instantánea espacial`, `las instantáneas de las tablas`. | `captura` *(reserved: 10 uses meaning a screenshot / regex capture group)*; `foto`; `punto de restauración`; English `snapshot` in prose — see § 7 residual 2 | `es/agents/hierarchical-maps.md:18,234`; `es/development/file-storage.md:39` |
+| extension | **extensión** / **extensiones** (147) — `extensiones personales`, `extensiones externas`. | `complemento` for an Engine extension *(reserved — see next row)*; `plugin` (3, all naming third-party code in dev docs); `añadido` | `es/extending/personal-extensions.md:3,11,15` |
+| add-on | **complemento** (5) — the pack's word for a bolt-on that is **not** an Engine extension: the Termux platform add-on, an optional animation add-on, a generic drop-in add-on in dev docs. Not restricted to Android/Termux. | `extensión` for these | `es/TROUBLESHOOTING.md:326` "no hace falta ningún **complemento**"; `es/game/storyboard.md:15` "**complemento** de animación opcional"; `es/development/chat-resource-drag-drop-plan.md:452` |
+| NPC | **NPC**, invariable acronym, masculine — `los NPC` (10), `un NPC`; 44 in all. First use glossed `NPC (personaje no jugador)` / `(personajes no jugadores)` (10). **In Spanish prose the acronym never takes `-s`** — `los NPCs` has 0 occurrences. `NPCs` does appear 6×: 4 inside frozen English labels (the **NPCs** tab, `**Use default voices for random NPCs**`) which are correct, and 2 in translated **link text**, which are residuals (§ 7, residual 9). | `PNJ` (0); `NPCs` in running Spanish prose; translating the acronym away | `es/agents/built-in-agents.md:115`; `es/agents/hierarchical-maps.md:263`; `es/game/party-and-npcs.md:79` |
+| persona | **persona**, feminine — `tu persona`, `una persona`, `las personas`, `la persona activa`, `el panel **Personas**`. Disambiguate on first use with a definition sentence, because the word collides with the everyday `persona`. | `perfil de usuario` as the term; `personaje del usuario`; `avatar` as the term *(reserved: 161 uses for the actual profile **picture**)* | `es/characters/personas.md:3,7`; `es/conversation/profiles.md:5` "Una **persona** es el perfil que te representa (el `{{user}}`)" |
+| swipe | **swipe**, masculine (110) — `un swipe`, `los swipes`; verb `hacer swipe` (1 — rare, prefer the noun). First use glossed `swipe (respuesta alternativa)` / `swipes (respuestas alternativas)` (12). | `deslizamiento`; `variante` as the term; `pasada` *(reserved: 20 uses meaning a **pass** over data)* | `es/chats/messages.md:1,3`; `es/chats/branches.md:23`; `es/agents/hierarchical-maps.md:234` |
+| macro | **macro** (126) — first use glossed `Un macro es un marcador de posición…`. **Gender is inconsistent in the shipped pack.** Counting case-insensitively, feminine leads 48–15: `las macros` 22, `una macro` 13, `la macro` 11, `esta macro` 2, against `los macros` 8, `el macro` 4, `un macro` 3. Feminine owns `es/prompts/macros.md`; masculine owns `es/characters/personas.md` and `es/conversation/profiles.md`. See § 7 residual 1; for **new** text follow the local file's existing gender rather than introducing a third pattern. | inventing a translated term (`macroinstrucción`) | feminine `es/prompts/macros.md`; masculine `es/characters/personas.md:11,13`; `es/conversation/profiles.md:22` |
+| placeholder | **marcador de posición** | `placeholder`; `comodín` | `es/characters/personas.md:13`; `es/chats/connected-chats.md:83` |
+| branch (chat / git) | **rama** (85 sg. / 40 pl.) — `rama de mensajes`, `crear una rama`, `la rama **`staging`**`. Bare `branch`/`branches` (9 + 11 = 20) only inside code, command text and frozen labels such as `**Chat Branches**`. | `bifurcación` for a branch *(the pack spends `bifurcación` (5) on a GitHub **fork** and on a branch-point in `es/development/optional-agent-packages.md:60`)*; `hilo` | `es/chats/branches.md:23`; `es/development/localization.md:74` "una rama enfocada de tu **bifurcación**" |
+| streaming | **streaming**, masculine loanword (32) — `la respuesta aparece en pantalla con streaming`, `mientras una respuesta está en streaming`. | `transmisión` (0 occurrences); `en directo` (0); `flujo` *(reserved: 166 uses for a ComfyUI **workflow**)* | `es/chats/sending-and-streaming.md:1,3,14` |
+| API key | **API key**, feminine (93 sg. / 10 pl.) — `una API key`, `tus API keys guardadas`; first use glossed `API key (clave de API)` (26; `claves de API` 2). | `clave API` (1 occurrence at `es/media/tts-setup.md:64` — a residual, don't propagate); `llave de API`; `token de API` as the term for an Engine API key *(1 legitimate use at `es/media/image-providers.md:96`, where it names **RunPod's own** "API token")* | `es/chats/chat-settings.md:28`; `es/agents/memory.md:46`; `es/characters/bot-browser.md:9` |
+| log | **registro** (74 sg. / 39 pl.) — `el registro persistente`, `el registro de la sesión`, `los registros del juego`. English `log` (12) only inside filenames, extensions and API identifiers (`server-*.log`, `.log`, `marinara.log.info`) — never in prose. | `bitácora` (0); `log` in prose | `es/TROUBLESHOOTING.md:324`; `es/extending/writing-personal-extensions.md:116` |
+| hash | **hash**, masculine loanword (47 sg. / 2 pl.) — `compara el hash que se muestra`, `los hashes`. | `resumen` as the term *(reserved: 137 uses meaning a **summary**)*; `huella` as the term *(the pack does use the verb `toma la huella del código`, 10)* | `es/extending/personal-extensions.md:15`; `es/agents/agents-overview.md:27` |
+| data folder | **carpeta de datos** (28) — `la carpeta de Marinara`. `directorio de datos` (3) survives only where the English said "directory" of a configured path. | `directorio` as the default word for a user-facing folder | `es/TROUBLESHOOTING.md:39`; `es/data/where-data-is-stored.md` |
+| host process | **el proceso host** — `host` stays a loanword for the process and for compounds (`nombre de host`, `zona horaria del host`). `anfitrión` (20) is the adjective for the **machine or server** that runs Marinara: `la computadora anfitriona`, `el dispositivo anfitrión`, `el servidor anfitrión`, `el operador del anfitrión`. | `proceso anfitrión` for the OS process (0); `proceso principal` (1, and it means something else) | `es/TROUBLESHOOTING.md:330` "el **proceso host** está congelado"; `es/installation/ios-pwa.md:23` "la dirección del **servidor anfitrión**"; `es/FAQ.md:13` "la **computadora anfitriona**" |
+| frozen / freeze | **congelado** (20) / **congelación** / **congelar**; Android's cached-app freezer is `el congelador de apps en caché`. | `bloqueado` for a frozen process — reserved and busy (51): blocked network traffic (`es/REMOTE_ACCESS.md`), blocked saves (`Guardado bloqueado`), disabled controls. `suspendido` as the term *(the pack uses the verb `suspende` for the action: "**suspende** todo el proceso de Termux")*; `helado` | `es/TROUBLESHOOTING.md:330,332` |
+| crashed | **caído** / **se cae** | `colapsado`; `crasheado` | `es/TROUBLESHOOTING.md:330` "está **congelado**, no **caído**"; `es/TROUBLESHOOTING.md:369` "El contenedor Lite **se cae**" |
+| unreachable | **inalcanzable** | `inaccesible`; `no disponible` | `es/TROUBLESHOOTING.md:330` "(Servidor **inalcanzable**)" |
+| unset (table default) | **sin configurar** (7) — in the *Default* column of an env-var table. | `no establecido` (1 residual); `sin definir` (2 residual); `vacío` as the unset-default *(reserved: 143 uses, and it is the pack's own default-column word for English "empty" — `es/CONFIGURATION.md:124` `BASIC_AUTH_USER` \| `vacío`)*; `ninguno` *(reserved: 109 uses glossing the **None** option)* | `es/CONFIGURATION.md:238`; `es/REMOTE_ACCESS.md` |
+| off (table default) | **desactivado** (206) | `apagado` *(23 — reserved for a device/feature being powered off, not for a table default)*; `no`; `false` | `es/CONFIGURATION.md:156` |
+| unlimited (table default) | **ilimitado** (5) | `sin límite` (2 residual); `infinito` (1 residual) | `es/CONFIGURATION.md:155`; `es/lorebooks/token-budgets.md` |
+| default (adj./adv.) | **predeterminado/a** (612 across all four inflections) / **de forma predeterminada** (180). | `por defecto` — **0 occurrences in the pack**; do not introduce it | `es/chats/guided-and-impersonate.md:36` "desactivado **de forma predeterminada**" |
+| wins over / takes precedence | **tiene prioridad sobre** (2) is the prescribed form, **but the pack is not consistent**: the banned-looking `gana sobre` actually occurs 3× and `anula` 8×. Prefer `tiene prioridad sobre` in new text; do not retro-fit the existing three. See § 7 residual 7. | `prevalece sobre` (0) | `es/CONFIGURATION.md:71,238`; counter-examples `es/characters/choosing-your-persona.md:32`; `es/prompts/generation-parameters.md:136`; `es/agents/knowledge-sources.md:71` |
+| lore / backstory | **trasfondo** (127) — also the head of the lorebook gloss `libro de trasfondo`. | `lore` in Spanish prose; `historia de fondo` (1); `mitología`. English `lore` does survive 16×, but **only** inside frozen labels (`**Selected lore**`, `**Linked lore**`), code identifiers (`lore_strict`, `{{lore}}`) and quoted English strings | `es/lorebooks/overview.md:3`; `es/development/hierarchical-locations-prd-v3.md:126` "Los nodos con respaldo de **trasfondo**"; frozen-label case `es/agents/hierarchical-maps.md:189` |
+| directive/prompt-adjacent "hint" | **indicación** (17) — **reserved**; the pack spends it on a *signal / hint / cue / on-screen prompt* (motion hints, voice cues, schedule guidance, installer prompts, UI strings, a typeless event), never on an LLM prompt. | using `indicación` for `prompt` | The distinction is drawn explicitly at `es/development/localization.md:7`: "cambia los controles y las **indicaciones** de Marinara, no los **prompts** del modelo". Also `es/game/storyboard.md:60,180` "**indicaciones** de movimiento"; `es/development/optional-agent-packages.md:88` "la **indicación** sin tipo `spatial_context_refresh`"; `es/roleplay/narrative-director.md:7` |
+
+---
+
+## 4. Typography & punctuation
+
+| Rule | Evidence |
+| --- | --- |
+| **Straight double quotes `"…"` are the pack standard** (1458 occurrences), used for quoted English UI strings, quoted output messages, and scare quotes. | `es/TROUBLESHOOTING.md:129` `"This parameter is sent to the model"`; `es/TROUBLESHOOTING.md:330` `"Opening chat..."` |
+| **Curly quotes `“…”` are a residual** (8 pairs in **3** files). They cluster on *in-world example sentences* and *quoted concept phrases* in narrative dev docs. Do **not** introduce new ones; do **not** mass-convert the existing ones either (that would reflow untouched lines). Single curly quotes `‘ ’` have 0 occurrences. | `es/agents/hierarchical-maps.md:260` (2 pairs), `:261`, `:477`; `es/development/code-cleanup-audit.md:114,202,233`; `es/development/hierarchical-locations-prd-v3.md:375` |
+| **Angle quotes `«…»` are never used** (0 occurrences). Do not "correct" the pack toward peninsular typographic style. | pack-wide grep: 0 hits |
+| **Em dash `—` (67)** for parenthetical asides, set **unspaced-or-spaced as the English source had it**; the pack most often mirrors the English spacing. **En dash `–` (4)** only for numeric and time ranges. | `es/agents/hierarchical-maps.md:261` "al que se pueda volver —o su descubrimiento— puede agregarlo"; `es/agents/built-in-agents.md:200` "(128**–**16.384)"; `es/noodle/settings.md:217` "23:00**–**07:00" |
+| **A colon frequently replaces the English em dash** when the aside is an explanation. This is the pack's habit and is fine to continue. | `es/TROUBLESHOOTING.md:330` "abres Termux**:** el proceso host está **congelado**" |
+| **No invisible or exotic spacing characters anywhere**: U+00A0 NBSP **0**, U+202F narrow NBSP **0**, U+3000 ideographic space **0**, U+200B ZWSP **0**, U+200D ZWJ **0**, U+00AD soft hyphen **0**, tabs **0**. Spanish needs none of them, and any one would change file bytes and break the manifest hash silently. | pack-wide scan: 0 hits each |
+| **The non-ASCII inventory is small and deliberate**: the six Spanish accented letters plus `ñ`/`ü`, `¿` `¡`, `—` `–` `…`, `→` (96) and `↓ ↑ ↔ ↘ ↙ ↺` in flow prose, box-drawing `─ │ ├ └` (66) in tree diagrams, `×` (4) in dimensions, `·` (1) as a table separator, `½` (1), a Greek `α` (1) in a LaTeX example, and a handful of emoji. A `ź` at `es/development/localization.md:44` is intentional — it is a **Polish** example string in the localization guide, not a defect. Anything outside this inventory in a diff is a mojibake or paste accident. | `es/media/comfyui.md:45` "`832×480`"; `es/development/localization.md:44` `"Napisz odpowiedź…"` |
+| **Spanish opening marks are mandatory**: `¿` (52) on every interrogative, `¡` (3) on exclamations. Headings that are questions carry both marks. | `es/CONFIGURATION.md` "## **¿**Cuándo configurarías Marinara**?**" |
+| **Numbers use es conventions in prose**: `.` as thousands separator (`16.384`, `8.000`, `4.000`), `,` as decimal separator (`1,5`). | `es/agents/built-in-agents.md:200` "(128–16.384)"; `es/game/combat.md:43` "multiplica el total por **1,5**" |
+| **Numbers inside code, literals, versions, IPs, ports and paths are byte-exact and never reformatted**: `192.168.1.0/24`, `127.0.0.1`, `7860`, `2.4.5`, `` `0` ``, `` `1` ``, `` `2` ``, `` `8` ``. | `es/CONFIGURATION.md:115,116,155,156`; `es/INSTALLATION.md:43` |
+| **Sentence terminators**: single `.`; no space before `.`, `,`, `:`, `;`, `?`, `!`. Spanish takes no French-style spacing. | pack-wide |
+| **List mechanics**: bullets are `- `; ordered lists are `1.`/`2.`/`3.`; bullet text is a full sentence with a terminal period; a leading bold lead-in keeps the English source's bold span. | `es/CONFIGURATION.md:24-27`; `es/agents/hierarchical-maps.md:91,97,98` |
+| **Markdown skeleton is untouchable**: fences, indentation, link targets, `#fragments`, backticked literals, table pipes and the source's column padding all stay byte-identical. Only prose, headings and **link text** translate. | branch `README.md` § "Updating a pack"; `es/FAQ.md:14` `[Acceso remoto](REMOTE_ACCESS.md)` — text translated, target untouched |
+| **Link text is translated *by policy* but only unevenly *in practice*.** Of 910 internal `.md` links, **54 keep a fully English link text** across 15 files, and the same target is routinely linked under several different Spanish names. Translate link text in new work, and **match whatever the neighbouring links in that file already say** rather than standardising the pack. Do not sweep-fix the existing ones — see § 7 residual 8. | English residue: `es/chats/export-import.md:80-82` `[Importing from SillyTavern]` / `[Backup and Restore]` / `[Settings Overview]`. Divergence: `connecting-to-a-provider.md` is linked as `[Conectarse a un proveedor de IA]` (28), `[Conectar con un proveedor de IA]` (9), `[Conectar a un proveedor de IA]` (3), `[Connecting to an AI Provider]` (3), and two more |
+| **No trailing whitespace and LF-only endings** — the shipped pack has 0 trailing-space lines and 0 CRLF files. | pack-wide grep |
+
+---
+
+## 5. UI labels & glosses
+
+**The base rule: a UI label the app renders in English is reproduced byte-exact in English, and
+the Spanish meaning goes in a parenthetical gloss after it.** The `es` app locale is only
+partially translated (`es.json` ships **131 keys**), which is exactly why the pack keeps English
+labels — the reader will see English on screen.
+
+| Rule | Evidence |
+| --- | --- |
+| **Primary gloss pattern**: `**English Label** (Gloss en español)` — bold on the English only, gloss in plain text inside parentheses, sentence case, no terminal period inside the parens. | `es/agents/agents-overview.md:25` "**Download Agents** (Descargar agentes)"; `es/agents/approvals-and-agent-suite.md:71` "**Save** (Guardar)" |
+| **The gloss is per-file, not once per pack.** `**Settings** (Configuración)` appears 53× across the pack — in exactly 53 distinct files, once each — because each guide re-glosses on its own first use. Inside a single file, the other 77 bare `**Settings**` spans are later repeats that drop the gloss. | `es/CONFIGURATION.md:59` — the file's single glossed `**Settings**`, against bare repeats at `:31,229,243,286,316`; `es/chats/chat-settings.md` and `es/agents/built-in-agents.md` have 0, because they gloss other labels instead |
+| **Colon-carrying bold lead-ins put the gloss inside the bold**: `**Updates (Actualizaciones):**` — because the English source bolded the trailing colon too. | `es/CONFIGURATION.md:24-27` |
+| **Menu paths gloss as a whole path**, with the separator preserved on both sides. The pack uses **three** separators, inherited from whatever the English source used — **`→`** (96, the most common inside bold labels), **`>`** (107 bold spans contain one) and ASCII **`->`** (52). Copy the source's separator; never normalise one into another, and keep the same one on both sides of the gloss. | `→`: `es/CONFIGURATION.md:20` "**Agents → Download Agents** (Agentes → Descargar agentes)". `>`: `es/development/localization.md:7` "**Settings > General > App Behavior > Language** (Configuración > General > Comportamiento de la app > Idioma)". `->`: `es/appearance/appearance-settings.md:3` "**Settings -> Appearance** (Configuración -> Apariencia)" |
+| **Labels that need no gloss** are left bare: transparent cognates, proper subsystem names, and labels the surrounding sentence already explains. Do not force a gloss where the pack left one off. | `es/agents/hierarchical-maps.md:91` "**Create with AI**" (unglossed); `es/TROUBLESHOOTING.md:129` "**Advanced Parameters**" (unglossed, in the same sentence where **Chat Settings** *is* glossed) |
+| **Quoted *strings* (not labels) use straight double quotes and no bold**, glossed only if the sentence needs it. | `es/TROUBLESHOOTING.md:129` `"This parameter is sent to the model"`; `es/TROUBLESHOOTING.md:330` `"Opening chat..."` |
+| **When a gloss itself contains parentheses in the English label, use a colon instead of nesting parens.** | `es/TROUBLESHOOTING.md:330` "**Unreachable (request timed out)** (Inalcanzable**:** se agotó el tiempo de espera de la solicitud)" (nested-gloss precedent also exists at `es/agents/memory.md:39`) |
+| **A gloss never replaces the label.** Never write only the Spanish for a control the reader must click. | `es/UPGRADING.md:156` "Si haces clic en **Apply Update**…" — bare English on repeat use |
+| **Byte-exactness of the label is absolute**: capitalization, ellipsis style (`...` vs `…`), spacing, and internal punctuation are copied from the app string, not normalized. `"Opening chat..."` keeps three ASCII dots; `**Checking…**` and `**Creating backup…**` keep the single-glyph U+2026 ellipsis. All 16 U+2026 in the pack sit inside English UI labels or quoted strings — never in Spanish prose. | `es/TROUBLESHOOTING.md:330` (`...`); `es/UPGRADING.md:139` (`**Checking…**`), `es/UPGRADING.md:27` (`**Creating backup…**`); `es/characters/creating-and-editing-characters.md:29` (`**Uploading…**`, `**Embedding…**`, `**Saving…**`) |
+| **Environment-variable names, commands, packages and file globs are never translated and never glossed inline**: `MARINARA_MAX_RESIDENT_CHATS`, `MARINARA_EAGER_STORAGE`, `UPDATES_APPLY_DISABLED`, `UPDATES_APPLY_ENABLED`, `termux-wake-lock`, `termux-wake-unlock`, `termux-tools`, `termux-api`, `Termux:API`, `server-*.log`, `DATA_DIR`. | `es/CONFIGURATION.md:155,156,238`; `es/TROUBLESHOOTING.md:324,326` |
+
+---
+
+## 6. Language-specific mechanics
+
+| Rule | Evidence |
+| --- | --- |
+| **Gender comes from the Spanish carrier noun, never from the English loanword.** `el prompt`, `un token`, `un preset`, `un lorebook`, `un swipe`, `un hash`, `un wake lock`, `un checkout`, `el chat` are all masculine; `una API key`, `una conexión`, `la caché`, `una instantánea`, `una extensión`, `una persona` are feminine. | `es/chats/chat-settings.md:28`; `es/TROUBLESHOOTING.md:75,324` |
+| **Loanwords pluralize with `-s` and stay unaccented**: `prompts`, `tokens`, `presets`, `lorebooks`, `swipes`, `hashes`, `NPC` (invariable acronym — **no** `NPCs`). | `es/lorebooks/overview.md`; `es/chats/branches.md:23`; `es/agents/built-in-agents.md:111` |
+| **Article + English proper name**: contract normally (`del panel`, `al chat`), but never contract *into* the English name itself. Write `el botón **Apply Update**`, not `el **Apply Update**`. | `es/UPGRADING.md:151`; `es/characters/personas.md:19` |
+| **Enclitic pronouns attach to imperatives and infinitives** and carry the accent when required: `tócala dos veces`, `quítale la optimización`, `arrástralo fuera`, `Ábrelo`, `inícialo de nuevo`. | `es/characters/library-organization.md:62,64`; `es/TROUBLESHOOTING.md:39,326` |
+| **`se`-impersonal is the pack's default for system behavior** — `se ejecuta` (136), `se muestra` (76), `se envía` (47), `se guarda` (28), `se aplica` (25), `se cargan` (6), `se descarta` (2). Prefer it over an invented agent. | `es/CONFIGURATION.md:155` "los chats **se cargan** cuando se abren"; `es/agents/hierarchical-maps.md:234` "El movimiento **se guarda** con el turno"; `es/extending/custom-tools.md:63` "**se descarta** al guardar" |
+| **Compound English feature names do not get hyphenated or hispanicized**: `Game Mode`, `World Info`, `Global Gallery`, `Card Browser`, `Local Model`. | `es/game/getting-started.md:1`; `es/characters/bot-browser.md:9` |
+| **Adjective agreement follows the Spanish noun even when the noun is a loanword**: `el prompt ensamblado` (3), `los lorebooks vinculados` (11), `los presets integrados`, `apps en caché`. The loanword takes the gender assigned in § 3 and the adjective agrees with *that*, not with the English word. | `es/development/frontend.md:158` "el **prompt ensamblado**"; `es/lorebooks/linking-to-characters.md` "**lorebooks vinculados**"; `es/data/importing-from-sillytavern.md:63` "los **presets integrados**"; `es/TROUBLESHOOTING.md:330` "**apps en caché**" |
+| **`de` + English name** is the standard genitive: `el lanzador **de** Termux`, `el editor **de** mapas`, `la notificación **de** Termux`, `el congelador **de** apps en caché`. No Saxon-genitive calques. | `es/CONFIGURATION.md:276`; `es/agents/hierarchical-maps.md:148`; `es/TROUBLESHOOTING.md:330,332` |
+| **Capitalization is Spanish, not English**: only the first word of a heading/sentence and proper nouns. Never title-case a translated heading to match the English source's title case. | `es/CONFIGURATION.md` "## Referencia completa de variables de entorno" |
+
+---
+
+## 7. QA checks & known traps
+
+### Mechanical checks (run before committing a pack edit)
+
+1. **`git diff` scoped to `es/` must show only the intended hunks.** No reflowed lines, no
+   whitespace-only lines, no reformatted tables. *(Cycle ruling — `i18n-brief.md`; and the shape
+   the 2026-09-01 delta actually shipped in, per `prd-notes-es.md`.)*
+2. **Rebuild and re-validate the manifest**, or the pack fails integrity on the client, which
+   verifies every file by `sha256` **and** `bytes`:
+   `node scripts/docs-i18n/build-manifest.mjs <path>/es --source-commit <engine-sha>` then
+   `node scripts/docs-i18n/validate-pack.mjs <path>/es`. *(Evidence: `es/manifest.json` carries
+   per-file `sha256` + `bytes`; procedure from the branch `README.md`.)*
+3. **Invisible-character sweep**: `grep -P "\xc2\xa0"` must return 0 (NBSP), trailing-space
+   `grep -n " $"` must return 0, and no file may gain CRLF. All three are 0 in the shipped pack;
+   any of them silently changes the hash. **On Windows, a PowerShell redirect or
+   `Set-Content` without `-Encoding utf8` will rewrite the file as ANSI/UTF-8-BOM and corrupt
+   every accented character** — edit with UTF-8-aware tooling only.
+4. **Frozen-literal diff**: every `MARINARA_*` / `UPDATES_*` name, `termux-*` command or package,
+   `Termux:API`, `server-*.log`, backticked numeric literal, version string (`2.4.5`), IP, port
+   and path must be identical to the English source. `diff <(grep -o '`[^`]*`' docs/X.md) <(grep
+   -o '`[^`]*`' es/X.md)` is the cheap version of this check.
+5. **Link-target diff**: translated link *text*, byte-identical link *targets* including
+   `#fragments`. A translated fragment is a silently dead link.
+6. **Table-shape check**: same number of `|` per row as the English source, and column padding
+   matched to the neighboring rows in the *pack* file (the pack's padding is its own, not the
+   English file's).
+7. **Terminology sweep** over the § 3 banned column. These are genuinely **0** in the shipped
+   pack and must stay 0: `por defecto`, `ordenador`, `computador`, `fichero`, `vídeo` (accented),
+   `celular`, `transmisión`, `PNJ`, `preajuste`, `ajuste predefinido`, `bitácora`, `desalojo`,
+   `evicción`, `salvaguarda`, `macroinstrucción`, `suministrador`, `iniciador`, `arrancador`,
+   `memoria caché`, `el caché`, `la prompt`, `perfil de usuario`, `deslizamiento`, `«`, `usted`,
+   `vosotros`. Do **not** assert 0 for terms this glossary marks *reserved* (`indicación`,
+   `aviso`, `ficha`, `plantilla`, `enlace`, `asistente`, `conversación`, `borrador`, `flujo`,
+   `avatar`, `resumen`, `captura`, `vacío`, `ninguno`, `bloqueado`) — they are legitimately
+   present in another sense, and a zero-expectation there produces false alarms.
+8. **Gloss-pattern check**: every newly introduced bold English label either has a
+   `(gloss)` on its first appearance in that file, or matches an unglossed precedent in the
+   same file.
+
+### Counting traps (they bit the re-derivation of this glossary)
+
+- **Word boundaries must be accent-aware.** A JS/PCRE `\b` or `\w` treats `á é í ó ú ñ ü` as
+  non-word characters, so `\bvideo\b` matches *inside* `vídeo`, and `\btoca\b` matches inside
+  `tócala`. Count with an explicit Unicode letter class (Python `[^\W\d_]` with `re.UNICODE`,
+  or `grep -P` with `\p{L}`). The same trap is recorded for `ru`, where `\w` misses Cyrillic
+  entirely — do not copy an ASCII-`\w` recipe between packs.
+- **Count case-insensitively when the term can start a sentence or a heading.** The masculine
+  `macro` forms were undercounted 15→7 by a case-sensitive grep, because `Un macro…` and
+  `### El macro {{user}}` were skipped.
+- **Separate singular from plural before quoting a number.** `archivo` 406 and `archivos` 266
+  are different facts; a combined 672 supports neither claim.
+- **On Windows, use a UTF-8-aware reader.** `Get-Content`/`Select-String` under the ANSI
+  codepage silently mis-decodes every accented character and returns wrong counts.
+
+### Known traps
+
+- **`persona` collides with the ordinary Spanish word.** In a sentence about people, `una
+  persona` reads as "a person". Every guide that introduces the feature defines it explicitly
+  first (`Una persona es tu propia tarjeta de personaje…`). Never introduce the feature term
+  without that definition. Evidence: `es/characters/personas.md:3,7`;
+  `es/conversation/profiles.md:5`.
+- **`indicación` is a false friend for `prompt`.** The pack already spends `indicación` on
+  *hint / cue / signal / on-screen prompt*. One sentence contrasts the two senses directly and
+  settles it: `es/development/localization.md:7` — "cambia los controles y las **indicaciones**
+  de Marinara, no los **prompts** del modelo". `es/game/storyboard.md` carries both senses in
+  the same file (`:60,180` motion hints vs. `:200` illustration prompts).
+- **`ficha` is spent on UI chips and tiles**, so it cannot be recycled for `token` — poker chips
+  (`es/conversation/table-games.md:112,114,122`), attachment chips
+  (`es/chats/sending-and-streaming.md:32`), emoji and sticker tiles
+  (`es/conversation/emoji-stickers-gifs.md:42,50,51,68`) and recent-chat tiles
+  (`es/home/welcome.md:14`).
+- **`asistente` is not free either.** It carries the assistant *chat role*
+  ("mensajes del usuario y del **asistente**"), *setup wizards* ("el **asistente** New Game
+  Setup") and Professor Mari. An Engine agent is always `agente`; `ayudante de IA` is the gloss,
+  not a synonym. Evidence: `es/agents/built-in-agents.md:17`;
+  `es/characters/choosing-your-persona.md:48`; `es/FAQ.md:161`.
+- **`enlace` means hyperlink, and `puerta de enlace` means gateway.** It appears exactly once in
+  the *definition* of a connection and must not be promoted into the term. Evidence:
+  `es/INSTALLATION.md:27`; `es/REMOTE_ACCESS.md:17`; `es/chats/chat-settings.md:28`.
+- **`respaldo` means *fallback*, not *backup*, in this pack.** Evidence:
+  `es/development/localization.md` "el respaldo en tiempo de ejecución" vs.
+  `es/data/backup-and-restore.md:9` "copia de seguridad".
+- **`rama` vs `bifurcación`**: `rama` = message branch / git branch; `bifurcación` = GitHub
+  fork. Swapping them makes contributor docs wrong. Evidence: `es/chats/branches.md:23`;
+  `es/development/localization.md`.
+- **Do not back-port `es.json` wording into the pack.** The app locale translates mode names
+  (`Ayuda de Conversación`, `Ayuda de Juego`) while the pack deliberately keeps
+  `modo Conversation` / `Game Mode`. With only 131 translated keys, most labels still render in
+  English, which is precisely what the pack's English-label-plus-gloss convention assumes.
+  *(Cycle ruling; cross-source evidence: `packages/client/src/localization/locales/es.json` vs.
+  `es/appearance/card-css-theming.md:211` and `es/game/getting-started.md:1`.)*
+- **Do not "fix" unrelated pre-existing pack issues while mirroring a delta.** That work is
+  tracked separately; touching it inflates the diff and breaks check 1.
+  *(Cycle ruling — `i18n-brief.md`.)*
+- **Naturalness critiques are out of scope for `es`.** The pack is literal by history and the
+  maintainer deferred the naturalness pass. Report calques; do not unilaterally de-calque.
+  *(Recorded maintainer ruling.)*
+
+### Known pack residuals (documented, not silently fixed)
+
+1. **`macro` gender is mixed** — counting case-insensitively, feminine dominates 48–15
+   (`las macros` 22, `una macro` 13, `la macro` 11, `esta macro` 2) but masculine survives
+   (`los macros` 8, `el macro` 4, `un macro` 3), including a heading
+   (`### El macro {{user}}`) two lines above `Un macro es un marcador de posición`. The split is
+   roughly per-file: `es/prompts/macros.md` is feminine throughout, while
+   `es/characters/personas.md` and `es/conversation/profiles.md` are masculine throughout.
+   Evidence: `es/characters/personas.md:11,13`; `es/conversation/profiles.md:22`;
+   `es/prompts/macros.md`.
+2. **`snapshot` is untranslated in one dev doc** — `es/development/architecture-map.md:95`
+   "persistencia de **snapshots** JSON" against `es/development/file-storage.md:39` "las
+   **instantáneas** de las tablas" (`instantánea` 43 pack-wide). This is the only genuine
+   instance. Of the 59 `snapshot` hits in total, 57 are in
+   `es/development/hierarchical-locations-prd-v3.md` and are identifier-adjacent, and one
+   (`es/home/professor-mari.md:86`) is inside a quoted English app message
+   ("Restored the previous app data snapshot.") — neither is the same defect.
+3. **`clave API` appears once** (`es/media/tts-setup.md:64`) against `clave de API` 26 times.
+4. **Eight curly-quote pairs** survive in **three** files against 1458 straight quotes. Evidence:
+   `es/agents/hierarchical-maps.md:260` (two pairs), `:261`, `:477`;
+   `es/development/code-cleanup-audit.md:114,202,233`;
+   `es/development/hierarchical-locations-prd-v3.md:375`.
+5. **Mirror-cycle note vs. shipped text — `checkout`.** `prd-notes-es.md` records the intent to
+   use `copia de trabajo` for *checkout*, citing `es/agents/hierarchical-maps.md`. The line that
+   actually shipped reads "nunca pueda reescribir un **checkout** de desarrollo"
+   (`es/CONFIGURATION.md:238`). **The pack is ground truth**: `checkout` (git) and `copia de
+   trabajo` (editor buffer) are two distinct terms, as recorded in § 3. The note's citation was
+   to the *editor-buffer* sense.
+6. **`Game Mode` is not glossed anywhere**, unlike `modo Conversation` (glossed once as
+   "Conversation (conversación)"). This is consistent with treating `Game Mode` as a frozen
+   product name, but the asymmetry is deliberate to record. Evidence:
+   `es/game/getting-started.md:1`; `es/integrations/discord-mirror.md:3`.
+7. **`gana sobre` outnumbers the prescribed `tiene prioridad sobre` 3–2.** The § 3 row keeps
+   `tiene prioridad sobre` as the form for new text, but the pack is genuinely split and the
+   three counter-examples are not defects to sweep. Evidence: prescribed at
+   `es/CONFIGURATION.md:71,238`; counter-examples at
+   `es/characters/choosing-your-persona.md:32`, `es/prompts/generation-parameters.md:136`,
+   `es/agents/knowledge-sources.md:71`. `anula` (8) is a third, milder variant.
+8. **Link text is unevenly translated.** 54 of 910 internal `.md` link texts are still fully
+   English (15 files), and several targets are linked under many different Spanish names:
+   `getting-started.md` has 15 distinct link texts, `overview.md` 10, `REMOTE_ACCESS.md` 7,
+   `agents-overview.md` 7, `connecting-to-a-provider.md` 6. Both halves are pre-existing debt,
+   out of scope for a delta. Evidence: `es/chats/export-import.md:80-82`;
+   `es/conversation/getting-started.md:29,49,152`; `es/integrations/home-assistant.md:12`.
+9. **`NPCs` with a Spanish plural `-s` reaches translated link text twice** —
+   `[Game Mode: Grupo y NPCs](party-and-npcs.md)` at `es/game/combat.md:102` and
+   `es/game/dice-and-skill-checks.md:107` — against `los NPC` (10) and `NPCs` 0 in running
+   prose. The other four `NPCs` are frozen English labels and are correct.
+10. **The `Release Channel` label is glossed two different ways.**
+    `es/UPGRADING.md:128` gives "(Canal de lanzamiento)"; `es/installation/windows.md:201` gives
+    "(Canal de versiones)". Only two occurrences carry a gloss, so neither is dominant. Match the
+    file you are editing; this is the clearest live counter-example to the
+    one-term-per-concept ruling in the appendix.
+11. **Capitalised heading-case leaks into two link texts** — `[Game Mode: Primeros pasos]`
+    (8×, e.g. `es/TROUBLESHOOTING.md:212`) against `[Game Mode: primeros pasos]` (11×, e.g.
+    `es/agents/hierarchical-maps.md:541`), for the same target and the same Spanish words. The
+    lowercase form matches the § 6 capitalization rule and the actual heading at
+    `es/game/getting-started.md:1`.
+
+---
+
+## Appendix — recorded rulings carried without in-pack evidence
+
+These are process/QA rulings from the original cycle, PR #4100, or the 2026-09-01 mirror cycle.
+They govern how the pack is edited, not what words it contains, so the pack itself cannot
+demonstrate them:
+
+- Informal `tú`, gender-neutral-where-natural, and established-loanwords-kept were the original
+  cycle's stated register policy (each is *also* independently pack-verified above).
+- **One standardized Spanish term per concept**, adopted so the docs viewer's literal-substring
+  search and hit counts stay consistent across the pack (PR #4100). **This is the stated intent,
+  not an achieved property of the shipped pack** — § 7 records the live exceptions (`macro`
+  gender, the `Release Channel` gloss, `canal de versiones`/`canal de versión`,
+  `tiene prioridad sobre`/`gana sobre`, and the link-text divergence). Honour the ruling in new
+  text; do not use it to justify sweeping the existing pack.
+- **Community loanwords are kept on purpose** — *prompt, preset, lorebook, swipe* named
+  explicitly in PR #4100.
+- **The pack skews literal by history; naturalness critiques were deliberately deferred by the
+  maintainer.** This glossary describes the pack as shipped.
+- **If `es` is ever revisited, the `de` glossary's anti-calque approach is the template.**
+- **Translation QA procedure** used for the original pack: per-file structural verification,
+  terminology-consistency sweeps, and an independent language-QA panel over 20 representative
+  guides (PR #4100).
+- **Delta discipline**: mirror the English anchor placement exactly, match the pack file's own
+  table padding, never reflow untouched lines, and never fix unrelated pre-existing pack issues
+  in a delta PR (`i18n-brief.md`, 2026-09-01 cycle).

--- a/glossaries/glossary-fr.md
+++ b/glossaries/glossary-fr.md
@@ -1,0 +1,379 @@
+# Marinara Engine — glossaire du pack de documentation `fr`
+
+## Provenance
+
+This is the **second-generation** glossary for the French documentation pack. The
+original working glossary written during the shipping cycle was lost to
+temp-directory cleanup and is not recoverable.
+
+It was **re-derived on 2026-09-01** from three sources, in authority order:
+
+1. **The shipped pack itself** (`docs-i18n` branch, `fr/`, 125 Markdown files) —
+   treated as ground truth. Every terminology row and typography rule below was
+   re-verified by scanning the pack as shipped, and cites at least one
+   `path:line` from it.
+2. **The decision write-up of the pack's shipping PR**, Pasta-Devs/Marinara-Engine
+   **#4191** ("Translation approach", "Validation done") — for rulings the pack
+   content cannot show on its own.
+3. **The 2026-09-01 mirror-cycle terminology notes** (`prd-notes-fr.md`), whose
+   per-row choices were made against this same pack three hours before this
+   glossary was written, plus the recorded decision ledger carried in project
+   memory.
+
+Supporting reference: `CONTRIBUTING.md § Translated documentation` on `staging`
+(French per-language conventions), and the app locale file
+`packages/client/src/localization/locales/fr.json`.
+
+Rules are marked one of two ways:
+
+- **[pack]** — verified against the shipped pack, with evidence.
+- **[ruling]** — a recorded maintainer/cycle decision that the pack content
+  cannot demonstrate (process, rationale, QA disposition). Kept because it was
+  decided, not because it can be proven from the files.
+
+Line numbers are those of the pack as it stands on 2026-09-01. If a file is
+re-translated, re-verify before citing.
+
+**Verification pass, 2026-09-01.** Every terminology row was re-scanned for both
+its prescribed term *and* its banned alternates, by codepoint, over all 125
+files. Corrections made in that pass, so the counts below are the scanned ones:
+the `tag` row was split into four (the pack uses `tag`, `étiquette` and
+`libellé` as standing terms, not banned ones); `curseur`/`pointeur` was split
+(the pack's `curseur` is overwhelmingly a *slider*); `actualisation` was
+promoted to its own **refresh** row; `figé` was split off from the Android
+`gel`; several flat bans were narrowed to the sense actually meant, with their
+other senses recorded so a future sweep does not "fix" correct prose; and the
+counts in §2.1, §2.3, §2.6, §3.7, §4.7, §4.15, §5.2, §5.7 and Q7 were corrected
+to the measured values. R4 was found to be wider than recorded, and R6 is new.
+
+---
+
+## 1. Register & address
+
+| # | Rule | Status | Evidence |
+| --- | --- | --- | --- |
+| 1.1 | **Tutoiement throughout.** Second person singular, everywhere, including reference tables and developer docs. 1 148 occurrences of `tu`, 936 of `ton/ta/tes`. | [pack] | `CONFIGURATION.md:3` "un réglage que tu écris dans un fichier texte simple" |
+| 1.2 | **Instructions are singular imperatives**, usually line-initial in steps and bullets: `Ouvre`, `Clique`, `Choisis`, `Active`, `Définis`, `Installe`, `Vérifie`. 211 line-initial instances. | [pack] | `FAQ.md:61` "Ouvre un chat Conversation et choisis **Schedule timezone**" |
+| 1.3 | **Never `vous`, `votre`, `vos`, or `-ez` imperatives** in new or edited prose. The pack's remaining instances are known residuals, listed in §8. | [pack] | Clean baseline: `CONFIGURATION.md`, `FAQ.md`, `INSTALLATION.md`, `REMOTE_ACCESS.md` contain zero |
+| 1.4 | **Warm, plain, explanatory tone.** Jargon is defined the first time it appears in a file rather than assumed (see §7.2). | [pack] | `TROUBLESHOOTING.md:12` "Le prompt, c'est le texte que Marinara envoie à l'IA" |
+| 1.5 | **No inclusive-writing punctuation.** Zero midpoints (`utilisateur·rice`), zero parenthesised endings (`développeur(euse)`), zero doublets (`celles et ceux`). | [pack] | 0 matches pack-wide for `[a-z]·[a-z]` and `\w+\(e\)s?` |
+| 1.6 | **Generic masculine for the reader-class noun**; where the role matters, use a periphrasis instead of a gendered doublet: `la personne qui exploite le serveur`, `la personne qui gère le serveur`. | [pack] | `CONFIGURATION.md:61`; `installation/ios-pwa.md:77` |
+| 1.7 | **Named entities keep their real-world gender agreement.** Professor Mari is feminine (`seule Professor Mari peut...`, `l'assistante intégrée`). | [pack] | `FAQ.md:143`, `FAQ.md:161` |
+| 1.8 | **Do not import register from `packages/client/src/localization/locales/fr.json`.** That file is vouvoiement (`Consultez le prompt utilisé...`), covers only 132 of 9 123 keys (~1.4 %), and uses curly apostrophes. The docs register is independent of it. | [ruling] (locale facts verified) | `fr.json` → `chat.help.actions.prompt`, `chat.help.targets.agents.body` |
+| 1.9 | **Register applies to prose only.** Text inside code fences, JSON samples, log excerpts, and byte-exact English UI labels is never re-registered. | [pack] | `CONFIGURATION.md:44-50` (JSON sample untouched) |
+
+---
+
+## 2. Product, feature & mode names
+
+| # | Rule | Status | Evidence |
+| --- | --- | --- | --- |
+| 2.1 | **`Marinara Engine` and `Marinara` are frozen**, never translated, never inflected, and take **no article**: `de Marinara Engine`, `sur Marinara Engine` — never `du Marinara Engine`. `Marinara Engine` occurs 248 times; `de Marinara` 182 times; **`du Marinara` 0 times**, which is the check that matters. | [pack] | `INSTALLATION.md:1` "# Installation de Marinara Engine"; `FAQ.md:3` |
+| 2.2 | **Mode names stay English: `Conversation`, `Roleplay`, `Game Mode`.** Never `mode Jeu`, `Jeu de rôle`, `mode Conversation` as a translation. (284 `Game Mode`, 406 `Roleplay`, 418 `Conversation`.) | [pack] + PR #4191 | `FAQ.md:53-55`; `CONFIGURATION.md:205` |
+| 2.3 | **Carrier patterns for mode names**, all attested — pick by sentence rhythm, do not invent a fifth: `en Game Mode` (60), `en Roleplay` (48), `en mode Conversation` (62), `le mode Roleplay` (12), `les chats Roleplay` (11). | [pack] | `FAQ.md:175` "Pour t'en servir en Game Mode"; `chats/group-chats.md:69` "Qui parle : le mode Roleplay"; `characters/sprites.md:141` |
+| 2.4 | **Feature and product sub-names stay English**: `Noodle`, `Professor Mari`, `Memory Recall`, `Chat Summary`, `Knowledge Retrieval`, `Storyboard`, `Local Whisper`, `Agent Suite`, `Danger Zone`. | [pack] | `FAQ.md:119` (Noodle), `FAQ.md:127-128`, `CONFIGURATION.md:31` |
+| 2.5 | **Agent package names stay English**, including inside French sentences and heading text: `Character Tracker`, `Beholder`, `Calls`, `Illustrator`. | [pack] | `agents/built-in-agents.md:111`, `:123`, `:276` |
+| 2.6 | **`GM` is the term (113); `maître du jeu` is only the first-use gloss** — glossed per file, not once pack-wide (19 glosses across 17 files, per §5.5). Never `MJ` (0). | [pack] | `FAQ.md:55` "un Game Master (le maître du jeu)"; `agents/hierarchical-maps.md:516`; thereafter bare `GM` (`FAQ.md:173-177`) |
+| 2.7 | **Doc-set section names in link text are translated**, because they are prose, not UI: `[Résoudre les problèmes de Marinara Engine](TROUBLESHOOTING.md)`. | [pack] | `FAQ.md:204`; `CONFIGURATION.md:335` |
+| 2.8 | **File names, paths, env-var names, CLI commands, and URLs are never translated or re-cased.** | [pack] | `CONFIGURATION.md:88` (`start.bat`, `start.sh`, `start-termux.sh`); `TROUBLESHOOTING.md:433` |
+
+---
+
+## 3. Core terminology
+
+Format: **English** | **pack term (gender)** | **banned alternates** | **evidence**.
+
+### 3.1 Prompting & model vocabulary
+
+| English | This pack | Banned | Evidence |
+| --- | --- | --- | --- |
+| prompt | **le prompt** (m.) | `amorce` (0); `invite`, `requête`, `consigne` **in this sense only** — each is a live pack word elsewhere: `invite`/`inviter` (23 uses, none of them *prompt*: `invite de commandes` = Windows command prompt at `installation/windows.md:66`, plus Noodle **Invites** and the verb "t'invite à"), `requête` = network/HTTP request (129, e.g. `CONFIGURATION.md:208`), `consigne` = guidance/instruction (24, e.g. **Stored guidance** → `consigne enregistrée` at `chats/messages.md:21`) | `CONFIGURATION.md:183` "voir le prompt exact envoyé au modèle" |
+| token | **le token** (m.), plural `les tokens` | **`jeton`** for an LLM token (0). All 13 `jeton` uses are other senses and are correct: poker chips (`conversation/table-games.md:109`), CSS design tokens (`appearance/card-css-theming.md:282`), selection tokens (`CONFIGURATION.md:244`), **interpolation tokens `{{name}}`** (`development/localization.md:65`, `:73`, `:92`), **OAuth access token** (`connections/providers-reference.md:51`) | `agents/agents-overview.md:55` "Un token est un petit morceau de texte" |
+| token budget | **budget de tokens** | `budget de jetons` | `agents/hierarchical-maps.md:678` |
+| preset | **le preset** (m.) | `préréglage` (0), `profil` (a distinct object — see next row); `prédéfini` in this sense (its 1 use, `development/frontend.md:338` "échantillons prédéfinis" = preset colour swatches, is a different sense and is fine) | `chats/chat-settings.md:55` "le mot **preset** désigne uniquement les presets de prompt" |
+| settings profile | **le profil de réglages** | `preset` | `chats/chat-settings.md:38`, `:55` |
+| generation parameters | **les paramètres (de génération)** | `réglages` in this sense | `TROUBLESHOOTING.md:129` "Le modèle refuse un paramètre" |
+| embedding | **l'embedding** (m.), glossed *une représentation numérique du texte* | `plongement`, `vecteur` | `CONFIGURATION.md:208`; `connections/local-model.md:13` |
+| streaming | **le streaming**, glossed *l'affichage au fil de l'écriture* | `diffusion en continu` | `TROUBLESHOOTING.md:132` "en cours de streaming, c'est-à-dire d'affichage au fil de l'écriture" |
+| macro | **la macro** (f.) | `raccourci` **in this sense only** — the pack's 17 `raccourci` uses are desktop shortcuts, keyboard shortcuts and slash-command shortcuts, and are all correct (`INSTALLATION.md:26`, `chats/slash-commands.md:3`) | `characters/personas.md:13`, `conversation/profiles.md:22` |
+| placeholder (macro in user text) | **l'espace réservé** (m.) | `marqueur` in this sense | `chats/guided-and-impersonate.md:88` "Une macro est un espace réservé que Marinara remplace" |
+| placeholder (ComfyUI/LTX workflow) | **le placeholder** (m., kept English) | `marqueur`, `balise de remplacement` — see residual R3 in §8 | `media/comfyui.md:55` "## Ajouter les placeholders de Marinara"; `game/ltx-2-3-storyboards.md:96` |
+| marker (prompt section / map pin) | **le marqueur** | — | `agents/built-in-agents.md:196` "le placement du contexte rappelé sur un marqueur de preset"; `agents/hierarchical-maps.md:841` |
+| tag (XML/HTML/thinking/macro delimiter) | **la balise** (f.), 32 uses | `tag` and `étiquette` **in this markup sense only** — see the three rows below, which are the other senses and are not banned | `chats/sending-and-streaming.md:98` "**Thinking Tags** (balises de réflexion)"; `prompts/presets.md:122`; `development/ios-pwa-safe-area.md:17` (meta tag) |
+| tag (metadata label on a character, chat, background or lorebook entry) | **le tag** (m.), plural `les tags` — 166 uses, the pack's standard term; glossed *une étiquette* | `balise` in this sense; `mot-clé` (reserved for lorebook trigger keys and agent **Activation Keywords**, 90 uses) | `characters/library-organization.md:86` "Les tags sont des étiquettes que tu ajoutes à un personnage"; `chats/managing-chats.md:101`; `characters/bot-browser.md:53` "## Filtrer par tags" |
+| label / caption / badge (visible UI text *about* a control or state) | **l'étiquette** (f.), 60 uses | — | `appearance/chat-backgrounds.md:29` "avec l'étiquette **Library**"; `game/party-and-npcs.md:77` "Les étiquettes de réputation des PNJ"; `characters/bot-browser.md:49` |
+| label (the caption a button or field displays) | **le libellé** (m.), 15 uses — narrower than `étiquette`: the text a control itself shows | — | `characters/creating-and-editing-characters.md:29` "Son libellé indique l'état en cours"; `game/hud-widgets.md:74` "**Label** (libellé)" |
+
+### 3.2 Content objects
+
+| English | This pack | Banned | Evidence |
+| --- | --- | --- | --- |
+| lorebook | **le lorebook** (m.), glossed *un recueil de faits sur ton univers* | `livre de lore` (0), `encyclopédie` (0); `codex` in this sense — its 6 uses are all the OpenAI **Codex** CLI product name (`connections/subscription-clis.md:55-74`) and must not be "corrected" | `FAQ.md:105`; gloss at `characters/personas.md:101` |
+| (lorebook) entry | **l'entrée** (f.) | `fiche` in this sense | `FAQ.md:105`, `lorebooks/entries.md` |
+| World Info | **World Info** (frozen) | `Infos du monde` | `FAQ.md:105` "un ensemble d'entrées de World Info" |
+| character card | **la fiche de personnage** | **`carte de personnage`** (0 occurrences) | `FAQ.md:99` "## Qu'est-ce qu'une fiche de personnage ?" |
+| character | **le personnage** | `perso`, `bot` | `FAQ.md:101` |
+| persona | **le persona** (m.), 59 uses | **`la persona`** for the French common noun, `le profil`. Note the pack does have 3 feminine agreements, all on the **capitalised English UI object** `Persona`, which is a different thing and is left alone: `la Persona Library` (`characters/personas.md:23`), `la Persona du joueur` (`development/optional-agent-packages.md:71`), `la Persona sélectionnée` (`extending/writing-personal-extensions.md:144`) | `FAQ.md:107`; `characters/personas.md:7` |
+| chat | **le chat** (m.) | `discussion` for the chat object; `conversation` (reserved for the mode name). The pack's 2 `discussion` uses are other senses and are fine: a narrative event (`agents/hierarchical-maps.md:832`) and "au fil de la discussion" (`integrations/discord-mirror.md:3`) | `CONFIGURATION.md:148`; `FAQ.md:53` |
+| message | **le message** | — | `chats/messages.md`; `FAQ.md:101` |
+| greeting / first message | **la salutation**; the character's opening line is **le message d'accueil** | `accueil` alone | `characters/creating-and-editing-characters.md:75` (`First Message` → message d'accueil); `chats/sending-and-streaming.md:54` (`salutations`) |
+| swipe (alternate response) | **le swipe** (m.), 105 uses, glossed *une réponse alternative* | `variante`; `balayage` for the response object — but `le balayage tactile` is correct for the **physical touch gesture**, and the pack uses both in one line: `settings/settings-overview.md:97` "**Intuitive swipe navigation** (navigation intuitive entre les swipes) : ... ou le balayage tactile" | `chats/messages.md:17` "une nouvelle réponse alternative, un swipe"; `chats/branches.md:23` |
+| sprite | **le sprite** (m.), glossed *l'image du personnage sur le plateau* | `lutin` | `installation/windows.md:156`; `TROUBLESHOOTING.md:188` |
+| storyboard | **le storyboard** (m.) | `scénarimage` | `FAQ.md:177`; `TROUBLESHOOTING.md:200` |
+| library (of characters/agents) | **la bibliothèque** | **`librairie`** (0 occurrences — false friend) | `agents/agents-overview.md:23` "C'est ta bibliothèque" |
+| spellbook | **le grimoire** | `livre de sorts` | `roleplay/combat-encounters.md:37` |
+
+### 3.3 Agents, connections, providers
+
+| English | This pack | Banned | Evidence |
+| --- | --- | --- | --- |
+| agent | **l'agent** (m.) | `bot` as a synonym for agent or character — its 16 uses are the `bot-browser` route/file names and poker "bot" players (`conversation/table-games.md:49`), which are fine. **`assistant` is not banned**: the pack uses it freely to gloss what an agent is ("un petit assistant IA", `agents/built-in-agents.md:7`, `agents/custom-agents.md:3`) and for setup wizards ("l'assistant **New Game Setup**"); just do not use it as *the* standing noun for an agent | `FAQ.md:115` "Un **agent** est une aide IA facultative" |
+| tracker | **le tracker** (m.) | `traqueur`, `suivi` | `agents/agents-overview.md:19`, `:50` |
+| pipeline phase | **la phase du pipeline** | `étape du traitement` | `agents/agents-overview.md:15` |
+| connection | **la connexion** (f.) | `connecteur` | `FAQ.md:67`; `CONFIGURATION.md:118` |
+| provider | **le fournisseur** | `prestataire`, `provider` | `FAQ.md:71` "Quels fournisseurs d'IA sont pris en charge ?" |
+| to support (a feature/provider) | **prendre en charge** | **`supporter` / `supporté`** (0 occurrences — false friend) | `FAQ.md:73` "Marinara prend en charge de nombreux fournisseurs" |
+| package (Marinara capability package) | **le package** (m.) | `paquet` in this sense — see residual R4 in §8 | `CONFIGURATION.md:22` "Cycle de vie et stockage des packages"; `FAQ.md:115` |
+| package (npm / OS / pnpm) | **le paquet** | `package` in this sense | `TROUBLESHOOTING.md:18` "pnpm est le gestionnaire de paquets" |
+| NPC | **le PNJ** | `NPC` in French prose (English only inside byte-exact UI labels such as **Auto-Generate NPC Avatars**) | `agents/hierarchical-maps.md:459`; `game/combat.md:102`; label at `agents/built-in-agents.md:115` |
+| party (Game Mode) | **l'équipe** (f.), 75 uses | `groupe` **for the party specifically** — `groupe` itself is a general pack word (132 uses: group chats, "un petit groupe de réglages", "le groupe **Writer Agents**") and is not banned outside this sense | `game/getting-started.md:82` "**Talk to Party** (parler à l'équipe)" |
+
+### 3.4 Install, update, runtime
+
+| English | This pack | Banned | Evidence |
+| --- | --- | --- | --- |
+| launcher | **le lanceur** | `démarreur`, `launcher` | `CONFIGURATION.md:88` "Les lanceurs shell (`start.bat`, `start.sh`, `start-termux.sh`)" |
+| update (noun, software) | **la mise à jour**, 172 uses | `update`; `actualisation` **in this sense only** — see the next row | `CONFIGURATION.md:24` |
+| refresh (noun/verb — reloading content, not upgrading software) | **l'actualisation** (f.) / **actualiser**, 29 uses — a distinct concept the pack keeps separate from `mise à jour` | `mise à jour` in this sense | `noodle/overview.md:115` "Avant qu'une actualisation fonctionne"; `agents/memory.md:64` "L'icône d'actualisation"; `roleplay/hud-and-trackers.md:70` "un petit bouton d'actualisation"; **Refresh voices** → `media/tts-setup.md:64` |
+| to apply an update | **appliquer une mise à jour** | `installer` in this sense | `CONFIGURATION.md:237` "Autorise le navigateur à appliquer les mises à jour ordinaires" |
+| release channel | **le canal (de publication)**, 17 uses | `canal de diffusion`; `chaîne` **in this sense only** — the pack's 33 `chaîne` uses are *string* (`chaîne JSON`, `chaîne vide`, `recherche par chaîne`) or *chain* (`chaîne audio de l'appel`, `chaîne de parents`) and are all correct | `UPGRADING.md:128` "**Release Channel** (canal de publication)"; `TROUBLESHOOTING.md:351` |
+| checkout (a git working tree) | **`"git checkout"` kept English**, glossed once per file as *une copie installée avec l'outil Git* | `caisse`, `extraction`, `paiement` | `UPGRADING.md:33`; also `UPGRADING.md:37` |
+| working copy (editor draft) | **la copie de travail** | `brouillon de travail` | `agents/hierarchical-maps.md:107`, `:156`, `:260` |
+| build (a compiled release **artifact**) | **la build** (f.), 34 uses | `version compilée`; `compilation` for the artifact — but **`la compilation` is correct for the compiling *process***, which is how all 9 of its uses read (`TROUBLESHOOTING.md:35` "pendant la compilation du paquet partagé", `:196` "compilations natives") | `TROUBLESHOOTING.md:49` "cette build a téléchargé le lanceur actualisé"; `conversation/calls.md:243` "une build \"Lite\"" |
+| commit | **le commit** (m.), glossed *une modification enregistrée* | `révision`; `validation` **in this sense only** — the pack's 41 `validation` uses are agent approval (`agents/memory.md:122` "une validation d'écriture par l'agent"), input validation (`development/frontend.md:414`, Zod schemas) and maintainer sign-off, and are all correct | `UPGRADING.md:145`; `development/localization.md:94` |
+| log / logs | **le log**, glossed *le journal du serveur* | `journal` as the standing term (it is the gloss word, and `journal persistant` is fine descriptively) | `CONFIGURATION.md:170` "Un log est le journal du serveur"; `CONFIGURATION.md:176` |
+| service worker | **le service worker** (m., kept English), glossed *un petit script que le navigateur utilise pour charger l'application vite et hors ligne* | `agent de service` | `UPGRADING.md:178`; `TROUBLESHOOTING.md:80` |
+| cache (noun) | **le cache** | `antémémoire` | `TROUBLESHOOTING.md:80`; `UPGRADING.md:147` |
+| to cache | **mettre en cache** / **garder en cache** | `cacher` | `CONFIGURATION.md:322`; `UPGRADING.md:147` |
+| backup (noun) | **la sauvegarde** | `backup`, `copie de secours` | `CONFIGURATION.md:158`; `FAQ.md:92` |
+| to back up | **sauvegarder** | `enregistrer` in this sense | `FAQ.md:132` "## Comment sauvegarder mes données ?" |
+| to save (an edit) | **enregistrer** | `sauvegarder` in this sense | `CONFIGURATION.md:33` "Avant l'enregistrement, chaque import affiche..." |
+| snapshot | **l'instantané** (m.), 101 uses | `snapshot`; `capture` as the noun for this object — but the regex **capture group** (`extending/regex-scripts.md:68-71`) and the verb `capturer` (`game/sessions-and-saves.md:125` "Elle en capture un") are correct and account for all 9 uses | `development/architecture-map.md:95` "persistance par instantanés JSON"; `development/file-storage.md:39` |
+| checkpoint (resume point) | **le point de contrôle** | `checkpoint` in this sense | `agents/built-in-agents.md:161` "reprendre au dernier point de contrôle" |
+| checkpoint (model weights file) | **le checkpoint** (m., kept English) | `point de contrôle` in this sense | `game/ltx-2-3-storyboards.md:56`, `:58` |
+| extension | **l'extension** (f.), 261 uses | `module complémentaire`, `greffon` (0 each); `plugin` for a Marinara extension — its 3 uses are build-tool plugins in developer docs (`@tailwindcss/vite`, `@fastify/websocket`) and are correct | `CONFIGURATION.md:59`; `FAQ.md:141` |
+| app / application | **l'application** (f.) | **`l'appli`, `l'app`** (0 occurrences) | `CONFIGURATION.md:18` "se règle dans l'application, pas ici" |
+
+### 3.5 Memory, power & mobile runtime
+
+| English | This pack | Banned | Evidence |
+| --- | --- | --- | --- |
+| in memory / resident | **en mémoire** | `résident` as an adjective (the pack uses `résider` only as a verb) | `CONFIGURATION.md:155` "garde en mémoire en même temps", `:156` "charger tous les chats en mémoire"; verb-only use at `appearance/fonts.md:32` |
+| server memory | **la mémoire du serveur** | `RAM du serveur` | `TROUBLESHOOTING.md:182`; `characters/bot-browser.md:116` |
+| least-recently-used | **le moins récemment utilisé** | `LRU`, `le moins récemment employé` | `CONFIGURATION.md:155`; cf. `chats/managing-chats.md:97` "les moins récemment actifs" |
+| to evict (from memory) | **retirer de la mémoire** | `éviction`, `expulser`, `évincer` | `CONFIGURATION.md:155` "est retiré de la mémoire (jamais du disque)" |
+| wake lock | **`` `wake lock` ``** — backticked, untranslated, glossed once as *qui empêche la mise en veille* | `verrou de réveil`, `verrou d'éveil` | `TROUBLESHOOTING.md:324` |
+| battery optimization | **l'optimisation de la batterie** | `économiseur de batterie`, `optimisation batterie` | `TROUBLESHOOTING.md:326`, `:332` |
+| to run in the background | **s'exécuter en arrière-plan** | `tourner en tâche de fond` | `TROUBLESHOOTING.md:326` |
+| background activity | **l'activité en arrière-plan** | `activité de fond` | `TROUBLESHOOTING.md:332` |
+| foreground | **au premier plan** | `à l'avant-plan` | `TROUBLESHOOTING.md:332` |
+| recents screen | **l'écran des applications récentes** | `menu multitâche` | `TROUBLESHOOTING.md:332` |
+| frozen (Android **process** freeze) | **gelé**; the mechanism is **le gel** (4 uses) | `suspendu` (reserve `suspension` for sleep); `figé` **for the process-freeze sense only** — `figé` is a common, correct pack word in two other senses (see the two rows below) and must not be swept | `TROUBLESHOOTING.md:330` "le processus hôte est **gelé**, pas planté" |
+| fixed / pinned / immutable | **figé**, ~28 of its 30 uses | — | `CONFIGURATION.md:94` "figé au démarrage du serveur"; `installation/containers.md:123` "une version figée"; `game/sessions-and-saves.md:24` "un instantané figé" |
+| frozen / hung (the **UI**, not the process) | **figé** — 2 uses, distinct from the Android `gel` above | — | `TROUBLESHOOTING.md:73` "## Écran blanc, figé ou d'apparence ancienne"; `UPGRADING.md:180` "l'application semble figée" |
+
+### 3.6 Interface vocabulary (used in French prose *about* controls)
+
+| English | This pack | Banned | Evidence |
+| --- | --- | --- | --- |
+| settings | **les réglages** | `paramètres` in this sense (reserved for generation parameters) | `CONFIGURATION.md:3`; gloss `FAQ.md:61` "**Chat Settings** (réglages du chat)" |
+| toggle / switch | **l'interrupteur** (m.) | `le toggle`, `la bascule` as a noun (`basculer` as a verb is fine) | `CONFIGURATION.md:253`; `TROUBLESHOOTING.md:129` |
+| tab | **l'onglet** (m.) | `tabulation` | `FAQ.md:134`; `FAQ.md:119` |
+| dropdown | **le menu déroulant** (91) | `liste déroulante` — 1 residual occurrence remains (R6 in §8) | `UPGRADING.md:128`; `connections/connecting-to-a-provider.md:34` |
+| checkbox | **la case à cocher** | `coche` | `characters/library-organization.md:103`; `chats/export-import.md:33` |
+| tooltip | **l'infobulle** (f.) | `bulle d'aide` | `TROUBLESHOOTING.md:129` |
+| slider control | **le curseur** (m.) — this is what `curseur` almost always means here (~28 of its 34 uses) | `glissière` (0) | `appearance/appearance-settings.md:57` "**Chat Font Size** ... est un curseur"; `media/tts-setup.md:104` "Le curseur **Speed**"; `chats/sending-and-streaming.md:68` |
+| mouse pointer (hover instructions) | **le pointeur** (m.), 5 uses — *not* banned; this is the pack's term for "hover over" | — | `integrations/message-translation.md:91` "Passe le pointeur sur un message"; `characters/choosing-your-persona.md:21`; `media/scene-backgrounds.md:57` |
+| mouse cursor (the drawn cursor) / text caret | **le curseur** | — | `appearance/appearance-settings.md:50` "**Custom Mouse Pointer** (curseur de souris personnalisé)"; caret at `conversation/calls.md:58` "place seulement le curseur dans le champ de texte" |
+| to upload | **téléverser** | **`uploader`** (0 prose occurrences) | `agents/built-in-agents.md:57`; `TROUBLESHOOTING.md:205` |
+| to download | **télécharger** | `downloader` | `CONFIGURATION.md:24` |
+| to overwrite | **écraser** | `remplacer` when data is destroyed | `characters/personas.md:139`; `chats/settings-profiles.md:68` |
+| unset (default-value cell) | **non défini** | `vide` in this sense | `CONFIGURATION.md:238`; `CONFIGURATION.md:280` "Laisse `TZ` non défini ... un `TZ=` vide équivaut aussi à non défini" |
+| empty (default-value cell) | **vide** | `non défini` in this sense | `CONFIGURATION.md:124`, `:125`, `:127` (18 such cells) |
+| off (default-value cell) | **désactivé** | `non` , `faux` | `CONFIGURATION.md:156` |
+
+### 3.7 False friends and calques the pack deliberately avoids
+
+| Trap | Pack behaviour | Evidence |
+| --- | --- | --- |
+| `librairie` for *library* | never used (0); `bibliothèque` (132) | `agents/agents-overview.md:23` |
+| `supporter` for *to support* | never used (0); `prendre en charge` (112) | `FAQ.md:73` |
+| `l'appli` / `l'app` (colloquial anglicisms) | never used (0 each); `l'application` (418) | pack-wide scan |
+| `checker` / `digital` as French verbs/adjectives | never used as French words (0). Both strings do appear inside **English proper names**, which is correct and must not be swept: **Continuity Checker** (`agents/built-in-agents.md:31`, `agents/agents-overview.md:75`) and **Digital Painting** (`media/style-profiles.md:39`) | as cited |
+| `éventuellement` | used **only** in the correct French sense *possibly / optionally*, never as *eventually* (3 occurrences) | `game/sessions-and-saves.md:56` "que tu as éventuellement écrite" |
+| `actuellement` | used **only** as *currently*, never as *actually* (10 occurrences) | `chats/export-import.md:24` "le chat actuellement ouvert" |
+| `jeton` for *LLM token* | never; `jeton` is reserved for poker chips and CSS design tokens | `agents/built-in-agents.md:300`; `appearance/card-css-theming.md:282` |
+
+---
+
+## 4. Typography & punctuation
+
+The governing decision is deliberate and product-first: **ASCII-only French
+typography**, so that literal substring search in the in-app docs viewer and
+copy-paste out of it both keep working. It is *not* strict French print
+convention, and that is intentional.
+
+| # | Rule | Status | Evidence |
+| --- | --- | --- | --- |
+| 4.1 | **Straight apostrophe `'` only.** 11 919 straight apostrophes pack-wide. Curly `’` is banned (3 residual occurrences, see R1 in §8). | [pack] | `CONFIGURATION.md:73` "tu n'as donc pas à en créer un" |
+| 4.2 | **Straight double quotes `"` only. No guillemets `« »` — zero in the pack.** | [pack] | `UPGRADING.md:145` `"N commits behind"`; `TROUBLESHOOTING.md:330` `"Opening chat..."` |
+| 4.3 | **No non-breaking spaces.** Zero U+00A0 and zero U+202F pack-wide. | [pack] | verified by codepoint scan over all 125 files |
+| 4.4 | **Plain ASCII space before `:` `;` `!` `?`.** 2 298 ` : `, 281 ` ; `, 41 ` ?`. | [pack] | `CONFIGURATION.md:61` "...exploite le serveur ; l'interrupteur de la Danger Zone..." |
+| 4.5 | **The rationale for 4.1-4.4:** guillemets and non-breaking spaces would break the docs viewer's literal substring search and make copied text unusable. Recorded in PR #4191 and `CONTRIBUTING.md:236`. | [ruling] | not derivable from the pack |
+| 4.6 | **Spaced en dash `–` (U+2013) is the parenthetical/appositive dash** — 60 occurrences, and the main carrier of first-use glosses (§7.2). Pairs open and close. | [pack] | `characters/personas.md:7` "dans chaque prompt – le texte que Marinara envoie à l'IA – pour que l'IA sache à qui elle parle" |
+| 4.7 | **Em dash `—` is banned in French prose.** 5 in the pack: **4 prose occurrences remain, all residual** (R2 in §8; note `data/where-data-is-stored.md:21` carries a matched *pair* on one line), plus 1 legitimate use in English content quoted inside a code span. | [pack] | legitimate quoted case: `lorebooks/entries.md:189` (English sample inside backticks) |
+| 4.8 | **Thousands are grouped with a plain ASCII space**, not a comma or period: `16 384`, `1 000 000`, `478 000`. | [pack] | `agents/built-in-agents.md:200`; `conversation/table-games.md:109`; `development/code-cleanup-audit.md:46` |
+| 4.9 | **Decimal separator is a comma**: `5,4 Go`, `3,2 Go`. | [pack] | `connections/local-model.md:72-73` |
+| 4.10 | **Numbers inside code spans, env values, CIDR blocks, and version strings are never re-formatted.** | [pack] | `REMOTE_ACCESS.md:90` `IP_ALLOWLIST=192.168.1.0/24,203.0.113.42` |
+| 4.11 | **Times use 24-hour `HH:MM`**, not `8 h 00`. All 7 clock times in the pack follow this. | [pack] | `game/map-time-weather.md:64` "à 08:00 du matin"; `conversation/schedules.md:102` `09:00-11:30`; `noodle/settings.md:90` "entre 23:00 et 07:00" |
+| 4.12 | **Dates use `DD/MM/YYYY`.** Thin evidence: the pack contains **exactly one** date, so treat this as a convention to follow rather than a broadly attested pattern. | [pack] | `development/hierarchical-locations-prd-v3.md:572` "le 13/07/2026" — the only occurrence |
+| 4.13 | **Accents are kept on capitals**: `À`, `É`, `È` (205 occurrences). | [pack] | `CONFIGURATION.md:124` "À définir avec `BASIC_AUTH_PASS`"; `UPGRADING.md:27` "À la fin" |
+| 4.14 | **Headings are French sentence case**, with a space before `?` in question headings. 1 861 headings. | [pack] | `CONFIGURATION.md:5` "## Dans quels cas configurer Marinara ?"; `agents/hierarchical-maps.md:288` |
+| 4.15 | **Never convert between `…` and `...`** — each is copied from whatever the source shows. `…` is not a French typography choice you apply; of its 16 uses, **12 are inside byte-exact UI labels** (**Checking…**, **Saving…**, **Search entries…**), **3 are elisions inside code spans or code blocks** copied from source, and **1 is a genuine French suspension point in prose**. | [pack] | labels: `UPGRADING.md:139` **Checking…**; code spans: `TROUBLESHOOTING.md:275` `messages.post-unshard-…`, `agents/built-in-agents.md:160`, `development/localization.md:54`; prose: `game/map-time-weather.md:79` "littoral, montagne… Côté météo"; contrast the ASCII form in a quoted string at `TROUBLESHOOTING.md:330` `"Opening chat..."` |
+| 4.16 | **List mechanics are structural, never localised**: bullet markers, numbering, indentation, table pipes and separator rows, code-fence lines, and blank-line placement are byte-identical to the English source. Only the cell text changes. | [pack] + branch README | `CONFIGURATION.md:44-50` (JSON block); `media/image-providers.md:172-176` (table skeleton) |
+| 4.17 | **Table columns are re-padded only within the rows you touch.** Do not reflow untouched rows — it produces a diff that hides the real change. | [ruling] (mirror cycle) | recorded in `prd-notes-fr.md` |
+| 4.18 | **Arrows and emoji in tables/paths are copied from the source, not localised** (`→`, `↔`, `⚠️`, `⛔`). | [pack] | `CONFIGURATION.md:31`; `TROUBLESHOOTING.md:351`; `extending/personal-extensions.md:169` |
+
+---
+
+## 5. UI labels & glosses
+
+| # | Rule | Status | Evidence |
+| --- | --- | --- | --- |
+| 5.1 | **The French app UI does not exist.** `fr.json` ships 132 of 9 123 keys, so a French reader sees English controls. Every in-app label therefore stays **byte-exact English** in the docs — same words, same capitalisation, same trailing `…`, same `&`. | [pack] + locale file | `packages/client/src/localization/locales/fr.json`; label use at `FAQ.md:96` **Import Profile** |
+| 5.2 | **Labels are bold**, glosses are not: `**Label**` + one space + `(gloss)`. 1 351 bold-label + parenthetical pairs in the pack, of which 1 225 open with a lowercase French gloss per §5.3 (the rest are the §5.4 capitalised exception or a non-gloss aside). | [pack] | `CONFIGURATION.md:24` "**Update** (mettre à jour)" |
+| 5.3 | **The gloss is lowercase French**, an infinitive phrase or noun phrase, no final period inside the parentheses. | [pack] | `FAQ.md:108` "**Add Lorebook** (ajouter un lorebook)"; `FAQ.md:107` "**Linked Characters** (personnages liés)" |
+| 5.4 | **Exception: a gloss that is itself a proper UI area keeps its capital**: `**Settings** (Paramètres)`. | [pack] | `FAQ.md:119` |
+| 5.5 | **Gloss once per file, on first use**; later occurrences of the same label in that file are bare. The scope is the *file*, not the pack — `**Update**` is glossed independently in `CONFIGURATION.md:24` and `FAQ.md:115`. | [pack] + PR #4191 | as cited |
+| 5.6 | **Navigation paths are glossed as a whole path**, separator included: `**Settings → Advanced → Danger Zone** (Paramètres → Avancé → Zone de danger)`. | [pack] | `CONFIGURATION.md:31` |
+| 5.7 | **The path separator is copied from the English source, not normalised.** Both occur — 47 spaced ` → ` and 73 spaced ` > ` separators inside or between bold spans; match whichever the source line uses. Two shapes are both attested: the whole path in one bold span (`**Agents > Download Agents**`) and one bold span per segment (`**Settings** > **Advanced** > **Danger Zone**`); copy the source's shape too. | [pack] | `CONFIGURATION.md:20` (`**Agents → Download Agents**`) vs `FAQ.md:175` (`**Agents > Download Agents**`); split form at `extending/personal-extensions.md:180` |
+| 5.8 | **Status strings and error banners are bold English with no parenthetical gloss** — the surrounding French sentence carries the meaning. This is a different class from navigation labels. | [pack] | `TROUBLESHOOTING.md:132` **A generation is already in progress for this chat**; `:164` **Embedding unavailable**; `:330` **Server unreachable**, **Unreachable (request timed out)** |
+| 5.9 | **Quoted app strings (tooltips, transient states) go in straight double quotes, un-glossed**, in-line in the French sentence. | [pack] | `TROUBLESHOOTING.md:129` `(l'infobulle indique "This parameter is sent to the model")`; `:330` `"Opening chat..."` |
+| 5.10 | **Option values inside a control keep their English name and take a French explanation after a colon**, not a parenthetical gloss. | [pack] | `UPGRADING.md:130` "- **Latest Stable** : suit les versions taguées `vX.Y.Z`." |
+| 5.11 | **A label with no French-side name gets no invented one.** `Support Diagnostics` is left plain English, unbolded, mirroring the English source. | [pack] | `TROUBLESHOOTING.md:330` |
+| 5.12 | **Never localise a label from `fr.json`.** Even for the 132 translated keys, the docs describe the English UI the reader actually sees. | [ruling] | follows from 5.1 |
+
+---
+
+## 6. Language-specific mechanics
+
+| # | Rule | Status | Evidence |
+| --- | --- | --- | --- |
+| 6.1 | **All borrowed product nouns are masculine**: `le prompt`, `le token`, `le preset`, `le lorebook`, `le persona`, `le swipe`, `le tracker`, `le sprite`, `le embedding` → `l'embedding`, `le storyboard`, `le commit`, `le package`, `le worker`, `le checkpoint`, `le pipeline`, `le log`. | [pack] | determiner scan over the pack; e.g. `FAQ.md:103` "qu'un lorebook", `chats/messages.md:17` "un swipe" |
+| 6.2 | **Exception: `build` is feminine** — `une ancienne build`, `une build "Lite"`. Both user-facing uses agree feminine; one developer-doc line disagrees (`un build`, R7 in §8). Keep writing it feminine. | [pack] | `TROUBLESHOOTING.md:49`; `conversation/calls.md:243` |
+| 6.3 | **`la connexion`, `la balise`, `la macro`, `la fiche`, `l'extension`, `l'entrée`, `la sauvegarde` are feminine**; `l'instantané`, `le canal`, `le lanceur`, `le marqueur`, `l'interrupteur`, `l'onglet` masculine. | [pack] | `FAQ.md:67`; `CONFIGURATION.md:59`; `development/architecture-map.md:95` |
+| 6.4 | **Plurals of loanwords take French `-s`**: `les prompts`, `les tokens`, `les lorebooks`, `les presets`, `les swipes`, `les packages`, `les placeholders`. No invariant forms, no `-es`. | [pack] | `UPGRADING.md:7` "les personas, les lorebooks, les presets, les connexions" |
+| 6.5 | **Elision and contraction apply normally around loanwords**: `l'agent`, `d'un lorebook`, `au prompt`, `du preset`, `aux tokens`. | [pack] | `CONFIGURATION.md:183`, `:205` |
+| 6.6 | **A bold English label is grammatically opaque** — do not elide or contract into it, and do not inflect it. Put the French article before the bold span or restructure: "ouvre **Chat Settings**", "le bouton **Check for Updates**". | [pack] | `UPGRADING.md:139`; `FAQ.md:61` |
+| 6.7 | **Prefer restructuring over an agreement you cannot justify.** Where an English label's gender is undecidable, the pack attaches a French carrier noun: `le champ **Clip Skip**`, `un interrupteur **Restore faces**`, `le menu déroulant **Release Channel**`, `le statut **Embedding unavailable**`. | [pack] | `media/image-providers.md:166`; `UPGRADING.md:128`; `TROUBLESHOOTING.md:164` |
+| 6.8 | **Link text is translated; link targets are not.** The `.md` path and the `#anchor` fragment stay byte-identical English, even when the visible text is French — including the `→` sub-section form. | [pack] | `chats/sending-and-streaming.md:56` `[... → Réutiliser une image de galerie ...](../characters/galleries.md#reuse-a-gallery-image-in-messages-and-greetings)`; `UPGRADING.md:188` |
+| 6.9 | **Compound technical terms take `de`, not a hyphen calque**: `budget de tokens`, `préfixe de prompt`, `canal de publication`, `gestionnaire de paquets`, `fiche de personnage`. | [pack] | `agents/hierarchical-maps.md:678`; `media/image-providers.md:166`; `TROUBLESHOOTING.md:18` |
+| 6.10 | **`en` + bare mode name; `de` + mode name after a noun**: `en Game Mode`, `les storyboards de Game Mode`, `les emplois du temps de Conversation`. | [pack] | `FAQ.md:175`; `TROUBLESHOOTING.md:200`; `CONFIGURATION.md:280` |
+
+---
+
+## 7. Explanatory conventions
+
+| # | Rule | Status | Evidence |
+| --- | --- | --- | --- |
+| 7.1 | **Jargon is defined on first use in each file**, in one of two shapes: a spaced-en-dash apposition, or a standalone `X, c'est ...` / `Un X est ...` sentence. | [pack] | `TROUBLESHOOTING.md:12`; `characters/personas.md:7` |
+| 7.2 | **Reuse the pack's fixed gloss wordings** rather than inventing new ones — they recur near-verbatim across files and readers rely on the repetition. | [pack] | see table below |
+| 7.3 | **A gloss never replaces the term.** The loanword is still used in the rest of the file. | [pack] | `noodle/settings.md:160` "un token est un petit morceau de texte" then plain `tokens` after |
+
+Fixed gloss wordings:
+
+| Term | Standard gloss | Evidence |
+| --- | --- | --- |
+| prompt | *le texte que Marinara envoie à l'IA* | `chats/group-chats.md:25`; `prompts/presets.md:9`; `roleplay/backgrounds.md:26` |
+| token | *un petit morceau de texte* | `agents/agents-overview.md:55`; `noodle/settings.md:160` |
+| lorebook | *un recueil de faits sur ton univers* | `characters/personas.md:101`; `roleplay/combat-encounters.md:37`; `noodle/settings.md:158` |
+| preset | *un modèle de prompt enregistré* | `characters/creating-and-editing-characters.md:116` |
+| sprite | *l'image du personnage sur le plateau* | `installation/windows.md:156`; `TROUBLESHOOTING.md:188` |
+| embedding | *une représentation numérique du texte* | `CONFIGURATION.md:208`; `connections/local-model.md:13` |
+| log | *le journal du serveur* | `CONFIGURATION.md:170` |
+| commit | *une modification enregistrée* | `UPGRADING.md:145` |
+| service worker | *un petit script que le navigateur utilise pour charger l'application vite et hors ligne* | `UPGRADING.md:178` |
+| macro | *un espace réservé que Marinara remplace par du vrai texte* | `chats/guided-and-impersonate.md:88` |
+| API key | *un code secret, un peu comme un mot de passe* | `media/scene-video.md:21` |
+| persona | *les personnages que tu incarnes* | `FAQ.md:107` |
+| streaming | *l'affichage au fil de l'écriture* | `TROUBLESHOOTING.md:132` |
+| wake lock | *qui empêche la mise en veille* | `TROUBLESHOOTING.md:324` |
+
+---
+
+## 8. QA checks & known traps
+
+### 8.1 Mechanical checks (run before committing any `fr/` change)
+
+Scan with a codepoint-aware tool — Windows `grep` under Git Bash mis-decodes
+UTF-8 accented bytes and will report false positives on `À`, `é`, `ç` when you
+search for `’` or `«`. Use Python with `encoding="utf-8"`, or `rg` with an
+explicit UTF-8 locale.
+
+| # | Check | Expected on a clean pack |
+| --- | --- | --- |
+| Q1 | `U+00AB` / `U+00BB` (guillemets) | 0 |
+| Q2 | `U+00A0` / `U+202F` (NBSP, narrow NBSP) | 0 |
+| Q3 | `U+2018` / `U+201C` / `U+201D` | 0 |
+| Q4 | `U+2019` (curly apostrophe) | 0 — **currently 3, see R1** |
+| Q5 | `U+2014` (em dash) in prose | 0 — **currently 4, see R2** |
+| Q6 | `\bvous\b`, `\bvotre\b`, `\bvos\b` (excluding `rendez-vous`) | 0 — **currently 7, in 3 files, see R5** |
+| Q7 | `\b\w{3,}ez\b` minus `chez/assez/nez/rez/rendez` (vous-imperatives) | 0 — **currently 28 across 5 files, see R5**. Keep `rendez` in the exclusion list or `rendez-vous` reports as a false positive. Run this with a Unicode-aware `\w` — see T7. |
+| Q8 | `librairie`, `l'appli`, `l'app`, `supporte(r)` as French words | 0 each. **Do not** flag bare `checker`/`digital`: they occur only inside the English names **Continuity Checker** and **Digital Painting** (§3.7). |
+| Q9 | `jeton` used for an LLM token | 0 (poker/CSS senses only) |
+| Q10 | `carte de personnage`, `préréglage`, `librairie` | 0 each |
+| Q10b | `\bla persona\b` **lowercase only** | 0. Case-insensitively there are 3 hits, all the capitalised English UI object `la Persona ...` — expected, leave them (§3.2) |
+| Q11 | Code fences, inline code spans, link targets, `#anchors` byte-identical to the English source | exact match |
+| Q12 | Heading count and heading levels match the English file | exact match |
+| Q13 | Line endings LF only; no CRLF | clean |
+| Q14 | `node scripts/docs-i18n/build-manifest.mjs <pack> --source-commit <sha>` then `validate-pack.mjs <pack>` | green, no orphans, valid hashes, no added images |
+
+### 8.2 Tooling traps
+
+| # | Trap | Status |
+| --- | --- | --- |
+| T1 | Git Bash `grep` with a bracket class containing non-ASCII characters matches accented Latin letters byte-wise and produces garbage hits. Always scan by codepoint. | [ruling] (observed 2026-09-01) |
+| T2 | `packages/client/src/localization/locales/fr.json` is vouvoiement with curly apostrophes and only ~1.4 % coverage. Copying strings out of it silently injects both a wrong register and a banned character. | [ruling] (locale file verified) |
+| T3 | Editors that "smarten" quotes will convert `'` → `’` and `"` → `« »` on save. Disable smart punctuation for this branch. | [ruling] |
+| T4 | Re-padding an existing Markdown table's untouched rows makes the real edit unreviewable. Pad only the rows you add, consistently with each other. | [ruling] (mirror cycle) |
+| T5 | Commit content and the regenerated `manifest.json` **together**; a stale manifest fails hash validation at download time. | [ruling] (branch README) |
+| T6 | The `docs-i18n` branch carrying `fr/` must be pushed **before** the Engine-side PR merges, or selecting Français fails with a clean 502. | [ruling] (PR #4191) |
+| T7 | **Never run the Q7 vouvoiement scan through a JavaScript regex.** JS `\w` is ASCII-only, so it does not match `é`/`è`/`ç`. `/\b\w{3,}ez\b/` reports `Vérifiez` as the wrong word `rifiez` (breaking any whole-word exclusion list) and **misses `préférez` entirely** — a real residual at `chats/sending-and-streaming.md:56`. Python's `re` (Unicode `\w` by default) or `rg` handle all of these correctly. | [pack] (verified 2026-09-01 against Node and Python on the pack's own strings) |
+
+### 8.3 Known pack residuals (documented, deliberately not fixed here)
+
+These are real inconsistencies in the shipped pack. They are recorded so that a
+future sweep can fix them as one intentional change, rather than being silently
+patched — or, worse, being copied as precedent.
+
+| # | Residual | Location | Disposition |
+| --- | --- | --- | --- |
+| **R1** | Curly apostrophes `’` (3), violating §4.1 | `agents/built-in-agents.md:159`, `:161` | leave for a future sweep |
+| **R2** | Em dashes `—` in French prose (4), violating §4.7 | `agents/custom-agents.md:113` (1), `:114` (1); `data/where-data-is-stored.md:21` (**2** — a matched pair around "par exemple, ... lorebook") | leave for a future sweep (the instance in `lorebooks/entries.md:189` is inside an English code span and is correct) |
+| **R3** | **placeholder → marqueur mismatch.** `media/image-providers.md:166` describes the byte-exact label **Upload a 1x1 placeholder when no reference image is provided** and then calls the same objects `marqueurs d'image de référence`; `:130`, `:138`, `:140`, `:183` use `marqueur` throughout — while `media/comfyui.md:55-59`, `game/ltx-2-3-storyboards.md:96-126` and `game/storyboard.md:266` call them `placeholders`, and `media/scene-video.md:38` calls them `balises de remplacement`. A reader following the cross-reference at `:140` sees three names for one thing. | `media/image-providers.md:166` (+ the files above) | **explicitly left for a future sweep** — recorded ledger ruling |
+| **R4** | `package` vs `paquet` overlap for Marinara capability packages. `CONFIGURATION.md:22`/`FAQ.md:115` use `packages` (313 pack-wide), but at least **7 lines across 3 files** use `paquet` for the same objects: `TROUBLESHOOTING.md:86` (installed cards/calls with their own routes), `:88` (`data/capability-packages` migration), `:90` (catalogue downloads), `:338` (legacy packages pruned by the launcher), `:396` (a package re-exported with an empty capability list); `conversation/selfies.md:11` ("le paquet optionnel **Illustrator**"); `CONFIGURATION.md:65` ("anciens paquets tiers" = external extensions). Wider than first recorded. | as listed | leave; prefer `package` in new prose (§3.3). `paquet` stays correct for npm/OS/pnpm packages (`TROUBLESHOOTING.md:18`) |
+| **R5** | **Vouvoiement residuals**, violating §1.3 — the clearest register regression in the pack: **28 vous-imperatives across 5 files**, plus **7 `vous`/`votre`/`vos` across 3 files**. Lines: `TROUBLESHOOTING.md:49`, `:243`, `:245`, `:266`, `:267`, `:273`, `:277` (17 imperatives, the worst cluster); `UPGRADING.md:186`, `:188`; `characters/galleries.md:73`, `:83`, `:85`, `:91`; `chats/sending-and-streaming.md:54`, `:56`; `agents/custom-agents.md:113`. Note `agents/custom-agents.md:113` carries both R2 and R5, i.e. that bullet block appears to predate the register pass. | as listed | leave for a future sweep; never use as precedent |
+| **R6** | `liste déroulante` (1) where the pack's standing term is `menu déroulant` (91), violating §3.6 | `noodle/settings.md:65` | leave for a future sweep |
+| **R7** | `build` agreed **masculine** once ("une installation et un build propres"), against the feminine agreement of §6.2 and both user-facing uses | `development/code-cleanup-audit.md:253` | leave for a future sweep; write `la build` in new prose |
+
+---
+
+## 9. Sources
+
+- Shipped pack: `docs-i18n` branch, `fr/` — 125 Markdown files + `manifest.json`
+  (working copy scanned: `scratchpad/wt-glossaries/fr/`).
+- Pasta-Devs/Marinara-Engine PR **#4191** — "Translation approach" and
+  "Validation done".
+- `prd-notes-fr.md` — 2026-09-01 mirror-cycle terminology notes.
+- `CONTRIBUTING.md:236` (`staging`) — French per-language conventions.
+- `packages/client/src/localization/locales/fr.json` — UI coverage reality check.

--- a/glossaries/glossary-hi.md
+++ b/glossaries/glossary-hi.md
@@ -1,0 +1,685 @@
+# Hindi (`hi`) — documentation-pack glossary
+
+## Provenance
+
+This is the **second-generation** `hi` glossary, **re-derived 2026-09-01** after the original
+working glossaries were lost to temp-directory cleanup. It was rebuilt from three sources, in
+authority order:
+
+1. **The shipped pack** at `docs-i18n:hi/` (125 files) — **ground truth**. Every terminology row
+   and prescriptive rule below was re-verified against the pack as shipped, with a cited evidence
+   file and line.
+2. **The pack's shipping PR decision write-up** — Pasta-Devs/Marinara-Engine **PR #4471**
+   ("Hindi conventions" section), the record of what the original cycle decided and why.
+3. **The 2026-09-01 mirror-cycle notes** (`prd-notes-hi.md`) — evidence-backed choices made during
+   the same-day delta mirror, each carrying its own in-pack citation.
+
+**How to read the rules.** Every prescriptive statement is either
+
+- **verified** — followed by a `file:line` citation into `hi/`, or a measured pack-wide count,
+  meaning the pack demonstrably does this today; or
+- marked **`[recorded ruling]`** — a maintainer or cycle decision the pack cannot show, because it
+  is a process rule, a tooling trap, or a negative finding. These are preserved as rulings, not
+  invented.
+
+Where the pack **contradicts** a rule in a small number of places, the rule stands and the
+exceptions are logged in §7 *Known pack residuals* — documented, not silently normalized.
+
+**Why the mechanical rules are hard rules.** The in-app docs search is a literal, case-insensitive
+substring scan with no normalization, stemming, or folding —
+`packages/server/src/routes/docs.routes.ts:557-596` (`const needle = query.toLowerCase()`,
+`line.toLowerCase().indexOf(needle)`). For Devanagari that means फ़ाइल and फाइल are simply
+different strings, a stray ZWNJ is an unmatchable byte, and a Devanagari numeral never answers a
+search for `7860`. Spelling discipline here is a search-correctness requirement, not a style
+preference.
+
+Line numbers refer to the pack as shipped at `docs-i18n` commit `43eef09e2`. Re-verify after any
+pack edit.
+
+---
+
+## 1. Register & address
+
+| Rule | Detail | Evidence |
+|---|---|---|
+| **आप only** | Second-person address is always **आप**. `तुम` and `तू` are banned for reader address. | आप ×1,600 pack-wide; `तुम` **0×**; the 12 `तू` strings are all substrings of बातूनी / तूफ़ान (`conversation/schedules.md:14`, `game/map-time-weather.md:79`), **0** pronoun uses |
+| **करें-style imperatives** | Instructions use the आप-imperative: `करें`, `खोलें`, `चुनें`, `सेट करें`, `चलाएँ`, `देखें`. The `कीजिए/कीजिये` register is banned outright. | `करें` ×2,042, `खोलें` ×469, `चलाएँ`, `देखें`; `कीजिए` **0×**, `कीजिये` **0×**; `CONFIGURATION.md:31`, `installation/containers.md:24` |
+| **करो/तुम survive only inside quoted in-fiction speech** | The two `करो` forms in the pack are example utterances a *user types to a character*, not reader address. Do not generalize. | `game/getting-started.md:141` (`"…हल्का मत करो"`), `home/professor-mari.md:164` |
+| **Modern technical Hindi, Google/Microsoft register** | Everyday vocabulary with Devanagari loanwords. **शुद्ध / Sanskritized purisms are banned.** | `संगणक` **0×**. Measured splits: इस्तेमाल 794 vs उपयोग 2 / प्रयोग 1; अगर 307 vs यदि **0**; हर 1,593 vs प्रत्येक **0**; ज़रूरी 215 vs आवश्यक **0**; मदद 109 vs सहायता **0**; कोशिश 59 vs प्रयास **0**; जवाब 413 vs उत्तर 2; सिर्फ़ 789 vs केवल 24 |
+| **No reader gendering** | Never make a verb or participle agree with the reader's gender. The polite plural आप takes `-ते हैं` and is neutral by construction; where a participle must agree it agrees with the **object**, not the reader. | `आप चाहते हैं` ×2 and **0** feminine reader forms (`आप चाहती`, `आप कर सकती`, `आप देखेंगी` all **0×**); `आपने सेट किया` / `आपने टाइप की` agree with the object |
+| **Devanagari loanwords, not calques** | Loan the technical noun (`फ़ाइल`, `सर्वर`, `प्रॉम्प्ट`, `लोरबुक`, `कनेक्शन`) rather than coining a Hindi equivalent. | `CONFIGURATION.md:3`; see §3 |
+| **`यानी` is the plain-language gloss connector** | Jargon gets a one-time inline definition introduced by `यानी` (or a parenthetical), then runs bare. | ×303 pack-wide; `CONFIGURATION.md:3` (`एनवायरनमेंट वेरिएबल यानी वह सेटिंग जो…`), `game/hud-widgets.md:3` (`HUD यानी heads-up display…`), `chats/slash-commands.md:3`, `prompts/macros.md:3` |
+| **The app locale `hi.json` is NOT the register authority** | `packages/client/src/localization/locales/hi.json` uses a markedly more Sanskritized register than the docs pack and must never be copied from. | `hi.json` ships `उपयोग`, `यदि`, `त्रुटि`, `नियंत्रण`, `सामग्री`, `सूचना`, `दृश्य`, `सहेजा गया`, and translates the mode names (`बातचीत`, `रोलप्ले`, `गेम`). The pack ships `इस्तेमाल` (×794), `अगर` (×307), `एरर` (×77, `त्रुटि` **0×**), `कंट्रोल` (×234 vs `नियंत्रण` ×8), `नोटिफ़िकेशन` (×22 vs `सूचना` ×4), `सेव` (×676 vs `सहेज` ×1), and keeps the mode names in Latin |
+
+---
+
+## 2. Product, feature & mode names
+
+**The frozen-name rule.** Product, mode, agent and feature names **stay in Latin script**. A
+Devanagari transliteration of a frozen name splits the literal-substring search index and is a
+defect, not a synonym (PR #4471).
+
+Measured: `Roleplay` 462 vs `रोलप्ले` 19 (all generic-sense, see below) · `Conversation` 465 vs
+`कन्वर्सेशन` 2 — one inside a label gloss (`appearance/chat-backgrounds.md:15`,
+`**Conversation Theme** (कन्वर्सेशन थीम)`), one inside a code-identifier gloss
+(`development/code-cleanup-audit.md:237`) · `Game Mode` 266 vs `गेम मोड` 1, inside a label gloss
+(`game/ltx-2-3-storyboards.md:3`) · `Noodle` 202, `नूडल` **0×** · `Professor Mari` 88,
+`प्रोफ़ेसर` **0×**.
+
+**The spaced-postposition rule.** Because the name cannot inflect, the Hindi postposition follows
+it as a **separate word**, never hyphenated and never attached:
+
+| Do | Never |
+|---|---|
+| `Marinara Engine में` | `Marinara-में`, `Marinaraमें` |
+| `Android पर`, `Termux पर`, `Docker पर` | `Androidपर` |
+| `Support Diagnostics की कॉपी` | any inflected/attached form |
+| `Marinara तक पहुँच` | — |
+
+Verified: **1,034** spaced `frozen name + postposition` constructions across **98** distinct
+name+postposition pairs — `Marinara को` ×72, `Marinara के` ×70, `Game Mode में` ×60, `Marinara में`
+×54, `Marinara Engine की` ×52 … The locative subset alone is 51 (`Marinara तक` ×11, `Android पर`
+×9, `Linux पर` ×5, `Windows पर` ×4, `Docker पर` ×4, `Noodle पर` ×4 …). Against that: **0**
+hyphen-attached postpositions and **0** occurrences of a Devanagari character immediately followed
+by a Latin letter, pack-wide. The rule is not a handful of special cases — it is how the pack
+inflects every frozen name, a thousand times over.
+
+**Exception — the danda attaches directly.** A sentence ending on a Latin token takes `।` with
+**no** intervening space (131 instances, e.g. `…Marinara Engine।`). This is the one place Latin and
+Devanagari touch.
+
+**The activity/mode sense split.** The *frozen mode name* is Latin; the *generic activity* is
+Devanagari:
+
+- `- **Conversation**: बिना रोलप्ले वाली सीधी AI चैट` — `home/welcome.md:36`
+- `डाइस वाले व्यवस्थित रोलप्लेइंग गेम के लिए…` — `roleplay/getting-started.md:15`
+- `बातचीत` (×22) likewise means *talking*, never the `Conversation` mode.
+
+**What stays English (never translated, never transliterated):**
+
+| Class | Members (as they appear) |
+|---|---|
+| Product & shell | `Marinara`, `Marinara Engine`, `Noodle`, `Professor Mari`, `Termux`, `Docker`, `Android`, `Windows`, `Linux`, `Node`, `Tailscale`, `SillyTavern`, `ComfyUI`, `Spotify`, `Home Assistant`, `Discord` |
+| Chat modes | `Conversation`, `Roleplay`, `Game Mode` (and bare `Game`) |
+| Agents & packages | `World Maps`, `Storyboard`, `Illustrator`, `Music DJ`, `Character Tracker`, `Local Model`, `Agent Suite`, `Memory Recall` |
+| Acronyms | `API`, `JSON`, `CSS`, `HUD`, `GM`, `NPC`, `DM`, `OOC`, `GIF`, `PWA`, `CSRF`, `APK`, `RAM`, `LTX` |
+| UI controls & panels | every bold label — see §5 |
+
+**Acronyms are expanded once, in a parenthesis or with `यानी`, then run bare:**
+
+- `NPC (नॉन-प्लेयर कैरेक्टर)` — `game/party-and-npcs.md:3` (`NPC` on 37 lines; `एनपीसी` **0×**)
+- `HUD यानी heads-up display, गेम स्क्रीन के … छोटे जानकारी-पैनल` — `game/hud-widgets.md:3`
+- `APK यानी Android ऐप की इंस्टॉल फ़ाइल` — `installation/android-termux.md:15`
+- `रेजेक्स "regular expression" का छोटा रूप है` — `extending/regex-scripts.md:7`
+
+**Articles:** Hindi has none. Do not import English `the`/`a` as `वह`/`एक` unless genuinely
+contrastive; the pack writes `कैरेक्टर कार्ड वह फ़ाइल है जो AI कैरेक्टर को परिभाषित करती है`
+(`characters/creating-and-editing-characters.md:7`) — the demonstrative is doing definitional work
+there, not standing in for an article.
+
+---
+
+## 3. Core terminology
+
+Banned alternates are **defect classes**: a reviewer finding one should treat it as a regression,
+not a synonym choice. Two renderings of one concept split the substring-search result set.
+
+**Bans are sense-scoped, and a bare grep will over-report.** A word banned as a rendering of *this
+row's* concept is often the pack's correct word for a *different* concept, and the pack uses it
+freely there. Before filing a regression, read the sense. Measured, and all legitimate:
+
+| Word | Banned as | But is the pack's word for | Count |
+|---|---|---|---|
+| संकेत | prompt | cue / hint / indicator (`[whispering]` voice cues, typing indicator, drop hint) | 20 |
+| संवाद | chat | dialogue (`**Dialogue Examples**`, `**Color Dialogues**`, spoken lines) | 13 |
+| बॉट | agent | bot (table-game bot, `Discord बॉट`, "the bot that replies") | 8 |
+| व्यक्तित्व | persona | personality (the `**Personality**` card field) | 5 |
+| स्टार्टर | launcher | starter set (`साथ आने वाला स्टार्टर सेट`, `game/game-assets.md:17`) | 5 |
+| विस्तार | extension | expansion (`AI मैप ड्राफ़्ट और विस्तार`), and `विस्तार से` = in detail | 9 |
+| प्लगइन | extension | a third-party plugin outside Marinara (Vite, Fastify, Termux plugin apps) | 4 |
+| झलक | snapshot | preview / show-through | 5 |
+| पड़ाव | checkpoint | milestone, waypoint | 3 |
+| वर्णन · कथन | narration | the verb *to describe*; `कहानी-कथन` = storytelling | 4 · 1 |
+| दृश्य | scene | *visual* as an adjective (`खास दृश्य फ़रमाइशों`) | 2 |
+
+Two more are pure substring artifacts and never appear as words at all: `कोष` (×11, always
+`कोष्ठक` = bracket) and `संबंध` (×15, almost always `संबंधित`/`असंबंधित` = related — exactly **1**
+bare use, `appearance/appearance-settings.md:30`). Tokenize before you count.
+
+| English term | This pack's term | Banned alternates | Evidence |
+|---|---|---|---|
+| prompt | **प्रॉम्प्ट** | संकेत, निर्देश-पाठ, सूचक | `prompts/presets.md:3`; `CONFIGURATION.md:33` |
+| token | **टोकन** | शब्दखंड, इकाई | `lorebooks/token-budgets.md:1`, `:5` |
+| token budget | **टोकन बजट** | टोकन सीमा (bare), टोकन कोटा | `lorebooks/token-budgets.md:1`; `agents/built-in-agents.md:200` |
+| preset | **प्रीसेट** | पूर्व-निर्धारित सेटिंग, पूर्वनिर्धारण | `prompts/presets.md:3` |
+| lorebook | **लोरबुक** (fem.) | विश्वकोश, ज्ञानकोश, लोर-पुस्तक | `lorebooks/overview.md:3`; `FAQ.md` |
+| lorebook entry | **एंट्री** (fem.) | प्रविष्टि, लेख | `lorebooks/entries.md`; `lorebooks/token-budgets.md:1` |
+| character | **कैरेक्टर** | पात्र, किरदार | कैरेक्टर ×1,315; किरदार **0×**; पात्र ×2 (residual, §7) — `characters/creating-and-editing-characters.md:7` |
+| character card | **कैरेक्टर कार्ड** | पात्र-कार्ड, चरित्र कार्ड | `characters/creating-and-editing-characters.md:7`; `lorebooks/linking-to-characters.md:9` |
+| persona | **पर्सोना** | उपयोगकर्ता प्रोफ़ाइल, व्यक्तित्व | `characters/personas.md:1` |
+| chat | **चैट** (fem.) | वार्तालाप, संवाद, बातचीत (that word means *talking*) | चैट ×1,934; वार्तालाप **0×** — `chats/managing-chats.md:3` |
+| message | **संदेश** | **मैसेज** as the bare count noun (banned) | संदेश ×816 vs मैसेज ×23. The 23 break down as मैसेजिंग ×15 · `डायरेक्ट मैसेज`/`डायरेक्ट-मैसेज` ×5 · `सैंडबॉक्स मैसेज`/`रनटाइम मैसेज` ×2 (`extending/writing-personal-extensions.md:227`, `:252`) · **1 bare verbal use**, `किसी दोस्त को मैसेज करते हैं` (`conversation/getting-started.md:9`) — `chats/messages.md:1`; `conversation/schedules.md:7` |
+| messaging (the app genre) | **मैसेजिंग** | संदेशन | `conversation/getting-started.md:3`; `roleplay/scenes.md:7` |
+| branch (chat) | **ब्रांच** (fem.) | शाखा — but **फ़ोर्क is the verb**, not a banned word | ब्रांच ×169. `फ़ोर्क` ×11 is the pack's word for the *fork action* and for a git fork (`चैट … पर फ़ोर्क हुआ`, `chats/branches.md:13`; `सीन की ब्रांच फ़ोर्क होती हैं`, `roleplay/scenes.md:78`; `अपने फ़ोर्क की एक अलग ब्रांच`, `development/localization.md:89`). Never use it as the branch *noun*. शाखा ×1, a residual (§7-F) — `chats/branches.md:3` |
+| agent | **एजेंट** | सहायक, बॉट, असिस्टेंट | एजेंट ×733. `असिस्टेंट` ×36 is **not** reserved for Professor Mari: its dominant pack sense is the **assistant message role** (`हर 8 यूज़र और असिस्टेंट संदेशों पर`, `agents/built-in-agents.md:45`; `असिस्टेंट के जवाब`, `असिस्टेंट स्वाइप`), plus generic `AI असिस्टेंट` (`appearance/card-css-theming.md:524`) and Professor Mari's own epithet `बिल्ट-इन असिस्टेंट` (`home/professor-mari.md:1`). What is banned is असिस्टेंट as a rendering of *agent* — `agents/agents-overview.md:1` |
+| capability (an agent declares) | **क्षमता** | योग्यता, सामर्थ्य | `CONFIGURATION.md:33` |
+| permission — **OS / browser prompt** | **अनुमति** | परमिशन, इजाज़त | `installation/android-termux.md:21` (`**Run commands in Termux environment** अनुमति दें`), `TROUBLESHOOTING.md:290`, `:291`, `:332`, `conversation/calls.md:235` (microphone) |
+| permission — **Marinara-level capability grant** | **परमिशन** | अनुमति, इजाज़त | परमिशन ×33 — `CONFIGURATION.md:33`; `agents/built-in-agents.md:202` (`` `agent-runtime`, `chat-read` … परमिशन ``); `extending/personal-extensions.md:130`; `development/personal-extensions.md:23`. Two shipped lines use अनुमति for this sense instead — a residual, §7-F |
+| permission — **an OS/filesystem permission *error*** | **परमिशन एरर** | अनुमति एरर | `TROUBLESHOOTING.md:369` (Docker/Podman volume); `installation/containers.md:234`; `home/professor-mari.md:175` |
+| "is allowed to" (predicate, allowlists/CORS) | **इजाज़त** (verbal, never a countable noun) | — | `CONFIGURATION.md:127`, `:138`, `:281`; `REMOTE_ACCESS.md:217` |
+| connection | **कनेक्शन** | संबंध, जुड़ाव | `connections/connecting-to-a-provider.md:3` |
+| provider | **प्रोवाइडर** | सेवा-प्रदाता, आपूर्तिकर्ता | `connections/providers-reference.md:3` |
+| API key | **API कुंजी** | API की, चाबी | कुंजी ×202 — `connections/connecting-to-a-provider.md:3`; `CONFIGURATION.md:154` |
+| launcher | **लॉन्चर** | प्रक्षेपक, स्टार्टर, आरंभक | लॉन्चर ×92 — `TROUBLESHOOTING.md:22`, `:314`, `:324`; `CONFIGURATION.md:274` |
+| apply an update | **अपडेट लागू करना** | अपडेट चढ़ाना, अपडेट इंस्टॉल करना (for the in-app *Apply* action) | `CONFIGURATION.md:221`, `:237`, `:238` |
+| release channel | **रिलीज़ चैनल** | विमोचन चैनल, रिलीज़ शाखा | `CONFIGURATION.md:237`; `installation/macos-linux.md:231`; `installation/windows.md:201` |
+| channel (Discord) | **चैनल** | माध्यम | `integrations/discord-mirror.md:7` |
+| checkout (working tree) | **चेकआउट** | कार्य-प्रति, निकासी | `installation/containers.md:24`; `TROUBLESHOOTING.md:39`; `CONFIGURATION.md:238` |
+| repository | **रिपॉज़िटरी** | भंडार, कोष | `CONFIGURATION.md:35`, `:37`; `installation/containers.md:24` |
+| wake lock | **`wake lock`** — left in English, **unbolded, unbackticked** | वेक लॉक, जागृति-लॉक, निद्रा-रोक | `TROUBLESHOOTING.md:324` (`लॉन्चर Android wake lock माँगता है`), `:330`; वेक लॉक **0×** |
+| `termux-wake-lock` / `termux-wake-unlock` / `termux-tools` | byte-exact in backticks | any transliteration | `TROUBLESHOOTING.md:326` |
+| battery optimization | **बैटरी ऑप्टिमाइज़ेशन** | बैटरी अनुकूलन, ऊर्जा बचत | `TROUBLESHOOTING.md:326` (`बैटरी ऑप्टिमाइज़ेशन हटाएँ`), `:332` (`…से छूट दें`) |
+| background activity / run in background | **बैकग्राउंड में चलना** — the OS allowance is `बैकग्राउंड में चलने की अनुमति` | पृष्ठभूमि, बैकग्राउंड परमिशन | `TROUBLESHOOTING.md:326`, `:332`; `TROUBLESHOOTING.md:80` |
+| foreground | **फ़ोरग्राउंड** — chosen for symmetry with the pack's `बैकग्राउंड` | अग्रभूमि | `TROUBLESHOOTING.md:328` (heading), `:332` |
+| freeze (cached-app freezer) | **फ़्रीज़** (bold for emphasis, not as a label) | जमना, हिमीकरण | `TROUBLESHOOTING.md:330`; फ़्रीज़ ×26 |
+| memory (RAM sense) | **मेमोरी** (fem.) | स्मृति, रैम-स्मृति, याददाश्त | मेमोरी ×120, स्मृति **0×** — `CONFIGURATION.md:155`; `TROUBLESHOOTING.md:314`; `connections/local-model.md:34` (`मेमोरी (RAM)`) |
+| in memory / resident | **मेमोरी में रखना** / **मेमोरी से हटाना** | निवासी, रेज़िडेंट, स्थायी-स्मृति | `CONFIGURATION.md:155` (`कितनी चैट मेमोरी में रख सकता है` … `मेमोरी से हटा दी जाती है … (डिस्क से यह कभी नहीं हटती)`), `:156` |
+| memory (a saved recall item) | **याद** / pl. **यादें** | मेमोरी (that is RAM), स्मरण | `agents/built-in-agents.md:153`; `agents/memory.md` |
+| Memory Recall (the feature) | **Memory Recall** (Latin) + gloss `(मेमोरी रिकॉल)` on first mention | मेमोरी वापसी | `TROUBLESHOOTING.md:159` |
+| least-recently-used | *no coined term* — phrase it as a relative clause | LRU, न्यूनतम-प्रयुक्त | `CONFIGURATION.md:155` (`वह चैट … जो सबसे लंबे समय से इस्तेमाल नहीं हुई`) — see the mirror-cycle note below |
+| cache (n. / v.) | **कैश** | संचय, अस्थायी भंडार | कैश ×44 — `TROUBLESHOOTING.md:75`, `:80`; `CONFIGURATION.md:322` |
+| backup | **बैकअप** | प्रतिलिपि, सुरक्षा प्रति | बैकअप ×87 — `data/backup-and-restore.md:9`; `CONFIGURATION.md:16` |
+| snapshot | **स्नैपशॉट** | झलक, क्षण-चित्र | स्नैपशॉट ×101 — `agents/hierarchical-maps.md:31`; `development/personal-extensions.md:22` |
+| checkpoint | **चेकपॉइंट** | जाँच-बिंदु, पड़ाव | `agents/built-in-agents.md:153`; `game/sessions-and-saves.md:84` |
+| extension (Marinara add-on) | **एक्सटेंशन** | विस्तार, संवर्धन, प्लगइन | एक्सटेंशन ×122 — `extending/personal-extensions.md:3`; `CONFIGURATION.md:59` |
+| store / storage | **स्टोरेज**, verb **सेव करना** | सहेजना, भंडारण | सेव ×676 vs सहेज ×1 (residual, §7) — `data/where-data-is-stored.md:21` |
+| data | **डेटा** | आँकड़े (5 residual uses), सामग्री | डेटा ×288 — `CONFIGURATION.md:152` |
+| environment variable | **एनवायरनमेंट वेरिएबल** | पर्यावरण चर, परिवेश-चर | `CONFIGURATION.md:3` |
+| default (the value) | **डिफ़ॉल्ट** | तयशुदा, पूर्वनिर्धारित — **for the *default* sense only** | डिफ़ॉल्ट ×614 — `CONFIGURATION.md:150` (table header `डिफ़ॉल्ट`). `तयशुदा` ×23 never means *default* in the pack: it is its word for **deterministic** (21 of 23 in `development/hierarchical-locations-prd-v3.md` — `तयशुदा क्रम`, `तयशुदा कटौती`, `ग्राफ़ वैलिडेशन तयशुदा है`), plus *fixed/specified* at `game/getting-started.md:73`, `noodle/settings.md:29`. Keep it for *deterministic*; never write it in a default column |
+| timeout | **टाइमआउट** | समय-सीमा (that is a limit, not a timeout) | `CONFIGURATION.md:15`, `:201` |
+| allowlist | **अलाउलिस्ट** | श्वेत-सूची, अनुमति-सूची, वाइटलिस्ट | अलाउलिस्ट ×44 — `CONFIGURATION.md:12`, `:110` |
+| log (server) | **लॉग**, v. **लॉगिंग** | अभिलेख, पंजी | `TROUBLESHOOTING.md:324`; `CONFIGURATION.md:106`, `:170` |
+| process | **प्रोसेस** | प्रक्रिया (reserved for *a procedure*) | प्रोसेस ×44, प्रक्रिया ×13 — `TROUBLESHOOTING.md:324`, `:330`; `development/personal-extensions.md:117` |
+| manufacturer (OEM) | **निर्माता** | कंपनी, विनिर्माता | `TROUBLESHOOTING.md:324`, `:326` |
+| behavior | **व्यवहार** preferred; `बर्ताव` **not yet settled** | आचरण | व्यवहार ×63 vs बर्ताव ×17 — `CONFIGURATION.md:25`, `:156`. The pack has **not** closed this split: बर्ताव carries the same sense in shipped user-facing guides (`कैरेक्टर … कैसा बर्ताव करे`, `conversation/profiles.md:40`; `एंट्री … कैसा बर्ताव करे`, `lorebooks/entries.md:114`; the heading `रनटाइम और रीस्टार्ट का बर्ताव`, `development/optional-agent-packages.md:139`), and `prompts/generation-parameters.md:152` uses **both in one sentence**. Write व्यवहार in new text; do not mass-rewrite existing बर्ताव as a drive-by — see §7-F |
+| macro | **मैक्रो** | बृहद्-आदेश, संक्षेपक | `prompts/macros.md:3` |
+| regex / regex script | **रेजेक्स** (with `रेगुलर एक्सप्रेशन` as the one-time expansion) | नियमित अभिव्यक्ति | रेजेक्स ×36 — `extending/regex-scripts.md:7` |
+| slash command | **स्लैश कमांड** | तिरछी-रेखा कमांड | `chats/slash-commands.md:3` |
+| widget | **विजेट** | घटक, उपकरण | `game/hud-widgets.md:3` |
+| tracker | **ट्रैकर** | अनुरेखक, निगरानीकर्ता | `roleplay/hud-and-trackers.md:3` |
+| scene | **सीन** | दृश्य | सीन ×346 — `roleplay/scenes.md:1` |
+| narration | **नैरेशन** (masc., see §6) | वर्णन, कथन | `game/getting-started.md:56`; `game/storyboard.md:14` |
+| embedding | **एम्बेडिंग** | अंतःस्थापन, सन्निवेशन | `lorebooks/semantic-search.md:3` |
+| semantic search | **सिमैंटिक सर्च** | अर्थ-आधारित खोज | `lorebooks/semantic-search.md:3` |
+| NPC | **NPC** (Latin, undeclined), expanded once as `(नॉन-प्लेयर कैरेक्टर)` | एनपीसी, गैर-खिलाड़ी पात्र | `game/party-and-npcs.md:3`; एनपीसी **0×** |
+| party (Game Mode) | **पार्टी** | दल, टोली | `game/party-and-npcs.md:3` |
+| dice roll / skill check | **डाइस** / **स्किल चेक** | पासा, कौशल-परीक्षण | `game/dice-and-skill-checks.md:3` |
+| gallery | **गैलरी** (fem.) | चित्रशाला | `characters/galleries.md:3` |
+| sprite | **स्प्राइट** | आकृति | `characters/sprites.md:1` |
+| export / import | **एक्सपोर्ट** / **इंपोर्ट** | निर्यात / आयात | `chats/export-import.md:3` |
+| exactly / byte-identical | **हूबहू** | यथावत् | हूबहू ×38 lines — `development/frontend.md:395`; `agents/knowledge-sources.md:14`; `CONFIGURATION.md:144` |
+| literal (text taken as-is, not interpreted) | **अक्षरशः** — a *different* word from हूबहू, not a banned alternate | — | अक्षरशः ×9: `अक्षरशः टेक्स्ट` (`prompts/macros.md:7`, `extending/regex-scripts.md:73`), `**Exact Text Model Request**` = `वही अक्षरशः रिक्वेस्ट` (`chats/peek-prompt.md:13`), `अक्षरशः वैल्यू` (`prompts/conditional-prompts.md:128`). `chats/connected-chats.md:57` uses both correctly in one breath: `इन्हें अक्षरशः टेक्स्ट की तरह लिखें … ताकि वह हूबहू दिखे।` हूबहू = *byte-identical to a source*; अक्षरशः = *read literally* |
+| user | **यूज़र** (in `यूज़र पर्सोना`, `यूज़र डेटा`) | उपयोगकर्ता | यूज़र ×86, उपयोगकर्ता **0×** — `characters/personas.md:1`; `CONFIGURATION.md:152` |
+| app | **ऐप** | एप्लिकेशन, अनुप्रयोग | ऐप ×466, एप्लिकेशन **0×** — `TROUBLESHOOTING.md:75` |
+
+### Default-column vocabulary (`CONFIGURATION.md` tables)
+
+The default column renders word-defaults in Hindi and keeps literal values in backticks. The
+`empty` / `unset` distinction is deliberate and must not be collapsed:
+
+| EN default | Pack rendering | Count | Evidence |
+|---|---|---|---|
+| *empty* (an empty **string** value) | **खाली** | 18 rows | `CONFIGURATION.md:124`, `:125`, `:127`, `:135-138`, `:154`, `:235`, `:244`, `:275`, `:292`, `:296`, `:297`, `:310`, `:317`, `:324`, `:325` |
+| *unset* (a set/not-set **flag**) | **सेट नहीं** | exactly 1 row | `CONFIGURATION.md:238` (`UPDATES_APPLY_DISABLED`); the inline form is `(या सेट न होना)` at `:155` |
+| *off* | **बंद** | | `CONFIGURATION.md:156` |
+| *unlimited* | **`0` (असीमित)** | | `CONFIGURATION.md:155` |
+| *automatic* | **अपने-आप** (hyphenated **in the default column only**) | 2 rows | `CONFIGURATION.md:132`, `:133` |
+| *built-in defaults* | **बिल्ट-इन डिफ़ॉल्ट** | | `CONFIGURATION.md:131` |
+
+### Terms carried from the 2026-09-01 mirror cycle
+
+Reproduced with the citations they shipped with (`prd-notes-hi.md`):
+
+- **`resident` / `in memory`** — reuse the pack's established **मेमोरी** for the RAM sense; there is
+  **no separate "resident" coinage** and none should be invented. `मेमोरी में रखना` carries it.
+  (`CONFIGURATION.md:155`; `TROUBLESHOOTING.md:314`; `connections/local-model.md:34`.)
+- **`least-recently-used`** — **`[recorded ruling]`** the pack has **no LRU precedent**. The nearest
+  candidate, `media/tts-setup.md:142` (`कैश अपनी सबसे पुरानी क्लिप खुद ही हटाता रहता है`), encodes
+  *oldest-created*, not *last-used*, and was rejected as unusable. Phrase it as an unambiguous
+  relative clause — `वह चैट … जो सबसे लंबे समय से इस्तेमाल नहीं हुई` (`CONFIGURATION.md:155`). A
+  later cycle may pin a canonical term; until then do not coin one.
+- **`unset` ≠ `empty`** — do not collapse. `खाली` is the empty-string default (18 rows), `सेट नहीं`
+  the flag default (1 row). Verified again this cycle; counts above.
+- **wake-lock vocabulary** — the Termux section's existing wording was reused verbatim in register
+  rather than re-coined: `wake lock` stays English and unbolded, `बैटरी ऑप्टिमाइज़ेशन` and
+  `बैकग्राउंड में चलने` are reused from `TROUBLESHOOTING.md:326`. `Termux:API` / `termux-api` were
+  dropped with the retired sentence.
+
+---
+
+## 4. Typography & punctuation
+
+| Rule | Detail | Evidence |
+|---|---|---|
+| **Danda `।` (U+0964) ends every Hindi sentence** | Including **mid-line** sentences. A line-end-anchored check will not see most of them. | 15,316 dandas total; **7,606** of them sit mid-line *counting prose lines only* (table rows excluded — those are counted in the table-cell row below; include them and it is 8,235). **0** instances of a Devanagari character followed by an ASCII full stop outside code fences |
+| **No space before the danda** | `…है।`, and after a Latin token `…Marinara Engine।` | 0 space-before-danda; 131 Latin+danda joins |
+| **No double danda `॥`** | | **0×** |
+| **Fragments take no terminator** | Metadata lines, inline dash-separated enumerations, and label fragments end bare. | Counting blocks that end on a bare Devanagari **letter** (the danda is itself in the Devanagari block — exclude U+0964 or every sentence scores as a fragment): **2** non-bullet prose blocks (`development/hierarchical-locations-prd-v3.md:3`, `:5` — both metadata lines) and **104** bullets; **87** after joining hard-wrapped continuations. Every one inspected is a genuine fragment. Also `:97`; `chats/settings-profiles.md:20` |
+| **Bullets: sentence → danda, fragment → bare** | | 2,371 bullets end `।`; 104 end on a bare Devanagari letter (fragments) — `CONFIGURATION.md:11-16` |
+| **Table cells: fragment is the norm** | Cells are predominantly noun phrases and take **no** danda; a cell containing a full sentence does. | Of Devanagari-bearing cells, 1,170 end on a bare Devanagari letter vs 457 danda-terminated (1,354 end without a danda once cells closing on `**`, backticks, Latin or digits are included) — `CONFIGURATION.md:124` (bare-ish) vs `:155` (sentences) |
+| **Headings never take a danda** | Including FAQ question headings, which keep their `?`. | **0** headings contain `।`; FAQ `##` headings 23/24 end in `?` (the 24th is `मिलती-जुलती गाइड`, `FAQ.md:202`) |
+| **Straight ASCII quotes only** | `"…"`. No curly `“ ” ‘ ’`, no guillemets. | curly **0×**, `«»` **0×**; 1,496 straight double quotes — `TROUBLESHOOTING.md:330` (`"Opening chat..."`) |
+| **International digits `0-9` only** | Devanagari digits `०-९` never appear: `०७८६०` would not answer a search for `7860`. | Devanagari digits **0×** pack-wide |
+| **Western 3-digit grouping** | `8,192`, `16,384`, `1,000,000`, `478,000`. **No** Indian `1,00,000` grouping, no `लाख`/`करोड़`. | 0 Indian-style groupings; `लाख` **0×**, `करोड़` **0×**; `agents/built-in-agents.md:200`, `development/file-storage.md` |
+| **Percent** | Numeral + `%` with no space for values; `प्रतिशत` only when the sentence reads as prose. | 65 `N%` vs 13 `प्रतिशत` |
+| **NFC, zero ZWJ/ZWNJ** | Decomposed nukta forms and invisible joiners are unmatchable bytes for the substring search. | all 125 files NFC-normalized; U+200C/U+200D **0×**; **0** precomposed nukta codepoints (U+0958-095F) — the pack uses base + U+093C consistently |
+| **No non-breaking spaces** | | U+00A0 **0×**, U+202F **0×** |
+| **Em dash is rare and spaced** | Prefer a danda-terminated clause. Where an em dash is used it is spaced. | 7 em dashes total, 1 en dash — `TROUBLESHOOTING.md:326`; the 2 unspaced ones at `data/where-data-is-stored.md:21` are a residual (§7) |
+| **Menu-path separator is `→` (U+2192)** | Prescribed form — but the pack does **not** yet follow it. `→` accounts for only **46** of the 107 menu paths; the other **61** use ASCII separators and are a live residual (§7-G), not a licence. Write `→` in new text. | `→`: `CONFIGURATION.md:31`, `agents/custom-agents.md:205` · ASCII residuals: `TROUBLESHOOTING.md:102`, `game/storyboard.md:62`, `UPGRADING.md:162` |
+| **Ellipsis inside verbatim UI strings is byte-exact** | Reproduce what the client renders; do not normalize. | `TROUBLESHOOTING.md:330` (`"Opening chat..."`, three ASCII periods) |
+| **Code fences, paths, URLs and link targets stay byte-identical to `en/`** | | 125/125 files: **0** code-fence mismatches against `docs/` |
+
+---
+
+## 5. UI labels & glosses
+
+**The byte-exact rule.** The `hi` app locale (`packages/client/src/localization/locales/hi.json`)
+covers **131 of 9,122** English UI keys — **1.4%**. Practically the whole interface renders **in
+English** for a Hindi reader, and the docs pack ships independently of the reader's UI-language
+setting. A translated control name in the docs would therefore match nothing on screen.
+
+So: **UI control names stay in English, bold, byte-exact as rendered.**
+
+Verified: of **6,356** bold Latin labels in the pack (6,222 counting only Title-case-initial spans),
+**6,299 appear verbatim in the English counterpart file**. The **57 exceptions span 41 (file, label)
+pairs**, and they are two different problems:
+
+- **12 pairs / 15 occurrences** are English-source drift — EN renamed or dropped the control since
+  the mirror. Not translation defects; enumerated at §7-E.
+- **The remaining 29 pairs / 42 occurrences are hi-side over-bolding**: the pack bolds a control the
+  English source mentions unbolded or not at all (`**Send**` ×5 in `chats/guided-and-impersonate.md`,
+  `**Danger Zone**` ×3 and `**Extensions**` ×3 in `development/personal-extensions.md`,
+  `**Gallery**` ×3 in `game/ltx-2-3-storyboards.md`, `**Presets**`, `**Share**`, `**Goals**`,
+  `**Impersonate**`, `**Sparkles**` …). That invents a label, which is exactly what the byte-exact
+  rule forbids. Logged at §7-H.
+
+### Pattern A — navigational / feature controls: bold EN + one-time parenthetical gloss
+
+The gloss is **Devanagari in parentheses**, given **once per document** on first mention; every
+later mention in that document runs bare.
+
+```
+इस गाइड में Marinara Engine के प्रॉम्प्ट प्रीसेट के बारे में बताया गया है। … **Preset Editor** (प्रीसेट एडिटर) में इसे कैसे बनाते हैं …
+```
+— `prompts/presets.md:3`
+
+Verified gloss-once behaviour: of the **45** files using the bold `**Chat Settings**`, **44 gloss it
+at least once** and run bare thereafter. Two miss the *first-mention* placement (§7-D): `FAQ.md`
+never glosses the bold label at all — its only gloss is on an unbolded mention at `FAQ.md:61` — and
+`prompts/presets.md` glosses at its second bold mention (`:141`), not its first (`:138`). Pack-wide,
+**562 of 6,356** bold labels carry a Devanagari parenthetical gloss (≈9%) — glosses are for the
+*first* navigational mention, not every mention.
+
+| Label | Gloss | Where |
+|---|---|---|
+| `**Settings**` | (सेटिंग्स) | `extending/personal-extensions.md:3` — 53 glossed instances |
+| `**Chat Settings**` | (चैट सेटिंग्स) | 43 glossed instances |
+| `**Agents**` | (एजेंट) | `development/optional-agent-packages.md:167` |
+| `**Connections**` | (कनेक्शन) | 24 glossed instances |
+| `**Lorebooks**` | (लोरबुक) | `lorebooks/overview.md:3` |
+| `**Preset Editor**` | (प्रीसेट एडिटर) | `prompts/presets.md:3` |
+| `**Persona Editor**` | (पर्सोना एडिटर) | `conversation/profiles.md:12`; `media/animated-expressions.md:32` |
+| `**Character Editor**` | (कैरेक्टर एडिटर) | `appearance/card-css-theming.md:21`; `characters/galleries.md:7` |
+| `**Memory Recall**` | (मेमोरी रिकॉल) | `TROUBLESHOOTING.md:159` |
+| `**Personal Extensions**` | (पर्सनल एक्सटेंशन) | `extending/personal-extensions.md:3` |
+| `**Download Backup**` | (बैकअप डाउनलोड) | `data/backup-and-restore.md:9` |
+| `**Game Mode**` | (गेम मोड) | `game/ltx-2-3-storyboards.md:3` |
+| `**Conversation Theme**` | (कन्वर्सेशन थीम) | `appearance/chat-backgrounds.md:15` |
+
+Gloss style: noun phrase for nouns, आप-imperative for verbs (`**Download Agents** (एजेंट डाउनलोड
+करें)`), no terminal punctuation inside the parentheses.
+
+### Arrow paths are glossed **whole**
+
+A menu path's gloss covers **every segment**, mirroring the `→` chain:
+
+```
+**Settings → Advanced → Danger Zone** (सेटिंग्स → एडवांस्ड → डेंजर ज़ोन)
+```
+— `CONFIGURATION.md:31`; likewise `**Agents → Download Agents** (एजेंट → एजेंट डाउनलोड करें)`
+(`CONFIGURATION.md:20`).
+
+A gloss covering only the first segment is a defect — two shipped instances are logged at §7-C.
+The gloss must also mirror the separator the label uses; `appearance/appearance-settings.md:3`
+(`**Settings -> Appearance** (सेटिंग्स -> अपीयरेंस)`) and `development/localization.md:9` carry an
+ASCII separator into the Devanagari gloss, which §7-G covers.
+
+### Pattern B — status and error strings: bold EN, **no gloss**
+
+Strings the app *emits* carry no parenthetical gloss; the surrounding Hindi sentence explains them.
+
+- `**Server unreachable**`, `**Unreachable (request timed out)**` — `TROUBLESHOOTING.md:330`
+- `**Save blocked: missing CSRF header**`, `**Save blocked: cross-site…**` — `TROUBLESHOOTING.md:114`
+- `**Waiting for vector**` — `TROUBLESHOOTING.md:163`
+- Emphasis bold on a Hindi word is *not* a label: `**फ़्रीज़**` at `TROUBLESHOOTING.md:330`.
+
+### Pattern C — long verbatim strings: straight double quotes, unbolded, unglossed
+
+- `"Opening chat..."` — `TROUBLESHOOTING.md:330`. `hi` is **not** one of the two locales (ko,
+  zh-Hans) that translate this string.
+- `"Timeline refreshes may include recent messages from this chat…"` — `noodle/settings.md:195`
+- `"currently dnd (At the office)"` — `noodle/settings.md:195`
+
+### Unbolded feature names with no pack precedent
+
+Stay Latin, with a spaced postposition: `Support Diagnostics की कॉपी` — `TROUBLESHOOTING.md:330`.
+Do not invent a bold label the English source does not bold.
+
+### Table cells may leave a path unglossed
+
+Inside a `CONFIGURATION.md` variable table the arrow path runs bare —
+`दूसरा गेट Settings → Advanced → Danger Zone में खुद चालू करना पड़ता है` (`CONFIGURATION.md:243`) —
+while the same path is glossed in prose at `:31`. Cell width, not inconsistency: keep it.
+
+### Never copy a gloss from `hi.json`
+
+**`[recorded ruling]`** The app locale is a different register (§1) and translates mode names. A
+gloss must be written in the pack's own register, never pasted from `hi.json`.
+
+---
+
+## 6. Language-specific mechanics
+
+### Nukta policy
+
+**Keep the nukta on ज़ and फ़ only.** Of the Perso-Arabic nukta letters, only these two are written:
+`ज़` ×3,013 and `फ़` ×5,909, against `क़` **0×**, `ग़` **0×**, and `ख़` ×2 (both residuals, §7-A).
+
+So: `फ़ाइल` (never `फाइल`), `ज़रूरी` (never `जरूरी`), `सिर्फ़`, `ज़्यादा`, `काफ़ी`, `फ़ोल्डर` —
+but `खास` (never `ख़ास`), `सख्त` (never `सख़्त`), `तारीखों` (never `तारीख़ों`).
+
+**`ड़` and `ढ़` are not covered by this rule** — they are obligatory native Devanagari letters, not
+optional Perso-Arabic nuktas: `ड़` ×2,057, `ढ़` ×455 (`बड़ा`, `जोड़ने`, `पढ़ें`, `बढ़ानी`).
+
+**Encoding:** nukta is always the combining U+093C after the base letter. Precomposed U+0958-095F
+codepoints appear **0×** and must never be introduced — NFC does not unify them, so they would be
+invisible to search.
+
+### Grammatical gender of loanwords
+
+Derived from the pack by adjective and verb agreement (`नया/नई`, `पूरा/पूरी`, `होता है/होती है`).
+Getting this wrong produces reader-visible agreement errors, so treat the list as normative.
+
+| Feminine | Masculine |
+|---|---|
+| चैट, फ़ाइल, एंट्री, ब्रांच, लोरबुक, इमेज, स्क्रिप्ट, लिस्ट, गाइड, कुंजी, मेमोरी, कॉपी, वैल्यू, विंडो, थीम, फ़ील्ड, एरर, सेटिंग, गैलरी, हिस्ट्री, रिपॉज़िटरी, इंस्टॉलेशन, डिवाइस, मैक्रो | प्रॉम्प्ट, टोकन, प्रीसेट, कार्ड, संदेश, एजेंट, कनेक्शन, सर्वर, फ़ोल्डर, बैकअप, कैश, स्नैपशॉट, पर्सोना, **नैरेशन**, सीन, मॉडल, अपडेट, वर्ज़न, चेकपॉइंट, पैकेज, टेम्पलेट, प्रोवाइडर, विजेट, लॉग, टैब, पैनल, बटन, ऐप, प्रोसेस, लॉन्चर |
+
+Measured signal: 92 feminine vs 5 masculine attributive adjectives on `चैट`, 25 vs 1 on `फ़ाइल`,
+20 vs 1 on `एंट्री` and on `ब्रांच`, 26 vs 3 on `इमेज`; 19 vs 4 masculine on `संदेश`, 12 vs 0 on
+`मॉडल`, 18 vs 0 on `वर्ज़न`, 46 masculine verb agreements vs 0 feminine on `बटन`.
+
+Sample evidence: `नई चैट` (`chats/managing-chats.md:19`) / `चैट … हटा दी जाती है`
+(`CONFIGURATION.md:155`) · `नई एंट्री` (`agents/approvals-and-agent-suite.md:7`), `एंट्री … जुड़ती
+है` (`characters/creating-and-editing-characters.md:151`) · `पूरे बैकअप की ZIP फ़ाइलों`
+(`FAQ.md:136`) · `नैरेशन के ऊपर` (`game/combat.md:7`), `GM के नैरेशन से`
+(`agents/built-in-agents.md:262`), `नैरेशन को` (`development/optional-agent-packages.md:96`) —
+masculine throughout, with **no** feminine counter-instance across all **41** uses (40 lines). The
+unified-masculine `नैरेशन` ruling from the lost glossary is confirmed by the pack.
+
+**Unattested — do not assume.** `एक्सटेंशन`, `ट्रैकर` and `स्टोरेज` appear only in oblique or
+postpositional positions and carry **zero** agreeing modifiers pack-wide, so the pack cannot settle
+their gender; `विजेट` and `मैक्रो` are attested only weakly. Whoever first writes an agreeing form
+for one of these sets the precedent — say so in the PR and add the row here.
+
+Method note: `N का` / `N की` is **not** a gender signal for `N` — the postposition agrees with the
+*following* noun. Only attributive adjectives (`नया/नई`) and predicate agreement (`होता है/होती है`)
+are usable.
+
+### Spacing and compounds
+
+- **Postpositions are separate words** after both Latin names (§2) and Devanagari nouns:
+  `Marinara Engine में`, `चैट की सेटिंग्स`.
+- **Hindi echo/paired compounds hyphenate:** `मिलती-जुलती` ×126, `समस्या-समाधान` ×24,
+  `एक-दूसरे` ×12, `साफ़-सुथरा` ×4, `गिने-चुने` (`CONFIGURATION.md:7`).
+- **Loaned English compounds hyphenate:** `बिल्ट-इन` ×88, `थर्ड-पार्टी` ×8, `फ़र्स्ट-पार्टी` ×5,
+  `नॉन-प्लेयर` (`game/party-and-npcs.md:3`), `फ़ाइल-स्टोरेज` (`CONFIGURATION.md:153`).
+- **`अपने आप` is unhyphenated in prose** (×274). The hyphenated `अपने-आप` is correct **only** as the
+  `CONFIGURATION.md` default-column value (`:132`, `:133`) — but that is just **2** of its **21**
+  shipped uses. The other **19 are prose** and are a residual (§7-F): `REMOTE_ACCESS.md:127`, `:134`,
+  `:136`; `TROUBLESHOOTING.md:294`, `:300`, `:310`; `FAQ.md:37`, `:47`; `installation/android-termux.md:9`,
+  `:24`; `CONFIGURATION.md:276`, `:277`; and others.
+
+### Recurring boilerplate headings — one rendering each
+
+| EN | Hindi | Count |
+|---|---|---|
+| Related guides | **मिलती-जुलती गाइड** | 116 (+1 residual `संबंधित गाइड`, §7-D) |
+| Troubleshooting | **समस्या-समाधान** | 21 |
+| Before you start | **शुरू करने से पहले** | 11 exact, +1 extended (`## शुरू करने से पहले: एम्बेडिंग सोर्स चुनें`, `lorebooks/semantic-search.md:17`) |
+| Quick start | **तुरंत शुरुआत** | 3 |
+
+Across all files whose heading count matches `en/`, **exactly one** English heading has more than
+one Hindi rendering — see §7-D. Keep it that way.
+
+### In-fiction and demonstration content is not translated
+
+Example lorebook keys, entry content, and literal-matching demonstrations stay English by design;
+translating them destroys the demonstration (`lorebooks/entries.md`). Example *user utterances* may
+use in-fiction informal address (§1).
+
+---
+
+## 7. QA checks & known traps
+
+### Tooling traps — read before writing any check
+
+1. **A line-end-anchored danda check is a false pass.** Most Hindi sentences in
+   this pack end **mid-line** (7,606 mid-line dandas in prose lines, 8,235 counting table rows). A
+   regex anchored with `$` will report a clean pack while missing nearly every sentence. Check
+   *sentences*, not lines.
+2. **Hard-wrapped source lines make the dual mistake.** Many pack files wrap paragraphs at ~80
+   columns (`agents/hierarchical-maps.md`, `FAQ.md`), so "line does not end in `।`" yields **354
+   false positives**. Join wrapped continuations before testing the terminator — that drops to
+   **87**, all legitimate fragments (mostly enumerated bullet lists in
+   `development/hierarchical-locations-prd-v3.md` and `agents/hierarchical-maps.md`).
+   **Exclude U+0964 from your "Devanagari" character class when testing terminators** — the danda
+   lives inside U+0900–U+097F, so a naive `[ऀ-ॿ]$` test scores every correctly terminated
+   sentence as a bare fragment. Use `[ऀ-ॣ०-ॿ]$`.
+3. **`[recorded ruling]` `\w` and MSYS `grep` are unsafe for Devanagari.** JavaScript `/\w/u` does not match Devanagari,
+   and MSYS `grep -P` / `sed` are byte-oriented, so `-o` output and character classes mis-slice
+   multibyte text. Run every Devanagari check through **ripgrep or a Python script reading UTF-8**.
+4. **`grep` substring counts over-report nukta pairs.** `सिर्फ` and `सिर्फ़` both "match" 789 times
+   because the former is a prefix of the latter. Tokenize before counting; the nukta detector below
+   does this correctly.
+
+### Mechanical checks (each catches a real `hi` regression class)
+
+| # | Check | Expected |
+|---|---|---|
+| 1 | **Nukta-stripped-key detector** — tokenize all Devanagari runs, group by the token with U+093C removed, flag any key with more than one surface form | 4 keys today, of which 2 are legitimate minimal pairs (`मोड`/`मोड़`, `पेड`/`पेड़`) and 2 are defects (§7-A) |
+| 2 | Perso-Arabic nuktas other than ज़/फ़ (`क़ ख़ ग़ य़` and precomposed U+0958-095F) | 0 (currently 2 `ख़` — §7-A) |
+| 3 | Devanagari digits `०-९` | 0 |
+| 4 | ZWJ / ZWNJ (U+200C, U+200D) | 0 |
+| 5 | Non-NFC files | 0 |
+| 6 | Curly quotes `“ ” ‘ ’`, guillemets | 0 |
+| 7 | Non-breaking space U+00A0 / U+202F | 0 |
+| 8 | Devanagari character followed by an ASCII `.` (outside code fences) | 0 |
+| 9 | Whitespace before `।`; any `॥` | 0 |
+| 10 | Danda inside a heading | 0 |
+| 11 | FAQ `##` headings not ending in `?` | 1 (`मिलती-जुलती गाइड` — correct) |
+| 12 | `तुम` / `तू` / `कीजिए` / `कीजिये` as reader address | 0 |
+| 13 | Purism markers: `संगणक`, `यदि`, `प्रत्येक`, `आवश्यक`, `सहायता`, `प्रयास`, `उपयोगकर्ता`, `एप्लिकेशन`, `त्रुटि` | 0 |
+| 14 | Devanagari transliterations of frozen names: `नूडल`, `प्रोफ़ेसर`, `मैरिनारा`, `टरमक्स`, `एनपीसी` | 0 |
+| 15 | A Devanagari character immediately adjacent to a Latin letter (no space) | 0 |
+| 16 | Hyphen-attached postposition after a Latin token (`[A-Za-z]-में` …) | 0 |
+| 17 | Bold Latin label not appearing verbatim in the `en/` counterpart file | 0 (currently **57 occurrences / 41 (file, label) pairs** — 12 pairs are EN drift §7-E, 29 are hi-side over-bolding §7-H) |
+| 18 | Arrow-path gloss whose segment count ≠ the label's segment count | 0 (currently 2 — §7-C) |
+| 19 | An EN heading with more than one Hindi rendering across the pack | 0 (currently 1 — §7-D) |
+| 20 | `- [text](target.md)` bullet whose text ≠ the target's H1, where `en/` *does* match | 0 (currently 18 of 452 checked — §7-D) |
+| 21 | Bare lowercase English words in unmarked prose (fences, backticks, bold labels, link targets and quoted strings excluded; ≥3 letters) | flag for review; currently 1,143 — §7-B. Definition-sensitive: loosen any exclusion and it climbs fast, so pin the script, not the number |
+| 22 | Structural parity vs `en/`: file count, heading count, code fences, link targets | 125/125 files, every one with an EN counterpart; 0 fence mismatches (2 heading + 5 link deltas are EN drift — §7-E) |
+| 23 | ASCII menu-path separator: `->` or `>` inside a bold label, or joining two adjacent bold labels | 0 (currently 61 — §7-G) |
+| 24 | `अपने-आप` outside the `CONFIGURATION.md` default column | 0 (currently 19 — §7-F) |
+
+Checks 22 and the manifest hashes are the pack-level gates run via
+`node scripts/docs-i18n/build-manifest.mjs hi` + `validate-pack.mjs hi` and `pnpm regression:docs`.
+
+### Process rulings preserved from the original cycle
+
+These are pipeline requirements, not text properties, so the pack cannot evidence them:
+
+- **`[recorded ruling]` The nukta-stripped-key detector is a required pipeline step**, not an
+  optional lint: PR #4471 states it audited *every Devanagari token pack-wide*. Check 1 above is
+  that detector; re-run it on any pack edit, because a single nukta slip silently halves a search
+  result set and nothing else in the pipeline notices.
+- **`[recorded ruling]` Term-split closure is a whole-pack sweep, not a per-file fix.** The original
+  cycle ran a 620-edit consistency sweep that drove transliteration splits to zero across 24 pairs
+  and link-text↔H1 mismatches from 267 to 0 (PR #4471). A mirror that fixes one file's spelling
+  without re-running the sweep re-opens the split.
+- **`[recorded ruling]` The `अनुमति` / `परमिशन` sense split came out of cross-panel reconciliation.**
+  Four independent native-reader QA panels read all 124 files end-to-end; the reconciliation pass
+  resolved the OS-prompt vs Marinara-capability collision as a recorded ruling (PR #4471). The split
+  itself is verified in §3; its provenance is why it is not negotiable in review.
+
+### Known pack residuals
+
+Documented, **not** silently fixed. Each is a real deviation from a rule above; fix them in a
+deliberate, reviewable change rather than as a drive-by.
+
+**A. Nukta violations (3 instances, rule §6).**
+
+| Location | Shipped | Should be | Caught by |
+|---|---|---|---|
+| `integrations/haptic-feedback.md:80` | `सख़्त` | `सख्त` (13 correct uses elsewhere) | checks 1 **and** 2 |
+| `agents/hierarchical-maps.md:629` | `काफी` | `काफ़ी` (17 correct uses elsewhere) | check 1 |
+| `agents/memory.md:54` | `तारीख़ों` | `तारीखों` | check 2 only — `तारीखों` never co-occurs, so the split-key detector cannot see it |
+
+The first and third add a banned `ख़`; the second drops a required `फ़`. Note that the two checks
+are **not** redundant: check 1 finds inconsistency, check 2 finds a banned letter used consistently.
+
+**B. Under-translated / code-mixed regions (rule §1, §3).**
+
+**1,143** bare lowercase English words survive in unmarked prose (check 21's definition), heavily
+concentrated:
+
+| File | Count | Note |
+|---|---|---|
+| `agents/hierarchical-maps.md` | 250 | Worst at `:611-660` (map export/import lore). `Exact entry ID तभी authoritative है जब वह destination lorebook की हो` (`:629`) is Hinglish, not the pack register. Also carries `केवल` ×4 and the `काफी` nukta defect. |
+| `noodle/settings.md` | 122 | The NoodleR publishing section `:84-98` keeps `post`, `publish`, `creators`, `toggle`, `default`, `counter`, `reserve` untranslated. |
+| `development/file-storage.md` | 90 | Developer-facing; lower priority. |
+| `characters/galleries.md` | 67 | **User-facing** — higher priority than its rank suggests. |
+| `TROUBLESHOOTING.md` | 66 | **User-facing** — same. |
+| `development/frontend.md` | 41 | Developer-facing. |
+| `agents/custom-agents.md` | 36 | `:113-114` — `render कर सकता है`, `activation keywords का इंतज़ार`, `error toast`. |
+
+A related register drift: `तथा` ×139 and `केवल` ×24 cluster in `development/` and
+`agents/hierarchical-maps.md`; `उत्तर` ×2 and `पात्रों` ×2 in `agents/built-in-agents.md:153`, `:155`
+are the only Sanskritized-register lines in a user-facing guide.
+
+**C. Truncated arrow-path glosses (2 instances, rule §5).**
+
+- `agents/custom-agents.md:205` — `**Settings → Advanced → Danger Zone** (सेटिंग्स)`
+- `agents/built-in-agents.md:3` — `**Agents → Download Agents** (एजेंट)`
+
+Both should gloss the whole path, as `CONFIGURATION.md:31` and `:20` do.
+
+**D. Link-text and heading splits (rule §5, §6).**
+
+- `extending/writing-personal-extensions.md:254` renders *Related guides* as `संबंधित गाइड` against
+  116 uses of `मिलती-जुलती गाइड`. (`chats/sending-and-streaming.md:16`, `:127` use `संबंधित गाइड`
+  as ordinary prose — those are fine.)
+- 18 of 452 "Related guides" bullets have link text that drifts from the target's H1 while the
+  English source matches exactly. 15 of them are `AI प्रोवाइडर से कनेक्ट करना` pointing at
+  `connections/connecting-to-a-provider.md`, whose H1 is `किसी AI प्रोवाइडर से कनेक्ट करना` — one
+  missing `किसी`. The other 3 point at `extending/writing-personal-extensions.md`,
+  `extending/personal-extensions.md` and `development/personal-extensions.md`. This degrades search
+  ranking; PR #4471 drove this class to zero once and it has drifted back.
+- `**Chat Settings**` first-mention gloss: `FAQ.md` never glosses the bold label (only the unbolded
+  mention at `:61`), and `prompts/presets.md` glosses at `:141` rather than at its first bold
+  mention `:138`. 44 of the 45 files gloss it somewhere.
+
+**E. English-source drift, **not** translation defects (as of 2026-09-01 `staging`).**
+
+This is the 12-pair / 15-occurrence slice of check 17; the other 29 pairs are §7-H.
+
+The pack is behind current `docs/` in a few places; the mirror cycle owns these:
+
+- `FAQ.md` and `prompts/macros.md` each lack one section EN has gained
+  (EN's *Lorebook size macro* in `macros.md`, one new FAQ question).
+- `media/tts-setup.md` lacks one EN link (`pocket-tts`).
+- 12 distinct (file, label) pairs — 15 occurrences — have no verbatim EN counterpart because EN has
+  since renamed or dropped the control: `LTX Director Video` (×6 across
+  `game/ltx-2-3-storyboards.md`, `development/ltx-director-storyboard.md`, `game/storyboard.md`;
+  current EN spells it `LTX Simple Image` and friends), `Subscribers` / `PPV` / `Subscriber access`
+  / `Subscriptions include PPV` (`noodle/settings.md`; EN's section is now
+  *Subscriptions and post access*), plus `Discard draft`, `Restore portable map lore`,
+  `Import a new copy` (`agents/hierarchical-maps.md`), `Game Mode`
+  (`appearance/card-css-theming.md`), `Character Tracker` (`characters/personas.md`).
+
+Verify against `docs/` before "fixing" any of these — the correct fix is a mirror, not a retranslation.
+
+**F. Minor style residuals.**
+
+- `अपने-आप` hyphenated in **19** prose places where `अपने आप` is the norm (274). Only 2 of its 21
+  uses (`CONFIGURATION.md:132`, `:133`) are the licensed default-column form. Check 24.
+- 2 unspaced em dashes at `data/where-data-is-stored.md:21`; the pack's other 5 are spaced.
+- `सहेज` ×1 against `सेव` ×676; `आँकड़े` ×5 against `डेटा` ×288; `पात्र` ×2 against `कैरेक्टर` ×1,315;
+  `याददाश्त` ×2 (`noodle/settings.md:145`, `:147`) against `मेमोरी` ×120.
+- `शाखा` ×1 at `agents/hierarchical-maps.md:652` — an *archived map-tree branch*, not a chat branch,
+  but it is still the banned alternate and `ब्रांच` (×169) would read correctly there.
+- **`अनुमति` used for a Marinara-level capability grant** in 2 places, against the §3 sense split:
+  `development/optional-agent-packages.md:74` (`` `prompt-context` अनुमति वाले पैकेज ``, where
+  `agents/built-in-agents.md:267` writes the same permission as `परमिशन`) and
+  `extending/personal-extensions.md:11` (`अलग से अनुमति माँगने वाले External Extensions फ़्लो`, where
+  the same file writes `परमिशन` at `:118`, `:130`, `:155`).
+- **`बर्ताव` ×17 against `व्यवहार` ×63** for *behavior*, with no sense boundary — `prompts/generation-parameters.md:152`
+  uses both in one sentence. Not forced this cycle; resolve in a whole-pack sweep, not per file.
+- `content` is split between `कंटेंट` (23, mostly `development/`) and `सामग्री` (56) with no clean
+  sense boundary. **`[recorded ruling]`** no forced ruling this cycle — flagged for the next
+  consistency sweep rather than normalized blind.
+
+**G. Menu-path separator: the pack is majority-ASCII (rule §4).**
+
+The prescribed `→` is the **minority** form. Measured across 107 menu paths:
+
+| Form | Count | Where |
+|---|---|---|
+| `→` inside a bold label (`**Settings → Advanced → Danger Zone**`) | 45 | `CONFIGURATION.md:20`, `:31`; `agents/custom-agents.md:205` |
+| `→` joining two bold labels | 1 | |
+| **`>` joining two bold labels** (`**Settings** > **Advanced** > **Admin Access**`) | **28** | `TROUBLESHOOTING.md:102`, `:139`, `:281`, `:425`; `settings/settings-overview.md:42`, `:57`, `:106`, `:138`; `extending/writing-personal-extensions.md:12`, `:14`, `:100`, `:250`; `noodle/settings.md:21`, `:43`, `:84`, `:141`, `:152`; `REMOTE_ACCESS.md:200`; `data/backup-and-restore.md:75`; `home/professor-mari.md:27`; `extending/personal-extensions.md:3`, `:180`, `:182` |
+| **`>` inside a bold label** (`**Chat Settings > Agents > Storyboards**`) | **23** | `game/storyboard.md:13`, `:25`, `:62`, `:106`, `:169`, `:280`, `:310`, `:318`; `game/getting-started.md:23`, `:63`; `FAQ.md:175`, `:183`; `TROUBLESHOOTING.md:225`; `development/localization.md:9`, `:124`; `media/scene-video.md:135`; `connections/local-model.md:165`; `game/ltx-2-3-storyboards.md:27` |
+| **`->` inside a bold label** | **10** | `UPGRADING.md:162`; `appearance/appearance-settings.md:3`; `appearance/custom-css-themes.md:64`, `:108`; `connections/local-model.md:191`; `data/importing-from-sillytavern.md:68`, `:91`; `development/noodle-internals.md:12`, `:14`, `:38` |
+
+Two consequences a reviewer must not miss. First, `appearance/appearance-settings.md:3` carries the
+ASCII form **into the Devanagari gloss** — `**Settings -> Appearance** (सेटिंग्स -> अपीयरेंस)` —
+and `development/localization.md:9` does the same with `>`. Second, three separator forms for one
+menu path split the literal substring index three ways, which is precisely the failure the §4 rules
+exist to prevent. Fix as one sweep (§7 process ruling), not file by file.
+
+ASCII `->` also appears in flow diagrams at `development/chat-resource-drag-drop-plan.md:349-361`,
+`development/hierarchical-locations-prd-v3.md:144-147`, `game/ltx-2-3-storyboards.md:11-14` and
+`game/storyboard.md:193-196`. Those are pipeline arrows, **not** menu paths — leave them.
+
+**H. Over-bolded labels the English source does not bold (rule §5).**
+
+29 (file, label) pairs / 42 occurrences, distinct from the EN drift at §7-E. The pack bolds a
+control that the EN counterpart mentions unbolded or not at all — inventing a label, which the
+byte-exact rule forbids. Heaviest: `**Send**` ×5 (`chats/guided-and-impersonate.md`),
+`**Danger Zone**` ×3 and `**Extensions**` ×3 (`development/personal-extensions.md`), `**Gallery**`
+×3 (`game/ltx-2-3-storyboards.md`), `**Chat Settings**` ×4 (`development/hierarchical-locations-prd-v3.md`)
+and ×1 (`CONFIGURATION.md`). Singles include `**Presets**`, `**Share**`, `**Goals**`, `**GM**`,
+`**Connection**`, `**Impersonate**`, `**New Draft**`, `**Sparkles**`, `**current story location**`,
+`**Game Assets**`, `**Conversation Commands**`, `**Character Editor**`, `**Persona Editor**`,
+`**Lorebooks**`, `**Agents**`, `**Settings**`, `**Connections**`, `**Character**`.
+
+Check the EN file before unbolding: some of these are cases where EN *should* bold the control and
+the fix belongs upstream in `docs/`, not in the translation.
+
+---
+
+## Change log
+
+| Date | Change |
+|---|---|
+| 2026-09-01 | **Verification pass against the shipped pack.** Every terminology row re-greped for its prescribed term *and* its banned alternates, and every mechanical claim re-measured. Corrections: the `→` menu-path rule was stated as already-held when the pack is in fact 61-to-46 ASCII (new §7-G, check 23); check 17 was reported as 12 exceptions when it is 57 across 41 pairs (new §7-H); `असिस्टेंट` is the *assistant message role*, not a Professor Mari reservation; `बर्ताव`/`व्यवहार`, `तयशुदा` (= deterministic) and `हूबहू`/`अक्षरशः` were flat bans the pack contradicts, now sense-scoped or logged as unresolved splits; `अपने-आप` is 19-in-prose, not default-column-only; the spaced-postposition count was 54 against a measured 1,034. Added a sense-scoped-ban table so a grep stops producing false regressions, the U+0964-inside-the-Devanagari-block terminator trap, and re-measured counts for `मैसेज`, the boilerplate headings, `नैरेशन`, the fragment/cell definitions and §7-B. Confirmed exactly as shipped: all §1 register splits, the nukta measurements and 4-key split detector, §7-A, §7-C, §7-D's 18 link drifts, §7-E's 12/15, the default-column table, and every typography scan (digits, quotes, ZWJ/ZWNJ, NFC, NBSP, grouping, fences). |
+| 2026-09-01 | Second-generation glossary re-derived from the shipped pack, PR #4471, and the 2026-09-01 mirror-cycle notes, after the originals were lost to temp-directory cleanup. Added the measured residual inventory (A–F), the re-derived loanword gender list confirming the unified-masculine `नैरेशन` ruling, the ज़/फ़-only nukta measurement (with `ड़`/`ढ़` explicitly excluded from the rule), the `hi.json` 1.4%-coverage finding behind the byte-exact UI rule, the `अनुमति`/`परमिशन`/`इजाज़त` three-way sense split, and the mid-line-danda and hard-wrap tooling traps. |

--- a/glossaries/glossary-ja.md
+++ b/glossaries/glossary-ja.md
@@ -1,0 +1,430 @@
+# Japanese (`ja`) — Marinara Engine documentation-pack glossary
+
+## Provenance
+
+This is the **second-generation** `ja` glossary. The original working glossary from the
+`ja` translation cycle was lost to temp-directory cleanup; nothing of it survives except
+the rulings preserved in project memory.
+
+Re-derived **2026-09-01** from, in authority order:
+
+1. **The shipped pack** at `wt-glossaries/ja/` — 125 files, `manifest.json` present, the
+   pack as it ships on the `docs-i18n` branch. This is the ground truth. Every terminology
+   and typography rule below was re-verified against it programmatically; each row cites a
+   pack file (and usually a line) that shows the rule in force.
+2. **The pack's shipping PR decision write-up** — `Pasta-Devs/Marinara-Engine` PR **#4345**
+   ("Japanese conventions" and "Validation performed" sections).
+3. **The 2026-09-01 mirror-cycle notes** — `scratchpad/prd-notes-ja.md`, evidence-backed
+   term choices made during the same-day catch-up pass, each with its own pack citation.
+4. **The recorded decision ledger** carried in project memory from the original cycle.
+5. **The app locale file** `packages/client/src/localization/locales/ja.json`, for
+   UI-gloss conventions.
+
+**Rules below are verified against the pack as shipped.** Anything that the pack cannot
+demonstrate — process rulings, rationales, maintainer calls — is explicitly tagged
+**[recorded ruling]** and carries no in-pack citation. Where the pack contradicts itself,
+that is written up in *§8 Known pack residuals* rather than silently normalized.
+
+Counts quoted below (e.g. "534 occurrences") are from the 2026-09-01 re-derivation sweep
+over all 125 files. **A bare number is an occurrence count** (every hit, including repeats
+on one line); where a line count is meant it says "lines" explicitly. The two differ a lot
+for common terms — スプライト is 197 occurrences across 155 lines — so never compare a
+number here against a `grep -c`, which counts *matching lines*, not matches.
+
+**Verification status (2026-09-01 review pass):** every count, citation and character-class
+claim below was re-run against `wt-glossaries/ja/`. Corrections from that pass are folded in;
+rows where the pack turned out to disagree with the previous draft now describe the pack.
+
+---
+
+## 1. Register & address
+
+| Rule | Detail | Evidence |
+| --- | --- | --- |
+| Body prose is **です・ます** | Polite/distal register throughout; the universal register for Japanese software documentation. `ます。` terminators appear 10,603 times. | `CONFIGURATION.md:7`, `lorebooks/token-budgets.md:5`, `data/where-data-is-stored.md:5` |
+| **Zero あなた** | The pack contains **0** instances of `あなた` and **0** of `貴方`. Japanese drops the subject; the reader is addressed by the verb form alone, never by a second-person pronoun. Do not introduce one, even where EN says "you". | whole-pack count = 0 |
+| Instructions use **〜てください** | The polite request form is the standard imperative: `てください` 831 + `でください` 119 = **950** request forms (on 875 lines). Never the bare imperative (`しろ`/`せよ`), never plain `〜すること` in body prose. `下さい` in kanji = **0**. | `CONFIGURATION.md:110` 「…を読んでください」, `TROUBLESHOOTING.md:182` 「貼り付け直してください」 |
+| Capability is **〜できます** | 633 occurrences. Preferred over 〜が可能です for the conversational-but-polite register the pack keeps. | `chats/slash-commands.md:7` 「Enterでも送信できます」, `lorebooks/token-budgets.md:21` 「**1**から**1000**まで設定できます」 |
+| On/off states are **オン/オフ** | Katakana, not 有効化/無効化, when describing a toggle the reader flips (206 occurrences of オンにし/オフにし, on 189 lines). 有効/無効 is reserved for the *state* of a feature or record. | `CONFIGURATION.md:31` 「…をオンにします」, `CONFIGURATION.md:37` 「デフォルトでは無効です」 |
+| Plain form (だ・である) only inside quoted fiction | The pack has exactly **3** plain-form sentence terminators, all inside roleplay/lorebook *example* content — never in the pack's own voice. | `lorebooks/entries.md:99-100`, `roleplay/getting-started.md:76` |
+| Gender-neutrality | Japanese needs no policy here: the pack uses no gendered pronoun for the reader, and character examples inherit whatever the EN source says. Do not add 彼/彼女 where EN has a name or a role noun. | whole-pack: no reader-directed pronoun |
+| `ユーザー` is a **role noun, not address** | 77 occurrences, all referring to a third party or a config concept (`ユーザー名`, 「ユーザー主導の到着」). Never used to mean "you, the reader". | `FAQ.md:14` 「Basic Auth(ユーザー名とパスワード)」, `agents/hierarchical-maps.md:234` |
+
+### Headings
+
+| Rule | Detail | Evidence |
+| --- | --- | --- |
+| Default heading style is **体言止め** (noun phrase) | Section headings end in a noun, with no verb ending and no 。 | `CONFIGURATION.md:108` 「## アクセス制御」, `chats/messages.md:29` 「## メッセージの編集」, `settings/settings-overview.md:1` 「# 設定の概要」 |
+| Plain dictionary-form verbs are allowed where EN is imperative/verbal | Never です・ます in a heading. | `INSTALLATION.md:5` 「## プラットフォームを選ぶ」, `lorebooks/overview.md:63` 「## 最初のロアブックとエントリーを作る」 |
+| **FAQ.md keeps question headings** with a half-width `?` | 23 headings across the pack end in `?`; there are **0** full-width `？` in the pack. | `FAQ.md:5`, `FAQ.md:99` 「## キャラクターカードとは?」 |
+| **TROUBLESHOOTING.md `###` headings are plain-form symptom clauses**, not 体言止め | This file's own established pattern overrides the 体言止め default; a symptom heading reads as the sentence the user would say. Mirror it when adding sections here. **Not absolute:** 2 of the 29 `###` headings are *task* headings rather than symptoms and correctly revert to the pack default — `:45` 「### ランチャーをpnpm 10.34.5へ更新する」 (dictionary form) and `:143` 「### メンテナー向け: 固定したローカルランタイムのアップデート」 (体言止め). Symptom → plain form; task → default. | `TROUBLESHOOTING.md:157` 「### Memory Recallが何も思い出さない」, `:258`, `:322`, `:328` |
+| Headings that name a UI surface stay English | See §3/§6. | `data/backup-and-restore.md:22` 「## Download Backup」, `settings/settings-overview.md:40` 「## App Behavior」 |
+| Repeated section titles are **normalized to one spelling** so in-app search indexes them as one term | 「## 関連ガイド」 appears in 117 of 125 files with identical text. | pack-wide heading census |
+
+---
+
+## 2. Product, feature & mode names
+
+| Rule | Detail | Evidence |
+| --- | --- | --- |
+| **Product names stay in Latin script, frozen** | `Marinara Engine`, `Marinara`, `Noodle`, `Professor Mari`, `Termux`, `Docker`. **0** instances of a katakanized `マリナーラ` anywhere in the pack. | `CONFIGURATION.md:3`, `FAQ.md:119`, `CONFIGURATION.md:25` (Docker) |
+| **Particles attach directly** to a Latin name — no carrier noun | 「Marinara Engineでは」, 「Noodleを設定するには」. Never 「Marinara Engineというアプリでは」 padding. | `CONFIGURATION.md:5` 「どんなときにMarinaraを設定するのか」, `FAQ.md:117` |
+| **Mode names stay English**: `Conversation`, `Roleplay`, `Game Mode` / `Game` | 850 lines carry one of these bare. Never 会話モード / ロールプレイモード in the docs pack (the *app locale* does translate them — see §6 trap). | `CONFIGURATION.md:205`, `characters/creating-and-editing-characters.md:116`, `chats/slash-commands.md:19` |
+| **Agent and package names stay English** | `World Maps`, `Beholder`, `Memory Recall`, `Chat Summary`, `Illustrator`, `Storyboard`, `Agent Suite`, `Card Browser`, `Local Model`. | `agents/built-in-agents.md:163` 「### World Maps」, `agents/built-in-agents.md:119` (Beholder), `agents/memory.md:80` 「## Chat Summary(Roleplay)」, `agents/approvals-and-agent-suite.md:59` |
+| **First-mention short-form convention**: `Marinara Engine(以下Marinara)` | Where a guide introduces the full product name and then shortens it. Half-width parens, tight. | `data/where-data-is-stored.md:5` |
+| Japanese has no articles — nothing to rule on | The EN article system simply disappears; do not compensate with この/その unless the EN text is genuinely deictic. | — |
+| **Feature names that are also common nouns are translated**, not frozen | `lorebook`→ロアブック, `persona`→ペルソナ, `agent`→エージェント; the **bold UI label** for the same thing stays English (`**Persona Editor**`). Prose term ≠ UI label. | `appearance/card-css-theming.md:21` 「ペルソナにも、**Persona Editor**(ペルソナエディター)に同じ欄があります」 |
+
+---
+
+## 3. Core terminology
+
+Half-width parens in the "this pack's term" column show the pack's gloss pattern, not part
+of the term.
+
+**How to read the "banned alternates" column.** Every alternate listed was swept pack-wide
+on 2026-09-01. An entry means *do not use this word to render this English term*. It does
+**not** mean the string is absent from the pack — several of these words are ordinary
+Japanese with a different job, and the pack uses them correctly in that other job. Those
+cases are marked **"reserved:"** with the sense they carry and their count, so a sweep does
+not "fix" correct prose. Alternates with no note are genuinely at **0**. Where the pack
+really does contradict its own term, the row says so and §8.3 carries the count and cites.
+
+The 2026-09-01 review found **15** previously-listed "bans" that were category errors — the
+listed word is ordinary Japanese doing a different job, and the pack uses it correctly:
+静止画 (30), 立ち絵 (22), 発言 (25), 空欄 (10), 無限 (4), 項目 (245), アドオン (4),
+World Info (10), まとめ (209), トークン単位 (1), 代理 (1), 人格 (1), 昇格 (9), 予備 (4), and
+既定値 (which renders *default*, not *preset*). They are now reservations, not bans.
+Acting on them would have collapsed the still-image/video distinction, the sprite gloss, the
+group-chat speaker vocabulary, the SillyTavern interop name, and the ordinary word for
+"list item". **When a "ban" has hundreds of hits, the rule is wrong, not the pack.**
+
+| English | This pack's term | Banned alternates | Evidence |
+| --- | --- | --- | --- |
+| prompt | プロンプト (604) | 指示文 (0). **プロンプト文 = 3 residuals**, see §8.3 — but プロンプト**文法** ("prompt grammar", `media/style-profiles.md:71`) is a different word; do not let a substring sweep eat it | `agents/agents-overview.md:17` |
+| token | トークン (110) | 字句 (0). *reserved:* トークン単位 (1) is ordinary prose 「トークン単位で決めます」 = "measured in tokens", not a competing term | `agents/agents-overview.md:55`, `chats/slash-commands.md:17`, reserved use at `lorebooks/linking-to-characters.md:101` |
+| token budget | トークン予算 (19) | see §8 for the 3 `トークンの予算` outliers | `lorebooks/token-budgets.md:1` 「# ロアブックのトークン予算と再帰」, `lorebooks/token-budgets.md:7` |
+| preset | プリセット (201) | プリセット設定 (0). 既定値 is **not** an alternate for this — it renders EN *default*; see the `default` row | `prompts/presets.md:5` 「## プリセットとは」, `agents/custom-agents.md:164` |
+| default | デフォルト (608, on 563 lines) | 既定 / 既定値 — 7 residuals, §8.3. The katakana form is the pack's term by a factor of ~87 | `CONFIGURATION.md:31`, `:37`, `:65` |
+| lorebook | ロアブック (548) | 伝承, 伝説の書, ローアブック (all 0). *reserved:* **World Info** (10) is **SillyTavern's** name for the same thing and is deliberately kept, in Latin, wherever the pack talks about interop — 「SillyTavernでは「World Info」と呼ばれます」, 「**World Info**ファイル」. Never translate it, and never use it for Marinara's own feature | `FAQ.md:105`, `lorebooks/overview.md:1`. Latin `Lorebook`/`Lorebooks` (122) is reserved for the UI panel/label; reserved World Info uses at `data/importing-from-sillytavern.md:13`, `lorebooks/import-export.md:10`, `lorebooks/overview.md:7` |
+| character card | キャラクターカード (90) | キャラカード, キャラ設定ファイル | `FAQ.md:101`, `agents/agents-overview.md:9` |
+| chat | チャット (1,909) | 対話 (0). 会話 is *reserved* for the `Conversation` mode concept | `agents/agents-overview.md:9`, `chats/branches.md:7` |
+| message | メッセージ (850) | メッセ as slang (0). *reserved:* 発言 (25) is "utterance / who speaks" — it carries the group-chat speaker vocabulary (「発言者の決め方」, 「発言頻度」) and must not be swept into メッセージ. Note メッセ**ンジャー** (7) is a legitimate word a `メッセ` sweep will false-positive on | `chats/messages.md:1` 「# メッセージの操作: 編集、削除、スワイプ、再生成」, `FAQ.md:127`; reserved uses at `chats/group-chats.md:69`, `:120` |
+| swipe | スワイプ (99, on 79 lines) | A bare-Latin `swipe` sweep returns **21** hits, of which **20 are correct**: bold UI labels (`**Next swipe**`, `**Jump to swipe 1-N**`), quoted app strings (「Cannot delete the last remaining swipe」), and code-fence identifiers (`swipeIndex`, `message_swipes/`). Exactly **1** is a genuine prose residual — §8.3 #6 | `chats/messages.md:47`, `chats/messages.md:60` |
+| agent | エージェント (742) | エージェンシー (0). *reserved:* 代理 (1) is the verb 「別のクライアントを代理している」 = "is proxying for", a networking sense | `agents/agents-overview.md:1`, `FAQ.md:113`; reserved use at `REMOTE_ACCESS.md:150` |
+| connection | 接続 (795, on 576 lines) | コネクション, 接続先設定 | `CONFIGURATION.md:18`, `connections/organizing-connections.md:47` |
+| provider | プロバイダー (372, on 301 lines) | プロバイダ | `CONFIGURATION.md:18`, `CONFIGURATION.md:251` |
+| launcher | ランチャー (48 lines) | 起動ツール, ランチャ | `CONFIGURATION.md:155`, `CONFIGURATION.md:238`, `TROUBLESHOOTING.md:324` |
+| update (noun/verb) | アップデート (141 lines) | 更新 as the *product* noun (更新 stays for "refresh"/"renew" senses) | `CONFIGURATION.md:24`, `UPGRADING.md:120` |
+| apply (an update) | アップデートを適用する | 更新を当てる, インストールする | `UPGRADING.md:120`, `CONFIGURATION.md:239`, `installation/containers.md:172` |
+| upgrade | アップグレード (2) | バージョンアップ (0). *reserved:* 昇格 (9) is "promote" in the World Maps / PRD sense (「生成されたシーンを昇格させる」) and the privilege sense (「権限昇格」) — never "upgrade a version" | `UPGRADING.md:186`, `TROUBLESHOOTING.md:275`; reserved uses at `development/hierarchical-locations-prd-v3.md:531`, `TROUBLESHOOTING.md:417` |
+| channel (release) | チャンネル (19 lines) | チャネル, リリース系統 | `CONFIGURATION.md:237`, `TROUBLESHOOTING.md:351` 「チャンネルの切り替え(Stable ↔ Staging)」 |
+| checkout (git) | チェックアウト | 作業コピー, クローン先 | `CONFIGURATION.md:238`, `TROUBLESHOOTING.md:39`, `installation/containers.md:24` |
+| wake lock | **`wake lock`, bare Latin** | ウェイクロック, 画面ロック解除 | `TROUBLESHOOTING.md:324` 「Androidのwake lockを要求し」. Commands `termux-wake-lock` / `termux-wake-unlock` stay byte-exact in code spans (`TROUBLESHOOTING.md:326`). |
+| battery optimization | バッテリー最適化 | 電池最適化, 省電力設定 | `TROUBLESHOOTING.md:326` 「バッテリー最適化の対象から外して」, `:332` |
+| background activity | バックグラウンド実行 / バックグラウンドでの動作 | 裏で動かす, バックグラウンド処理 (reserved for server-side background work) | `TROUBLESHOOTING.md:326`, `:332` |
+| memory / in memory (RAM) | メモリー / **メモリー上** (32) | メモリ (1 residual, §8.3 #4), RAM上 (0), **常駐** (0 in this sense) | `TROUBLESHOOTING.md:182` 「サーバーのメモリー上にだけ存在し」, `characters/bot-browser.md:116`, `CONFIGURATION.md:155` |
+| resident (service/panel) | 常駐 — **reserved for services and UI panels, never for data in RAM** | using 常駐 for chats/records held in memory | `installation/containers.md:10`, `:36`, `extending/personal-extensions.md:23` |
+| memory (the *feature*) | 記憶 (96, on 74 lines) — e.g. `**Memory Recall**`(記憶の呼び出し) | メモリー for the feature | `FAQ.md:127`, `TROUBLESHOOTING.md:155` 「## 記憶機能と要約」 |
+| cache (noun/verb) | キャッシュ (43) | 一時保存, キャッシング | `CONFIGURATION.md:322`, `TROUBLESHOOTING.md:80`, `agents/approvals-and-agent-suite.md:95` |
+| backup | バックアップ (90) | 控え as a term — it appears exactly **once** as a backup noun (`UPGRADING.md:15` 「控えの取り方」) and that is prose, not the term. Of the 11 控え strings, the rest are the unrelated 控えめ ("sparing") and 控える ("note down"). *reserved:* 予備 (4) means "spare / held in reserve" — 「予備のタイムゾーン」 (fallback TZ), 「予備の書き出し」 (alternate greetings), 「小さな予備」 (a pool of prepared posts) | `data/backup-and-restore.md:1`, `CONFIGURATION.md:16`, `FAQ.md:132`; reserved uses at `CONFIGURATION.md:280`, `noodle/settings.md:86` |
+| snapshot (data) | スナップショット (100) | 断面 (0). **静止画 is NOT an alternate** — it is the pack's term for a *still image* as opposed to a video clip (30 occurrences, load-bearing across `game/storyboard.md`, `media/scene-video.md`, `characters/sprites.md`). Banning it would collapse the still-vs-video distinction the Storyboard and video docs are built on | `agents/built-in-agents.md:119`, `agents/hierarchical-maps.md:18`, `FAQ.md:145`; 静止画 in its own sense at `game/storyboard.md:59`, `media/scene-video.md:7` |
+| checkpoint | チェックポイント (37, on 32 lines) | 中間保存, セーブポイント | `agents/built-in-agents.md:153`, `development/architecture-map.md:89` |
+| extension | 拡張機能 (116) | エクステンション (0). *reserved:* アドオン (4) — `Addons` stays English as a UI label, and アドオン is its sanctioned **gloss** (`extending/personal-extensions.md:3` 「**Addons**(アドオン)」); the other 3 are ネイティブアドオン, Node's "native addon" | `CONFIGURATION.md:57` 「### 外部拡張機能(External Extensions)」, `FAQ.md:141`; reserved uses at `extending/personal-extensions.md:3`, `:159` |
+| NPC | **`NPC`, bare Latin** (37 lines) | ノンプレイヤーキャラクター, 非操作キャラ. The full form appears **once**, as a first-mention gloss: 「NPC(プレイヤー以外のキャラクター)」 | `game/party-and-npcs.md:1` 「# Game Mode: パーティーとNPC」, `:3` (gloss), `agents/built-in-agents.md:111` |
+| persona | ペルソナ (441) | ユーザーキャラ (0). *reserved:* 人格 (1) appears only inside 別人格 glossing the UI label **Inspired alter ego** | `characters/personas.md:1` 「# ペルソナの作成と編集」, `agents/custom-agents.md:65`, `agents/approvals-and-agent-suite.md:59`; reserved use at `noodle/settings.md:28` |
+| entry (lorebook) | エントリー (456) | エントリ (0 — but see §8.3 for the trailing-ー residuals in sibling terms). *reserved:* 項目 (245) is the ordinary word for a list item, a form field or a JSON member (「次の項目を順に確認してください」, 「括弧、カンマ、項目を直します」) — it is everywhere and is **not** a competing rendering of lorebook *entry* | `FAQ.md:105`, `lorebooks/entries.md:119`; reserved uses at `TROUBLESHOOTING.md:96`, `:218` |
+| folder | フォルダー (378) | フォルダ, ディレクトリ (see §8) | `CONFIGURATION.md:26`, `characters/library-organization.md:68` |
+| server | サーバー (534) | サーバ | `CONFIGURATION.md:1` 「# サーバー設定リファレンス」 |
+| browser | ブラウザー (181) | ブラウザ | `TROUBLESHOOTING.md:75`, `:80` |
+| tracker | トラッカー (63 lines) | 追跡器, トラッカ | `agents/agents-overview.md:19`, `CONFIGURATION.md:206` |
+| macro | マクロ (101 lines) | マクロ命令, 置換タグ | `prompts/macros.md:1` 「# プロンプトマクロ」, `agents/custom-agents.md:166`, `characters/personas.md:11` |
+| embedding / to vectorize | 埋め込み (106) / ベクトル化 (20 lines) | エンベディング, 数値化 | `CONFIGURATION.md:208`, `agents/knowledge-sources.md:89` (both terms in one line), `lorebooks/semantic-search.md:3` |
+| regex / regular expression | 正規表現 (39 lines) | レギュラーエクスプレッション | `extending/regex-scripts.md:7`, `characters/import-export.md:38` |
+| slash command | スラッシュコマンド (27, on 23 lines) | `/`コマンド | `chats/slash-commands.md:1` |
+| sprite | スプライト (197, on 155 lines) | — . **立ち絵 is NOT banned**: it is the pack's own *explanatory gloss* for スプライト and appears 22 times, including as a heading (`media/animated-expressions.md:28` 「## アニメーション立ち絵をオンにする」). The established pattern is 「スプライトとは…キャラクターの立ち絵です」 — term first, 立ち絵 as the plain-Japanese explanation. Keep both | `characters/sprites.md:76`, `CONFIGURATION.md:213`; gloss pattern at `characters/sprites.md:7`, `agents/built-in-agents.md:85` |
+| **branch — chat sense** | **分岐** (152, on 101 lines) | ブランチ for a chat branch. The whole guide is 「# チャットの分岐」 and defines 「分岐とは、選んだ地点までの履歴を共有するチャットのコピーです」 | `chats/branches.md:1`, `:3`, `:7` |
+| **branch — git sense** | **ブランチ** (14, on 13 lines) | 分岐 for a git branch | `CONFIGURATION.md:316` 「`docs-i18n`ブランチ」, `UPGRADING.md:141`, `development/localization.md:87` |
+| greeting (first message) | 挨拶メッセージ | グリーティング, 初回メッセージ | `FAQ.md:101`, `characters/creating-and-editing-characters.md:73`, `:76` |
+| summary | 要約 (116, on 94 lines) | サマリー (0). *reserved:* まとめ (209) is almost entirely the verb/adverbial まとめる・まとめて ("gather", "collectively") — 「変数の一覧はページの後半にまとめてあります」. Do not sweep it; only the *noun* 「まとめ」 meaning a summary is off-limits | `TROUBLESHOOTING.md:155`, `agents/approvals-and-agent-suite.md:7`; reserved uses at `CONFIGURATION.md:3`, `FAQ.md:128` |
+| state machine | ステートマシン (2) | **状態機械 / 有限状態機械 (0 in pack)** — carve-out: the loanword wins even in `development/` docs | `development/architecture-map.md:89`, `development/hierarchical-locations-prd-v3.md:27` |
+| unset (config default) | 未設定 (24) | 未指定, なし (0). *reserved:* 空欄 (10) is the UI instruction "leave the field blank" (「空欄のままにすると…」) — a thing the reader does to an input, not the config state 未設定 describes | `CONFIGURATION.md:238`, `:213`, `:280` 「`TZ=`のように空にした場合も、未設定として扱います」; reserved uses at `conversation/profiles.md:18`, `conversation/schedules.md:75` |
+| unlimited (`0` value) | 無制限 (6) | 制限なし (0). *reserved:* 無限 (4) belongs to fixed technical compounds — 無限クエリー (infinite query), 無限スクロール, 無限ループ — all in `development/` | `CONFIGURATION.md:155` 「`0`(無制限)」, `lorebooks/entries.md:119`; reserved uses at `development/frontend.md:148`, `:251` |
+| least-recently-used | 最後に使われてから最も時間が経ったもの | 最も古い / 作成日が古いものから (these render EN *oldest*, a different concept) | `CONFIGURATION.md:155`. **Newly coined 2026-09-01** — see §8. |
+| library | ライブラリー (115, on 107 lines) | ライブラリ | `agents/custom-agents.md:24`, `agents/hierarchical-maps.md:424` |
+| category | カテゴリー (68) | カテゴリ | `lorebooks/overview.md:39` 「## カテゴリー」, `:41` |
+| gallery | ギャラリー (122) | ギャラリ | `characters/galleries.md:73` |
+| repository | リポジトリー (51) | リポジトリ (1 residual, §8) | `CONFIGURATION.md:35` 「### 独自のエージェントリポジトリー」 |
+| inventory | インベントリー (11) | インベントリ (1 residual, §8) | `agents/custom-agents.md:90` |
+| party | パーティー (78) | パーティ (パーティクル "particle" is a different word and keeps its own spelling — `development/frontend.md:265`) | `game/party-and-npcs.md:7` 「## パーティーバー」, `development/architecture-map.md:89` |
+| installer | インストーラー (31) | インストーラ | `INSTALLATION.md:26` 「**Windows installer**(Windowsインストーラー)」, `CONFIGURATION.md:275` |
+| editor | エディター (203) | エディタ | `FAQ.md:101` 「**Character Editor**(キャラクターエディター)」 |
+| parameter | パラメーター (91) | パラメータ | `TROUBLESHOOTING.md:129` |
+| computer | コンピューター (177) | コンピュータ | `FAQ.md:7`, `FAQ.md:13`, `data/where-data-is-stored.md:5` |
+| container | コンテナー (49) | コンテナ (1 residual, §8) | `installation/containers.md:36`, `data/where-data-is-stored.md:11` |
+| filter | フィルター (11) | フィルタ | `lorebooks/entries.md:104` |
+| security | **セキュリティ** — documented short-form exception | セキュリティー | `development/personal-extensions.md:5` 「## セキュリティ不変条件」, `development/file-storage.md:33`; 7 occurrences, セキュリティー = 0 |
+| community | **コミュニティ** — documented short-form exception | コミュニティー | `FAQ.md:200`, `TROUBLESHOOTING.md:430`; 11 occurrences, コミュニティー = 0 |
+
+---
+
+## 4. Typography & punctuation
+
+| Rule | Detail | Evidence |
+| --- | --- | --- |
+| **Prose quoting is 「」** | 413 balanced pairs. `『』` = 0. Curly ASCII quotes `“ ”` = 0. | `TROUBLESHOOTING.md:330`, `connections/organizing-connections.md:47`, `UPGRADING.md:164` |
+| **Quoted English UI strings inside 「」 stay byte-exact** | Including the label's own ellipsis character and its own internal ASCII quotes. 318 pure-ASCII strings sit inside 「」. | `TROUBLESHOOTING.md:330` 「Opening chat...」 (ASCII `...`, because the app's string uses ASCII), `UPGRADING.md:164`, `agents/built-in-agents.md:254` |
+| **Sentence terminator is 。; comma is 、** | 16,667 / 16,606 occurrences. ASCII `.` and `,` are never sentence punctuation in prose. | pack-wide |
+| **Parentheses are half-width ASCII `( )`, attached tightly** | 3,551 ASCII parens; only 4 full-width `（ ）` survive (§8). Units and glosses attach with no space: `` `300000`(5分) ``. | `CONFIGURATION.md:205`, `:207`, `agents/agents-overview.md:17` |
+| **All Latin letters and digits are half-width ASCII** | 0 full-width alphanumerics pack-wide. Full-width `７８６０` would never match an in-app search for `7860`. | verified programmatically over all 125 files |
+| **No ideographic space (U+3000), no NBSP (U+00A0)** | 0 of each. | verified programmatically |
+| **All text NFC-normalized** | 0 non-NFC files. Decomposed kana (e.g. `か` + U+3099) silently breaks the docs viewer's substring search. | verified programmatically |
+| **No full-width `？` or `！`** | 0 of each; questions use half-width `?`. | pack-wide |
+| Thousands separators are ASCII commas | `16,384`, `1,000,000`. Ranges use a half-width hyphen: `128-16,384`, `1-100`. | `agents/built-in-agents.md:200`, `conversation/table-games.md:109` |
+| Ellipsis follows the source string | U+2026 `…` (16) where the app's own label uses it (`**Creating backup…**`); ASCII `...` (101) where the app's string does. Never "correct" one into the other. | `UPGRADING.md:27`, `:135` vs `TROUBLESHOOTING.md:330` |
+| 中黒 `・` only for genuine list-within-a-word | 14 occurrences, e.g. 「ボール・イン・ハンド」, 「下書き・拡張する」. Not used as a general separator. | `agents/built-in-agents.md:304`, `agents/hierarchical-maps.md:180` |
+| Em dash `—` is source-mirrored, not native punctuation | 3 occurrences, all mirroring an EN run-in dash or living inside an English example. Prefer 。/、 or a colon. | `agents/custom-agents.md:113`, `lorebooks/entries.md:189` |
+| Range tilde is full-width `～` (U+FF5E) | 7 occurrences: 2 version ranges (`2.3.5～3.x`), 5 numeric/clock ranges (`1～24`, `23:00～07:00`). U+301C `〜` = 0 — do not swap it in. Note the *grammatical* 〜 used in this glossary's own prose (「〜てください」) never appears in the pack. | `agents/hierarchical-maps.md:3`, `:424`, `noodle/settings.md:89`, `:90` |
+| Colon in a heading or a run-in label is **ASCII `:` + one space** | | `chats/messages.md:1` 「# メッセージの操作: 編集、削除、スワイプ、再生成」, `chats/messages.md:54` |
+| Navigation separators mirror the EN source | Two distinct shapes, and they differ in **where the bold ends**, not just in the glyph. `→` (85 occurrences on 50 lines) sits almost always *inside* one bold span: `**Settings → Advanced → Danger Zone**`. `>` appears as `**A** > **B**` with the separator *outside* the bold (47 occurrences on 28 lines). Only 1 line in the pack uses `**A** → **B**` (`media/image-providers.md:190`). The pack copies whichever the EN line uses — never normalize the glyph, and never move the `**` boundary while doing it. | `CONFIGURATION.md:31` 「**Settings → Advanced → Danger Zone**」 vs `TROUBLESHOOTING.md:161` 「**Chat Settings** > **Memory Recall**」 |
+| **List mechanics** | `- ` bullets (3,151) and `1. ` ordered items (1,474), mirroring EN structure exactly. Full-sentence items end in 。; noun-phrase or 〜とき fragment items take no terminator (150 such lines). | `CONFIGURATION.md:11-13`, `agents/custom-agents.md:13-15` |
+| Table cells use single-space pipes, no column padding | Matches the EN pack's table format. | `CONFIGURATION.md:155`, `:205-213` |
+
+---
+
+## 5. UI labels & glosses
+
+| Rule | Detail | Evidence |
+| --- | --- | --- |
+| **UI labels are byte-exact English in bold** | `**Settings**`, `**Review Agent Outputs**`, `**Check for Updates**`. The `ja` UI locale is ~1.4% complete (132 of 9,123 EN keys), so the reader is looking at English chrome. | `packages/client/src/localization/locales/ja.json` (132 keys) vs `en.json` (9,123); `agents/agents-overview.md:49` |
+| **Gloss pattern: `**English Label**(日本語)`** — half-width parens, tight, no space | **1,323** `**Label**(` + Japanese glosses pack-wide (on 1,103 lines), out of 1,407 `**Label**(` constructions of any kind — the other 84 open with Latin or a digit. The gloss explains; it never replaces. | `FAQ.md:101` 「**Character Editor**(キャラクターエディター)」, `TROUBLESHOOTING.md:12` 「**Debug mode**(デバッグモード)」, `installation/android-termux.md:19` |
+| Multi-step navigation glosses the **whole chain** once | | `CONFIGURATION.md:31` 「**Settings → Advanced → Danger Zone**(設定 → 詳細設定 → 危険な操作)」 |
+| **Gloss navigational labels; do NOT gloss status/error strings** | Status and error strings appear bold-English with no Japanese in parens, because the user must recognize the literal string on screen. | `TROUBLESHOOTING.md:330` 「**Server unreachable**と表示し」/「**Unreachable (request timed out)**」; `TROUBLESHOOTING.md:163` 「状態が**Waiting for vector**の場合」; `agents/memory.md:57` |
+| Glossed once per section, bare thereafter | After the first gloss in a section the bare `**Label**` is used. | `CONFIGURATION.md:31` glossed → `:37` bare |
+| **Full sentences the app renders go in 「」, byte-exact** | | `connections/organizing-connections.md:47` 「Delete "your connection name"? This cannot be undone.」, `UPGRADING.md:133` |
+| **6 justified ASCII-quote survivors** | Where the app's own string contains ASCII quotes, those quotes are preserved rather than converted to 「」 — the quotes belong to the app, not to the pack. All 6 live in user-facing guides. **[recorded ruling]** that these 6 are justified; the *count and locations* are verified. **Scope the sweep:** an unfiltered `"` sweep returns 324 quote pairs, ~97% of them JSON/CSS inside fenced code blocks. Strip fences *and* inline code spans first — that leaves **11**: these 6 plus the 5 in §8.3 #7. | `appearance/custom-css-themes.md:29`, `characters/bot-browser.md:85`, `characters/library-organization.md:22`, `:68`, `:93`, `connections/organizing-connections.md:47` |
+| An untranslated feature name in running text stays Latin, unbolded | e.g. `Support Diagnostics`, `Agents Manager`, `Marinara Lite`. | `TROUBLESHOOTING.md:330`, `agents/memory.md:78` |
+| Term-of-art gloss uses the same paren pattern | `regex`は「regular expression」(正規表現)の略です — the only place 「」+gloss combine. | `extending/regex-scripts.md:7` |
+| Code spans, paths, env var names, URLs and link targets are **byte-identical** to EN | Never translate inside `` ` ``; never localize a `#fragment`. | `CONFIGURATION.md:26`, `wt-glossaries/README.md` (branch rule) |
+
+---
+
+## 6. Language-specific mechanics
+
+### 6.1 The boundary-spacing rule (the pack's single most mechanical convention)
+
+**Japanese↔Latin boundaries are tight — no space.** The sweep found **9,789** tight
+`Latin→kana` boundaries (on 5,284 lines) and **13** spaced ones, on 13 lines, every one
+explained by exception D or E below.
+
+| Boundary | Rule | Evidence |
+| --- | --- | --- |
+| kana/kanji ↔ Latin word | tight; 9,789 `Latin→kana` + 5,358 `kana→Latin` | `CONFIGURATION.md:3` 「環境変数を使ってMarinara Engineのサーバー側の…」 |
+| kana/kanji ↔ **bold** span | tight in **both** directions except the carve-outs below; `[JA] **` = **0 violations**, against 4,040 tight `**`+kana cases | `CONFIGURATION.md:37` 「Danger Zoneで**Allow custom Agent imports**をオンにしたうえで」 |
+| kana/kanji ↔ `` `code` `` | tight; `[JA] ` + backtick` = **0 violations**, against 1,895 tight cases (1,208 lines) | `CONFIGURATION.md:26` 「パッケージは`DATA_DIR/capability-packages`の下にあります」 |
+| kana/kanji ↔ `[link](...)` | tight; 1,803 cases (1,457 lines) | `CONFIGURATION.md:18` 「…は[AIプロバイダーへの接続](connections/connecting-to-a-provider.md)を参照してください」 |
+| 、 or 。 ↔ Latin | tight; 3,047 `、。→Latin` + 727 `Latin→、。` = 3,331 both directions (2,168 lines) | `CONFIGURATION.md:24` |
+
+**Five sanctioned exceptions.** Every one of the 69 `**` → space → Japanese boundaries is
+explained by A, B or B′, and they sum exactly: 17 + 51 + 1 = **69**, **0 unexplained**.
+Every one of the 13 spaced Latin↔kana boundaries is explained by D or E: 3 + 10 = **13**.
+
+- **A. Bold label with the colon inside the bold** — `**ラベル:** 本文` (**17** cases).
+  `CONFIGURATION.md:24-27`, `appearance/card-css-theming.md:52`, `development/code-cleanup-audit.md:3`
+- **B. Run-in label terminated by 。 inside the bold** — `**…します。** 続きの文` (**51** cases).
+  `characters/bot-browser.md:173`, `characters/galleries.md:79`, `connections/local-model.md:193`
+- **B′. Run-in label terminated by 」 inside the bold** (**1** case) —
+  `connections/local-model.md:185` 「**「Sidecar runtime install is disabled.」** ランタイムの…」
+- **C. Numbered headings** — a leading digit in a heading takes the normal Japanese counter
+  with no space (41 headings): `FAQ.md:49` 「## 3つのチャットモードとは?」, `agents/memory.md:5`.
+  (This is a *tight* pattern; it is listed here because it looks like a spacing decision.)
+- **D. Bare URLs are spaced** (3 cases): `installation/macos-linux.md:22`, `:98`, `:177`
+  「ブラウザーで http://127.0.0.1:7860 を開きます」. Spaced on *both* sides at `:98` and `:177`;
+  at `:22` the left neighbour is 、 so only the right side is spaced.
+  **Rationale [recorded ruling]:** GitHub's GFM autolinker would otherwise swallow the
+  adjacent kana into the link, and the app's own `markdown.tsx` does not autolink at all —
+  so the space is for the GitHub rendering of the `docs-i18n` branch, not for the viewer.
+- **E. Decimal outline numbers in headings** (**10** cases, all in
+  `development/code-cleanup-audit.md`): `### 1.1 到達不能なソースモジュール`, `### 6.2 大きく重複したUI領域: …`.
+  A dotted section number (`1.1`, `3.2`, `6.3`) is an outline label, not a counter, so it
+  takes a space before the heading text. Distinct from exception C — C is 「3つの…」, a
+  counter fused to what it counts; E is 「1.1 …」, a numbering scheme sitting beside a title.
+  `:82`, `:91`, `:97`, `:103`, `:141`, `:147`, `:177`, `:216`, `:224`, `:231`.
+
+### 6.2 Other mechanics
+
+- **Particles carry the grammar**; the pack never inserts a carrier noun to host a particle
+  after a Latin name (`Noodleを`, `Marinaraは`, `**Settings**を`). See §2.
+- **Compounds use の sparingly.** The pack prefers a bare katakana compound where the term is
+  established (`トークン予算`, `キャラクターカード`, `スラッシュコマンド`) and の where the
+  relationship is genuinely possessive (`ロアブックのトークン予算`, `メッセージの操作`).
+  `lorebooks/token-budgets.md:1` shows both in one heading.
+- **Counters follow the noun, not EN word order**: 「2つのトークン予算」, 「3つのフェーズ」,
+  「123件」. `lorebooks/token-budgets.md:7`, `agents/agents-overview.md:13`.
+- **No inflection/declension burden** — Japanese has none, so unlike the European packs
+  there is no case-ending decision for a frozen Latin product name. This is why the frozen-name
+  rule is cheap here and must not be softened.
+- **Do not copy the app locale's spacing style.** `ja.json` spaces Latin from kana
+  (「Atlas Cloud の API キーを取得」, 「Marinara の上部に Android の時刻」) — the **docs pack
+  does the opposite**. **13 of the locale's 132 strings** use the spaced style; every string
+  that mixes scripts does. Reading a locale string for a gloss is fine; copying its spacing
+  into pack prose is a regression. Evidence: `ja.json` keys
+  `connections.mediaSources.atlas.apiKeyLink`, `settings.application.androidStatusBar.help`.
+  Note `ja.json` stores **flat dotted keys**, not nested objects — a nested lookup returns
+  nothing and will make you think the key is missing.
+
+---
+
+## 7. Process rulings carried forward (no in-pack evidence)
+
+These come from the recorded ledger and PR #4345. They govern how a pack change is made,
+not what the shipped bytes look like, so nothing in `ja/` can confirm them.
+
+- **[recorded ruling]** ロアブック was chosen to match the Japanese SillyTavern community's
+  established term, so migrating users recognize it. (The spelling is verified in-pack; the
+  *reason* is the ruling.)
+- **[recorded ruling]** Pipeline for a pack change: translate → structural verify → fix →
+  re-verify, then a pack-wide consistency sweep. The original cycle's sweep applied 3,687
+  fixes (spacing normalization, link-text↔H1 audit 185→0, 長音符 unification, heading
+  normalization).
+- **[recorded ruling]** Four independent native-reader QA panels read all 123 files against
+  the English source (~160 further fixes), followed by a reconciliation pass that resolved
+  every cross-panel conflict — including the quote-delimiter ruling (126 ASCII-quoted UI
+  strings → 「」, 6 justified survivors) and the run-in-label spacing unification.
+  *(The "123 files" is the original cycle's count. The shipped pack is **125** files today;
+  the 2 added since have not been through a native-reader panel.)*
+- **[recorded ruling]** The `日本語` label in `docs-languages.ts` must byte-match the
+  **Language** dropdown's `Intl.DisplayNames` output; verified by executing the same code
+  path, not by inspecting the pack.
+- **[recorded ruling]** Bare-URL spacing rationale (GFM autolink vs. `markdown.tsx`) — see §6.1 D.
+- **[recorded ruling]** The 6 surviving ASCII quote pairs are *justified*, not residual — see §5.
+- **[recorded ruling]** `最後に使われてから最も時間が経ったもの` is a **newly coined** term for
+  "least-recently-used", not a reuse. The 2026-09-01 cycle searched exhaustively
+  (最近使/最も古い/いちばん古い/最も長く/使われていない/直近/古い順/退避/追い出/LRU/パフォーマンス)
+  across all of `ja/` and confirmed **there is no LRU precedent in this pack** — verified twice,
+  once in the original cycle and once on 2026-09-01. Nearest neighbours
+  (`characters/library-organization.md` 「作成日が古いものから」, `media/tts-setup.md`
+  「古いものから自動的に整理されます」) render EN *oldest*, a different concept, and must not be
+  reused for LRU. Pin this term for future cycles.
+
+---
+
+## 8. QA checks & known traps
+
+### 8.1 Mechanical checks (run all of these before shipping a `ja` pack change)
+
+Each check below is expressed against the pack directory; all currently pass except where
+§8.3 records a residual.
+
+1. **NFC normalization** — every file must satisfy `unicodedata.normalize("NFC", s) == s`.
+   Decomposed kana breaks the docs viewer's literal substring search silently. Currently 0/125 failures.
+2. **No full-width alphanumerics** — `[０-９Ａ-Ｚａ-ｚ]` must be empty.
+   A full-width `７８６０` never matches a search for `7860`. Currently 0.
+3. **No U+3000 and no U+00A0.** Currently 0 each.
+4. **No full-width `？` / `！`.** Currently 0 each.
+5. **Trailing-ー sweep** — for each of サーバー/ユーザー/フォルダー/ブラウザー/プロバイダー/
+   エディター/コンピューター/メモリー/パラメーター/コンテナー/インストーラー/リポジトリー/
+   ライブラリー/カテゴリー/インベントリー/ギャラリー/バッテリー/パーティー/エントリー/フィルター,
+   grep the short form with a negative lookahead on ー. Expected: 0, except the 4 residuals in §8.3.
+   **Sanctioned short forms:** セキュリティ, コミュニティ (their long forms must be 0).
+6. **Zero あなた / 貴方.**
+7. **Boundary-spacing check** — `[kana|kanji] \*\*` must be **0**; `[kana|kanji] ` + backtick must
+   be **0**; `\*\* [kana|kanji]` must be explained *only* by a preceding `:`, `。`, or `」` inside
+   the bold (currently 17 + 51 + 1 = 69, 0 unexplained). Spaced Latin↔kana must be **only**
+   bare URLs or decimal outline heading numbers (currently 3 + 10 = 13). A bare
+   "expected: 3" here is wrong and will send you hunting the 10 legitimate
+   `development/code-cleanup-audit.md` headings — see §6.1 E.
+8. **Link-text ↔ H1 parity, EN-anchored.** For every intra-pack `.md` link: if the *EN* link
+   text equals the *EN* target's H1, the *ja* link text must equal the *ja* target's H1.
+   Comparing ja link text to ja H1 without the EN anchor produces 127 false positives (EN
+   deliberately shortens link text). Currently 3 real failures — §8.3.
+9. **Structural parity vs. the EN source at the pack's recorded source commit** — heading
+   count, heading levels, link targets (including `#fragments`), and byte-identical code
+   fences. **Trap:** running this against current `staging` reports phantom failures
+   (`FAQ.md`, `prompts/macros.md`, `TROUBLESHOOTING.md`, `game/ltx-2-3-storyboards.md` all
+   diverge today purely because EN moved on — e.g. commit `34ecca6e9` added a macro and
+   `93926e69c` added the frozen-server section). Always pin the EN side to the commit the
+   pack was built from.
+10. **`node scripts/docs-i18n/validate-pack.mjs <path>/ja`** plus a manifest re-hash
+    (`build-manifest.mjs`); content and `manifest.json` must be committed together.
+    Note the shipped `manifest.json` records only `language` and a 125-entry
+    `{path, sha256, bytes}` list — it does **not** carry the source commit, so §8.9's pin
+    has to come from the PR/branch history.
+11. **Heading-normalization check** — repeated section titles must be spelled identically so
+    the in-app search indexes them as one term (「関連ガイド」 ×117 today).
+12. **Search smoke test** — query the docs viewer with プロンプト, 接続, ロアブック, 設定 and
+    confirm CJK highlight + NFC input matching.
+
+### 8.2 Known traps
+
+- **`grep -P` cannot handle `\x{3000}`-class escapes in this environment** ("character value
+  in \x{} is too large") and will report a silent 0. Use Python/`perl` for every Unicode
+  class check in §8.1 — a passing `grep -P` here is meaningless.
+- **PowerShell's default console encoding (cp1252) cannot print Japanese**; a check script
+  that `print()`s matched text will die with `UnicodeEncodeError` rather than report a
+  finding. Write results to a UTF-8 file and read that instead. (Reconfirmed 2026-09-01 —
+  it still throws.)
+- **`\b` and `\w` do not do what you want next to CJK — this silently *undercounts*.**
+  A word boundary needs a word char on one side and a non-word char on the other. Python,
+  PCRE and Java treat kana and kanji as word characters, so in `Lorebookを開く` there is **no**
+  boundary between `k` and `を` and `\bLorebooks?\b` never matches. This is not theoretical:
+  during the 2026-09-01 review `\bLorebooks?\b` returned **88** where the true count is
+  **122**, and `\bPersonal Extensions?\b` returned **7** where the true count is **18** —
+  a 28% and a 61% undercount, both of which would have "confirmed" a wrong residual.
+  **Never anchor a Latin-term sweep with `\b` in this pack.** Match the bare string and
+  disambiguate with explicit lookarounds instead.
+  The mirror-image trap bites in JavaScript, where `\w` is ASCII-only and matches *no*
+  kana or kanji at all, so a JS-side `\w`-based boundary check silently passes on
+  everything Japanese. The `ru` glossary documents the same class of trap for Cyrillic;
+  keep both notes alive, because a checker written once tends to get copied across packs.
+- **Katakana substrings collide with longer legitimate words.** A naive sweep for a banned
+  short form hits the longer word that contains it: `メッセ` matches メッセ**ンジャー** (7 legit),
+  `プロンプト文` matches プロンプト**文法** (1 legit), `パーティ` matches パーティ**クル** (1 legit).
+  Every trailing-ー check in §8.1 #5 needs its negative lookahead, and every katakana ban
+  needs one too. Verify a "violation" by reading the line before changing it.
+- **Occurrence counts and line counts are different numbers, and this file quotes
+  occurrences.** `grep -c` reports *lines*. スプライト is 197 occurrences on 155 lines; 接続 is
+  795 on 576. Several counts in the pre-2026-09-01 draft of this glossary were line counts
+  presented as occurrence counts, which is how the discrepancy was found. State which you mean.
+- **Never "fix" an ellipsis or an ASCII quote inside a quoted app string** — those bytes
+  belong to the app's own string (§4, §5).
+- **Never normalize `→` vs `>`** in navigation chains; mirror EN (§4).
+- **TROUBLESHOOTING.md's `###` headings are deliberately not 体言止め** (§1). A well-meaning
+  heading sweep will "fix" them into noun phrases and break the file's pattern.
+- **Do not translate mode names** (`Conversation`/`Roleplay`/`Game Mode`) in the docs pack
+  even though `ja.json` translates them for the UI (§2, §6.2).
+- **Do not use 常駐 for data held in RAM** — it is reserved for services/panels (§3).
+- **Do not reuse 「古いものから」 for least-recently-used** (§7).
+- **Do not "fix" 静止画 into スナップショット.** 静止画 = a still image as opposed to a video clip;
+  スナップショット = a captured data state. 30 occurrences across the Storyboard and video guides
+  depend on the distinction (§3).
+- **Do not "fix" 立ち絵 into スプライト.** 立ち絵 is the pack's plain-Japanese *gloss* for スプライト,
+  used 22 times in the established 「スプライトとは…立ち絵です」 pattern and in one heading (§3).
+- **Do not sweep 発言 into メッセージ.** 発言 carries the group-chat speaker vocabulary
+  (「発言者の決め方」, **Talkativeness**(発言頻度)); メッセージ is the object, 発言 is the act (§3).
+- **`swipe` in bold or in 「」 is correct.** 20 of the 21 bare-Latin `swipe` hits are UI labels,
+  quoted app strings, or code identifiers. Only `TROUBLESHOOTING.md:260` is a real residual (§8.3).
+- **Chat branching is 分岐, not ブランチ.** ブランチ is the git sense only. Reversing these is the
+  single easiest way to make `chats/branches.md` read as a version-control document (§3).
+
+### 8.3 Known pack residuals (documented, not silently fixed)
+
+Present in the shipped pack as of the 2026-09-01 re-derivation. Recorded here so the next
+cycle can decide; do not quietly change them mid-task.
+
+| # | Residual | Location |
+| --- | --- | --- |
+| 1 | 4 full-width parens `（）` against the half-width convention | `TROUBLESHOOTING.md:260`, `:275`, `characters/galleries.md:73`, `:89` |
+| 2 | `インベントリ` (should be インベントリー) | `agents/built-in-agents.md:145` |
+| 3 | `コンテナ版` (should be コンテナー版) | `agents/memory.md:78` |
+| 4 | `メモリ` (should be メモリー) | `data/backup-and-restore.md:31` |
+| 5 | `リポジトリ` (should be リポジトリー) | `extending/writing-personal-extensions.md:106` |
+| 6 | Bare Latin `swipe` in prose where the rest of the pack uses スワイプ. The **only** one of the pack's 21 `swipe` tokens that is not a bold UI label, a quoted app string, or a code identifier | `TROUBLESHOOTING.md:260` |
+| 7 | **5** extra ASCII-quoted strings beyond the 6 justified survivors (11 total outside code fences and code spans) — **4** quoted validation-error strings on one line, plus 1 quoted literal value that would be better as a code span | `development/optional-agent-packages.md:83` (×4), `:89` (×1) |
+| 8 | Link text `Personal Extensions` vs. target H1 「個人用拡張機能」 (3 links); the pack also splits the term itself — frozen Latin `Personal Extension(s)` ×18 vs. 「個人用拡張機能」 ×9 | `extending/writing-personal-extensions.md:3`, `:256`, `:259`; H1s at `extending/personal-extensions.md:1` and `development/personal-extensions.md:1` |
+| 9 | `ディレクトリ` (6) vs `ディレクトリー` (5) — genuinely unresolved. The trailing-ー rule makes ディレクトリー the compliant form; user-facing prose should prefer フォルダー (378) and reserve "directory" for server/CLI contexts | `TROUBLESHOOTING.md:241` vs. elsewhere |
+| 10 | `トークン予算` (19) vs `トークンの予算` (3). The compact form is the pack's term; two outliers are in a `development/` PRD, but one is in a user-facing guide | `development/hierarchical-locations-prd-v3.md:784`, `:1115`, **`prompts/macros.md:128`** |
+| 11 | One `##` heading in です・ます form against the 体言止め/plain-form heading rule | `home/professor-mari.md:42` 「## アプリ自身のファイルの読み書きもできます」 |
+| 12 | `プロンプト文` (3) where the pack's term is plain `プロンプト` (604). One is in a user-facing guide; two are in a `development/` PRD. Do **not** confuse these with `プロンプト文法` ("prompt grammar", `media/style-profiles.md:71`), which is correct | `conversation/profiles.md:53`, `development/hierarchical-locations-prd-v3.md:331`, `:712` |
+| 13 | `既定` / `既定値` (7) where the pack's term for EN *default* is `デフォルト` (608). Mixed registers for the same concept; `既定` is the more formal MS-style rendering | `extending/personal-extensions.md:67`, `extending/writing-personal-extensions.md:131`, `:207`, `noodle/settings.md:88`, `:89`, `TROUBLESHOOTING.md:402` |
+| 14 | 2 of TROUBLESHOOTING.md's 29 `###` headings are task headings, not symptom clauses, so they follow the pack default instead of the file's plain-form pattern. Arguably correct rather than residual — recorded so a heading sweep does not treat them as misses | `TROUBLESHOOTING.md:45`, `:143` |

--- a/glossaries/glossary-ko.md
+++ b/glossaries/glossary-ko.md
@@ -1,0 +1,529 @@
+# Korean (`ko`) documentation-pack glossary
+
+## Provenance
+
+This is the **second-generation** Korean glossary. The original working glossary written during the
+`ko` translation cycle was lost to temp-directory cleanup, so this file was **re-derived on
+2026-09-01** from, in authority order:
+
+1. **The shipped `ko` pack itself** (125 files on the `docs-i18n` branch) — the ground truth. Every
+   prescriptive rule below either cites a pack file that demonstrates it, or is explicitly labelled
+   a **[recorded ruling]**.
+2. **The pack's shipping PR decision write-up** — [Pasta-Devs/Marinara-Engine#4374](https://github.com/Pasta-Devs/Marinara-Engine/pull/4374),
+   plus its companion UI-string PR [#4376](https://github.com/Pasta-Devs/Marinara-Engine/pull/4376)
+   (`ko.json` fixes that the docs review surfaced).
+3. **The 2026-09-01 mirror-cycle terminology notes** (`prd-notes-ko.md`) — evidence-backed choices
+   made while mirroring drifted guides into the pack the same day.
+4. **`packages/client/src/localization/locales/ko.json`** — the app's shipped Korean UI translation,
+   which is the authority for every UI-label gloss.
+
+Rules are stated as they hold **in the pack as shipped**, not as they were originally aspired to.
+Where the pack deviates from a rule, the deviation is listed in
+[§7.3 Known pack residuals](#73-known-pack-residuals) rather than silently smoothed over.
+
+Citations are `path:line` relative to the pack root (`docs-i18n:ko/`). Counts were taken by
+mechanical census over all 125 `.md` files on 2026-09-01.
+
+**Verification pass (2026-09-01).** Every terminology row, every typography claim and every
+`path:line` citation in this file was re-checked against the pack. The register census (§1), the
+Latin-name particle table (§2), the Unicode/typography table (§4) and the `ko.json` gloss samples
+(§5) reproduced exactly. Corrections were applied where the pack disagreed — chiefly six terms that
+were listed as banned but are live in a different sense (now §6.4), the navigation-path counts in §5
+rule 9, and the gloss total. Four residuals found during this pass were added as **R5**–**R8**; of
+these **R8 is a content gap** (two English sections with no Korean counterpart) rather than a
+consistency wrinkle, and is the one worth fixing first. Two §7.1 checks that claimed "all pass" did
+not — checks 15 and 16 — and now state their real results.
+
+Claims that cannot be checked against the shipped pack — process rulings, historical counts from the
+original cycle, and engine behaviour — are marked **[recorded ruling]** and were left as received.
+Where a recorded ruling is contradicted by the shipped pack, the pack wins and the ruling is
+annotated (see §6.5 on the "163 mismatches" figure).
+
+---
+
+## 1. Register & address
+
+| Rule | Evidence |
+|---|---|
+| **합니다체** throughout. Declaratives end `-습니다` / `-ㅂ니다` / `-입니다`. Census: 3,684 `습니다`, 3,042 `합니다`, 2,064 `입니다`. | `CONFIGURATION.md:3`, `FAQ.md:7` |
+| **Imperatives are `~하세요`**, never `~하십시오`, `~해 주세요`, `~바랍니다`, or bare `~해라`. Census: 3,073 sentence-final `세요.`; **0** occurrences of `십시오`, `해 주세요`, `바랍니다`, `해라`. | `INSTALLATION.md:49`, `FAQ.md:13` |
+| **해요체 and 한다체 are banned.** Census: 0 sentence-final `-어요/-아요`, 0 sentence-final `-ㄴ다.` in prose. | pack-wide census |
+| **당신 is banned.** Korean drops the subject; 당신 reads confrontational in documentation. Census: **0** occurrences pack-wide. Second person is expressed by omission, or by 내/나 from the reader's viewpoint ("내 컴퓨터", "자신의 호스트 IP"). | `FAQ.md:9`, `INSTALLATION.md:43` |
+| **저희 / 우리 are effectively banned** for the product's voice — the product is named, not personified as "we". Census: 0 `저희`; 2 `우리` (generic, non-product). Prose says **Marinara**/**Marinara Engine** does X. | `CONFIGURATION.md:24` ("Marinara는 … 매번 묻습니다") |
+| **Gender-neutral by construction.** Korean docs carry no grammatical gender; the pack never assigns a gender to the reader, to characters generically, or to Professor Mari. Refer to the reader by role ("사용자", "서버 운영자") or by omission. | `CONFIGURATION.md:61` ("환경 변수는 서버 운영자의 허가이고…") |
+| **Guide-opening formula:** a user-facing guide opens `이 가이드에서는 …를 설명합니다.` / `…를 안내합니다.` **108 of 125** files use it. The 17 exceptions are the 11 `development/` PRDs and audits (engineering memos) plus `agents/hierarchical-maps.md`, `chats/settings-profiles.md`, `extending/personal-extensions.md`, `extending/writing-personal-extensions.md`, `game/storyboard.md`, `media/comfyui.md` — reference pages that open with a definition instead. | `lorebooks/overview.md:3`, `prompts/presets.md:3`, `agents/agents-overview.md:3` |
+| **Headings are noun phrases**, usually `-기` verbal nouns (411 of 1,861 headings end in `기`). FAQ-style headings are the one exception: **24** headings end in `?` — 19 in `-나요?`, 5 in `-인가요?` / `-한가요?`. Never imperative headings. | `INSTALLATION.md:5` (`## 플랫폼 고르기`), `FAQ.md:5` (`## …어떻게 하나요?`), `FAQ.md:49` (`…무엇인가요?`) |
+| **Exclamation marks are rare** (34 pack-wide, mostly inside quoted UI strings or code). Prose is declarative. | pack-wide census |
+
+---
+
+## 2. Product, feature & mode names
+
+**Core rule — product and feature names stay in Latin script.** They are never transcribed into
+Hangul. This is the rule that PR #4376 enforced back into `ko.json` (미니 마리의 깜짝 방문 →
+`Mini Mari의 깜짝 방문`).
+
+| Category | Treatment | Evidence |
+|---|---|---|
+| Product name | `Marinara Engine` / `Marinara` — Latin, never 마리나라. | `CONFIGURATION.md:7`, `FAQ.md:7` |
+| Chat modes | `Conversation`, `Roleplay`, `Game Mode` — Latin, **glossed on first use in a file** in the bold-label form of §5: `**Conversation**(대화)`, `**Roleplay**(롤플레이)`, `**Game Mode**(게임 모드)`; bare Latin thereafter. | `FAQ.md:53-55`, `integrations/discord-mirror.md:3` |
+| In-app surfaces | `Preset Editor`, `Character Editor`, `Card Browser`, `Memory Recall`, `World Maps`, `Peek Prompt`, `Professor Mari`, `Noodle`, `Impersonate` — Latin. Glossed once if the app ships a Korean string for them. | `prompts/presets.md:1`, `agents/memory.md:3`, `chats/peek-prompt.md:1` |
+| Platform/vendor names | `Termux`, `Docker`, `Podman`, `Android`, `Node.js`, `GitHub`, `Discord`, `Tailscale`, `ComfyUI` — Latin. | `INSTALLATION.md:20,35`, `installation/containers.md:10` |
+| Acronyms | `HUD`, `NPC`, `GM`, `PWA`, `APK`, `TTS`, `LTS` — Latin. Glossed on first use where a reader needs it: `NPC(플레이어가 아닌 캐릭터)`, `PWA(Progressive Web App, 앱처럼 설치할 수 있는 웹사이트)`, `LTS는 Long Term Support(장기 지원)의 줄임말`. | `game/dice-and-skill-checks.md:68`, `FAQ.md:43`, `UPGRADING.md:46` |
+| Concept nouns that are *not* names | Translated: 에이전트, 로어북, 프리셋, 페르소나, 캐릭터 카드, 연결, 채팅. A **name** is capitalised in the English source and identifies a specific surface; a **concept** is lowercase and gets Korean. | `agents/agents-overview.md:3` (panel `**Agents**(에이전트)` vs. concept 에이전트) |
+| Code literals | Byte-identical, never translated, never glossed: `start.sh`, `.env`, `DATA_DIR`, `termux-wake-lock`, `{{user}}`, `agents.json`. | `FAQ.md:9`, `TROUBLESHOOTING.md:326` |
+
+### Carrier nouns
+
+A Latin name may take a Korean **carrier noun** when the English relies on capitalisation alone to
+signal the category: `**Lorebooks**(로어북) 패널`, `**Agents** 패널`, `Marinara 폴더`,
+`Discord 채널`, `릴리스 채널`. The carrier is chosen so the sentence still parses when the reader
+is on the English UI. Evidence: `lorebooks/overview.md:3`, `agents/custom-agents.md:42`,
+`TROUBLESHOOTING.md:39`, `integrations/discord-mirror.md:3`.
+
+### Particles after Latin names — the batchim rule
+
+**A particle after a Latin name agrees with the batchim of the name's *Korean reading*, not with its
+English spelling.** The pack is 100% consistent on this; a census of every name+particle site found
+**zero** counterexamples for the names below.
+
+| Name | Korean reading | Batchim | Particles used in the pack | Evidence |
+|---|---|---|---|---|
+| Marinara Engine | 마리나라 엔진 | ㄴ | 은 / 이 / 을 / 으로 / 과 (17 / 37 / 24 / 4 / 1) | `CONFIGURATION.md:7` |
+| Marinara | 마리나라 | none | 는 / 가 / 를 (209 / 259 / 115) | `CONFIGURATION.md:24` |
+| HUD | 에이치유디 | none | **와** (11), 는 (5), 가 (1) — never 과/은/이 | `agents/agents-overview.md:73` |
+| Noodle | 누들 | ㄹ | **이** (20), **은** (10) — never 가/는 | `FAQ.md:117` |
+| Termux | 터먹스 | none | **를** (15), 가 (7), 는 (5) — never 을/이/은 | `FAQ.md:45` |
+| Conversation | 컨버세이션 | ㄴ | 은 (15), 을 (13), 이 (7) | `chats/connected-chats.md:55` |
+| Roleplay | 롤플레이 | none | 와 (36), 는 (13) | `roleplay/scenes.md:82` |
+| Game Mode | 게임 모드 | none | 는 (23), 가 (7) | `FAQ.md:55` |
+| World Maps | 월드 맵스 | none | 는 / 를 / 가 | `agents/hierarchical-maps.md:785` |
+| Node.js | 노드제이에스 | none | 와 (6), 가 (5) | `INSTALLATION.md:28,35` |
+| Docker | 도커 | none | 와 (4), 는 (2), 를 (1) | `installation/containers.md:10` |
+
+Practical consequence: `Windows와`, `Android와`, `Docker와` (vowel-final readings) but `Noodle은`,
+`Marinara Engine은`, `Conversation은` (consonant-final readings).
+
+### What stays English with no Korean at all
+
+Command output, error strings the user must match on screen, file names, env-var names, JSON keys,
+and shell commands. Quoted UI text the app does **not** translate stays English inside ASCII double
+quotes: `"This parameter is sent to the model"` (`TROUBLESHOOTING.md:129`).
+
+---
+
+## 3. Core terminology
+
+Evidence column gives one pack file that shows the term in use. "Banned alternates" are forms that
+must **not** appear as a rendering of that English term; every one listed below was verified at
+**0 occurrences** pack-wide in that sense on 2026-09-01.
+
+Two cautions when you re-run this census:
+
+- **A banned form may be a live word in a different sense.** 접속, 갱신, 반영, 시간 제한, 안내 문구,
+  복구 and 대화 are all *in use* in the pack with meanings of their own — they are not banned
+  outright, only as substitutes for the term in that row. They are listed in
+  [§6.4 Deliberate semantic splits](#64-deliberate-semantic-splits), not here.
+- **Substring matching produces false hits.** Korean has no word delimiter. A plain `grep` for 램
+  returns 52 matches, all inside 프로그램 / 다이어그램 (standalone 램: **0**); 넘기기 returns 2, both
+  the verb 넘기다 "to exceed" (`lorebooks/entries.md:207`, `media/comfyui.md:53`), not "swipe"; 다운
+  returns 108, all 다운로드 / 다운그레이드 / 드롭다운 / 쇼다운, never "crashed". Anchor the pattern or
+  check every hit by hand.
+
+| English | Pack term | Banned alternates | Evidence |
+|---|---|---|---|
+| prompt | 프롬프트 | 프롬트, 프람프트 | `agents/memory.md:9` |
+| prompt preset | 프롬프트 프리셋 | 프리세트, 프리셋트 | `prompts/presets.md:3` |
+| preset (noun) | 프리셋 | 사전 설정 | `prompts/presets.md:5` |
+| token | 토큰 | 토큰수(closed), 토우큰 | `lorebooks/token-budgets.md:3` |
+| token budget | 토큰 예산 | 토큰예산 (closed form banned) | `lorebooks/token-budgets.md:1` |
+| lorebook | 로어북 | 로어 북, 설정집, 세계관집 | `lorebooks/overview.md:3` |
+| character card | 캐릭터 카드 | 캐릭터카드 (closed form banned) | `characters/creating-and-editing-characters.md:5` |
+| chat (the app object — a chat thread) | 채팅 (1,992 uses) | 챗 — **not** 대화, which is a live word in three other senses (§6.4) | `chats/managing-chats.md:1` |
+| message | 메시지 | **메세지** | `chats/messages.md:1` |
+| swipe | 스와이프 | 스와입, 넘기기 | `chats/messages.md:1` |
+| regenerate | 재생성 | 재생산 | `chats/messages.md:1` |
+| generate again (distinct concept) | 다시 생성 | — | `game/map-time-weather.md:47`, `settings/settings-overview.md:98` |
+| agent | 에이전트 | 대리자, 에이젼트 | `agents/agents-overview.md:3` |
+| connection (provider link) | 연결 | 커넥션 — **not** 접속, which is live in the network sense (§6.4) | `connections/connecting-to-a-provider.md:3` |
+| AI provider | AI 제공자 | 공급자, 프로바이더 | `connections/connecting-to-a-provider.md:3` |
+| persona | 페르소나 | 퍼소나, 인격 | `characters/personas.md:3` |
+| NPC | NPC (Latin), first-use gloss `NPC(플레이어가 아닌 캐릭터)` | 엔피씨 | `game/dice-and-skill-checks.md:68` |
+| tracker | 트래커 | 트랙커, 추적기(bare) | `roleplay/hud-and-trackers.md:25` |
+| launcher | 런처 (91 uses) | **실행 스크립트** (0 uses; see note) | `UPGRADING.md:37,42`, `CONFIGURATION.md:278` |
+| start script (the files) | 시작 스크립트 | — (used only for the literal `start.sh`/`start.bat`/`start-termux.sh` trio) | `FAQ.md:9` |
+| update (software/package) | 업데이트 / 업데이트하다 | 업뎃 — **not** 갱신, which is live for record updates (§6.4) | `UPGRADING.md:118` |
+| apply (an update, a setting) | 적용 / 적용하다 | — **not** 반영, which is live for "takes effect" (§6.4) | `UPGRADING.md:118`, `CONFIGURATION.md:237` |
+| release | 릴리스 | **릴리즈** (0 pack-wide; also normalized in `ko.json` by PR #4376) | `connections/local-model.md:60` |
+| release channel | 릴리스 채널 | 업데이트 채널, 배포 채널 | `installation/windows.md:201`, `CONFIGURATION.md:237` |
+| channel (Discord) | 채널 | 채널방 | `integrations/discord-mirror.md:3` |
+| checkout (git working tree) | 체크아웃 | 체크 아웃 — **not** 작업 사본, which is the editor's *working copy* of a map/definition and unrelated to git (12 uses, `agents/hierarchical-maps.md:96`) | `TROUBLESHOOTING.md:39`, `CONFIGURATION.md:238` |
+| wake lock | **wake lock** (untranslated English noun) | 웨이크 락, 절전 잠금 | `TROUBLESHOOTING.md:324` |
+| battery optimization | 배터리 최적화 (idiom: `배터리 최적화 대상에서 제외`) | 배터리 절약, 배터리 세이버 | `TROUBLESHOOTING.md:326,332` |
+| background activity | 백그라운드 활동 | 백그라운드 동작 | `TROUBLESHOOTING.md:332` |
+| run in background | 백그라운드 실행 | 후면 실행 | `TROUBLESHOOTING.md:326` |
+| foreground | 포그라운드 | 전면 | `TROUBLESHOOTING.md:332` |
+| add-on (Termux extras) | 부가 기능 | 애드온(reserved: `Settings → Addons` gloss) | `TROUBLESHOOTING.md:326` |
+| Addons (the settings section) | 애드온 | — | `extending/personal-extensions.md:3` |
+| memory (RAM) | 메모리 — idioms `메모리에 유지`, `메모리로 올라오다`, `메모리에서 내리다` | 램 (0 standalone; grep hits are 프로그램/다이어그램), 기억장치 | `CONFIGURATION.md:155,156` |
+| in-memory | 인메모리 | 인 메모리, 메모리 내 | `development/architecture-map.md:95` |
+| load into memory | 메모리로 읽어 들이다 | 메모리에 로드 | `development/file-storage.md:39` |
+| Memory Recall (the feature) | `Memory Recall`(기억 회상) — **기억**, kept distinct from 메모리 (RAM) | 메모리 회상 | `agents/memory.md:3` |
+| least-recently-used | `가장 오래전에 사용한 것` (no loanword; follows the pack's 오래 idiom) | LRU, 최소 사용 | `CONFIGURATION.md:155`; cf. `chats/managing-chats.md:97` "활동한 지 오래된 채팅" |
+| cache | 캐시 | **캐쉬** | `CONFIGURATION.md:322` |
+| backup | 백업 | 백엎, 예비 저장 | `data/backup-and-restore.md:1` |
+| restore (from a backup/profile) | 복원 | 복구 — live, but for *recovery/repair* (§6.4) | `data/backup-and-restore.md:1,79` |
+| snapshot | 스냅샷 | **스냅숏** (the 국립국어원 form — deliberately not used; `ko.json` uses 스냅샷) | `chats/branches.md:26`, `development/architecture-map.md:95` |
+| crash | 크래시 / 크래시 복구 | 추락, 다운 | `development/architecture-map.md:95`, `TROUBLESHOOTING.md:330` |
+| conflict | 충돌 | 컨플릭트 | `development/file-storage.md:35` |
+| frozen (process) | 동결 / 동결된 | 얼어붙은, 프리즈 | `TROUBLESHOOTING.md:330` |
+| extension (the feature) | 확장 / 확장 기능 | 익스텐션 | `extending/personal-extensions.md:1` |
+| Personal Extensions | `Personal Extensions`(개인 확장) | 개인용 확장 | `extending/personal-extensions.md:3` |
+| External Extensions | `External Extensions`(외부 확장) | 외부 확장 프로그램 | `CONFIGURATION.md:57` |
+| custom (in prose) | 사용자 지정 (210 uses) | 커스텀 in prose; 맞춤 | `CONFIGURATION.md:31` |
+| Custom X (as a UI label gloss) | 커스텀 — **only** when `ko.json` ships 커스텀 for that label | — | `agents/agents-overview.md:29`, `game/hud-widgets.md:11` |
+| content | 콘텐츠 | **컨텐츠** | `CONFIGURATION.md:65` |
+| data | 데이터 | **데이타** | `data/where-data-is-stored.md:1` |
+| directory | 디렉터리 | 디렉토리 | `TROUBLESHOOTING.md:245` |
+| context | 컨텍스트 | 콘텍스트 | `agents/approvals-and-agent-suite.md:79` |
+| embedding | 임베딩 | 임배딩 | `lorebooks/semantic-search.md:11` |
+| asset | 에셋 | 애셋, 자산 | `game/game-assets.md:1` |
+| schedule | 스케줄 | **스케쥴** | `conversation/schedules.md:1` |
+| webhook | 웹훅 | 웹 훅 | `chats/connected-chats.md:83` |
+| checksum | 체크섬 | 체크썸 | `connections/local-model.md:60` |
+| profile | 프로필 | 프로파일 | `chats/settings-profiles.md:1` |
+| secret (admin/local secret) | 시크릿 | 비밀 키, 암호 | `CONFIGURATION.md:229` |
+| access control | 접근 제어 | 액세스 제어 | `FAQ.md:9` |
+| timeout (the named setting / env var) | 타임아웃 | — **not** 시간 제한, which is live for an unnamed execution limit (§6.4) | `CONFIGURATION.md:199,201` |
+| timed out (the event) | 시간 초과 | 타임아웃됨 | `media/comfyui.md:53`, `TROUBLESHOOTING.md:330` |
+| placeholder (field hint) | 플레이스홀더 | — **not** 안내 문구, which is live when prose *describes* the on-screen hint (§6.4) | `characters/personas.md:27`, `chats/connected-chats.md:83` |
+| placeholder (substituted token / stand-in) | 자리 표시자 for `{{macro}}`-style tokens | 플레이스홀더 in the `{{macro}}` sense — but see residual **R5**, the ComfyUI/LTX `%token%` docs use 플레이스홀더 | `characters/personas.md:13`, `agents/knowledge-sources.md:63` |
+| refresh (noun) | 새로고침 | 새로 고침 (see §7.3) | `FAQ.md:119` |
+| refresh (verb) | 새로 고치다 (spaced) | 새로고침하다 in prose | `CONFIGURATION.md:65` |
+| preview | 미리보기 | 미리 보기 (0 pack-wide) | `agents/hierarchical-maps.md:297` |
+| default (value) | 기본값 (406 uses) | 디폴트 (0 pack-wide) | `CONFIGURATION.md:131`, `media/comfyui.md:167` |
+| off (as a default) | 꺼짐 | 끄기, false | `CONFIGURATION.md:156`, `agents/memory.md:118` |
+| unset (as a default) | 설정하지 않음 / `…설정하지 않으면` | 미설정, 빈 값 | `CONFIGURATION.md:238,280`, `CONFIGURATION.md:155` |
+| unlimited | `0`(제한 없음) — 4 uses | 무제한 — **2 residual uses**, see **R6** | `CONFIGURATION.md:155` |
+| selfie | 셀카 | 셀피 | `conversation/selfies.md:1` |
+| dice / skill check | 주사위 / 스킬 판정 | 스킬 체크 | `game/dice-and-skill-checks.md:5,68` |
+
+**Note on 런처 vs 실행 스크립트 [recorded ruling]:** the reconciliation pass unified on **런처**;
+`실행 스크립트` has 0 occurrences pack-wide. The *outcome* is verified above; the reconciliation
+rationale itself is a recorded maintainer ruling (PR #4374, "런처 unification with recorded
+rationale"). `시작 스크립트` survives only where the docs literally name the three shipped script
+files (`FAQ.md:9`).
+
+---
+
+## 4. Typography & punctuation
+
+All of the following were verified by a full-pack Unicode scan on 2026-09-01 (125 files).
+
+| Rule | Census result |
+|---|---|
+| **All Latin letters and digits are half-width ASCII.** No full-width forms (`Ａ`, `１`, `（`). | **0** characters in `U+FF01–U+FF5E` |
+| **No ideographic space `U+3000`, no NBSP `U+00A0`/`U+202F`/`U+2007`.** Word separation is the plain ASCII space. | **0** |
+| **Straight ASCII quotes only** — `"` and `'`. Curly quotes `“ ” ‘ ’` are banned. 1,500 `"` and 53 `'` pack-wide, all straight. | **0** curly |
+| **Text is NFC-normalized.** No decomposed Hangul jamo (`U+1100–U+11FF`, `U+3130–U+318F`). | **0** jamo; **0** files fail NFC |
+| **Sentence terminator is the ASCII full stop `.`** — no `。`. Every declarative and every imperative ends `습니다.` / `세요.` | pack-wide |
+| **Em/en dashes are not a prose device.** 3 occurrences total: 2 as a list-item separator in `agents/custom-agents.md:113-114`, 1 inside a byte-preserved English code span (`lorebooks/entries.md:189`). Prose uses a full stop or a comma instead. | 3 (see §7.3) |
+| **Ellipsis:** prose does not use one. The 16 `…` (U+2026) and 101 `...` sites are all **quoted UI strings or code**, reproduced byte-for-byte from the app. The app itself is inconsistent (`en.json` has `Saving…` with U+2026 but `Opening chat...` with three ASCII dots), and the pack mirrors each string exactly. | 16 `…`, 101 `...` |
+| **Interpunct `·` (U+00B7)** is used only as a compact separator inside tables and dense enumerations — 4 occurrences on 3 lines. | `INSTALLATION.md:14`, `development/file-storage.md:31` (×2), `agents/hierarchical-maps.md:785` |
+| **Numbers are bare ASCII digits** with an ASCII comma as the thousands separator when the English source has one. 23 such numbers pack-wide (`16,384`, `478,000`, `1,000,000`). | `agents/built-in-agents.md:200`, `development/code-cleanup-audit.md:46`, `conversation/table-games.md:109` |
+| **Counters attach with no space:** `3개`, `3가지`, `5분`, `15초`. Never `3 개`. Census: 190 `N개`, 96 `N가지`, 32 `N분`, 50 `N초`; **0** spaced. | `FAQ.md:51`, `CONFIGURATION.md:205` |
+| **Parenthetical glosses take no space before `(`.** 2,476 Korean glosses, **0** with a leading space. | §5 |
+| **Parenthesised amplifications also take no space:** `300000`(5분), `0`(제한 없음), `1800000`(30분). | `CONFIGURATION.md:155,205`, `media/comfyui.md:168` |
+| **List mechanics:** `-` for bullets, `1.` for ordered steps. A definition bullet is `- **Label**(gloss): body` or `- **Label** — body`; ordered steps are full sentences ending in `~하세요.` | `INSTALLATION.md:19-20`, `FAQ.md:13-25` |
+| **Code fences keep their English info string byte-identical** and their contents are never translated. 12 info strings in use: `bash` (80), `text` (32), `bat` (18), `env` (17), `json` (12), `ts` (10), `css` (9), `html` (6), `yaml` (5), `js` (5), `typescript` (1), `tsx` (1). | `INSTALLATION.md:41`, `CONFIGURATION.md:41` |
+| **Tables keep the English source's column count and alignment row**; pipes are written unpadded, matching the existing files' style. | `INSTALLATION.md:9-14` |
+
+---
+
+## 5. UI labels & glosses
+
+**The gloss contract.** A reader may be on the Korean UI or on the English UI. The pack serves both:
+the **bold English label** is what the English-UI reader sees, and the **parenthetical Korean gloss**
+is what the Korean-UI reader sees.
+
+```
+4. **Download Backup**(백업 다운로드)을 클릭하세요.
+```
+— `UPGRADING.md:24`. Census: **2,486** `**Latin label**(…)` constructions outside code fences, of
+which **2,476** have a Korean gloss. The other 10 are English or numeric parentheticals on the same
+pattern — `**Default**(17px)`, `**RP**(Roleplay)`, `**Messages per batch**(20)` — which follow the
+no-space rule but are not glosses (`appearance/appearance-settings.md:56`, `chats/export-import.md:31`,
+`agents/built-in-agents.md:159`).
+
+### Rules
+
+1. **The gloss is byte-exact `ko.json`.** It is copied from the app's shipped Korean string, not
+   re-translated. Verified samples: `Save`→저장, `Install`→설치, `Keep`→유지, `Restore`→복원,
+   `Admin Access`→관리자 접근, `Download Backup`→백업 다운로드, `Refresh App`→앱 새로고침,
+   `Release Channel`→릴리스 채널, `Chat Layout`→채팅 레이아웃, `Add Variable`→변수 추가,
+   `Group`→그룹, `Custom Agents`→커스텀 에이전트, `Custom HUD Widgets`→커스텀 HUD 위젯.
+   Evidence: `REMOTE_ACCESS.md:190`, `agents/agents-overview.md:25,29`, `FAQ.md:165`,
+   `CONFIGURATION.md:229`, `installation/windows.md:201`, `game/hud-widgets.md:11`,
+   cross-checked against `packages/client/src/localization/locales/ko.json`.
+2. **Gloss fidelity beats prose consistency.** Prose says 사용자 지정 for "custom" (210 uses), but a
+   gloss of a label whose `ko.json` string says 커스텀 reproduces 커스텀 — all 7 커스텀 sites in the
+   pack are glosses. Evidence: `agents/agents-overview.md:29`, `roleplay/hud-and-trackers.md:25`;
+   `ko.json` `Custom Agents`→커스텀 에이전트, `Custom HUD Widgets`→커스텀 HUD 위젯.
+3. **Byte-exact means byte-exact, ellipsis included.** `"채팅 여는 중..."` keeps `ko.json`'s three
+   ASCII dots; `Uploading…`/`Saving…` keep the app's U+2026. Evidence: `TROUBLESHOOTING.md:330`,
+   `characters/creating-and-editing-characters.md:29`.
+4. **No space before the paren; no space inside it.** `**Install**(설치)`, never `**Install** (설치)`.
+   Verified: **0** spaced glosses in 2,476. A `\*\*[A-Za-z][^*]*\*\* \(` sweep returns 2 hits, both
+   **false positives** — `**Mode** (**Merged (Narrator)** / **Individual**)` and
+   `**Response Order** (Sequential / Smart / Manual)` at `chats/group-chats.md:111,113`. Those are
+   English option enumerations in a table, not glosses. Do not "fix" them.
+5. **Gloss once per file, then bare.** After the first glossed mention, later mentions in the same
+   file use the bold English alone. Evidence: `agents/custom-agents.md:42` glosses
+   `**Custom Agents**(커스텀 에이전트)` on first mention, then uses bare `**Custom Agents**` later in
+   that same line and again at `:111` and `:187`.
+6. **A label the app does not translate gets no gloss** and stays plain English. Where the English UI
+   itself renders the string unbolded, the pack leaves it unbolded too:
+   `Support Diagnostics(지원 진단 정보)` is written without bold because the source is unbolded.
+   Evidence: `TROUBLESHOOTING.md:330`; cf. `CONFIGURATION.md:242` (`Agents Manager에서`).
+7. **Untranslated English UI text quoted in prose sits in straight ASCII double quotes**, unglossed:
+   `"This parameter is sent to the model"`. Evidence: `TROUBLESHOOTING.md:129`.
+8. **Multi-part gloss uses a comma, not nested parens.** `**Unreachable (request timed out)**(연결할 수 없음, 요청 시간 초과)`.
+   Evidence: `TROUBLESHOOTING.md:330`.
+9. **Navigation paths.** Two separators are in force — `→` and ` > ` — and **each appears in both
+   structural positions**, so neither separator implies a structure. Match whichever the English
+   source uses, and keep the source's bolding.
+
+   | Separator | Total | Inside one bold run | Between separate bold labels | Remainder |
+   |---|---|---|---|---|
+   | `→` | 118 | 63 | 27 | 28 — arrows inside a gloss paren (`(에이전트 → 에이전트 다운로드)`) and 2nd-and-later arrows in a multi-segment run |
+   | ` > ` | 94 | 31 | 50 | 13 — **9 CSS child selectors**, not paths; 4 are 2nd-and-later separators in a multi-segment run |
+
+   Examples: `**Agents → Download Agents**(에이전트 → 에이전트 다운로드)` (`agents/built-in-agents.md:3`,
+   one bold run); `**Settings**(설정) → **General**(일반) → **Documentation Language**`
+   (`UPGRADING.md:13`, separate labels); `**Agents > Download Agents**` (`FAQ.md:175`, one bold run);
+   `**Settings**(설정) > **Addons**(애드온)` (`extending/personal-extensions.md:3`, separate labels);
+   `**Settings > General > App Behavior > Language**(설정 > 일반 > 앱 동작 > 언어)`
+   (`development/localization.md:9`, a four-segment run). The 9 non-path ` > ` hits are
+   `.mari-message-avatar > div` selectors in `appearance/card-css-theming.md` — exclude code fences
+   and inline code before counting.
+
+**[Recorded ruling] — the `ko.json` feedback loop.** `ko.json` is the authority for glosses, but when
+the docs review finds a *bug* in `ko.json`, the fix goes **upstream first and is then mirrored into
+the pack** — the pack never inherits a known-bad string. This produced PR #4376 (stale-item labels,
+`Mini Mari` de-transcription, 사용자 지정 소스, 재생성 unification, 상세도, and the 릴리즈→릴리스
+normalization). The pack's glosses are aligned with the **corrected** strings, which is why #4374 and
+#4376 had to land together. The process itself is not observable in the pack.
+
+---
+
+## 6. Language-specific mechanics
+
+### 6.1 Particles after a glossed label — **RULE §A-2**
+
+> **A particle following a `**Label**(gloss)` construction agrees with the batchim of the Korean
+> reading of the *English label*, not with the parenthetical gloss.**
+
+This is the pack's single most counter-intuitive rule and the one most likely to be "corrected" by a
+well-meaning reviewer. The reader speaks the label, not the gloss.
+
+Minimal pairs — the two halves are exact mirror images of each other:
+
+| Site | Written | Label reading | Gloss | Why |
+|---|---|---|---|---|
+| `REMOTE_ACCESS.md:190` | `**Save**(저장)를` | 세이브 — no batchim → **를** | 저장 *has* batchim, would take 을 | label wins |
+| `agents/agents-overview.md:25` | `**Install**(설치)을` | 인스톨 — ㄹ batchim → **을** | 설치 has *no* batchim, would take 를 | label wins |
+| `FAQ.md:165` | `**Keep**(유지)과` | 킵 — ㅂ batchim → **과** | 유지 would take 와 | label wins |
+| `CONFIGURATION.md:229` | `**Admin Access**(관리자 접근)로` | 액세스 — no batchim → **로** | 접근 would take 으로 | label wins |
+| `agents/knowledge-sources.md:42` | `**Add Agent**(에이전트 추가)를` | 에이전트 — no batchim → **를** | 추가 also takes 를 | agree |
+| `appearance/appearance-settings.md:74` | `**Chat Layout**(채팅 레이아웃)은` | 레이아웃 — ㅅ batchim → **은** | 레이아웃 also 은 | agree |
+| `lorebooks/entries.md:128` | `**Group**(그룹)과` | 그룹 — ㅂ batchim → **과** | 그룹 also 과 | agree |
+
+Census: the pack has **813** `**Label**(gloss)<particle>` sites (mechanically reproducible — this
+figure re-verified on 2026-09-01). On the ~334 of those where the two candidate readings *diverge*,
+the English label governs at **318** and the gloss governs at **3** (all `-ble` labels — see §7.3);
+the remainder are cases where both readings agree or the reading is ambiguous.
+
+> **Reproducing the divergence split.** Only the 813 total falls out of a regex. Splitting it into
+> "diverges / agrees" requires transliterating each English label to Hangul and reading its final
+> batchim, so the 334 / 318 / 3 breakdown depends on the transliteration table you use and is **not**
+> reproducible by `grep` alone. The three gloss-governed exceptions are individually verified and
+> cited in §7.3; treat the aggregate as a considered estimate, not a mechanical count.
+
+**Watch out for the copula.** `**Achievement unlocked**(업적 잠금 해제됨)이고` and
+`**RPG Attributes**(RPG 속성)이고` are the copula `이다`, not the subject particle 이/가. The copula
+attaches after any noun regardless of batchim and is **not** governed by §A-2. Evidence:
+`home/achievements.md:74`, `characters/colors-and-stats.md:58`.
+
+**[Recorded ruling]** The original cycle audited **882** name+particle sites and fixed **63** wrong
+particles, then normalized the particle-after-gloss convention across **803** sites (PR #4374). Those
+counts are historical and not observable in the shipped pack; only the resulting consistency is.
+
+**Note on the 2026-09-01 mirror-cycle wording.** `prd-notes-ko.md` records "Particles follow the
+Korean gloss (…없음)을), per pack precedent." The *output* at that site is correct
+(`**Server unreachable**(서버에 연결할 수 없음)을`, `TROUBLESHOOTING.md:330`) because 언리처블 ends in
+블 (ㄹ batchim) and 없음 ends in ㅁ — both readings demand 을. The note's **stated rationale is
+imprecise**; §A-2 as written above is the operative rule. Future cycles should quote §A-2, not the
+note.
+
+### 6.2 Compound spacing
+
+**One spacing per compound** — the in-app docs search is literal substring matching, so a split and a
+closed form fragment the index. **[Recorded ruling: the matcher's literal-substring behaviour is an
+engine fact from PR #4374, not observable in the pack.]**
+
+| Compound | Form | Census |
+|---|---|---|
+| refresh (noun) | **새로고침**, closed | 78 closed / 3 spaced (see §7.3) |
+| refresh (verb) | **새로 고치다**, spaced | 16 |
+| preview | **미리보기**, closed | 55 closed / **0** spaced |
+| character card | **캐릭터 카드**, spaced | 96 / 0 closed |
+| token budget | **토큰 예산**, spaced | 29 / 0 closed |
+| lorebook | **로어북**, closed | 587 / 0 spaced |
+
+The general pattern: a fully lexicalized noun closes (새로고침, 미리보기, 로어북, 웹훅, 퀵타임 in
+engineering docs); a noun phrase built from two live nouns stays spaced (캐릭터 카드, 토큰 예산,
+릴리스 채널); a **verb** form derived from a closed noun re-opens (`새로고침` → `새로 고치세요`,
+`CONFIGURATION.md:65`).
+
+### 6.3 One transcription per term
+
+Every loanword has exactly one spelling, enforced pack-wide. Verified at **0 occurrences** for every
+banned form: 메세지, 컨텐츠, 데이타, 릴리즈, 캐쉬, 스케쥴, 스냅숏, 프리세트, 디렉토리, 애셋, 임배딩,
+콘텍스트, 프로파일, 트랙커, 스와입.
+
+### 6.4 Deliberate semantic splits
+
+These look like inconsistencies to a bulk-consistency script and are **not**:
+
+| Pair | Split | Evidence |
+|---|---|---|
+| 플레이스홀더 / 자리 표시자 | a field's on-screen hint vs. a substituted `{{macro}}` token or stand-in content (but see **R5**) | `characters/personas.md:27` vs `characters/personas.md:13` |
+| 플레이스홀더 / 안내 문구 | the **placeholder** as a named UI concept vs. prose **describing** the on-screen hint ("the hint reads …"). 14 uses | `characters/personas.md:27` vs `game/dice-and-skill-checks.md:49`, `characters/sprites.md:33` |
+| 재생성 / 다시 생성 | "regenerate" (the app action) vs. "generate again/another" — the two ko.json labels `Generate another map` and `Reroll past the newest swipe` deliberately keep 다시 생성 | `chats/messages.md:1` vs `game/map-time-weather.md:47`, `settings/settings-overview.md:98` |
+| 메모리 / 기억 | RAM vs. the Memory Recall feature | `CONFIGURATION.md:155` vs `agents/memory.md:3` |
+| 크래시 / 충돌 | process crash vs. data or name conflict | `TROUBLESHOOTING.md:330` vs `development/file-storage.md:35` |
+| 채팅 / 대화 | the **chat object** (a thread you open, 1,992 uses) vs. 대화 in its three live senses: the `**Conversation**(대화)` mode gloss (43), talking/dialogue in general (67), and `대화 상자` = *dialog box* (6). 대화 is banned only as a rendering of "chat" | `chats/managing-chats.md:1` vs `FAQ.md:53`, `agents/agents-overview.md:7`, `TROUBLESHOOTING.md:294` |
+| 사용자 지정 / 커스텀 | prose vs. a `ko.json` label gloss | `CONFIGURATION.md:31` vs `agents/agents-overview.md:29` |
+| 부가 기능 / 애드온 | Termux extras vs. the `Settings → Addons` section | `TROUBLESHOOTING.md:326` vs `extending/personal-extensions.md:3` |
+| 연결 / 접속 | the **Connection** feature (a saved provider link) vs. *reaching* a host over the network. 접속 has 67 uses and is correct in that sense; `FAQ.md:65` puts both in one sentence: "**연결**은 Marinara가 AI 서비스 한 곳에 **접속**하는 방법을 저장해 둔 것입니다" | `connections/connecting-to-a-provider.md:3` vs `FAQ.md:27,65` |
+| 업데이트 / 갱신 | a software or package **update** vs. **updating a stored record** (a lorebook entry, a tracker, a canonical definition). 53 uses, concentrated in `agents/` | `UPGRADING.md:118` vs `agents/custom-agents.md:88`, `agents/built-in-agents.md:214` |
+| 적용 / 반영 | *applying* a change (a user action) vs. a change **taking effect / being reflected** somewhere (a result). 64 uses; `CONFIGURATION.md:90` heads a section `## 재시작과 즉시 반영` | `CONFIGURATION.md:237` vs `CONFIGURATION.md:90`, `appearance/custom-css-themes.md:9` |
+| 타임아웃 / 시간 초과 / 시간 제한 | the named **setting** vs. the **event** vs. an unnamed server-imposed **execution limit** (custom-tool calls, regex safety). 5 uses | `CONFIGURATION.md:201` vs `media/comfyui.md:53` vs `extending/custom-tools.md:104,168` |
+| 복원 / 복구 | user-facing **restore** from a backup or profile vs. **recovery/repair** in general — crash recovery, workspace repair, malformed-JSON repair, broken-reference recovery. 17 uses, broader than crash recovery alone | `data/backup-and-restore.md:79` vs `development/architecture-map.md:95`, `TROUBLESHOOTING.md:67`, `agents/hierarchical-maps.md:699` |
+
+### 6.5 Sentence construction
+
+- **Subject-dropping is the default.** Do not reintroduce a subject to mirror English "you".
+- **`~할 수 있습니다`** is the standard capability construction (318 uses).
+- **번역투 is out.** Prefer `Marinara는 …합니다` over a passive calque of "X is done by Marinara".
+  The QA panels rewrote translationese in the final pass **[recorded ruling — the rewrites are in the
+  pack, the review pass is not]**.
+- **Link text matches the target's H1, or shortens it.** Measured over the pack's 910 relative `.md`
+  links: 768 are exact H1 matches, 129 are a **shortening** of the H1 (`[장면 동영상]` →
+  `# 장면 동영상 생성`; `[문제 해결]` → `# Marinara Engine 문제 해결`), and 7 are anchor links that
+  correctly name the target *section* instead. Shortening is normal and correct — the rule is that
+  link text never **contradicts** the H1. 6 links do diverge; they are residual **R7**. The original
+  cycle's claim of "163 mismatches driven to 0" is a **[recorded ruling]** about a different, stricter
+  metric and does not describe the shipped pack — do not treat exact-match as the invariant.
+
+---
+
+## 7. QA checks & known traps
+
+### 7.1 Mechanical checks
+
+Run these over `ko/**/*.md` before shipping any change to the pack. Each maps to a rule above.
+
+| # | Check | Expected |
+|---|---|---|
+| 1 | Full-width Latin/digits `[！-～]`, ideographic space `　` | 0 |
+| 2 | NBSP family `[   ]` | 0 |
+| 3 | Curly quotes `[‘’“”]` | 0 |
+| 4 | Decomposed jamo `[ᄀ-ᇿ㄰-㆏]` | 0 |
+| 5 | `NFC(text) == text` for every file | all pass |
+| 6 | Banned transcriptions: 메세지, 컨텐츠, 데이타, 릴리즈, 캐쉬, 스케쥴, 스냅숏, 디렉토리, 프리세트, 애셋, 임배딩, 콘텍스트, 프로파일, 트랙커, 스와입 | 0 each |
+| 7 | `당신`, `십시오`, `해 주세요`, `바랍니다` | 0 each |
+| 8 | Sentence-final `-어요/-아요` and `-ㄴ다.` | 0 each |
+| 9 | `미리 보기` (spaced) | 0 |
+| 10 | `새로 고침` (spaced noun) | 3 known — see §7.3; any new one is a regression |
+| 11 | Gloss with a leading space: `\*\*[A-Za-z][^*]*\*\* \(` | 2 known **false positives** (`chats/group-chats.md:111,113`, English option lists — see §5 rule 4); 0 real |
+| 12 | §A-2 particle audit: for every `**Label**(gloss)<particle>`, the particle must match the batchim of the *label's* Korean reading | 3 known exceptions — see §7.3 |
+| 13 | Latin-name particle audit: `HUD와/는/가`, `Noodle은/이`, `Termux를/가/는`, `Marinara Engine은/이/을` | no counterexamples |
+| 14 | Code fences: info strings and fence bodies byte-identical to the English source | all pass |
+| 15 | Heading count and heading order match the English source (`docs/`) | **123 of 125 files match**; `FAQ.md` and `prompts/macros.md` are each one section short — see **R8** |
+| 16a | Every relative `.md` link resolves inside the pack | **0 broken** of 910 |
+| 16b | Link text equals the target file's H1 **or a shortening of it** | 768 exact + 129 shortened + 7 anchor links naming a section = 904; **6 unexplained**, see **R7** |
+| 17 | Every `**Label**(gloss)` gloss appears as a value in `ko.json` | see §7.2 note on ko.json drift; exclude the 10 non-Korean parentheticals listed in §5 |
+| 17b | Terms that are banned *in one sense only* (접속, 갱신, 반영, 시간 제한, 안내 문구, 복구) — read every hit, do not bulk-replace | see §6.4 |
+| 18 | `node scripts/docs-i18n/validate-pack.mjs` and `manifest.json` sha256/bytes re-hash | pass / 0 mismatches |
+| 19 | `pnpm regression:docs` still lists `ko`; `pnpm check` passes | pass |
+
+Checks 18–19 are **[recorded rulings]** from the PR's validation section — they are pipeline steps,
+not properties of the text.
+
+### 7.2 Known traps
+
+- **`ko.json` drift is the top gloss regression.** Glosses are byte-exact copies, so any `ko.json`
+  value change silently invalidates every doc that quotes it. `ko.json` has already grown from 6,905
+  keys (at #4374) to **8,681** as of 2026-09-01. Re-run check 17 whenever `ko.json` moves, and fix
+  upstream rather than inheriting a bad string.
+- **The `-ble` blind spot.** `Enable`, `Disable`, `Variable` read 이네이블 / 디세이블 / 베리어블 —
+  all ending in 블 with a ㄹ batchim, so §A-2 wants 을/은/과. The pack has three sites that instead
+  followed the gloss (§7.3). The pack *does* get bare `**Disable**은` right at
+  `extending/writing-personal-extensions.md:236`, so the two forms sit in the pack side by side.
+  Do not "harmonize" them without a maintainer call.
+- **Never reason about batchim from English spelling.** `Game Mode는` (모드, no batchim) and
+  `HUD와` (에이치유디, no batchim) both end in a written consonant. Always transliterate first.
+- **The copula trap.** `(gloss)이고` / `(gloss)이다` / `(gloss)입니다` are the copula and are exempt
+  from §A-2. A naive particle script will flag them; suppress that class.
+- **Windows tooling — Hangul and the console codepage.** A Python audit script that prints Hangul
+  dies with `UnicodeEncodeError: 'charmap' codec` under the default Windows console codepage. Set
+  `PYTHONIOENCODING=utf-8` (or write results to a UTF-8 file) before any census over this pack.
+  **[Recorded cycle ruling — observed while re-deriving this glossary on 2026-09-01.]**
+- **`\w` does not match Hangul in JS-flavoured regex.** In JavaScript, `\w` is exactly
+  `[A-Za-z0-9_]`, so a particle-audit or gloss-audit pattern written as `\*\*\w+\*\*\(\w+\)` matches
+  **nothing** on the Korean side and silently reports a clean run. Use an explicit `[가-힣]` class,
+  or `\p{Script=Hangul}` with the `u` flag. Python's `re` module *does* treat Hangul as `\w` on `str`
+  patterns, so a check that passes in Python and "passes" in Node is the signature of this bug —
+  confirm any zero-result sweep against a pattern you know should match.
+- **Substring false positives in a Hangul census.** See the caution at the head of §3 for the
+  known cases (램, 넘기기, 다운). One more bites the typography checks: `\d 개` returns 1 hit, from
+  "v2.3.0 **개**발 주기" — not a spaced counter. Always print the surrounding line before you believe
+  a count.
+- **Exclude code fences and inline code before counting punctuation.** 9 of the 94 ` > ` occurrences
+  are CSS child selectors in `appearance/card-css-theming.md`, not navigation paths (§5 rule 9).
+- **PowerShell 5.1 quoting.** Embedded quotes break native-command `-m`-style arguments; write the
+  message to a file and pass `-F`. **[Recorded ruling, project-wide.]**
+- **The in-app docs search is literal substring matching**, which is *why* one-spelling/one-spacing is
+  a hard rule rather than a style preference, and why NFD input silently breaks search.
+  **[Recorded ruling from PR #4374; not observable in the pack.]**
+- **Do not reflow untouched lines.** Mirror-cycle edits keep the surrounding line wrapping and the
+  files' unpadded table pipes intact, so diffs stay reviewable.
+  **[Recorded ruling — `prd-notes-ko.md`, 2026-09-01.]**
+
+### 7.3 Known pack residuals
+
+Documented, not silently fixed. Each is a real deviation from a rule above that exists in the pack as
+shipped.
+
+| # | Residual | Sites | Rule it deviates from |
+|---|---|---|---|
+| R1 | `새로 고침` as a spaced **noun** | `agents/built-in-agents.md:190` ("타임라인 새로 고침"), `development/optional-agent-packages.md:95` ("새로 고침 알림"), `extending/writing-personal-extensions.md:236` ("페이지 새로 고침") | §6.2 — the noun should be closed (`새로고침`, 78 sites) |
+| R2 | §A-2 followed the **gloss** instead of the label, all three on `-ble` labels | `extending/personal-extensions.md:202` (`**Disable**(비활성화)를`), `game/party-and-npcs.md:46` (`**Enable**(활성화)를`), `prompts/preset-variables.md:29` (`**Add Variable**(변수 추가)를`) | §6.1 — label reading ends in 블 (ㄹ), so 을 is expected |
+| R3 | `퀵타임` (closed, 3 sites in `development/`) vs `퀵 타임` (spaced, 2 sites in `game/`) | `development/architecture-map.md:129,154,289` vs `game/combat.md:82`, `game/getting-started.md:114` | §6.2 — one spacing per compound |
+| R4 | Em dash used as a prose/list separator | `agents/custom-agents.md:113,114` | §4 — em/en dashes are not a prose device (the third dash, `lorebooks/entries.md:189`, is inside a byte-preserved English code span and is **correct**) |
+| R5 | 플레이스홀더 used for a **substituted token**, the sense §6.4 assigns to 자리 표시자 | `game/ltx-2-3-storyboards.md:94,96,98,119,126`, `development/ltx-director-storyboard.md:63,75` | §6.4 — these are ComfyUI/LTX workflow `%token%` slots, i.e. substituted tokens. 자리 표시자 (10 uses) covers only `{{macro}}` tokens; the `%…%` workflow docs consistently say 플레이스홀더. Arguably a *third* sense rather than an error — needs a maintainer call before either is changed |
+| R6 | 무제한 instead of `0`(제한 없음) | `lorebooks/token-budgets.md:20,36` ("**0**으로 두면 무제한입니다") | §3 — the 4 `제한 없음` sites are the majority form; both render "unlimited" |
+| R7 | Link text that neither matches nor shortens the target's H1 (6 of 910) | `INSTALLATION.md:14` (`Android 설치 가이드` → H1 `Android (Termux) 설치 가이드`, drops "(Termux)"); `extending/personal-extensions.md:11,206` and `extending/writing-personal-extensions.md:3,256` (**the two `extending/` files cross-link each other under names neither H1 uses** — H1s are `개인 확장` and `Personal Extensions 작성`, links say the reverse); `extending/writing-personal-extensions.md:257` (`서버 구성` → H1 `서버 설정 참고 문서`) | §6.5 — the 4-link `extending/` pair is the substantive one; §3 lists `Personal Extensions`(개인 확장), so both names are legitimate but the pairing is inverted |
+| R8 | **Two English sections have no Korean counterpart** — content drift, not terminology | `ko/FAQ.md` lacks `## Does each Conversation chat have its own schedule?` (`docs/FAQ.md:63-71`); `ko/prompts/macros.md` lacks `## Lorebook size macro` (`docs/prompts/macros.md:132-138`), so `{{lorebooksize::ID}}` is documented **nowhere in the ko pack** (0 occurrences across all 125 files) | §7.1 check 15 — heading parity with the English source |
+
+None of R1–R7 is search-breaking for a Korean reader typing a whole word, but R1, R3, R5 and R6 do
+split the index for those exact strings. Fix them in a dedicated consistency pass, not as drive-by
+edits inside an unrelated mirror commit — and settle R5 with a maintainer before touching it, since
+the ComfyUI/LTX usage may be a deliberate third sense rather than drift.
+
+**R8 is the only residual that costs a reader information rather than consistency**, and it is the
+one to fix first: a Korean reader has no documentation for `{{lorebooksize::ID}}` at all, and no
+answer to the per-chat schedule question. Both are ordinary "English source moved on" drift and
+should be mirrored in the next cycle. R7's `extending/` pair is worth settling in the same pass,
+since both file names are legitimate per §3 and only the pairing is inverted.

--- a/glossaries/glossary-pl.md
+++ b/glossaries/glossary-pl.md
@@ -1,0 +1,829 @@
+# Polish (`pl`) documentation-pack glossary
+
+## Provenance
+
+This is the **second-generation** glossary for the `pl` documentation pack on the
+`docs-i18n` branch. It was **re-derived on 2026-09-01**, after the original
+working glossaries were lost to temp-directory cleanup, from three sources in
+authority order:
+
+1. **The shipped pack itself** (`pl/`, 125 guides + `manifest.json`) — treated as
+   ground truth. Every prescriptive rule below is either verified against the pack
+   by scan and cited as `path:line`, or explicitly marked as a recorded ruling.
+   All scans were run in Python with `str` regexes, never with shell `grep` —
+   see T-5, which explains why the distinction is load-bearing for Polish and not
+   pedantry.
+2. **The pack's shipping PR decision write-up** — Marinara-Engine PR
+   [#4235](https://github.com/Pasta-Devs/Marinara-Engine/pull/4235) ("Polish
+   documentation language pack", closes #4258), plus the Polish clause added by
+   that PR to `CONTRIBUTING.md § Translated documentation` (line 238 on
+   `staging`). That one line is a genuinely independent check on this glossary,
+   because it states the same rules in prose without reference to the pack bytes:
+   *"ty" with 2nd-person imperatives* (R-1), *avoid reader-gendering past-tense
+   forms* (R-3), *product names stay UNDECLINED with a carrier noun where the case
+   demands — "w aplikacji Marinara Engine", never "w Marinarze" — while assimilated
+   loanwords decline normally* (R-8/R-9/R-10/R-20), *straight ASCII quotes only,
+   never „…", and no non-breaking spaces* (R-95/R-98), *mode names
+   Conversation/Roleplay/Game Mode stay English* (R-14). Where a rule below is
+   corroborated there as well as in the pack, it is about as settled as anything
+   in this document gets.
+3. **The 2026-09-01 mirror-cycle notes** (`prd-notes-pl.md`) — per-row,
+   evidence-cited choices made while mirroring three English deltas (storage
+   table, security table, Termux troubleshooting) plus three new UI labels. All
+   of those choices are now landed in the pack and are re-verified here against
+   the shipped text, not against the notes.
+
+Where a source ruling is a **process rule** or a **claim about app behavior** that
+the pack's own bytes cannot demonstrate, it is kept but labelled `RR-n`
+(**recorded ruling**) rather than counted as verified.
+
+Rule IDs: `R-n` = verified against the pack. `RR-n` = recorded maintainer/cycle
+ruling, no in-pack evidence possible. Counts of "0 hits" are themselves evidence —
+a pack-wide scan returning nothing is how a prohibition gets verified, *provided*
+the scanner can see Polish letters (T-5).
+
+Where the pack contradicts itself, this document says so rather than picking a
+winner silently: the rule states the target form and a numbered entry under §7
+records the counter-evidence with counts and file cites. §7 residuals 1, 6 and 7
+are live splits, not stray typos — treat them as open work, not as noise.
+
+Pack facts at the time of derivation: 125 files, 1:1 with English `docs/`, no
+extra and no missing files, and `manifest.json` lists exactly those 125; all
+NFC-normalized (0 combining marks); no BOM; LF endings; no trailing whitespace;
+exactly one `# ` H1 per file.
+
+---
+
+## 1. Register & address
+
+**R-1 — Informal `ty`, second-person singular imperatives.** The reader is
+addressed directly and informally, with 2sg imperatives for every instruction.
+*Evidence:* `chats/slash-commands.md:7` — "wpisz ją w polu wiadomości na dole
+czatu i naciśnij przycisk **Send**"; `lorebooks/overview.md:25` — "Otwórz go z
+paska bocznego aplikacji."
+
+**R-2 — No formal register.** `Pan` / `Pani` / `Państwo` and the corporate
+`proszę + infinitive` construction never appear. *Evidence:* 0 hits pack-wide for
+`\bPan(i|u|a|ie)?\b`, `\bPaństw\w*` and `proszę \w+ć`.
+
+**R-3 — Gender-neutrality is absolute for the reader.** Polish past-tense verbs
+encode gender, so 2sg past forms in `-łeś` / `-łaś` are banned outright.
+*Evidence:* 0 hits pack-wide for `\w+ł[ae]ś\b` across all 125 files, and 0 for the
+conditionals `\w+ł[ab]yś\b`. (The 42 hits for `-łem/-łam` are all false positives
+inside ordinary nouns in the instrumental case — `hasłem`, `tłem`, `źródłem`,
+`kanałem` — not verbs.) This is the rule whose check is easiest to fake a pass on;
+read T-5 before you trust a clean result here.
+
+**R-4 — The gender-neutral toolkit.** To avoid gendered past tense, the pack uses,
+in rough order of frequency: 2sg imperatives; present tense; impersonal `-się`
+constructions; and the modal frames `da się`, `można`, `warto`, `trzeba`.
+*Evidence:* `CONFIGURATION.md:9` — "Konfigurację zmienia się zwykle po to, żeby";
+`lorebooks/overview.md:21` — "Marinara umie też dopasowywać wpisy po znaczeniu";
+`lorebooks/overview.md:31` — "dzięki czemu da się naraz wyeksportować lub usunąć
+kilka lorebooków"; `UPGRADING.md:19` — "Warto ją zrobić przed każdym większym
+skokiem".
+
+**R-5 — Reader pronouns are lowercase.** `ciebie`, `tobie`, `twój/twoja/twoje` are
+written lowercase mid-sentence; the capitalized epistolary forms `Ciebie`,
+`Tobie`, `Twój` are not the pack's convention. *Evidence:* 51 lowercase `ciebie`
+vs. 7 capitalized mid-sentence occurrences — `home/achievements.md:53` "profil,
+który reprezentuje ciebie w czacie"; `appearance/chat-backgrounds.md:80` "Marinara
+wraca za ciebie do tła wbudowanego". The 7 capitalized cases are a known residual
+(§7 residual 2).
+
+**R-6 — Address is used sparingly.** Capability and behavior statements are
+impersonal; the second person is reserved for actions the reader performs.
+*Evidence:* `CONFIGURATION.md:7` — "Marinara Engine działa od razu po instalacji"
+(impersonal statement) immediately followed by the imperative instruction block at
+`CONFIGURATION.md:9`.
+
+**R-7 — Definitional glosses use the `X to …` copula, not a verb.** Jargon is
+introduced with a bare nominal definition. *Evidence:* `chats/peek-prompt.md:5`
+"Prompt to cały blok instrukcji i historii czatu"; `agents/built-in-agents.md:7`
+"Agent to niewielki pomocnik AI"; `characters/personas.md:7` "Persona to ktoś, kim
+jesteś w czacie"; `chats/chat-settings.md:28` "Połączenie to zapisany skrót do
+dostawcy AI".
+
+**RR-1 — Why informal `ty`.** Chosen to match the informal-register precedent set
+by every earlier pack (es/de/fr/pt-br) and Polish consumer-software convention.
+The result is verifiable (R-1); the cross-pack rationale is a PR #4235 ruling.
+
+---
+
+## 2. Product, feature & mode names
+
+**R-8 — Marinara product names are never declined.** No case-inflected form of the
+brand exists anywhere in the pack. *Evidence:* 0 hits pack-wide for
+`Marinar(ze|y|ą|ę|om|ami|ach)\b`.
+
+**R-9 — Oblique cases take a declinable carrier noun.** The standard carrier is
+`aplikacja`, inflected while the name stays frozen. *Evidence:* 427 hits for
+`aplikacj\w+ Marinara Engine`, distributed `aplikacji` 319 / `aplikację` 57 /
+`aplikacja` 33 / `aplikacją` 18. `CONFIGURATION.md:3` — "zmieniać ustawienia
+serwera w aplikacji Marinara Engine"; `TROUBLESHOOTING.md:63` — "uruchom aplikację
+Marinara Engine ponownie".
+
+**R-10 — A preposition takes the carrier noun, not the bare frozen name.**
+`w Marinara Engine`, `do Marinara`, `z Marinara` do not occur anywhere.
+*Evidence:* 0 hits pack-wide for `\bw(e)? Marinara`, `\bdo Marinara`,
+`\bz Marinara`, and 427 carrier-noun constructions instead (R-9). The rule is not
+absolute in the shipped pack: 6 bare-preposition uses survive with `przez` and
+`pod`, all in the same two files. See §7 residual 11. New text should use the
+carrier.
+
+**R-11 — Bare `Marinara` is allowed as a nominative subject, with feminine
+agreement.** *Evidence:* `CONFIGURATION.md:20` — "Marinara sama wybiera z katalogu
+… ścieżkę"; `CONFIGURATION.md:71` — "Marinara nie wykonuje znaku `$`";
+`lorebooks/overview.md:21` — "Marinara umie też dopasowywać wpisy".
+
+**R-12 — `silnik Marinara` is not a carrier.** The engine-as-noun framing is never
+attached to the brand. *Evidence:* 0 hits pack-wide for `silnik\w* Marinara`. The
+word `silnik` itself is common (28 occurrences across 15 files) but always in the
+generic sense — a game engine, an ONNX engine, "the engine" as the codebase
+(`agents/built-in-agents.md:202` "silnik od wersji `2.3.5`";
+`conversation/calls.md:241` "ONNX to silnik, który uruchamia lokalny model mowy";
+`CONFIGURATION.md:278`).
+
+**R-13 — Third-party product names take the same carrier-noun treatment.**
+*Evidence:* `system Windows` ×20 (`FAQ.md:15` "W systemie Windows uruchom to
+polecenie"); `środowisko Termux` ×18 (`CONFIGURATION.md:278`); `kontener Docker`
+×20 (`CONFIGURATION.md:25` "w kontenerze Docker") plus `obraz Docker` ×2;
+`serwis GitHub` ×9 (`CONFIGURATION.md:27` "gdy połączenie HTTPS z serwisem GitHub
+jest niedostępne"). `Termux`, `GitHub` and `Windows` are never declined (0 hits
+for `Termuxie`, `Termuxa`, `GitHubie`, `GitHuba`, `Windowsie`, `Windowsa`);
+`Docker` is declined 3 times — see §7 residual 8.
+
+**R-14 — Mode names stay English behind the carrier noun `tryb`.**
+`Conversation`, `Roleplay`, `Game Mode` are never translated. *Evidence:*
+`FAQ.md:53-55` — "**Conversation**: czat w stylu SMS-ów…", "**Game Mode**:
+prowadzona przygoda tekstowa"; `agents/knowledge-sources.md:16` — "Obaj agenci
+działają wyłącznie na czatach w trybie **Roleplay**. W trybie Conversation Mode
+ani w trybie Game Mode nie da się ich dodać."; `characters/sprites.md:12` — "tylko
+w trybie **Roleplay Mode** i **Game Mode**".
+
+**R-15 — Panel, section, tab and control names stay English, in bold.**
+*Evidence:* `CONFIGURATION.md:20` — "Otwórz sekcję **Agents → Download Agents**";
+`lorebooks/overview.md:25` — "Panel **Lorebooks**"; `UPGRADING.md:128` — "Lista
+rozwijana **Release Channel**".
+
+**R-16 — Named features stay English.** Peek Prompt, Memory Recall, Impersonate,
+Chat Summary, Release Channel, Support Diagnostics, Danger Zone, World Info.
+*Evidence:* `chats/peek-prompt.md:5` "Dzięki funkcji **Peek Prompt**";
+`chats/guided-and-impersonate.md:59` "Funkcja Impersonate każe AI napisać";
+`TROUBLESHOOTING.md:330` "kopia z sekcji Support Diagnostics";
+`characters/personas.md:101` / `lorebooks/overview.md:7` "**World Info**".
+
+**R-17 — Agent names stay English.** *Evidence:* `FAQ.md:173` "Agent
+**Storyboard**"; `agents/built-in-agents.md:111` "Character Tracker";
+`agents/approvals-and-agent-suite.md:40` "Agent **Card Evolution Auditor**".
+
+**R-18 — Professor Mari is frozen and takes the feminine carrier `asystentka`.**
+*Evidence:* `FAQ.md:161` — "Professor Mari to wbudowana asystentka na ekranie
+głównym"; `CONFIGURATION.md:322` — "Jak długo asystentka Professor Mari trzyma w
+pamięci podręcznej odczyt z wiki."
+
+**R-19 — A heading may stay English when the heading *is* the UI control name.**
+*Evidence:* `UPGRADING.md:126` "### Release Channel"; `UPGRADING.md:137`
+"### Check for Updates"; `agents/approvals-and-agent-suite.md:91` "## Panel Cached
+prompt injections" (carrier + English name).
+
+**R-20 — Ordinary loanwords, unlike product names, decline fully.** The freeze
+applies to *names*, not to vocabulary — the two policies coexist in a single
+sentence. *Evidence:* `lorebooks/overview.md:9` — "Marinara Engine dodaje tekst
+tego wpisu do promptu" (frozen name, declined loanword); `CONFIGURATION.md:18` —
+"klucze API dostawców AI, postacie i opcje czatu". Full paradigms in §6.
+
+**RR-2 — Why the freeze.** A declined product name fragments the docs viewer's
+literal substring search: "Marinarze" does not contain-match "Marinara". Recorded
+in PR #4235 and in `CONTRIBUTING.md:238`. The rule's *effect* is verified (R-8);
+the search-behavior claim is not observable from pack bytes.
+
+---
+
+## 3. Core terminology
+
+Table conventions: **Term** is the English source word. **Pack's term** is the
+form the shipped `pl/` pack uses, with the inflections it actually shows.
+**Banned** lists alternates that must not be introduced (including forms that are
+*correct Polish* but split the substring search, and forms that are reserved for a
+different sense). **Evidence** is one file in the pack that shows the term.
+
+| # | English term | Pack's term | Banned alternates | Evidence |
+|---|---|---|---|---|
+| R-21 | prompt | `prompt`, declines fully: promptu, promptem, prompcie, prompty, promptów | podpowiedź (reserved: tooltip), monit, polecenie (reserved: shell command), zachęta, znak zachęty | `chats/peek-prompt.md:5` |
+| R-22 | prompt (first-use gloss) | "prompt to tekst, który Marinara wysyła do AI" — in parentheses on first use per file | ad-hoc paraphrases of the gloss | `lorebooks/entries.md:5`, `game/storyboard.md:5` |
+| R-23 | token | `token`, declines: tokeny, tokenów, tokenach | żeton (reserved: poker chips, `conversation/table-games.md:109`), znacznik | `chats/slash-commands.md:17` |
+| R-24 | token (first-use gloss) | "token to mały kawałek tekstu" / "jednostka, którą większość dostawców AI mierzy i rozlicza tekst" | — | `chats/messages.md:95`, `lorebooks/entries.md:19` |
+| R-25 | preset | `preset`, declines: presetu, presetem, presety, presetów | ustawienie wstępne, szablon (bare — reserved: template), profil (reserved: settings profile / persona profile) | `prompts/presets.md:7` |
+| R-26 | lorebook | `lorebook`, declines: lorebooka, lorebookiem, lorebooki, lorebooków | księga wiedzy (this is the app's `pl.json` UI string — see §7 residual 10), zbiór wiedzy, kompendium | `lorebooks/overview.md:7` |
+| R-27 | World Info | `World Info` — kept English as the stated synonym of lorebook | Informacje o świecie | `lorebooks/overview.md:7` |
+| R-28 | lorebook entry | `wpis` (wpisu, wpisy, wpisów) | pozycja, rekord, notka | `lorebooks/entries.md:5` |
+| R-29 | keyword / key | `słowo kluczowe` (słowa kluczowe, słów kluczowych) | klucz, hasło | `agents/custom-agents.md:122` |
+| R-30 | character card | `karta postaci` | karta znaku, karta bohatera | `FAQ.md:99` |
+| R-31 | chat (the object) | `czat`, fully assimilated and declined: czatu, czacie, czatem, czaty, czatów, czatach | chat (English spelling in Polish prose), pogawędka, konwersacja | `CONFIGURATION.md:18` |
+| R-32 | conversation (human sense) | `rozmowa` | — (do not use `rozmowa` for the chat object; that is `czat`) | `agents/built-in-agents.md:153` |
+| R-33 | message | `wiadomość` (wiadomości, wiadomościach) | komunikat (reserved: system/error message, `TROUBLESHOOTING.md:330`) | `chats/messages.md:95` |
+| R-34 | agent | `agent`, declines: agenta, agentem, agenci, agentów | asystent (reserved for Professor Mari), bot | `agents/built-in-agents.md:7` |
+| R-35 | connection | `połączenie` (połączenia, połączeniu) — gloss "zapisany skrót do dostawcy AI" | łącze, konfiguracja połączenia | `chats/chat-settings.md:28` |
+| R-36 | provider | `dostawca (AI)` (dostawcy, dostawców) | usługodawca, provider | `connections/connecting-to-a-provider.md:7` |
+| R-37 | launcher | `program uruchamiający` (programy uruchamiające) ×46 is the dominant form; two rival forms survive — `launcher` in `UPGRADING.md`, `skrypt startowy` throughout `installation/macos-linux.md` — see §7 residual 1 | uruchamiacz (0 hits), skrypt uruchomieniowy | `TROUBLESHOOTING.md:324`, `CONFIGURATION.md:278` |
+| R-38 | update (noun) | `aktualizacja` (aktualizacje, aktualizacji) | uaktualnienie (0 hits pack-wide), upgrade | `UPGRADING.md:19` |
+| R-39 | apply (an update) | `wgrać` / `wgrywanie` / `wgranie aktualizacji` | zastosować aktualizację (reserved for the *remote* apply framing, `installation/windows.md:213`), zaaplikować, nałożyć | `CONFIGURATION.md:239` |
+| R-40 | release channel | `kanał wydań`; channel switch = `zmiana kanału` | kanał wersji, tor wydawniczy | `UPGRADING.md:128`, `CONFIGURATION.md:237` |
+| R-41 | checkout (a Git working copy) | `kopia repozytorium`; the literal string `git checkout` stays frozen in quotes | kopia robocza (**reserved**: an editor draft, `agents/hierarchical-maps.md:100`), wypożyczenie, kasa | `TROUBLESHOOTING.md:39`, `UPGRADING.md:33` |
+| R-42 | development checkout | `deweloperska kopia repozytorium` | deweloperska kopia robocza | `CONFIGURATION.md:238` |
+| R-43 | loopback | `pętla zwrotna` | interfejs zwrotny, localhost (as a translation) | `CONFIGURATION.md:238` |
+| R-44 | wake lock | `blokada uśpienia`; the commands `termux-wake-lock` / `termux-wake-unlock` stay byte-exact in backticks | blokada wybudzenia, wake lock (untranslated in prose) | `TROUBLESHOOTING.md:324`, `:326` |
+| R-45 | battery optimization | `optymalizacja baterii` (wyłącz … optymalizację baterii) | oszczędzanie baterii, optymalizacja zużycia energii | `TROUBLESHOOTING.md:326` |
+| R-46 | background activity | `działanie w tle` (zezwól aplikacji Termux na działanie w tle) | aktywność w tle, praca w tle | `TROUBLESHOOTING.md:326`, `:332` |
+| R-47 | memory (RAM) / in memory | `pamięć`; residency = `trzymać w pamięci`, `żyć wyłącznie w pamięci` | RAM (as a prose noun outside hardware requirements) | `CONFIGURATION.md:155`, `characters/bot-browser.md:116`, `TROUBLESHOOTING.md:182` |
+| R-48 | dropped from memory / evicted | `usuwany z pamięci (nigdy z dysku)`; the concept = `usuwanie z pamięci` | eksmisja, wyrzucanie, usuwanie danych (ambiguous with deletion) | `CONFIGURATION.md:155` |
+| R-49 | least-recently-used | `najdawniej używany` | najrzadziej używany (that is LFU, a different policy), ostatnio nieużywany | `CONFIGURATION.md:155` |
+| R-50 | memories (agent memory vault) | `wspomnienia` (wspomnienie, wspomnień) — distinct from R-47 `pamięć` | pamięci (plural of RAM sense) | `TROUBLESHOOTING.md:163`, `agents/built-in-agents.md:153` |
+| R-51 | phone memory | `pamięć telefonu` | pamięć urządzenia mobilnego | `TROUBLESHOOTING.md:347` |
+| R-52 | cache | prose: `pamięć podręczna` (w pamięci podręcznej) ×24; developer docs keep `cache` with an apostrophe before Polish endings (`cache'u` ×2) | bufor / buforowanie (**leaks twice** for *prompt caching* — §7 residual 12), podręczna pamięć (word order), keszowanie | `TROUBLESHOOTING.md:80`, `development/frontend.md:559` |
+| R-53 | backup | `kopia zapasowa` (kopię zapasową, kopii zapasowych) | backup (in Polish prose), zabezpieczenie danych | `FAQ.md:132`, `UPGRADING.md:19` |
+| R-54 | snapshot | `migawka` (migawki, migawkę) | zrzut (reserved: screenshot/dump), stan zapisany, snapshot | `characters/creating-and-editing-characters.md:128`, `agents/hierarchical-maps.md:381` |
+| R-55 | checkpoint | `punkt kontrolny` (×17) | checkpoint (**reserved**: the ComfyUI/LTX model file, `game/ltx-2-3-storyboards.md:43`), punkt zapisu | `agents/built-in-agents.md:153` |
+| R-56 | extension | `rozszerzenie` (rozszerzenia, rozszerzeń); the panel/menu name **Extensions** stays English | dodatek (**reserved**: glosses the **Addons** settings section, `CONFIGURATION.md:312`), wtyczka (reserved: a build-tool plugin, `development/frontend.md:372`), plugin | `CONFIGURATION.md:57`, `development/personal-extensions.md:93` |
+| R-57 | NPC | `NPC` frozen and undeclined, behind the carrier noun `postać`: `postać NPC`, `postaci NPC`; first-use gloss "(postaci niezależnej)" | BN, NPC-e, NPC-ów, postać niezależna as the standing term | `game/dice-and-skill-checks.md:68`, `game/party-and-npcs.md:79` |
+| R-58 | persona | `persona` (persony, personie, person) — gloss "postać, w którą się wcielasz" | profil użytkownika (ambiguous with settings profile), awatar | `characters/personas.md:7`, `chats/slash-commands.md:98` |
+| R-59 | slash command | `komenda slash` (komendy slash, komendę) | polecenie slash, ukośnikowe polecenie | `chats/slash-commands.md:1` |
+| R-60 | shell / CLI command | `polecenie` (poleceniem, polecenia) | komenda (reserved for R-59), rozkaz | `TROUBLESHOOTING.md:23`, `FAQ.md:15` |
+| R-61 | sprite | `sprite` with an ASCII apostrophe before Polish endings: sprite'y, sprite'ów, sprite'ami, sprite'a | sprajt, duszek, spritey (no apostrophe) | `CONFIGURATION.md:104`, `characters/sprites.md:12` |
+| R-62 | swipe (response variant) | `swipe` with apostrophe: swipe'y, swipe'em | przesunięcie, machnięcie | `agents/hierarchical-maps.md:379` |
+| R-63 | variant (of a response) | `wariant` (warianty, wariantów) | wersja (reserved: version) | `TROUBLESHOOTING.md:260` |
+| R-64 | widget | `widget` in Latin spelling, declines: widgety, widgetach, widgetów | widżet (0 hits in the pack; this *is* the app's `pl.json` spelling — see §7 residual 10) | `game/hud-widgets.md:1`, `roleplay/hud-and-trackers.md:3` |
+| R-65 | tracker | `tracker` (trackery, trackerów) | śledzik, monitor | `CONFIGURATION.md:206`, `roleplay/hud-and-trackers.md:3` |
+| R-66 | HUD | `HUD` frozen and undeclined, behind the carrier `pasek HUD` | interfejs nagłówkowy, HUD-u | `roleplay/hud-and-trackers.md:3`, `roleplay/getting-started.md:9` |
+| R-67 | branch (chat or Git) | `gałąź` (gałęzi, gałęzie) | odnoga, branch | `CONFIGURATION.md:316` |
+| R-68 | summary | `podsumowanie` (podsumowania); the shortened text = `streszczenie` | skrót, sumaryzacja | `FAQ.md:128` |
+| R-69 | embedding | `embedding` (embeddingów, embeddingi) | osadzenie, wektor (reserved: vector) | `CONFIGURATION.md:15`, `agents/memory.md:36` |
+| R-70 | macro | `makro` (makra) | makropolecenie | `agents/custom-agents.md:166` |
+| R-71 | sandbox | `piaskownica` (piaskownicy) | sandbox, izolatka | `FAQ.md:145`, `TROUBLESHOOTING.md:419` |
+| R-72 | theme (CSS) | `motyw` (motywu, motywy) | temat, skórka | `appearance/custom-css-themes.md:31` |
+| R-73 | sticker | `naklejka` (naklejki) | stiker, nalepka | `characters/galleries.md:43` |
+| R-74 | badge | `plakietka` (plakietkę) ×25 | odznaka (**reserved**: the collectible achievement badge, `home/achievements.md:7`), znaczek | `agents/custom-agents.md:40`, `lorebooks/overview.md:35` |
+| R-75 | tooltip | `podpowiedź` ("jej podpowiedź brzmi **Edit theme CSS**") | dymek (**reserved**: the chat message bubble / `.mari-message-bubble`, `appearance/card-css-theming.md:83`), tooltip, chmurka | `appearance/custom-css-themes.md:31` |
+| R-76 | toggle / switch | `przełącznik` | suwak (reserved: R-77), włącznik | `CONFIGURATION.md:31` |
+| R-77 | slider | `suwak` | pasek przewijania | `appearance/appearance-settings.md:90` |
+| R-78 | dropdown | `lista rozwijana` | rozwijane menu, dropdown | `UPGRADING.md:128` |
+| R-79 | checkbox | `pole wyboru` | checkbox, kratka | `characters/bot-browser.md:77` |
+| R-80 | placeholder text | `tekst zastępczy` | placeholder (**reserved**: the byte-exact English label **Upload a 1x1 placeholder…**, `media/comfyui.md:141`), tekst podpowiedzi | `REMOTE_ACCESS.md:190`, `lorebooks/overview.md:33` |
+| R-81 | tab | `zakładka` (zakładce, zakładki) | karta (reserved: character card / browser tab — "w osobnej karcie", `agents/built-in-agents.md:186`) | `FAQ.md:51` |
+| R-82 | panel | `panel` (panelu, panele) | okienko (**reserved**: a small floating/minimized window, `conversation/calls.md:159`) | `lorebooks/overview.md:25` |
+| R-83 | modal / dialog | `okno` (okno **Create Lorebook**, w oknie) | modal, dialog, okienko dialogowe | `lorebooks/overview.md:29`, `CONFIGURATION.md:124` |
+| R-84 | folder (on disk / in library) | `folder` (folderu, foldery, folderach) | katalog (reserved: R-85), teczka | `CONFIGURATION.md:26`, `lorebooks/overview.md:37` |
+| R-85 | catalog (of agent packages) | `katalog` | sklep, repozytorium (reserved: Git repo) | `CONFIGURATION.md:20` |
+| R-86 | storage (as a subsystem) | `przechowywanie`; the on-disk area = the frozen path `storage` | składowanie, magazynowanie | `CONFIGURATION.md:22`, `data/where-data-is-stored.md:21` |
+| R-87 | restart | `restart` / `uruchomić ponownie` (uruchom ponownie) | reset (reserved: **Reset** control), przeładowanie | `CONFIGURATION.md:92`, `TROUBLESHOOTING.md:23` |
+| R-88 | game master (GM) | `mistrz gry`; the character name **GM** stays English | narrator (reserved: Narrative Director) | `FAQ.md:55` |
+| R-89 | party | `drużyna` (drużyny) | grupa, ekipa | `game/party-and-npcs.md:19` |
+| R-90 | dice / dice roll | `kość`, `rzut kością` (kostka for the die object) | kostki do gry, dice | `agents/built-in-agents.md:226` |
+| R-91 | env default: empty | `pusta` (feminine, agreeing with the implied `wartość`) | puste, brak | `CONFIGURATION.md:154` |
+| R-92 | env default: unset | `nieustawiona` in the Defaults column — the pack's **only** occurrence, so treat it as the form to reuse rather than as an attested paradigm; there is no established prose form (`brak ustawienia` and `nieustawione` have 0 hits) | niezdefiniowana, pusta (reserved: R-91) | `CONFIGURATION.md:238` |
+| R-93 | env default: off | `wyłączone` | off, nieaktywne | `CONFIGURATION.md:156` |
+| R-94 | `0` (unlimited) | `` `0` (bez limitu) `` | nieograniczone, bez ograniczeń | `CONFIGURATION.md:155` |
+
+---
+
+## 4. Typography & punctuation
+
+**R-95 — Straight ASCII double quotes only.** Polish typographic quotes `„…"` are
+banned outright, as are curly `""`. *Evidence:* 0 hits pack-wide for U+201E,
+U+201C, U+201D; 1500 ASCII `"` across 99 files. `TROUBLESHOOTING.md:330` —
+`komunikacie "Opening chat..."`; `UPGRADING.md:133` — `wyświetla ostrzeżenie:
+"Staging builds are pre-release tester builds. …"`.
+
+**R-96 — No curly apostrophe.** *Evidence:* 0 hits pack-wide for U+2019, including
+inside declined loanwords. (Note this diverges from the app's own `pl.json`, which
+writes `sprite’ów` — see §7 residual 10.)
+
+**R-97 — ASCII apostrophe `'` carries Polish endings on Latin-final loanwords.**
+*Evidence:* `sprite'y`, `sprite'ów`, `sprite'ami` (`CONFIGURATION.md:104`,
+`characters/sprites.md:12`); `swipe'em` (`agents/hierarchical-maps.md:379`);
+`cache'u` (`development/frontend.md:215`, `:559`).
+
+**R-98 — No non-breaking spaces, anywhere.** *Evidence:* 0 hits pack-wide for
+U+00A0. Polish orthography tolerates NBSP after one-letter prepositions; the pack
+does not use it, because it is not a plain ASCII space for search and copy-paste
+purposes.
+
+**R-99 — The en dash `–`, spaced, is the default parenthetical/interruption
+dash.** *Evidence:* 279 occurrences across 74 files. `CONFIGURATION.md:18` —
+"Prawie całą resztę – klucze API dostawców AI, postacie i opcje czatu – ustawia
+się w aplikacji"; `lorebooks/overview.md:17` — "każda wzmianka o mieście Eldoria –
+twoja albo postaci – sprawia".
+
+**R-100 — Em dash `—` is a minority form confined to a handful of files; do not
+introduce new ones.** *Evidence:* 14 occurrences in 7 files, against 279 en
+dashes. Within `TROUBLESHOOTING.md` the em dash is the local precedent (lines 49,
+260, 326, 330) and the 2026-09-01 delta deliberately followed it; outside that
+file, use the en dash. See §7 residual 5.
+
+**R-101 — U+2026 `…` never appears in freeform Polish prose.** Of the 15
+occurrences, 12 are byte-exact English UI labels and 3 are elisions carried over
+unchanged from the English source inside code spans or code blocks.
+*Evidence, labels:* `UPGRADING.md:139` **Checking…**, `data/backup-and-restore.md:30`
+**Creating backup…**, `lorebooks/entries.md:31` **Autosaving…** / **Saving…**,
+`UPGRADING.md:27` **Creating backup…**, `:135` **Switching…**, `:182`
+**Refreshing…**, `characters/creating-and-editing-characters.md:29` **Uploading…**
+/ **Embedding…** / **Saving…**, `connections/connecting-to-a-provider.md:34`
+**Search models…**, `lorebooks/entries.md:13` **Search entries…**. Each matches
+`en.json` exactly (`settings.notifications.customSound.status.loading` =
+`"Checking…"`, `ui.panels.advancedsettings.creatingBackup` = `"Creating
+backup…"`, `editor.save.uploading` = `"Uploading…"`).
+*The 3 non-label uses,* each identical to the English source line:
+`TROUBLESHOOTING.md:275` `` `messages.post-unshard-…` `` (elided path),
+`agents/built-in-agents.md:160` `` `<context><memory_nags>…</memory_nags></context>` ``
+(elided XML body), `development/localization.md:53` `"chat.input.placeholder":
+"Napisz odpowiedź…"` (a locale-file example that is Polish in `docs/` too).
+Do not add a fourth: outside a quoted label or a mirrored code fence, write out the
+sentence. Where the app itself writes three ASCII dots, the pack does too:
+`TROUBLESHOOTING.md:330` `"Opening chat..."` = `ui.chat.chatarea.openingChat`.
+
+**R-102 — Decimal separator is a comma.** *Evidence:*
+`connections/local-model.md:73` "około 3,2 GB"; `:77` "około 5,9 GB pobierania i
+około 7,5 GB RAM".
+
+**R-103 — Thousands separator is a plain space, never a comma.** *Evidence:* 13
+space-grouped figures — `conversation/table-games.md:109` "od 100 do 1 000 000";
+`development/code-cleanup-audit.md:46` "478 000 linii";
+`development/hierarchical-locations-prd-v3.md:356` "2 048 tokenów", `:289` "4 000
+znaków"; `extending/writing-personal-extensions.md:225` "1 000 000 bajtów".
+(One residual comma-grouped English figure survives — see §7 residual 4.)
+
+**R-104 — Headings never end with a period.** *Evidence:* 0 of 1861 headings.
+Question headings keep `?` (24 of them, e.g. `FAQ.md` "## Czym jest karta
+postaci?"; `CONFIGURATION.md:5` "## Kiedy warto zmieniać konfigurację?").
+
+**R-105 — No space before `:` `;` `!` `?`.** Polish is not French. *Evidence:* all
+13 pack-wide hits for `" [;:!?]"` are inside fenced code blocks (CSS `!important`,
+JS `?.`, `!==`); prose has zero.
+
+**R-106 — Bullets that are full sentences end with a period; a fragment series may
+be chained with semicolons.** *Evidence:* 2343 of 3184 bullets end with `.`;
+`development/personal-extensions.md:93-95` shows the semicolon-chained fragment
+style.
+
+**R-107 — Ranges use a plain ASCII hyphen.** *Evidence:*
+`agents/built-in-agents.md:200` "(1-100)", "(1-20)"; `chats/slash-commands.md:50`
+"`/hide 2-5,9,12`".
+
+**R-108 — `→` is the target UI-path separator, but the pack has not settled.**
+*Evidence:* 80 U+2192 across 21 files, of which ~74 are UI paths —
+`CONFIGURATION.md:20` "**Agents → Download Agents**"; `CONFIGURATION.md:31`
+"**Settings → Advanced → Danger Zone**". The remaining ~6 arrows are not paths:
+in-world location chains (`agents/hierarchical-maps.md:366` `Tower → Floor 7 →
+Alchemy Lab`, `:490`), sort-option labels (`lorebooks/entries.md:14` **Name A→Z**)
+and a logical "leads to" (`:377`). Two rival separators are nearly as common — `>`
+(74 UI-path occurrences) and the prose connector `, dalej` (28) — so this is a
+forward rule, not a description of a consistent pack. See §7 residual 6.
+
+**R-109 — Files are NFC-normalized, LF-terminated, BOM-free, with no trailing
+whitespace, and exactly one `# ` H1.** *Evidence:* verified across all 125 files;
+0 combining marks pack-wide.
+
+**RR-3 — Why straight quotes.** PR #4235 records two reasons: the app's own Quote
+style default is Straight, and mixing quote forms splits search hits. The outcome
+is verified (R-95); the app-behavior reasoning is not observable in the pack.
+
+---
+
+## 5. UI labels & glosses
+
+**R-110 — English UI labels are reproduced byte-exactly, in bold.** Casing,
+punctuation, ellipsis character and spelling all follow the app string, not
+Polish orthography. *Evidence:* `UPGRADING.md:139` **Check for Updates**,
+**Checking…**; `characters/creating-and-editing-characters.md:29` **Uploading…**,
+**Embedding…**, **Saving…**; each matches `packages/client/src/localization/locales/en.json`
+verbatim.
+
+**R-111 — The gloss pattern is: bold English label, one space, Polish gloss in
+parentheses.** *Evidence:* 962 instances of `**Label** (gloss)` pack-wide.
+`chats/chat-settings.md:28` — "Sekcja **Connection** (połączenie)";
+`UPGRADING.md:128` — "**Release Channel** (kanał wydań)";
+`agents/custom-agents.md:40` — "przycisk **Save** (zapis)".
+
+**R-112 — The gloss is lowercase descriptive Polish, usually a verbal noun.**
+*Evidence:* `CONFIGURATION.md:20` "(agenci, pobieranie agentów)";
+`characters/personas.md` "(powiązane postacie)"; `data/backup-and-restore.md`
+"(pobranie kopii zapasowej)". Of 962 glosses, 836 begin lowercase, 116 begin
+uppercase and 10 begin with something else (a digit, a backtick or a quote). (The
+116 capitalized ones are a residual — §7 residual 3.)
+
+**R-113 — Gloss once per document, on first use; later mentions are the bare bold
+label.** *Evidence:* `lorebooks/overview.md:3` glosses "**Lorebooks**
+(Lorebooki)"; `:25`, `:29`, `:30` then use **Lorebooks**, **New**, **Import**
+with icon-shape glosses only.
+
+**R-114 — Icon-only controls get a shape-describing gloss.** *Evidence:*
+`lorebooks/overview.md:29` "Przycisk **New** (nowy, znak plus)"; `:30`
+"**Import** (import, strzałka w dół)"; `:31` "**Select** (wybór, znak
+zaznaczenia)"; `characters/galleries.md:48` "przycisk oznaczania z podpowiedzią
+**Tag as emoji or sticker**".
+
+**R-115 — A quoted runtime string (not a control label) is set in straight ASCII
+double quotes and needs no gloss.** *Evidence:* `UPGRADING.md:133`; `TROUBLESHOOTING.md:129`
+"This parameter is sent to the model"; `integrations/haptic-feedback.md:38`
+"Allow this agent to send touch cues during the chat."
+
+**R-116 — A label with no natural Polish gloss stays bare English behind a carrier
+noun.** *Evidence:* `TROUBLESHOOTING.md:330` — "kopia z sekcji Support
+Diagnostics" (no parenthetical); `agents/approvals-and-agent-suite.md:91` —
+"## Panel Cached prompt injections".
+
+**R-117 — A bold label that *does* carry a gloss keeps it even when the label is
+long.** *Evidence:* `TROUBLESHOOTING.md:330` — "**Unreachable (request timed
+out)** (nieosiągalny, przekroczono limit czasu żądania)"; "**Server unreachable**
+(serwer nieosiągalny)".
+
+**R-118 — UI path arrows are glossed as a Polish chain in one parenthesis.**
+*Evidence:* `CONFIGURATION.md:20` "**Agents → Download Agents** (agenci,
+pobieranie agentów)"; `CONFIGURATION.md:31` "**Settings → Advanced → Danger Zone**
+(ustawienia, zaawansowane, strefa zagrożenia)".
+
+**R-119 — The pack does not import the app's shipped Polish UI strings as
+glosses.** The `pl.json` locale covers only 592 of `en.json`'s 9121 translatable
+keys (6.5%; flattened leaf keys, `_meta` excluded), so
+almost every label a Polish reader sees is still English — which is why the
+English-label-plus-gloss convention holds throughout. Where `pl.json` *does*
+translate a label, the pack still uses its own gloss: `pl.json`
+`navigation.topbar.lorebooks` = "Księgi wiedzy", while the pack writes "**Lorebooks**
+(Lorebooki)" (`lorebooks/overview.md:3`). *Evidence:* both files as cited.
+
+**RR-4 — Forward rule for gloss capitalization.** Write glosses lowercase (R-112).
+Capitalize a gloss only when it is verbatim the app's shipped Polish string from
+`pl.json` (e.g. "Ustawienia" = `navigation.topbar.settings`). The pack mostly
+already behaves this way: **Settings** is glossed `(Ustawienia)` 49 times against
+`(ustawienia)` 6, and `Ustawienia` *is* the shipped string. What is genuinely
+unresolved is the 116 uppercase glosses overall (R-112) and the 58 labels carrying
+more than one gloss (§7 residual 3). This is a cycle ruling because the criterion —
+"is this string in `pl.json`?" — was chosen here, not inherited from the pack.
+
+Note for anyone re-deriving this: a pack-wide count of `(Ustawieni*` vs
+`(ustawieni*` gives 51 vs 59 and looks like an even split. It is an artifact — the
+lowercase bucket is dominated by `(ustawienia czatu)` ×44 glossing **Chat
+Settings**, a different label. Always count per label.
+
+---
+
+## 6. Language-specific mechanics
+
+**R-120 — Assimilated loanwords take full Polish inflection.** prompt →
+promptu / prompcie / prompty / promptów; token → tokeny / tokenów; czat → czatu /
+czacie / czatów; preset → presetu / presety / presetów; lorebook → lorebooka /
+lorebooki / lorebooków; agent → agenta / agenci / agentów; tracker → trackery /
+trackerów; embedding → embeddingów; widget → widgety / widgetach. *Evidence:*
+`lorebooks/overview.md:31` "kilka lorebooków"; `CONFIGURATION.md:15`
+"embeddingów"; `chats/slash-commands.md:17` "zużywać tokeny".
+
+**R-121 — Genitive plural of these borrowings is `-ów`.** *Evidence:* lorebooków,
+presetów, tokenów, agentów, widgetów, trackerów, promptów — all attested above.
+
+**R-122 — The apostrophe is used only where the Latin stem ends in a silent or
+foreign-sounding letter.** `sprite'y` / `swipe'em` / `cache'u` take it (stem-final
+silent `e`); `prompty`, `tokeny`, `presety`, `czaty`, `widgety` do not. *Evidence:*
+the two groups as cited in R-97 and R-120; no `prompt'y`-style forms occur.
+
+**R-123 — Frozen acronyms take a carrier noun instead of an inflected ending.**
+`postać NPC` / `postaci NPC` rather than `NPC-a`; `pasek HUD` rather than `HUD-u`.
+*Evidence:* `game/party-and-npcs.md:79` "co każda postać NPC do Ciebie czuje";
+`roleplay/hud-and-trackers.md:3` "czym jest pasek HUD w trybie Roleplay". 0 hits
+for hyphen-inflected `NPC-` or `HUD-` forms.
+
+**R-124 — First-use glossing of a frozen acronym goes in parentheses after the
+carrier phrase.** *Evidence:* `game/dice-and-skill-checks.md:68` — "przekonanie
+postaci NPC (postaci niezależnej)".
+
+**R-125 — Impersonal `-się` is the default voice for capability and behavior
+statements; the imperative is the default for steps.** *Evidence:*
+`CONFIGURATION.md:9` "Konfigurację zmienia się zwykle po to, żeby";
+`CONFIGURATION.md:18` "ustawia się w aplikacji, a nie tutaj"; against
+`lorebooks/overview.md:25` "Otwórz go z paska bocznego aplikacji."
+
+**R-126 — Possibility is expressed with `da się` / `można` / `warto` / `trzeba`,
+never with a gendered past modal.** *Evidence:* `lorebooks/overview.md:31` "da się
+naraz wyeksportować"; `UPGRADING.md:19` "Warto ją zrobić"; `FAQ.md:136` "można też
+włączyć". 0 hits pack-wide for the conditional forms `-łbyś` / `-łabyś`.
+
+**R-127 — Verbal nouns (`pobranie`, `wgrywanie`, `import`, `zapis`) carry
+action-label glosses, keeping them gender-free.** *Evidence:*
+`CONFIGURATION.md:221` "kopie zapasowe, czyszczenie danych, wgrywanie
+aktualizacji"; `agents/custom-agents.md:40` "**Save** (zapis)".
+
+**R-128 — Polish diacritics are mandatory and complete.** No ASCII-stripped forms
+(`pamieci`, `wlacz`, `czesc`) appear in the pack; all 125 files are NFC.
+*Evidence:* R-109 plus every quoted line above. Note that intermediate cycle notes
+may be written ASCII-stripped for tooling reasons — the pack never is.
+
+**R-129 — Link text is the target file's H1, or a clean prefix of it.**
+*Evidence:* the pack has 910 intra-pack `.md` links. 128 of them (in 37 files) use
+text that is not literally the target's H1, but 109 of those are clean prefixes —
+`FAQ.md` "[Dostęp zdalny]" → H1 "Dostęp zdalny: Basic Auth i lista dozwolonych
+adresów IP". Only 19 links (in 10 files) are neither the H1 nor a prefix of it;
+they are listed in §7 residual 7. The English source, measured the same way, has
+208 non-literal link texts of 912 and 102 non-prefix ones, so the pack really did
+normalize link text toward the translated H1 — by roughly 5× on the
+non-prefix count.
+
+**R-130 — Code, paths, URLs and link targets are byte-identical to English.**
+*Evidence:* comparing all 125 pl files with `docs/`: 0 fence-sequence differences;
+link-target lists match on 120 of 125 files, with the 5 differences all being
+links present only in the newer English source (upstream drift, §7 residual 9).
+
+---
+
+## 7. QA checks & known traps
+
+### Mechanical checks (run these on any pl pack edit)
+
+Each check is written so that **a non-empty result is a defect**.
+
+**Run every one of these in Python, not `grep`.** Checks 1–3 and 15 all hinge on
+`\w` or `\b` next to a Polish diacritic, and command-line `grep` gets that wrong —
+see T-5 below, which is the single most dangerous trap on this list. The patterns
+are written in Python `re` syntax against `str` (not `bytes`), which is
+Unicode-aware by default:
+
+```python
+import re, pathlib
+files = {p: p.read_text(encoding="utf-8") for p in pathlib.Path("pl").rglob("*.md")}
+def check(pattern):
+    rx = re.compile(pattern)
+    return [(p, i, ln) for p, t in files.items()
+            for i, ln in enumerate(t.split("\n"), 1) if rx.search(ln)]
+```
+
+1. **Declined product name** — `check(r'Marinar(ze|y|ą|ę|om|ami|ach)\b')`.
+   Must be empty (R-8). Also `check(r'\b(w|we|do|z|od|dla|na|przez|pod|przy) Marinar')`
+   for missing carrier nouns (R-10) — this one currently returns the 6 known
+   residuals in §7 residual 11, so diff against that list rather than expecting
+   zero.
+2. **Reader gendering** — `check(r'\w+ł[ae]ś\b')`. Must be empty (R-3).
+   Extend with `\w+ł[ab]yś\b` for conditionals (also currently 0).
+3. **Formal register leak** — `check(r'\bPan(i|u|a|ie)?\b|proszę \w+ć|\bPaństw\w*')`.
+   Must be empty (R-2).
+4. **Typographic quotes** — grep for U+201E, U+201C, U+201D, U+2019, U+00AB,
+   U+00BB. Must be empty (R-95, R-96).
+5. **Non-breaking space** — grep for U+00A0. Must be empty (R-98).
+6. **Curly apostrophe in declension** — grep for `’`. Must be empty; the correct
+   form is `sprite'y` with ASCII `'` (R-97).
+7. **New em dashes** — grep for U+2014 outside `TROUBLESHOOTING.md`. Any hit in a
+   file that had none is a regression toward the wrong dash (R-99, R-100). Baseline
+   is 14 occurrences in 7 files (§7 residual 5).
+8. **Ellipsis in prose** — grep for U+2026 and confirm every hit sits inside a
+   bold English label, a quoted app string, or one of the 3 code-span/code-block
+   elisions mirrored from English (R-101). Baseline is 15.
+9. **English thousands separator** — `check(r'[0-9],[0-9]{3}')` and check each hit
+   is a real decimal comma and not a copied English figure (R-103). Two hits are
+   expected: `agents/built-in-agents.md:200` (the known residual 4) and
+   `REMOTE_ACCESS.md:90` `IP_ALLOWLIST=192.168.1.0/24,203.0.113.42`, which is a
+   comma-separated CIDR list, not a number.
+10. **Space before punctuation** — `check(r' [;:!?]')` and confirm every hit is
+    inside a fenced code block (R-105). Baseline is 13, all fenced.
+11. **Heading terminators** — no heading may end in `.` (R-104); every file has
+    exactly one `# ` H1 (R-109).
+12. **Normalization** — assert `NFC(text) == text` for every file, no BOM, LF
+    endings, no trailing whitespace (R-109).
+13. **Structural parity vs English** — same file set as `docs/`; identical fenced
+    code-block sequence; identical link-target list. The link-target check is what
+    catches a translated `#fragment` or a rewritten relative path (R-130).
+14. **Link text ↔ H1** — for every intra-pack `.md` link, the link text must equal
+    the target's H1 or be a prefix of it (R-129).
+15. **Terminology split** — check each banned alternate in §3. The ones that
+    currently return **zero** and must stay at zero: `księg\w* wiedzy`, `widżet`,
+    `uaktualnieni`, `polecen\w* slash`, `ukośnikow`, `sprajt`, `duszek`,
+    `usługodawc`, `skórk`, `stiker`, `nalepk`, `teczk`, `checkbox`, `dropdown`,
+    `włącznik`, `makropolecen`, `izolatk`, `kanał\w* wersji`, `wypożyczeni`.
+    The ones that return hits **in a reserved sense only** — read the §3 row before
+    calling any of them a defect: `podpowied` (tooltip, R-75), `żeton` (poker
+    chips, R-23), `szablon`/`profil` (template / settings profile, R-25),
+    `komunikat` (system message, R-33), `klucz` (API key, R-29), `kopi\w* robocz`
+    (editor draft, R-41), `dymek` (message bubble, R-75), `odznak` (achievement
+    badge, R-74), `dodatk` (**Addons**, R-56), `checkpoint` (ComfyUI model file,
+    R-55), `okienk` (small floating window, R-82).
+16. **Gloss shape** — every new `**English Label**` on first use in a file should
+    carry `(gloss)` or sit behind a carrier noun (R-111, R-116); the gloss should
+    start lowercase unless it is a verbatim `pl.json` string (RR-4). Count per
+    label, never pack-wide — see the note under RR-4.
+17. **Manifest** — after any content edit run
+    `node scripts/docs-i18n/build-manifest.mjs <pack>/pl --source-commit <sha>`
+    then `node scripts/docs-i18n/validate-pack.mjs <pack>/pl` from an Engine
+    checkout, and commit content plus manifest together (RR-5). `--source-commit`
+    is optional in the script and no shipped pack currently carries a
+    `sourceCommit` key — `pl/manifest.json` has only `language` and `files` (125
+    entries, matching the 125 `.md` files), as do all nine sibling packs. Passing
+    it is still the README's instruction; just do not read its absence in the
+    current manifest as a pl-specific defect.
+
+### Tooling traps
+
+**T-1 — ASCII-stripped intermediate notes.** Working notes for this language are
+sometimes produced without diacritics (`pamieci`, `wylacz`) because of Windows
+console encoding. Never paste from such a note into the pack; re-type with full
+diacritics (R-128). When scripting greps on Windows, set `PYTHONIOENCODING=utf-8`
+and read/write with `encoding='utf-8'` — the default `cp1252` codec throws on
+`ś`, `ż`, `ł` and will silently truncate a scan.
+
+**T-2 — Git Bash `$'\uXXXX'` does not expand.** The `\uXXXX` escape is
+not supported in this shell's `$'...'` quoting, so the pattern reaches `grep` as
+the six literal characters `\u2014` and matches nothing — another false clean:
+
+```
+$ printf '%s' $'\u2014' | xxd | head -1
+00000000: 5c75 3230 3134                           \u2014
+$ grep -rl $'\u2014' pl/ | wc -l
+0                                    # <- wrong, reads as a clean pack
+$ grep -rl '—' pl/ | wc -l
+7                                    # correct: 7 files carry an em dash
+```
+
+Pasting the literal character works, but then you cannot tell by reading the
+command whether you pasted an em dash or an en dash — and that is exactly the
+distinction R-99/R-100 turn on. Use a Python scan with an explicit `chr(0x2014)`
+for every codepoint-level check above.
+
+**T-3 — Cross-file `#fragment` links point at English anchors.** Because link
+targets stay byte-identical to English (R-130) while headings are translated, 8 of
+the pack's cross-file fragment links have no matching Polish heading slug (e.g.
+`lorebooks/overview.md` → `entries.md#authoring-strategy-choosing-the-right-entry`,
+`UPGRADING.md` → `TROUBLESHOOTING.md#chats-show-no-messages-after-switching-to-an-older-version`).
+This is the intended trade-off, not a bug to "fix" by translating the fragment —
+translating it would break the link for every reader whose pack falls back to
+English. Do not add same-file fragment links: the pack currently has 0.
+
+**T-4 — Declension is not the only search hazard.** A gloss written two ways
+(`(Ustawienia)` vs `(ustawienia)`) splits a reader's literal search just as a
+declined name would. Prefer the §3 form over a synonym even when the synonym reads
+better.
+
+**T-5 — `\w` and `\b` do not see Polish letters. This is the worst trap here.**
+Polish `ą ć ę ł ń ó ś ż ź` are outside ASCII, and a regex engine in byte or
+ASCII mode treats them as *non-word* characters. `\w+` then refuses to cross them
+and `\b` fires in the wrong places, so a pattern built around a Polish stem
+matches **nothing** — and a check whose contract is "empty output means clean"
+reports a clean pack that was never scanned. Reproduction, on a line that plainly
+contains three banned forms:
+
+```
+$ printf 'Jeśli wpisałeś tekst, to zrobiłaś to dobrze. Wybrałeś?\n' > t.txt
+$ grep -cE '\w+ł[ae]ś\b' t.txt      # the check as it is tempting to write
+0                                    # <- silently, catastrophically wrong
+$ grep -cE '[[:alpha:]]+ł[ae]ś' t.txt
+1                                    # correct
+```
+
+Python's `re` on `str` is Unicode-aware and gets it right
+(`re.findall(r'\w+ł[ae]ś\b', t)` → `['wpisałeś', 'zrobiłaś', 'Wybrałeś']`), but
+the same pattern on `bytes`, or with `re.ASCII`, returns `[]`. So: decode to
+`str`, never pass `re.ASCII`, never scan `bytes`. If a shell grep is unavoidable,
+use POSIX classes (`[[:alpha:]]`) and drop `\b` entirely rather than trusting it
+next to a diacritic. Note this cuts both ways for verification too — a "0 hits"
+result is only evidence of a prohibition (per the header) if the tool that
+produced it can see Polish letters at all.
+
+### Known pack residuals (documented, not silently fixed)
+
+1. **Three words for "launcher".** The dominant form is `program uruchamiający`,
+   46 occurrences across 6 files (`TROUBLESHOOTING.md` ×16, `CONFIGURATION.md` ×14,
+   `installation/windows.md` ×12, `home/professor-mari.md` ×2, `FAQ.md` ×1,
+   `UPGRADING.md` ×1). Against it:
+   - the bare loanword `launcher`, 12 times in prose — `UPGRADING.md:37`, `:46`,
+     `:48`, `:52`, `:62`, `:66`, `:82`, `:85`, `:101`, `:194`, plus `FAQ.md:167`
+     and `development/file-storage.md:31`. (`TROUBLESHOOTING.md:270` and `:277`
+     also contain the string, but only inside the script path
+     `scripts/protect-launcher-data.mjs`, which is code and correctly frozen.)
+   - `skrypt startowy`, 11 times, **all** in `installation/macos-linux.md`
+     (`:3`, `:70`, `:86`, `:102`, `:104`, `:115`, `:128`, `:132`, `:181`, `:217`,
+     `:225`).
+     English calls it "the launcher" throughout that file, so this is a whole-file
+     divergence, not a slip — and it is the alternate R-37 previously listed as
+     banned with 0 hits, which was wrong.
+
+   New text should use `program uruchamiający` (R-37). Do not mass-rewrite
+   `installation/macos-linux.md` as a side effect of an unrelated edit; that file
+   is internally consistent and deserves its own change.
+2. **Capitalized reader pronouns.** 7 mid-sentence `Ciebie` / `Tobie` against 51
+   lowercase `ciebie`: `conversation/profiles.md:5` (×2), `:78`,
+   `game/party-and-npcs.md:19`, `:79`, `:90`, `:105`. Lowercase is the rule (R-5).
+3. **Gloss capitalization split.** 116 of 962 glosses start uppercase (836 start
+   lowercase, 10 start with a digit/backtick/quote). Per label the picture is much
+   less even than a naive pack-wide count suggests: `**Settings**` is glossed
+   `(Ustawienia)` 49 times against `(ustawienia)` 6 — see the note under RR-4.
+   Separately, 58 of 609 distinct labels carry more than one gloss — some
+   legitimately (icon shape vs meaning, e.g. **Chat Settings** → "ikona koła
+   zębatego" / "ustawienia czatu", and it also has "ikona zębatki" and the combined
+   "ustawienia czatu, ikona koła zębatego"), some not (**Admin Access** → "dostęp
+   administracyjny" / "dostęp administratora"; **Review Agent Outputs** →
+   "przeglądanie wyników agentów" / "sprawdzanie wyników agentów").
+4. **English thousands separator survives once.** `agents/built-in-agents.md:200`
+   — "limit tokenów przywołania (128-16,384)". Polish wants `16 384` (R-103).
+5. **Em dashes in 7 files.** 14 U+2014 against 279 U+2013 (R-100):
+   `TROUBLESHOOTING.md:49`, `:260`, `:326`, `:330`;
+   `agents/custom-agents.md:113`, `:114`; `data/where-data-is-stored.md:21`;
+   `development/file-storage.md:35`; `extending/personal-extensions.md:67`;
+   `lorebooks/entries.md:189`; `noodle/settings.md:84`.
+6. **UI-path separator split — much closer to even than it looks.** `→` ×80 in 21
+   files (≈74 of them actual UI paths) against `>` ×74 in 14 files, plus the prose
+   connector `, dalej` ×28 in 15 files. The `>` total is 43 occurrences between two
+   bold spans (`TROUBLESHOOTING.md:425` "**Settings** > **Advanced** > **Message
+   Tools**") and 31 inside a single bold span (`FAQ.md:175` "**Agents > Download
+   Agents**"); `, dalej` is at e.g. `agents/agents-overview.md:76`. The split runs
+   by file, not by sentence, which is what makes it fixable: `game/storyboard.md`
+   (`>` ×14, arrows 0), `settings/settings-overview.md` (8, 0) and
+   `extending/writing-personal-extensions.md` (7, 0) never use the arrow at all,
+   while `conversation/calls.md` leans on `, dalej` (×11) and
+   `agents/hierarchical-maps.md` (arrows ×17, `>` 0) and `CONFIGURATION.md`
+   (12, 0) are already clean. Only `TROUBLESHOOTING.md` (arrows ×6, `>` ×15) and
+   `FAQ.md` (2, 3) mix the two inside one file. `→` is the target form (R-108) but
+   this is a live inconsistency, not a stray residual: converging it is a
+   deliberate per-file sweep, not a drive-by fix.
+7. **Nineteen link texts that are neither the H1 nor a prefix of it** (R-129),
+   in 10 files. The clearest violations, where a title was paraphrased:
+   `extending/personal-extensions.md` links to `writing-personal-extensions.md` as
+   "Tworzenie rozszerzeń osobistych" (×1) and "przewodnika tworzenia rozszerzeń
+   osobistych" (×1) while that file's H1 is "Pisanie własnych rozszerzeń";
+   `extending/writing-personal-extensions.md` links back with untranslated text
+   "Personal Extensions" (×2) and "Architektura Personal Extension" against the
+   Polish H1s "Rozszerzenia osobiste" / "Architektura rozszerzeń osobistych";
+   `agents/built-in-agents.md` → `noodle/overview.md` as "Noodle: oś czasu
+   społeczności w aplikacji" against H1 "Noodle: wbudowana oś czasu
+   społecznościowa"; `characters/colors-and-stats.md` and
+   `roleplay/getting-started.md` (×2) → "HUD i trackery" / "HUD i trackery w trybie
+   Roleplay" against H1 "Pasek HUD i trackery w trybie Roleplay";
+   `FAQ.md` → "PWA na iOS" against H1 "Przewodnik po PWA na iOS / iPadOS";
+   `settings/settings-overview.md` → "Muzyka" against H1 "Music DJ: Spotify,
+   YouTube i muzyka lokalna". The rest are mid-sentence descriptive links where the
+   text is a noun phrase rather than a title (`extending/writing-personal-extensions.md`
+   "tabelę platform", "kontekstu aktywnego czatu", "paneli renderowanych przez
+   aplikację Marinara"; `roleplay/getting-started.md` "tryb Conversation";
+   `lorebooks/overview.md` "Strategia pisania", "Przykład w praktyce";
+   `UPGRADING.md` "Po przejściu na starszą wersję czaty nie pokazują wiadomości",
+   which is a section title used as whole-file link text;
+   `chats/sending-and-streaming.md` "Galerie postaci → Ponowne używanie obrazu z
+   galerii w wiadomościach i powitaniach"). Those read fine and are only
+   technically R-129 violations; fix the paraphrased titles first.
+8. **Third-party name declined 3 times.** `Dockera` / `w Dockerze` at
+   `TROUBLESHOOTING.md:245`, `:404`, `:417`, against 22 carrier-noun uses
+   (`kontener Docker` ×20, `obraz Docker` ×2). Docker is the only third-party name
+   the pack ever declines — `Termux`, `GitHub` and `Windows` are clean. Prefer the
+   carrier (R-13).
+9. **Upstream drift: 5 English links not yet mirrored.** English `docs/` has since
+   gained links absent from the pack — `CONFIGURATION.md#restart-or-hot-reload`;
+   `agents/built-in-agents.md` → huggingface.co/GetBeholder/Beholder-GGUF;
+   `characters/creating-and-editing-characters.md` →
+   `galleries.md#reuse-a-gallery-image-in-messages-and-greetings`;
+   `extending/personal-extensions.md` →
+   `../TROUBLESHOOTING.md#a-server-extension-says-no-supported-sandbox-is-available`;
+   `media/tts-setup.md` → github.com/kyutai-labs/pocket-tts. These are English-side
+   additions, not dropped Polish links.
+10. **Pack/app vocabulary divergence.** The pack says `lorebook` (R-26) and
+    `widget` (R-64) where the shipped `pl.json` says "Księgi wiedzy" and "Widżety
+    gry"; the pack says `prompt` (R-21) where `pl.json` says "polecenie"
+    (`onboarding.presets.body`). The pack's forms are the standing convention —
+    the locale covers only 6.5% of keys, so the docs' readers overwhelmingly see
+    English labels, and switching the docs to the sparse UI vocabulary would split
+    every prompt/lorebook search (R-119). Flag it if the locale coverage ever
+    grows substantially. (The apostrophe diverges too: `pl.json` writes `sprite’ów`
+    with U+2019 in 10 strings, the pack writes `sprite'ów` with ASCII — R-96.)
+11. **Bare preposition plus the frozen name, 6 times.** R-10 holds for `w`, `we`,
+    `do` and `z` (0 hits each), but not for `przez` and `pod`:
+    `extending/personal-extensions.md:27` "panelu rysowanego przez Marinara
+    Engine", `:67`, `:140`, `:155`; `characters/import-export.md:3` "typy plików
+    obsługiwane przez Marinara"; `FAQ.md:37` "nie mogła podszyć się pod Marinara
+    Engine". All six read as the frozen name standing in for an accusative, which
+    is exactly what the carrier noun exists to avoid. Prefer "przez aplikację
+    Marinara Engine" in new text.
+12. **`buforowanie` for caching, twice.** `connections/providers-reference.md:30`
+    "Obsługuje buforowanie promptu" and `:76` "wysyła wskazówki o buforowaniu"
+    translate *prompt caching* with the alternate R-52 bans. The prose form is
+    `pamięć podręczna` (24 occurrences); `buforowanie` should become
+    `zapisywanie promptu w pamięci podręcznej` or similar. Unrelated `bufor` hits
+    at `development/code-cleanup-audit.md:16` and `development/file-storage.md:33`
+    are genuine buffers and are fine.
+
+### Recorded rulings without in-pack evidence
+
+- **RR-1** — informal `ty` chosen for cross-pack register consistency (§1).
+- **RR-2** — the frozen-name rule exists because declension breaks the viewer's
+  literal substring search (§2).
+- **RR-3** — straight quotes chosen because the app's Quote style default is
+  Straight and mixed quote forms split search hits (§4).
+- **RR-4** — forward rule for gloss capitalization: lowercase unless the gloss is
+  verbatim a shipped `pl.json` string (§5). The criterion is the ruling; the pack
+  largely already complies for **Settings** (49 `(Ustawienia)` vs 6
+  `(ustawienia)`), so what this actually resolves is the wider 116-gloss
+  uppercase tail and the 58 multi-gloss labels (§7 residual 3).
+- **RR-5** — process: after editing, run `build-manifest.mjs` then
+  `validate-pack.mjs` and commit content plus manifest together
+  (`docs-i18n/README.md`, `CONTRIBUTING.md:244`).
+- **RR-6** — process: renames and deletions under `docs/` MUST be mirrored here,
+  or a `[docs-i18n] <affected paths>` follow-up issue opened; a translation left
+  at an old path is silently ignored by the app (`CONTRIBUTING.md:231`).
+- **RR-7** — process: PR #4235 mandates a mechanical declension/address/typography/
+  terminology sweep plus an independent language-QA panel before a pack ships;
+  §7's checks are the mechanical half of that sweep.
+- **RR-8** — process: PR #4235 records runtime verification against a throwaway
+  data dir with a materialized pack (viewer categories, titles, diacritic search,
+  Settings coverage counts, switch flows) as part of shipping validation.

--- a/glossaries/glossary-pt-br.md
+++ b/glossaries/glossary-pt-br.md
@@ -1,0 +1,599 @@
+# Marinara Engine — glossário do pacote de documentação `pt-br`
+
+**Português do Brasil · docs-i18n language pack `pt-br` · label `Português (Brasil)`**
+
+## Provenance
+
+This is the **second-generation glossary** for the `pt-br` documentation pack. It was
+**re-derived on 2026-09-01**, after the original working glossaries were lost to
+temp-directory cleanup, from three sources in authority order:
+
+1. **The shipped pack as ground truth** — `pt-br/` on the `docs-i18n` branch, 125 guides
+   (125 `.md` files) plus `manifest.json`, 126 files in all, mirroring `docs/` on `staging`
+   1:1 (same 125 paths, no orphans either way). Every prescriptive
+   rule below was re-checked against those bytes with `grep`; each terminology row cites a
+   pack file that shows the term in use.
+2. **The pack's shipping PR decision write-up** — `Pasta-Devs/Marinara-Engine` PR **#4229**
+   ("Brazilian Portuguese documentation pack", language #5 after `es`/`de`/`fr`), plus the
+   per-language conventions it landed in `CONTRIBUTING.md` line 237.
+3. **The 2026-09-01 mirror-cycle terminology notes** (`prd-notes-pt-br.md`), whose rows are
+   themselves in the pack now and are cited as pack evidence below.
+
+Where a rule comes from a **recorded maintainer or cycle ruling** that the pack cannot
+mechanically show — process decisions, QA procedure, the history behind a reversed rule —
+it is tagged **[RULING]** and carries no evidence citation. Everything else is verified
+against the pack as shipped. Where the ledger and the pack disagree, the **pack wins** and
+the disagreement is written down rather than quietly harmonised (see §7.3 and §7.4).
+
+Evidence paths are relative to the pack root (`pt-br/`). Line numbers are from the shipped
+bytes; treat them as pointers, re-grep the string if a file has moved on.
+
+**Counting convention.** Unless a row says otherwise, a count is *case-insensitive, whole
+word, singular + plural*, where "whole word" means the match is not flanked by
+`[A-Za-zÀ-ÿ]` — an ASCII-only `\b` silently drops accented words (§7.2). Counts were
+re-measured on 2026-09-01 with a Python scan over all 125 `.md` files; where this
+re-measure disagreed with the ledger, the re-measure is what is written down.
+
+---
+
+## 1. Register & address
+
+| Rule | Verified how |
+|---|---|
+| **Address the reader as `você`.** Never `tu`, never `vós`, never `o senhor / a senhora`. | 1 309 hits for `você`; **0** for `tu`, `teu`, `tua`, `vós`, `o senhor`. |
+| **Imperatives take the 3rd-person (você) form**: `Clique`, `Abra`, `Veja`, `Use`, `Escolha`, `Defina`. The `tu` imperative (`Clica`, `Abre`, `Vê`) is banned. | `Clique` 392 · `Abra` 324 · `Veja` 237 · `Use` 331 · `Escolha` 161 · `Defina` 46; `Clica` 0, `Vê` 0. `installation/android-termux.md:90` shows the canonical shape. |
+| **Informal but not chatty.** No slang, no exclamation marks in instructions, no `nós` cheerleading (`vamos configurar…`). `vamos` survives only inside quoted example text — in-fiction dialogue or an example the reader is told to type. | `vamos` **5** hits, every one quoted: `agents/hierarchical-maps.md:444,445,806` ("Vamos para a Kitchen"), `lorebooks/entries.md:97` (`> **John:** Vamos visitar o castelo do Vlad.`), `conversation/getting-started.md:117` ("vamos jogar uno", an example the reader types). `iremos` 0. |
+| **Possessives stay light.** Prefer the bare noun over `o seu`/`a sua` where Portuguese does not need it; `seu`/`sua` is reserved for genuine reader-ownership ("os seus dados"). | Singular `seu` 166 · `sua` 191; plural `seus` 100 · `suas` 47. `data/where-data-is-stored.md:1` "Onde Marinara salva os seus dados" vs `CONFIGURATION.md:3` "A maioria dos usuários nunca precisa desta página." |
+| **Gender-neutrality: default generic masculine, no typographic workarounds.** Write `o usuário`, `os usuários`. Banned: `usuário(a)`, `usuári@`, `usuárixs`, `todes`, `ele/ela` slashes. | `o usuário` 22; `usuária` 0, `usuário(a)` 0, `@s` 0, `xs` 0, `ele/ela` 0, `dele/dela` 0. |
+| **Avoid gendering the reader at all** where possible — the docs address actions, not people, so the question rarely arises. | Whole-pack: no reader-directed past participle agreeing in gender. |
+| **Brazilian vocabulary only, European Portuguese banned.** `arquivo` (828) not `ficheiro`; `salvar` (525 across all `salv-` forms, 84 of them the bare infinitive) not `guardar`-as-save; `tela` (212) not `ecrã`; `usuário` (141) not `utilizador`; `celular` (109) not `telemóvel`; `gerenciar` (`gerenci-` 84) not `gerir`; `clique em` not `carregue em`. | `ficheiro` 0 · `ecrã` 0 · `utilizador` 0 · `telemóvel` 0 · `aceder` 0 · `gerir` 0 · `carregar em` 0 · `rato` 0. `CONFIGURATION.md:3`, `chats/managing-chats.md:1` ("Como gerenciar a lista de chats"). |
+| **`guardar` is allowed only in its Brazilian sense "to store / to hold"**, never as the Save command. Save is always `salvar`. | `guardar` (infinitive) 7 hits, all store-sense. `agents/memory.md:71` "Marinara guarda blocos de memória"; `CONFIGURATION.md:71` "O arquivo `.env` guarda dados". Save sense uses `salvar`: `characters/personas.md:133` "Toda vez que você salva uma mudança". |
+| **Current *Acordo Ortográfico* spelling.** No trema, no pre-reform accents. | `ü` 0 · `freqüe` 0 · `conseqüe` 0 · `idéia` 0 · `pára` 0 · `vôo` 0 · `pólo` 0. |
+| **False-friend guardrails.** `library` → `biblioteca` (never `livraria` = bookshop); `actually` → `na verdade` (never `atualmente`, which correctly means *currently*); `eventually` → `com o tempo` / `mais tarde` (never `eventualmente`, which means *occasionally*). | `biblioteca` 130, `livraria` **0**; `eventualmente` **0**; `atualmente` 1, in its correct *currently* sense (`extending/writing-personal-extensions.md:203` "atualmente `1`"). `lorebooks/overview.md:25` "a biblioteca onde você navega". These three pairs are all that survived of the original anti-calque table (§7.5); rebuild the rest from sweeps. |
+| **Tone: explain the jargon inline the first time.** The pack consistently defines a loanword in the same sentence it introduces it. | `lorebooks/overview.md:9` "insere o texto daquela entrada no prompt. O prompt é o conjunto de instruções ocultas e de histórico…"; `agents/knowledge-sources.md:7` "Um token é um pedacinho de texto que a IA lê". |
+
+---
+
+## 2. Product, feature & mode names
+
+### 2.1 The product name and its article — **MAINTAINER RULING**
+
+**[RULING] The maintainer-ruled standard is `do Marinara` / `no Marinara` — with the
+article.** This *reversed* the original glossary's no-article rule; the reversal itself is a
+recorded ruling with no in-pack artifact, but the shipped outcome is verifiable and
+one-sided:
+
+| Form | Hits | Verdict |
+|---|---|---|
+| `do Marinara` | 258 | **standard** |
+| `no Marinara` | 62 | **standard** |
+| `de Marinara` (uncontracted) | 2 | residual, both in the same fixed formula (see below) |
+| `em Marinara` | 0 | — |
+| `do Marinara Engine` / `no Marinara Engine` | 92 / 28 | **standard** |
+| `de Marinara Engine` | **0** | — |
+
+Precise statement of the rule as the pack actually applies it:
+
+1. **`de` and `em` always contract**: `do Marinara`, `no Marinara`, `do Marinara Engine`,
+   `no Marinara Engine`. Evidence: `agents/agents-overview.md:3`, `appearance/appearance-settings.md:3,50`, `lorebooks/overview.md:3` ("o que é um lorebook
+   **no** Marinara Engine"), `development/file-storage.md:3` ("a arquitetura de persistência
+   local **do** Marinara Engine").
+2. **Subject position stays bare**: `Marinara verifica…`, `Marinara aceita apenas…`,
+   `Marinara escolhe sozinho…`. Sentence-initial bare `Marinara` **266** vs sentence-initial
+   `O Marinara` **10** (42 hits of a standalone `o/O Marinara` in any position).
+   Evidence: `CONFIGURATION.md:20,55`, `characters/personas.md:7`.
+3. **Other prepositions stay bare**: `com Marinara` 17 vs `com o Marinara` 1;
+   `sobre Marinara` 1 vs `sobre o Marinara` 0. Evidence: `FAQ.md:3` "sobre Marinara Engine".
+4. **The one fixed uncontracted formula is the first-mention alias**, which is idiomatic and
+   must be left alone: `agents/memory.md:7` "Marinara Engine (chamado **de Marinara** daqui
+   em diante)"; `installation/macos-linux.md:3` "(chamado só **de Marinara** daqui em
+   diante)". This is `chamar de X`, not a missing article.
+
+So the QA check is **not** "insert an article everywhere" — it is "`de/em` + Marinara must
+never appear uncontracted outside the `chamado de` formula".
+
+### 2.2 Names that stay English
+
+| Kept in English | Evidence |
+|---|---|
+| **Mode names** — `Conversation Mode` (142), `Roleplay` (411), `Game Mode` (258). Never `modo Conversa`, `Modo Jogo`, or `Interpretação de papéis` *as the mode's name*. | H1s: `conversation/getting-started.md:1` "Conversation Mode: primeiros passos"; `game/combat.md:1` "Game Mode: combate". `modo Conversa` 0, `Modo Jogo` 0. Also PR #4229 and `CONTRIBUTING.md:237`. Two documented nuances below. |
+| **Nuance — `Modo Conversation` (4 hits)** mirrors English's *generic lowercase* "Conversation mode", which is a descriptor, not the frozen product name. Leave it; do not "fix" it to `Conversation Mode`. | `development/architecture-map.md:117`, `development/frontend.md:247,618` (EN: "### Conversation mode"), `game/storyboard.md:319` (EN: "Conversation is not supported"). |
+| **Nuance — `interpretação de papéis` (2 hits)** is allowed as a one-time parenthetical *gloss* of `Roleplay`, never as a replacement name. | `chats/group-chats.md:9` "**Roleplay** (interpretação de papéis)"; `game/party-and-npcs.md:5` "um RPG (jogo de interpretação de papéis)". |
+| **`World Maps`** — the user-facing feature name, matching the English H1 exactly. | `agents/hierarchical-maps.md:1` "# World Maps: instalação, criação e viagem" (EN: "# World Maps: Setup, Authoring, and Travel"); `World Maps` 34 hits. |
+| **`Hierarchical Maps`** — retained only where English retains it, i.e. the developer PRD. | `development/hierarchical-locations-prd-v3.md:1` "# Hierarchical Maps e contexto espacial V3" (EN: "# Hierarchical Maps and Spatial Context V3"). |
+| **`Haptic Feedback`** — the *feature and agent name* stays English; never `retorno háptico`. **But `feedback tátil` is the pack's descriptive common noun for the thing itself** and is correct where English uses lowercase "haptic feedback". | `Haptic Feedback` 13, `retorno háptico` **0**, `feedback tátil` **7** — all in `integrations/haptic-feedback.md:5,7,11,15,30,102` and its intro line 3, e.g. `:5` "## O que é feedback tátil". Name form: `integrations/haptic-feedback.md:1` "# Configuração do Haptic Feedback"; `agents/built-in-agents.md:244` "### Haptic Feedback". |
+| **Named agents, packages and surfaces** — `Professor Mari` (93), `Noodle` (205), `Agent Suite` (9), `Danger Zone` (23), `Music DJ`, `Beholder`, `Card Evolution Auditor`, `Storyboard`, `Support Diagnostics`, `Illustrator`. | `agents/approvals-and-agent-suite.md:3,40`; `TROUBLESHOOTING.md:330`; `home/professor-mari.md`. |
+| **Third-party names** — `Termux`, `Android`, `Docker`, `Podman`, `Node`, `F-Droid`, `SillyTavern`, `Spotify`, `Giphy`, `Home Assistant`, `Intiface`. | `installation/android-termux.md:11`; `installation/containers.md`. |
+
+**[RULING]** The English resolution for `Hierarchical Maps` and `Haptic Feedback` was decided
+*per UI evidence*. That evidence still holds and is checkable: `pt-BR.json` is a **partial
+locale** (136 lines against `en.json`'s 9 127) and contains **no** key for either feature, so
+a Brazilian user sees those controls in English. Path:
+`packages/client/src/localization/locales/pt-BR.json`.
+
+### 2.3 Carrier nouns and gender of the frozen names
+
+Frozen English names take a Portuguese carrier noun or article that fixes their gender:
+
+- `o painel **Lorebooks**`, `o painel **Personas**` — `lorebooks/overview.md:23`,
+  `characters/personas.md:9`.
+- `a janela **Review Character Card Updates**` — `agents/approvals-and-agent-suite.md:40`.
+- `o botão **Apply Update**`, `o botão **Save**` — `installation/windows.md:204`,
+  `characters/creating-and-editing-characters.md:29`.
+- `a opção **Enable Agents**`, `a seção **Updates**`, `a aba **Advanced**` —
+  `agents/agents-overview.md:42`, `installation/macos-linux.md:229`.
+- `o agente **Combat**`, `o agente **Card Evolution Auditor**` —
+  `roleplay/combat-encounters.md:9`, `agents/approvals-and-agent-suite.md:40`.
+- **`Professor Mari` is feminine, with no exceptions in the shipped bytes.**
+  Feminine-marked forms total **41 across 17 files**: bare `a Professor Mari` 19,
+  `da Professor Mari` 18, `à Professor Mari` 2, `pela Professor Mari` 2. Masculine forms —
+  `o` / `do` / `ao` / `pelo Professor Mari` — are **0**. `Professor Mari` unmarked (no
+  article) is 93 hits overall. Evidence: `CONFIGURATION.md:63,320,321,322`,
+  `home/professor-mari.md:3,5,15`, `extending/personal-extensions.md:3`,
+  `conversation/profiles.md:30,32,36`.
+
+---
+
+## 3. Core terminology
+
+Table columns: English term · this pack's term · banned alternates · one pack file that
+shows it.
+
+**How to read the "Banned alternates" column.** A word listed as banned is banned *for this
+meaning only*. Many of these strings do occur in the pack in an unrelated sense, and a naive
+grep will light them up — the "legitimate other sense" notes are there so a sweep does not
+file a false regression. Where the pack genuinely contradicts its own rule, the row says so
+and points at §7.3.
+
+| English | `pt-br` term | Banned alternates | Evidence |
+|---|---|---|---|
+| prompt | **o prompt** (m., loanword, plural `os prompts`) | `a prompt`, `solicitação`, `comando de entrada`. Legit other sense: `solicitação` (9) = an HTTP request or a credential prompt — `CONFIGURATION.md:140`, `installation/containers.md:83` | `lorebooks/overview.md:9`; `prompt(s)` 914; `o/os prompt(s)` 152 vs feminine article **0** |
+| token | **o token** (m., `os tokens`) | `a token`, `ficha`, `símbolo`. Legit other sense: `ficha(s)` (26) = poker chips and Game Mode character sheets, never a token — `conversation/table-games.md:109,112` | `agents/knowledge-sources.md:7` "Um token é um pedacinho de texto que a IA lê"; `chats/messages.md:95`; `token(s)` 171 |
+| preset | **o preset** (m., `os presets`) | `predefinição` (**0**), `pré-ajuste` (**0**), `perfil` for a preset | `prompts/presets.md:88`; `preset(s)` 301; `o/os preset(s)` 53 vs feminine **0** |
+| lorebook | **o lorebook** (m., `os lorebooks`) — alias **World Info** (13) given once, both names kept English | `livro de lore` (**0**), `a lorebook`, `enciclopédia` (**0**) | `lorebooks/overview.md:3,7`; `lorebook(s)` 706; `o/os lorebook(s)` 103 vs feminine **0** |
+| character card | **o card de personagem** (m., loan `card`), plural `cards de personagem` | `cartão de personagem` (§7.3, residual 2). **Not banned:** `ficha de personagem` — that is the Game Mode party character sheet, a different object (`game/party-and-npcs.md:15,21`, `game/getting-started.md:115`) | `agents/agents-overview.md:9`; `agents/approvals-and-agent-suite.md:18`; `card(s)` 551, `card de personagem` 59 |
+| card (UI panel/tile) | **o cartão** | `card` for a UI panel | `connections/local-self-hosted.md:79` "o cartão **Connection Tests**"; `extending/regex-scripts.md:134,136,138`; `media/scene-video.md:127,129`; `cartão/cartões` 14, of which 12 are UI cards and 2 are residual 2 |
+| chat | **o chat** (m., `os chats`) | `a chat`, `conversa` when it means the record, `bate-papo` (**0**) | `chats/managing-chats.md:1`; `chat(s)` 2 435; `o/os chat(s)` 321 vs feminine **0** |
+| conversation (the human sense) | **a conversa** — the ongoing exchange between reader and character, and group talk. Never the stored chat record | using `conversa` for the chat object | `chats/group-chats.md:1` "Chats em grupo e conversas em grupo"; `chats/connected-chats.md:15` "uma conversa paralela"; `agents/built-in-agents.md:153` "examina a conversa em lotes"; `conversa(s)` 75, of which ~49 carry a determiner |
+| message | **a mensagem** (f.) | `msg` (**0**), `recado` (**0**) | `chats/messages.md:1` "Ações de mensagem: editar, excluir, swipe e regenerar"; `mensagem/mensagens` 850 |
+| swipe | **o swipe** (m., verb `dar swipe` / noun kept) | `deslizar` as the noun (1 residual, §7.3), `variação` for a swipe. Legit other sense: `variação` (2) = a Named prompt option — `agents/custom-agents.md:147,149` | `chats/messages.md:1`; `TROUBLESHOOTING.md:260`; `swipe(s)` 111 |
+| turn | **o turno** | `rodada` **in the prompt/chat sense**. Legit other sense: `rodada` (18) = a combat round, a poker round, a tool-call round — `game/combat.md:22,26,30`, `CONFIGURATION.md:215` | `agents/knowledge-sources.md:7` "as entradas a cada turno desperdiça tokens"; `turno(s)` 198 |
+| agent | **o agente** (m.) — but the panel/product name stays `**Agents**` | `assistente` for an Agent, `bot` for an Agent. Legit other senses: `assistente` (91) = the assistant chat role, a setup wizard, or Professor Mari; `bot` (13) = `Bot Browser`, `/api/bot-browser/`, a table-game bot | `agents/agents-overview.md:1` "Agentes: ajudantes de IA para os seus chats"; `agente(s)` 727 |
+| connection | **a conexão** (f.) | `ligação`, `conta`, `integração` for an AI connection. Legit other senses: `ligação` (35) = a map link or a connected-chat link; `integração` (50) = a package's integration type | `connections/connecting-to-a-provider.md`; `agents/custom-agents.md:162`; `conexão/conexões` 592 |
+| provider (AI) | **o provedor** | `fornecedor` (**0**), `provedora` (**0**) | `connections/providers-reference.md:15`; `provedor(es)` 373 |
+| launcher | **o inicializador** | `lançador` (3 residual, §7.3), `launcher` untranslated in prose | `CONFIGURATION.md:71,88,142`; `TROUBLESHOOTING.md:324`; `inicializador(es)` 73. `launcher` has exactly 3 hits and all three are the script path `scripts/protect-launcher-data.mjs` (`TROUBLESHOOTING.md:270,277`, `development/file-storage.md:31`) |
+| launch script | **o script de inicialização** | `script de lançamento` (**0**) | `FAQ.md:9`; `installation/macos-linux.md:3` |
+| update (noun) / apply an update | **a atualização** / **aplicar a atualização** — the button stays `**Apply Update**` | `upgrade` (**0**), `atualizar` as a noun | `installation/android-termux.md:90`; `installation/windows.md:204`; `UPGRADING.md:1` "Atualizando Marinara Engine"; `atualização/atualizações` 210 |
+| release channel | **o canal (de versão)** | `faixa`, `trilha`, `canal de lançamento` for the release channel. Legit other senses: `faixa` (95) = a CIDR range, a valid value range, a HUD/safe-area strip; `trilha` (47) = `trilha de navegação` (breadcrumb), `trilha musical`, `trilha do catálogo` | `CONFIGURATION.md:237,238`; `installation/windows.md:201`; `installation/macos-linux.md:231`; `UPGRADING.md:128,135`; `canal/canais` 26 |
+| channel (Discord) | **o canal do Discord** | `sala`, `servidor` | `chats/connected-chats.md:83`; `integrations/discord-mirror.md:3` (8 of the 26 `canal` hits) |
+| channel (network port sense) | **o canal numerado** | reusing `canal` bare where `porta` is meant | `connections/local-self-hosted.md:37` "A porta é o canal numerado que o servidor…" |
+| breadcrumb (Maps) | **a trilha de navegação** | `migalhas`, `breadcrumb` | `agents/hierarchical-maps.md:23,41,377,487,605` |
+| catalog track | **a trilha do catálogo** | `canal do catálogo` | `CONFIGURATION.md:20` |
+| editor working copy (Maps/PRD) | **a cópia de trabalho** — a *local, unsaved* editor buffer, not a Git tree | using it for a Git checkout | `agents/hierarchical-maps.md:162,186,198,265,702`; `development/hierarchical-locations-prd-v3.md:126,880,987`; 12 hits, none of them Git |
+| checkout (Git working tree) | **`checkout` stays English in prose**; the install itself is **a instalação via Git**, and the dev tree is **a cópia de desenvolvimento** | translating `git checkout` in a command; `clone` as a Portuguese noun for the tree | `TROUBLESHOOTING.md:39` "Se o próprio checkout não conseguir atualizar"; `UPGRADING.md:33,37`; `installation/containers.md:24` "um checkout do Marinara Engine". `instalação via Git` 5 (`CONFIGURATION.md:237`, `UPGRADING.md:145,169,196`); `cópia de desenvolvimento` 1 (`CONFIGURATION.md:238`). `clone` (19) is legitimate as `git clone` and as the UI button **Clone** (`lorebooks/entries.md:401`, `media/style-profiles.md:55,58`) |
+| wake lock | **o wake lock** — untranslated, **unbolded**, lowercase | `bloqueio de ativação` (**0**), `trava de vigília` (**0**), bolding it as if it were a UI label | Exactly 2 hits: `TROUBLESHOOTING.md:324` "solicita um wake lock do Android" and `:330` |
+| battery optimization | **a otimização de bateria** | `otimização da bateria` (**0**), `economia de bateria` (**0**) | `TROUBLESHOOTING.md:326,332`; 2 hits |
+| background activity / run in background | **a atividade em segundo plano** / **rodar em segundo plano** | `plano de fundo` for process background, `background` in prose. Legit other senses: `plano de fundo` (144) = a wallpaper or scene background; `background` (89) = English UI/CSS/env names such as **Background Change**, `--background`, `SPRITE_BACKGROUND_REMOVAL_ENGINE` | `TROUBLESHOOTING.md:326,332`; `em segundo plano` 23 |
+| foreground | **primeiro plano** (`trazido para primeiro plano`, `manter em primeiro plano`) | `frente`, `foreground` in prose. Legit other sense: `foreground` (3) = the CSS tokens `--foreground`, `--primary-foreground`, `--muted-foreground` in `appearance/custom-css-themes.md:75,77,81` | `TROUBLESHOOTING.md:328` (H3) and `:332`; `primeiro plano` 3 |
+| frozen (process) | **congelado** / **o congelamento** | `travado` for the OS-frozen process state. Legit other senses: `travado` (11) = a *locked* setting or panel (`CONFIGURATION.md:94,217`, `game/hud-widgets.md:54`) or a *stuck* page/command (`UPGRADING.md:180`, `home/professor-mari.md:55`) | `TROUBLESHOOTING.md:330` "o processo do host está **congelado**"; `congelado` 21, `congelamento` 3 |
+| crash | **a falha** / **cair por falha** | `crashar` (**0**), `quebrar` for a crash. Legit other sense: `quebrar` (6) = to break in general — `home/welcome.md:49` "Se algo quebrar", `development/ios-pwa-safe-area.md:57` | `TROUBLESHOOTING.md:330` "e não caiu por falha"; `development/file-storage.md:35` "recuperação após falha"; `falha(s)` 85 |
+| phone vendor / OEM | **o fabricante do celular** | `fornecedor`, `OEM` (**0**) | `TROUBLESHOOTING.md:324,326,332`; `fabricante` 3 |
+| memory / in memory | **a memória** / **em memória**, **na memória** | `na memória RAM`, `residente` (**0**) | `CONFIGURATION.md:155` "mantém em memória"; `development/file-storage.md:31`; `characters/bot-browser.md:116` "guardados apenas na memória do servidor"; `memória(s)` 87, `em/na memória` 17 |
+| phone memory (OOM) | **a memória do celular** | `RAM do aparelho` | `CONFIGURATION.md:155`; `TROUBLESHOOTING.md:314` "o Android ficou sem memória" |
+| least-recently-used | **o … usado menos recentemente** | `menos usado recentemente`, `LRU` bare | `CONFIGURATION.md:155` (the one hit); built on `chats/managing-chats.md:96,97` "atividade mais recente" / "atividade mais antiga" |
+| evict / drop from memory | **descartar** — `descartado da memória`, `desativa o descarte` | `expulsar` (**0**), `remover da memória` (implies disk deletion) | `CONFIGURATION.md:155`; root shared with `development/file-storage.md:35`, `lorebooks/import-export.md:45`; `descart-` forms 46 |
+| cache | **o cache** (m.) — `guardar em cache`, `em cache`, `acertos de cache` | `memória temporária` (**0**), `a cache` | `CONFIGURATION.md:322`; `agents/approvals-and-agent-suite.md:3,95`; `chats/messages.md:95`; 47 hits |
+| backup | **o backup** (m., `os backups`) — verb `fazer backup` | `cópia de segurança` (**0**), `salvaguarda` (**0**) | `data/backup-and-restore.md:1` "Fazer backup e restaurar Marinara"; 143 hits |
+| snapshot (version history / state) | **o instantâneo** | `snapshot` in user-facing prose, `foto`, `captura` | `characters/creating-and-editing-characters.md:128,141,143`; `characters/personas.md:133`; `chats/branches.md:24`; 12 hits |
+| snapshot (English, byte-exact) | left as `snapshot` **only** inside developer-internals docs, English UI labels, and quoted UI strings | translating a quoted string; using `snapshot` in a user-facing guide | 45 hits, fully accounted for: 43 under `development/` (36 of them in `hierarchical-locations-prd-v3.md`), the label **Stats Snapshot** at `game/sessions-and-saves.md:72`, and the quoted string `"Restored the previous app data snapshot."` at `home/professor-mari.md:86` |
+| extension | **a extensão** (f.) — the product surface stays `**Personal Extensions**` / `**External Extensions**` | `plugin`, `add-on` (**0**) for Marinara extensions. Legit other sense: `plugin` (5) = a Tailwind/Fastify/PostCSS plugin or a Termux plugin app | `CONFIGURATION.md:57,59`; `extensão/extensões` 102; `extending/personal-extensions.md:3` |
+| NPC | **o NPC** (m., `os NPCs`) — the term itself is never translated | `PNJ` (**0**), or replacing `NPC` with `personagem não jogável`. **First-mention gloss is allowed** and the pack uses it: `NPC (personagem não jogável)` | `game/party-and-npcs.md:1,3,65,99`; `NPC(s)` 49. The gloss appears in 7 files — `agents/built-in-agents.md:111`, `game/dice-and-skill-checks.md:68`, `game/getting-started.md:11`, `game/party-and-npcs.md:3`, `game/sessions-and-saves.md:70`, `integrations/discord-mirror.md:47`, `media/tts-setup.md:89` |
+| persona | **a persona** (f.) | `o persona` (**0**), `perfil` for the persona object. Legit other sense: `perfil/perfis` (274) = the separate Profiles features — Conversation Mode profiles, settings profiles, style profiles, Noodle profiles | `characters/personas.md:3,7,9`; `characters/choosing-your-persona.md:3`; `a/as persona(s)` 97 |
+| app / application | **o aplicativo** — enforced everywhere in Portuguese prose | **`app`** as a Portuguese noun | `aplicativo` 443. `app` has **73** hits and every one is non-prose: a path or identifier (`/app/data`, `App.tsx`, `app.ts`, `--sidebar`-style code), an English UI label (**Refresh App**, **App Style**, **App Behavior**, **Install App**), the phrase `Progressive Web App`/PWA, a quoted English string, the CSS class `mari-app`, or the fixed technical term `app shell` (§7.3, residual 6) |
+| user | **o usuário** | `utilizador` (**0**) | `CONFIGURATION.md:3,152`; 141 hits |
+| file / folder | **o arquivo** / **a pasta** | `ficheiro` (**0**), `diretório` in user-facing prose (6 residual, §7.3) | `CONFIGURATION.md:71`; `data/where-data-is-stored.md:11`; `arquivo(s)` 828, `pasta(s)` 426 |
+| save (verb) | **salvar** | `guardar` as save, `gravar` (1, and it means "to write to disk") | `characters/personas.md:133`; `salv-` forms 525 (infinitive `salvar` 84) |
+| delete | **excluir** | `deletar` (**0**); `apagar` for user data (6 residual, §7.3) | `data/clearing-data.md:3` "aprende a excluir os seus dados"; `excluir` 118, all `exclu-` forms 212 |
+| screen | **a tela** | `ecrã` (**0**) | `agents/custom-agents.md:33`; `tela(s)` 212 |
+| library (of characters/lorebooks) | **a biblioteca** | `livraria` (**0**) | `lorebooks/overview.md:23,25`; `characters/library-organization.md`; 130 hits |
+| toggle | **o botão liga/desliga** | `alternador` (**0**); `interruptor` and `botão de alternância` (4 residual, §7.3). Legit other senses: `toggle` (9) and `switch` (15) only ever appear as code identifiers or English UI labels (**Switch branch**, **Boolean toggle**) | `agents/memory.md:71`; `extending/regex-scripts.md:134`; 139 hits |
+| dropdown | **o menu suspenso** | `lista suspensa` (**0**), `dropdown` in prose. Legit other sense: `dropdown` (1) is the English UI option label **Dropdown** at `prompts/preset-variables.md:33` | `connections/connecting-to-a-provider.md:34`; `media/scene-video.md:127`; 96 hits |
+| slider | **o controle deslizante** | `cursor deslizante` (**0**), `slider` in prose. Legit other sense: `slider` (2) appears only inside code blocks (`kind: "slider"`) | `appearance/appearance-settings.md:87,90,95`; 26 hits |
+| tab | **a aba** | `separador` for a tab, `guia` (reserved for *guide*). Legit other sense: `separador` (3) = a separator character — `chats/messages.md:74`, `prompts/preset-variables.md:19` | `installation/macos-linux.md:229`; `extending/regex-scripts.md:136`; `aba(s)` 311 |
+| guide (document) | **o guia** | `manual` as a noun for a guide. Legit other sense: `manual`/`manualmente` (130) = manual/by hand — `CONFIGURATION.md:37`, `FAQ.md:47` | `agents/agents-overview.md:3`; `guia(s)` 409 |
+| checkbox | **a caixa de seleção** | `checkbox` (**0**) | `characters/bot-browser.md:72,77,81`; `data/clearing-data.md:44`; 22 hits |
+| sidebar vs side panel | **a barra lateral** is the app rail with the tab icons; **o painel lateral** is the panel that opens inside it (Chat Settings, Agents, Personas). Both are correct — they are different objects | `sidebar` in prose. Legit other sense: `sidebar` (3) = the CSS tokens `--sidebar`, `--sidebar-border` and one ASCII layout diagram | `barra lateral` 30 — `lorebooks/overview.md:25`, `characters/creating-and-editing-characters.md:13`, `agents/hierarchical-maps.md:120`. `painel lateral` 34 — `agents/agents-overview.md:23,37`, `chats/group-chats.md:43,45` |
+| slash command | **o comando de barra** | `comando slash` (**0**), `barra de comandos` (**0**) | `chats/slash-commands.md:1` "Referência de comandos de barra"; 27 hits |
+| streaming | **o streaming** (m.) | `transmissão` for the token stream. Legit other sense: `transmissão` (1) = a broadcast, at `roleplay/getting-started.md:96` | `chats/sending-and-streaming.md:1` "Enviar mensagens e streaming"; `streaming` 36 |
+| embedding (the object) | **o embedding** (m., `os embeddings`) | `incorporação` (**0**) as the noun | `agents/memory.md:71`; `lorebooks/semantic-search.md:11`; `embedding(s)` 118 |
+| vectorizing (the action) | **a vetorização** / `vetorizado`, `vetorizada` — the *process* of producing embeddings, matching the **Vectorize** button | using `vetorização` for the embedding object | `lorebooks/semantic-search.md:75,88,96,104`; `connections/local-model.md:151`; `vetorização` 9 + `vetorizad-` 6 = 15 hits |
+| tracker | **o tracker** (m.) | `rastreador` (**0**) | `roleplay/hud-and-trackers.md`; `chats/branches.md:24`; `tracker(s)` 158 |
+| sprite | **o sprite** (m.) | `boneco` (**0**), `imagem de personagem` (**0**) | `characters/sprites.md:1` "Sprites de personagem (expressões e corpo inteiro)"; `sprite(s)` 268 |
+| achievement | **a conquista** — the panel and button stay `**Achievements**` | `realização` (**0**), `troféu` for the achievement. Legit other sense: `troféu` (1) = the literal trophy icon at `home/achievements.md:15` | `home/achievements.md:13,15,25`; `conquista(s)` 29 |
+| API key | **a chave de API** | `chave da API` (**0**), `API key` in Portuguese prose. Legit other sense: `API Key` (26) is the English UI field label and quoted English text | `conversation/emoji-stickers-gifs.md:79`; `connections/providers-reference.md:11`; `chave(s) de API` 105 |
+| model | **o modelo** | `motor` for an AI model. Legit other sense: `motor` (12) = an *engine* — the sprite background-removal engine, the regex engine, the ONNX runtime, the game engine | `connections/providers-reference.md:15`; `modelo(s)` 683 |
+| prompt override | **a substituição de prompt** — the UI section stays `**Prompt Overrides**` | `sobrescrita` **as the name of this feature** (**0**), `override` as a Portuguese noun. Legit other senses: `override` (39) is always an English UI name (**Scenario Override**, **Connection Override**, **Prompt Overrides**) or `docker-compose.override.yml`; `sobrescrit-` (7) is the ordinary verb "to overwrite" — `chats/chat-settings.md:51`, `home/professor-mari.md:90` | `prompts/prompt-overrides.md:3`; `development/noodle-internals.md:7,22`; 4 hits |
+| unset (config default) | **não definido** — distinct from `vazio` (empty) and `desligado` (off) in the same table | using `vazio` for unset | 5 hits: `CONFIGURATION.md:155`, `:238` (`UPDATES_APPLY_DISABLED` default), `:280` "um `TZ=` vazio também conta como não definido"; `TROUBLESHOOTING.md:365`; `installation/android-termux.md:15` |
+| timeout | **o tempo limite** / **tempo … esgotado** | `timeout` in prose. Legit other sense: `timeout` (27) appears only inside env-var names such as `CHAT_GENERATION_TIMEOUT_MS` | `CONFIGURATION.md:15,201`; `TROUBLESHOOTING.md:330` "tempo da requisição esgotado"; `tempo(s) limite` 31 |
+| allowlist | **a lista de IPs permitidos** | `whitelist` (**0**), `lista branca` (**0**) | `REMOTE_ACCESS.md:1,3,85,87`; `FAQ.md:14,37`; `CONFIGURATION.md:12,110`; 28 hits |
+| shard / sharded storage | **o fragmento** / **fragmentos identificados pela chave de propriedade**; the verb is **fragmentar** | `shard` as a Portuguese noun. Legit other sense: `shard` (4) appears only in code identifiers — the `unshard` command and `SHARD_KEY_COLUMNS` | `development/file-storage.md:31,35,64`; `data/where-data-is-stored.md:21`; `fragmento(s)` 9 |
+
+---
+
+## 4. Typography & punctuation
+
+All figures below are whole-pack counts over the shipped bytes.
+
+| Rule | Verified how |
+|---|---|
+| **Straight ASCII double quotes only** (`"…"`). Curly quotes `“ ” ‘ ’` and guillemets `« »` are banned — Portuguese typographic quotes are *not* used in this pack. | `“ ” ‘ ’` **0 occurrences**; `« »` **0**. `TROUBLESHOOTING.md:330` `"Opening chat..."`; `home/achievements.md:61`. Matches `CONTRIBUTING.md:237` ("straight quotes"). |
+| **En dash `–` is the parenthetical dash**, spaced. Em dash `—` is not the house dash. | `–` 54 hits in 11 files (`lorebooks/entries.md:174,179,185`; `game/game-assets.md:95`; `agents/hierarchical-maps.md:613`); `—` only 7, in 4 files, all residual (§7.3, residual 1). `CONTRIBUTING.md:237` says "en dashes". |
+| **Menu paths use `→`**, normally inside a single bold span, then one Portuguese gloss with the same arrows. 45 of the 82 arrows sit inside a bold span; the other 37 are in glosses, backticked location paths, or the four unbolded table cells noted below. | `→` 82 hits in 21 files. `agents/built-in-agents.md:3` `**Agents → Download Agents** (agentes → baixar agentes)`; `CONFIGURATION.md:31` `**Settings → Advanced → Danger Zone** (Configurações → Avançado → Zona de perigo)`. Non-menu uses that are correct: backticked Maps hierarchies (`agents/hierarchical-maps.md:389,513,705` — `` `Tower → Floor 7 → Alchemy Lab` ``) and "then" between two bold labels (`lorebooks/entries.md:377`). Unbolded menu paths inside table cells — `CONFIGURATION.md:243,316`, 4 arrows — are residual (§7.3, residual 9). |
+| **No NBSP, no narrow NBSP, no soft hyphen, no ideographic space, no zero-width joiner.** Portuguese needs no pre-punctuation space. | U+00A0 **0**, U+202F **0**, U+2011 **0**, U+00AD **0**, U+3000 **0**, U+200B **0**, U+200D **0**. Also U+2212 (minus), U+2012, U+2015, U+2032: all **0**. |
+| **Ellipsis: never author one.** `…` (U+2026, 15 hits in 8 files) and `...` (ASCII, 102 hits) appear **only** where they are copied byte-exact out of an English UI string, an English code/XML placeholder, or a path pattern that English also shows with an ellipsis. Do not normalise either direction. | `…`: UI labels at `UPGRADING.md:27,135,139,182`, `lorebooks/entries.md:13,31`, `characters/creating-and-editing-characters.md:29`, `connections/connecting-to-a-provider.md:34`, `data/backup-and-restore.md:30`; non-label but still English-mirrored at `TROUBLESHOOTING.md:275` (`` `messages.post-unshard-…` ``), `agents/built-in-agents.md:160` (`<memory_nags>…</memory_nags>`), `development/localization.md:51` (a Polish sample string). ASCII form at `TROUBLESHOOTING.md:330` `"Opening chat..."`, `characters/bot-browser.md:34,57,136` (**Search characters...**, **Importing...**). See §5.1 for why. |
+| **Decimal comma, thousands period** — Brazilian convention, in prose and tables. | `connections/local-model.md:72,73,77` "cerca de 5,4 GB", "cerca de 3,6 GB"; `game/combat.md:43` "multiplica o total por 1,5"; `agents/built-in-agents.md:200` "16.384"; `conversation/table-games.md:109` "1.000". |
+| **Never reformat numbers inside code, paths, versions, or IPs.** `192.168.1.42`, `0.0-1.0`, `7860`, `versionCode` stay byte-identical to English. | `FAQ.md:30` `http://192.168.1.42:7860`; `agents/built-in-agents.md:250` `0.0-1.0`. |
+| **Percent sign is closed up**: `75%`, `250%`. | 65 closed-up hits; `appearance/appearance-settings.md:87,90` ("de 0% a 100%", "de 75% a 250%"). A digit followed by space-then-`%` occurs **0** times. |
+| **Headings are sentence case in Portuguese**, with English proper names keeping their own capitalisation. | `chats/managing-chats.md:1` "Como gerenciar a lista de chats"; `game/combat.md:1` "Game Mode: combate"; `characters/sprites.md:1` "Sprites de personagem (expressões e corpo inteiro)". |
+| **Bold is allowed inside headings** when the heading names a UI surface. | `lorebooks/overview.md:23` `## O painel **Lorebooks**`. |
+| **List mechanics**: full-sentence bullets end with a period; label bullets use `- **Label**: gloss` or `- **Label** — gloss` and still end with a period. Numbered procedure steps end with a period. | `CONFIGURATION.md:22-29`; `agents/custom-agents.md:113,114`; `FAQ.md:13-30`. |
+| **Colon before a code fence or a menu path**, not a comma. | `FAQ.md:15`; `installation/windows.md:204`. |
+| **Files are LF, UTF-8, no BOM, with a trailing newline.** | Re-verified over all 126 files: 0 CRLF files, 0 BOM, 0 files missing a trailing newline. Enforced by the branch's `.gitattributes`; the Engine's own root file pins `* text=auto eol=lf` (added for #5598), and the pack needs the same because `manifest.json` hashes working-tree bytes. |
+
+---
+
+## 5. UI labels & glosses
+
+### 5.1 Byte-exact rule
+
+**Any string the reader will see on screen is reproduced byte-for-byte from English.** That
+includes capitalisation, the ellipsis character, trailing periods, and the `/` in
+`Install / Start Marinara`. Never translate it, never "fix" it, never localise its
+punctuation.
+
+- `**Install / Start Marinara**` — the slash and its spaces are part of the string. 7 hits:
+  `INSTALLATION.md:27`, `TROUBLESHOOTING.md:289,300,310`, `UPGRADING.md:103`,
+  `installation/android-termux.md:19,22`.
+- `characters/creating-and-editing-characters.md:29` `**Uploading…**`, `**Embedding…**`,
+  `**Saving…**` — U+2026, because `en.json` uses U+2026 for those keys.
+- `TROUBLESHOOTING.md:330` `"Opening chat..."` — ASCII dots, because
+  `en.json` key `ui.chat.chatarea.openingChat` is literally `"Opening chat..."`.
+  Source of truth: `packages/client/src/localization/locales/en.json`.
+- `lorebooks/entries.md:13` `**Search entries…**` ↔ `en.json` `chat.settings.inlineLorebook.search`.
+- `data/backup-and-restore.md:30` `**Creating backup…**` ↔ `en.json`
+  `ui.panels.advancedsettings.creatingBackup`.
+
+### 5.2 The two presentation patterns
+
+**Pattern A — bold label + one parenthetical Portuguese gloss** (the dominant one; **974**
+bold spans are immediately followed by a parenthetical, against **6 752** bold spans in
+total — i.e. the gloss is a *first-mention* device, not a per-occurrence one. Note that not
+every bold span is an English label: some bold Portuguese, so 6 752 is an upper bound on
+"bold English labels", and 974 an upper bound on glosses, since a few parentheticals are
+not glosses):
+
+```
+Abra **Agents → Download Agents** (baixar agentes) para instalar ou desinstalar.
+```
+`CONFIGURATION.md:20`. More: `installation/android-termux.md:90` `**Settings**
+(Configurações)`, `**Check for Updates**` (procurar atualizações), `**Apply Update**`
+(aplicar a atualização); `FAQ.md:9` `**Access blocked**` (acesso bloqueado);
+`TROUBLESHOOTING.md:330` `**Server unreachable**` (servidor inacessível) and
+`**Unreachable (request timed out)**` (inacessível: tempo da requisição esgotado).
+
+Gloss mechanics:
+- The gloss is **lowercase** unless it is itself a proper name or a menu label that the
+  Portuguese UI would capitalise (`(Configurações)`, `(Configurações → Avançado → Zona de
+  perigo)`).
+- **Gloss once per file, at first mention.** In `installation/android-termux.md`,
+  `**Settings**` occurs exactly once, at line 90, and carries its gloss there. In files
+  where a label recurs, only the first mention is glossed — `UPGRADING.md:13` glosses
+  `**Settings** (Configurações)` and later lines use it bare.
+- When a gloss would itself need parentheses, use a **colon** inside the gloss rather than
+  nesting: `**Unreachable (request timed out)** (inacessível: tempo da requisição esgotado)`
+  — `TROUBLESHOOTING.md:330`.
+- **Do not stack three parentheticals in one sentence.** Where a third label appears, leave
+  it unglossed as a proper name — `Support Diagnostics` in `TROUBLESHOOTING.md:330`, which
+  also mirrors English in not bolding it.
+
+**Pattern B — quoted status/help string, byte-exact, no gloss.** Full sentences the app
+prints are quoted in straight double quotes and left in English with no Portuguese
+rendering:
+
+```
+Aparece a mensagem "Restored the previous app data snapshot."
+```
+`home/professor-mari.md:86`. More: `TROUBLESHOOTING.md:129`
+`"This parameter is sent to the model"`; `home/achievements.md:61`; `UPGRADING.md:133,164`;
+`media/scene-backgrounds.md:81` `"Every image request needs a prompt."`;
+`media/scene-video.md:127`. **`pt-br` is not one of the locales that translate these.**
+Re-measured: **678** double-quoted spans in prose (fenced and inline code excluded), of
+which **15** are Portuguese — and every one of those 15 is an allowed exception, not a
+translated UI message: a quoted cross-reference to another section's Portuguese title
+(`appearance/card-css-theming.md` "O que você não pode estilizar";
+`conversation/calls.md` "Ative as chamadas em um chat") or example dialogue and example
+prompts the reader types (`game/combat.md` "Eu chuto areia na lente rachada do Ruin
+Guard."; `home/professor-mari.md` "o que você lembra?"; `lorebooks/entries.md` "não saia do
+personagem"; `agents/hierarchical-maps.md` "Vamos para a Kitchen"). A Portuguese quoted
+string that is neither of those is a regression.
+
+### 5.3 Emphasis on state words
+
+An English state word that the UI itself shows keeps the English bold; a Portuguese state
+word takes bold only where English bolds it: `agents/approvals-and-agent-suite.md:55` marks
+the edit as `**stale**` (desatualizada); `TROUBLESHOOTING.md:330` writes `**congelado**`,
+keeping English's bold on `frozen` while translating the word.
+
+---
+
+## 6. Language-specific mechanics
+
+| Mechanic | Rule | Evidence |
+|---|---|---|
+| **Preposition + article contraction** | Mandatory throughout: `de`+`o` → `do`, `em`+`o` → `no`, `a`+`o` → `ao`, `por`+`o` → `pelo`, `de`+`a` → `da`. This is what makes the product-name rule in §2.1 a *contraction* rule, not an *article* rule. | `CONFIGURATION.md:20` "do catálogo"; `agents/agents-overview.md:3` "no Marinara" |
+| **Gender assignment for English loanwords** | Tech loans are **masculine by default**: `o prompt`, `o token`, `o preset`, `o lorebook`, `o chat`, `o card`, `o backup`, `o cache`, `o swipe`, `o tracker`, `o sprite`, `o embedding`, `o streaming`, `o NPC`, `o wake lock`. The exceptions are loans with an obvious Portuguese feminine anchor: **`a persona`**, **`a API`**, **`a URL`**. | Masculine-article hits: prompt 152 · lorebook 103 · preset 53 · chat 321 · card 94 · token 18, each with **0** genuine feminine counterparts. `a persona(s)` 97 vs `o persona(s)` **0**; `characters/personas.md:3` "uma persona" |
+| **Plural of loanwords** | Add `-s` and leave the stem alone: `prompts`, `tokens`, `presets`, `lorebooks`, `chats`, `cards`, `backups`, `sprites`, `NPCs`, `swipes`. Never `NPC's`, never an invariable plural. | `game/party-and-npcs.md:1` "equipe e NPCs"; `characters/galleries.md:91` |
+| **Adjective agreement with the carrier noun**, not with the English name | `a janela **Review Character Card Updates**` → feminine agreement; `o painel **Lorebooks**` → masculine. | `agents/approvals-and-agent-suite.md:40`; `lorebooks/overview.md:23` |
+| **Verb "to support"** | Use `ter suporte a`, not the calque `suportar`. | `connections/subscription-clis.md:51` "só têm suporte a chat de texto", `:129` "só tem suporte a chat de texto"; `suporte a` 15. **One residual**: `connections/local-self-hosted.md:59` "não suporta chamadas de ferramenta" (§7.3, residual 10) — that is the only `suportar` form in the pack |
+| **Hyphenation of prefixes** | Follow the Acordo: `pré-visualização`, `pós-processamento`, but `automaticamente`, `autoridade` closed. | `pré-visualização` 7 (`CONFIGURATION.md:55` ×2, `:242`; `agents/hierarchical-maps.md:349,666,881`; `characters/colors-and-stats.md:13`); `pós-processamento` 6 (`agents/built-in-agents.md:147,198`; `development/frontend.md:567`; `media/illustrator-agent.md:7`; `development/architecture-map.md:90,290`) |
+| **`por que` / `porque` / `por quê`** | Standard Brazilian orthography; interrogative headings use `Por que…`. | `FAQ.md` question headings |
+| **Do not translate code, paths, env-var names, URLs, link targets, or fragments** | `DATA_DIR`, `/app/data`, `start-termux.sh`, `ipconfig`, `.env`, `#anchors` all stay byte-identical. This is enforced by the branch rules and by `validate-pack.mjs`. | `CONFIGURATION.md:76,152`; `FAQ.md:15,30`; `docs-i18n/README.md` step 1 |
+| **Table cells keep the pack's compact pipe formatting** | No English-style column padding; write `| a | b |` and let it be ragged. | `CONFIGURATION.md:152-160`; `connections/local-model.md:72` |
+
+---
+
+## 7. QA checks & known traps
+
+### 7.1 Mechanical checks (run these before shipping an edit)
+
+Run from the pack root (`pt-br/`) unless stated. Every expected count below is the state of
+the pack as shipped.
+
+1. **European Portuguese sweep** — must be **0** hits:
+   `grep -rEn "ficheiro|ecrã|utilizador|telemóvel|\bgerir\b|\baceder\b|carregar em|\brato\b" .`
+   (`rato` needs eyeballing: it is a substring of `barato`/`retrato`.)
+2. **`app` sweep** — every hit must be a path or identifier, a code block, an English UI
+   label (**Refresh App**, **App Style**, **App Behavior**, **Install App**), the phrase
+   `Progressive Web App`, a quoted English string, the CSS class `mari-app`, or the fixed
+   term `app shell`: `grep -rEn "\bapp\b" .` — **73 hits today, all accounted for**. A hit
+   that is none of those (an `app` used as a Portuguese noun) is the regression.
+3. **Product-name contraction** — must be **0** outside the `chamado de` formula:
+   `grep -rEn "\b(de|em) Marinara" .` (2 hits today, both `chamado (só) de Marinara`:
+   `agents/memory.md:7`, `installation/macos-linux.md:3`).
+4. **Address form** — must be **0**: `grep -rEn "\b(tu|vós|teu|tua)\b|o senhor|\bClica\b" .`
+5. **Curly quotes / guillemets** — must be **0**: `grep -rn "[“”‘’«»]" .`
+6. **Em dash** — 7 known residuals in 4 files (§7.3); any new one is a regression:
+   `grep -rn "—" .`
+7. **Invisible characters** — must be **0** for U+00A0, U+202F, U+2011, U+00AD, U+3000,
+   U+200B, U+200D: `grep -rnP "\x{00A0}"` (or a Python scan; plain `grep -E` with a
+   `\uXXXX` escape does *not* work in this shell — see §7.2).
+8. **Loanword gender** — must be **0 *real* hits**:
+   `grep -rEn "\bas? (prompts?|tokens?|presets?|lorebooks?|chats?|cards?|backups?)\b" .`
+   This grep returns **9 hits today and every one is a false positive** — the `a` is the
+   preposition (`vinculados a chats`, `suporte a chat de texto`, `dedicada a embeddings`,
+   `chat a chat`) or is inside a quoted English string (`"Every image request needs a
+   prompt."`). Eyeball each hit; the check passes only when none is a genuine article.
+   The reliable positive control: masculine-article counts in §6.
+9. **Line endings / BOM / trailing newline** — 0 CRLF files, 0 BOM, 0 missing final newline.
+10. **UI-string byte-exactness** — for every quoted or bolded English label, diff it against
+    `packages/client/src/localization/locales/en.json`. Watch the ellipsis: `en.json` mixes
+    `…` (e.g. `ui.panels.advancedsettings.creatingBackup`) and `...` (e.g.
+    `ui.chat.chatarea.openingChat`). Normalising either way is a regression.
+11. **Link text ↔ target H1** — recompute the mirroring table (see §7.4) and compare with the
+    baseline using the *same* classifier: 902 whole-file links, 745 exact, 14 case-only,
+    143 differing beyond case. Do not compare a fresh split against a differently-classified
+    ledger number (§7.4).
+12. **Pack validator** — from an Engine checkout at the matching `staging` commit:
+    `node scripts/docs-i18n/validate-pack.mjs <path>/pt-br` then
+    `node scripts/docs-i18n/build-manifest.mjs <path>/pt-br --source-commit <engine-sha>`.
+    Validator re-run on 2026-09-01: **passed — "Pack validation passed: 125 translated
+    docs, 125 English docs."**
+
+### 7.2 Tooling traps
+
+- **`grep -E` in this Git-Bash shell does not expand `$'\uXXXX'` escapes**, and a bracket
+  expression like `[“”]` matches *bytes*, producing spectacular false counts
+  (52 039 "curly quotes" in a pack that has none). Use the `Grep` tool with the literal
+  character pasted in, or a small Python scan with `encoding='utf-8'`.
+- **Python on this machine prints to a cp1252 console.** Any script that prints `→` or `…`
+  dies with `UnicodeEncodeError`. Wrap stdout:
+  `sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')`.
+- **Word boundaries break on accented characters** in this locale: `grep -Eo "\bvocê\b"`
+  returns 0 in a file with 1 309 occurrences, because ASCII `\b` sees the boundary *inside*
+  `você`. Drop the trailing `\b` after an accented letter, or use the explicit class this
+  glossary counts with: `(?<![A-Za-zÀ-ÿ])…(?![A-Za-zÀ-ÿ])`. Same failure mode hits `conexão`,
+  `atualização`, `extensão`, `instantâneo`, `pré-visualização`. This is the Latin-script
+  version of a trap that is total in non-Latin scripts — a JS-style `\w`/`\b` matches no
+  Cyrillic, CJK or Devanagari character at all, so a `\w`-based sweep silently reports zero
+  on those packs. Never trust a zero from a `\b`/`\w` pattern on non-ASCII text.
+- **`\bde Marinara\b` also matches `onde Marinara`.** Anchor on a leading space or `(^|\s)`.
+- **A "banned term" grep almost always over-fires.** Most banned alternates in §3 exist in
+  the pack in an unrelated sense (`faixa` = CIDR range, `motor` = engine, `perfil` =
+  Profiles feature, `manual` = manually, `rodada` = combat round, `ficha` = poker chip).
+  Read the §3 "legit other sense" notes before filing a regression from a raw count.
+- **Never let Git check the pack out as CRLF.** The branch `.gitattributes` must pin LF
+  (the Engine root uses `* text=auto eol=lf`, added for #5598) precisely because
+  `manifest.json` hashes working-tree bytes and `raw.githubusercontent.com` serves LF. A
+  CRLF checkout invalidates all 125 hashes at once.
+- **`validate-pack.mjs` is narrower than it looks.** Read against the script itself: it
+  checks orphan files with no English counterpart, a leading `# ` H1 on every file,
+  relative link *targets* existing in the English source, images the English source does
+  not have, and `manifest.json` presence, completeness and hash freshness. It does **not**
+  check terminology, link *text*, UI-string byte-exactness, fragment validity, or content
+  drift — the pack passes today while carrying the drift in residual 8.
+
+### 7.3 Known pack residuals — documented, not silently fixed
+
+These exist in the shipped bytes. Leave them alone unless a maintainer asks for a cleanup
+pass; they are listed so a future sweep does not "discover" them as new regressions.
+
+1. **7 em dashes** in 4 files, where the house dash is the en dash:
+   `agents/custom-agents.md:113,114` (label bullets), `TROUBLESHOOTING.md:260,326`,
+   `data/where-data-is-stored.md:21` (**two** on that one line, a paired parenthetical),
+   `lorebooks/entries.md:189` (inside quoted English example content, so arguably correct).
+2. **`cartão` used for the character card** in `characters/galleries.md:81,91` ("no cartão",
+   "as exportações de cartão PNG"), against the pack's dominant `card de personagem` (59).
+   The other 12 `cartão`/`cartões` hits are the correct UI-card sense.
+3. **`interruptor` for a toggle** in `agents/agents-overview.md:42,43` and
+   `prompts/preset-variables.md:17`, against the dominant `botão liga/desliga` (139 hits);
+   plus one **`botão de alternância`** in `chats/connected-chats.md:75`.
+4. **`Personal Extensions` translated in one file, kept English in its sibling**:
+   `extending/personal-extensions.md:1` H1 is "Extensões pessoais" (EN H1: "Personal
+   Extensions") while `extending/writing-personal-extensions.md:1` is "Como escrever
+   Personal Extensions" (EN: "Writing Personal Extensions"). The two cross-links between
+   them therefore cannot both mirror their targets.
+5. ~~One `o Professor Mari`.~~ **Withdrawn on 2026-09-01: this residual does not exist.**
+   A full sweep finds **0** masculine-marked forms (`o` / `do` / `ao` / `pelo Professor
+   Mari`) against 41 feminine-marked ones. See §2.3. The slot is kept numbered so the
+   cross-references in older notes still resolve.
+6. **`app shell` kept as a technical term** in `development/ios-pwa-safe-area.md:29,35,54,
+   67,68,69,96,97`. This is the only prose survival of `app` and it is deliberate — the term
+   names a specific DOM container (`mari-app`), not "the application".
+7. **`manifest.json` carries no `sourceCommit`.** `build-manifest.mjs` accepts
+   `--source-commit` and writes the field only when given; the shipped `pt-br/manifest.json`
+   has just `language` and `files`. There is consequently **no recorded English baseline**
+   for this pack. Supply `--source-commit` on the next rebuild.
+8. **Content drift against `docs/` at `staging` HEAD** (2026-09-01): 8 files where the
+   English side has since gained links or table rows —
+   `CONFIGURATION.md` (+3 table rows, +1 link), `FAQ.md` (+1 heading),
+   `agents/built-in-agents.md` (+1 link), `characters/creating-and-editing-characters.md`
+   (+1 link), `development/frontend.md` (+2 table rows),
+   `extending/personal-extensions.md` (+1 row, +1 link), `media/tts-setup.md` (+1 link),
+   `prompts/macros.md` (+1 heading). `validate-pack.mjs` passes anyway (see §7.2). Because
+   of residual 7 this cannot be attributed to a specific English revision. Re-measured
+   2026-09-01 against `docs/` and unchanged: the same 8 files, the same deltas, and the
+   file sets are otherwise identical in both directions (0 orphans, 0 missing).
+9. **Four unbolded menu-path arrows in table cells**: `CONFIGURATION.md:243`
+   ("consentir em Settings → Advanced → Danger Zone") and `:316`
+   ("(Settings → General → Documentation Language)"). The house pattern puts a menu path
+   inside one bold span; these two cells mirror English's unbolded prose instead.
+10. **One `suportar` calque**: `connections/local-self-hosted.md:59` "não suporta chamadas
+    de ferramenta", against the house `ter suporte a` (§6). It is the only `suportar` form
+    in the pack.
+11. **`lançador` for launcher, 3 hits, all in developer docs**:
+    `development/code-cleanup-audit.md:242`, `development/optional-agent-packages.md:140`
+    (×2), against the user-facing `inicializador` (73).
+12. **`checkout` left untranslated in Portuguese prose, 3 hits**: `TROUBLESHOOTING.md:39`,
+    `UPGRADING.md:37`, `installation/containers.md:24`. This is now written up as the rule
+    in §3 rather than as a defect, because the pack is consistent about it and there is no
+    competing Portuguese rendering — but it *was* recorded as banned, so it is listed here.
+13. **`diretório` in user-facing prose, 6 hits**, all `diretório de dados` in
+    `TROUBLESHOOTING.md:241,243,245`, against the house `pasta` (426).
+14. **`apagar` used for user data, 6 hits**, including `data/clearing-data.md:3,42,54`
+    ("apagar tudo de uma vez", "apagar parte dos dados"), against the house `excluir` (118).
+    The ledger recorded `apagar` as banned for user data; the pack does not honour that.
+15. **One `deslizar` as a noun**: `settings/settings-overview.md:97` "o deslizar do dedo",
+    inside the gloss of **Intuitive swipe navigation**, against the house `swipe` (111).
+
+### 7.4 Link-text ↔ H1 mirroring — the ledger claim, corrected
+
+**[RULING]** The recorded cycle ruling reads: *"Link-text↔H1 mirroring is mechanically
+enforced (0 paraphrases)."* PR #4229 states it more narrowly: *"link text unified to each
+target's actual H1 for the most-linked guides."*
+
+**The pack does not support the absolute form.** Measured over all 902 whole-file relative
+links (fragment links and external URLs excluded), re-run on 2026-09-01 against both trees:
+
+| | `pt-br` | `docs/` (English baseline) |
+|---|---|---|
+| whole-file links | 902 | 902 |
+| link text == target H1 | **745** (82.6 %) | 703 (77.9 %) |
+| case-only difference | 14 | 11 |
+| differs beyond case | **143** | 188 |
+| — of those, short form of the H1 | 115 | 105 |
+| — of those, **reworded** | **28** | 83 |
+
+So the audit was real and substantial — the pack roughly *tripled* the exact-mirroring
+margin over English and cut reworded link text to about a third of English's — but
+"0 paraphrases" is not true of the shipped bytes. **Record the ruling, enforce the
+measurable version**: no *new* reworded link text, and the set below is the accepted one.
+
+**The short-form/reworded split is classifier-sensitive; the first three rows are not.**
+The ledger recorded 118/25 for `pt-br` and 112/76 for English; this re-measure gets 115/28
+and 105/83 from the same 902/745/14/11/703 skeleton. The difference is entirely where you
+draw "short form": the classifier used here counts a link as *short form* only when the H1
+starts with the link text, or the link text equals the H1's text before its first `:` or
+its first `(`. Anything else — a suffix match, a case-differing prefix — lands in
+*reworded*. **Re-run with this same rule before comparing**, or the delta is an artifact.
+
+The 28 reworded links under that classifier, by source → target:
+
+- `CONFIGURATION.md` → `media/scene-video.md` ×2 — "Vídeo de cena" vs "Geração de vídeo de cena"
+- `settings/settings-overview.md` → `media/scene-video.md` ×1 — same pair
+- `settings/settings-overview.md` → `media/music.md` — "Música" vs "Music DJ: Spotify, YouTube e músicas locais"
+- `TROUBLESHOOTING.md`, `extending/personal-extensions.md`,
+  `extending/writing-personal-extensions.md`, `integrations/home-assistant.md` ×2
+  → `CONFIGURATION.md` (5 links) — "Configuração do servidor" vs "Referência de configuração do servidor"
+- `INSTALLATION.md` → `installation/windows.md` ×2 — "Instalação no Windows" vs "Guia de instalação no Windows"
+- `INSTALLATION.md` and `FAQ.md` → `installation/android-termux.md` ×2 — vs "Guia de instalação no Android (Termux)"
+- `chats/branches.md` → `chats/managing-chats.md` ×2 — "Gerenciar a lista de chats" vs "Como gerenciar a lista de chats"
+- `chats/guided-and-impersonate.md` → `prompts/presets.md` ×2 — "Presets" vs "Editor de presets e gerenciador de prompts"
+- `extending/personal-extensions.md` → `extending/writing-personal-extensions.md` ×2 and
+  `extending/writing-personal-extensions.md` → `extending/personal-extensions.md` ×2 — the
+  four cross-links of residual 4, which cannot all mirror because the sibling H1s disagree
+- `extending/writing-personal-extensions.md` → `development/personal-extensions.md` — "Arquitetura de Personal Extensions" vs "Arquitetura das Personal Extensions"
+- `media/animated-expressions.md` → `characters/sprites.md` ×2 — "Sprites de Personagem" vs "Sprites de personagem (expressões e corpo inteiro)" (case-differing prefix)
+- `agents/built-in-agents.md` → `noodle/overview.md` — "…a linha do tempo social do aplicativo" vs "…dentro do aplicativo"
+- `agents/built-in-agents.md` → `game/storyboard.md` — "Agente Storyboard: Roleplay e Game Mode" vs "Guia do agente Storyboard"
+- `lorebooks/overview.md` → `lorebooks/entries.md` — "guia de entradas" vs the full H1
+- `noodle/settings.md` → `conversation/schedules.md` — "agendas de personagem" vs "Agendas de personagem e mensagens autônomas"
+
+### 7.5 Recorded rulings kept without pack evidence
+
+Carried forward from the original cycle; the pack cannot show them, so they are recorded,
+not verified:
+
+- **The article standard was a maintainer ruling that reversed an earlier decision.** The
+  original glossary prescribed *no* article with the product name; the maintainer overruled
+  it to `do/no Marinara`. The pack shows only the outcome (§2.1, one-sided and verified),
+  never the reversal — there is no in-pack artifact of the earlier rule or its overturning.
+- **"Link-text↔H1 mirroring mechanically enforced, 0 paraphrases"** — recorded as stated,
+  and **disproved** by the pack: 28 reworded link texts survive. §7.4 carries the
+  measurable replacement rule and the accepted set.
+- **Process ruling (PR #4229): every file passed structural verification, dialect,
+  address-form and terminology sweeps, plus an independent language-QA panel.** No artifact
+  of those sweeps ships with the pack.
+- **Process ruling (PR #4229): runtime verification against a throwaway data dir** with a
+  materialized pack — viewer fully Portuguese, Settings coverage counts, switch flows. Not
+  reproducible from pack bytes.
+- **Process ruling: the original glossary carried an explicit anti-calque table.** Its
+  individual entries are lost; only the three false-friend pairs recorded in the ledger
+  (`livraria`/`biblioteca`, `atualmente`, `eventualmente`) survived, and those *are*
+  verified in §1. Treat the anti-calque table as reconstructable only from future sweeps.
+- **Repo process ruling: `[docs-i18n]` follow-ups are batched, not filed per PR.** A change
+  to `docs/` that renames or deletes a file must still be mirrored here or the translation is
+  silently orphaned (`CLAUDE.md`, `CONTRIBUTING.md § Translated documentation`).
+
+---
+
+## 8. Quick reference card
+
+```
+você + 3rd-person imperative      Clique · Abra · Veja · Use · Escolha · Defina
+Brazilian only                    arquivo salvar tela usuário celular gerenciar
+                                  NEVER ficheiro guardar(=save) ecrã utilizador gerir
+product name                      do/no Marinara · bare Marinara as subject
+                                  the only "de Marinara" is "chamado de Marinara"
+app                               aplicativo (never "app" as a Portuguese noun;
+                                  all 73 "app" hits are paths, UI labels, PWA, app shell)
+modes                             Conversation Mode · Roleplay · Game Mode (English)
+                                  but "Modo Conversation" where EN says "Conversation mode"
+frozen names                      World Maps · Haptic Feedback · Professor Mari (f., 0 masc.)
+                                  Noodle · Agent Suite · Danger Zone · Support Diagnostics
+                                  BUT the common noun is "feedback tátil"
+loan genders                      o prompt/token/preset/lorebook/chat/card/backup/
+                                  cache/swipe/tracker/sprite/NPC/wake lock
+                                  a persona · a API · a URL
+NPC                               never PNJ; first-mention gloss
+                                  "NPC (personagem não jogável)" IS used
+sidebar vs panel                  barra lateral = the rail · painel lateral = the panel
+                                  in it — both correct, different objects
+embedding vs vetorização          o embedding = the object · a vetorização = the action
+quotes                            "straight" only — no “ ” ‘ ’ « »
+dashes                            – (en dash), spaced · never — (7 residuals)
+menu paths                        **A → B → C** (gloss → em → português)
+numbers                           5,4 GB · 16.384 · 75%
+UI strings                        byte-exact English; ellipsis exactly as en.json has it
+gloss                             **English Label** (gloss em minúsculas) — once per file
+files                             LF · UTF-8 · no BOM · trailing newline · 125 .md + manifest
+```

--- a/glossaries/glossary-ru.md
+++ b/glossaries/glossary-ru.md
@@ -1,0 +1,620 @@
+# Russian (`ru`) — documentation-pack glossary
+
+## Provenance
+
+This is the **second-generation** `ru` glossary, **re-derived 2026-09-01** after the original
+working glossaries were lost to temp-directory cleanup. It was rebuilt from three sources, in
+authority order:
+
+1. **The shipped pack** at `docs-i18n:ru/` (125 files) — **ground truth**. Every terminology row
+   and prescriptive rule below was re-verified against the pack as shipped, with a cited evidence
+   file and line.
+2. **The pack's shipping PR decision write-up** — Pasta-Devs/Marinara-Engine **PR #4281**
+   ("Russian conventions" section), which is the record of what the original cycle decided and why.
+3. **The 2026-09-01 mirror-cycle notes** (`prd-notes-ru.md`) — evidence-backed choices made during
+   the same-day delta mirror, each carrying its own in-pack citation.
+
+**How to read the rules.** Every prescriptive statement is either
+
+- **verified** — followed by a `file:line` citation into `ru/`, meaning the pack demonstrably does
+  this today; or
+- marked **`[recorded ruling]`** — a maintainer or cycle decision that the pack cannot show,
+  because it is a process rule, a tooling trap, or a negative finding. These are preserved as
+  rulings, not invented.
+
+Where the pack **contradicts** a rule in a small number of places, the rule stands and the
+exceptions are logged in §7 *Known pack residuals* — documented, not silently normalized.
+
+Line numbers refer to the pack as shipped in PR #4281. Re-verify after any pack edit.
+
+**Verification pass, 2026-09-01 (same day).** Every row below was re-scanned against the 125 shipped
+`ru/*.md` files with a UTF-8 Python scanner (never MSYS `grep` — see §7 trap 2). That pass changed
+four things worth flagging up front:
+
+- **Two rulings previously marked unverifiable are in fact attested**, both in the same table row
+  `CONFIGURATION.md:155`: the **least-recently-used** rendering and the **noun** `вытеснение`. They
+  are now verified rows, not rulings. The earlier "no precedent" finding was a false negative — the
+  exact failure mode trap 2 describes.
+- **The ellipsis question is settled**, by reading `en.json` rather than the pack. See §4 and
+  residual E.
+- **Banned alternates needed scoping.** Most "banned" words are live pack vocabulary in a *different*
+  sense (`подсказка` = tooltip, `эпизод` = Storyboard episode, `пост` = Noodle post …). A bare grep
+  for a banned alternate is therefore not a defect check. §3 now states the sense each ban covers and
+  gives the false-positive count.
+- **Several evidence citations were off** and have been corrected against the shipped files.
+
+---
+
+## 1. Register & address
+
+| Rule | Detail | Evidence |
+|---|---|---|
+| Formal **lowercase `вы`** | Russian is the **first formal-address pack** (de/fr/pt-br/pl are informal). `ты` reads noticeably over-familiar in app documentation; mainstream Russian software convention (Yandex, VK, Telegram) is lowercase `вы`. | 419 lowercase `вы` in prose outside code fences; `FAQ.md:37`, `CONFIGURATION.md:3` |
+| **Never honorific `Вы`** mid-sentence | Capitalized `Вы` is reserved for sentence-initial position only. A mid-sentence `Вы` is a defect. | **39** capitalized `Вы` outside code fences, **all 39 sentence-initial**; **0** mid-sentence pack-wide. Examples: `conversation/calls.md:17`, `lorebooks/entries.md:303` |
+| **Plural imperative** for instructions | `Нажмите`, `Откройте`, `Задайте`, `Выберите`, `Проверьте`, `Введите`, `Смотрите`. Singular imperatives (`Нажми`, `Открой`) are banned. | `Нажмите` ×366, `Откройте` ×293, `Выберите` ×126; singular forms ×0 |
+| **Gender neutrality comes free** | The plural agreement `вы` takes (`вы хотите`, `вы увидите`, `вы работаете`) is gender-neutral by construction. No gendered participle or past-tense form ever needs to agree with the reader, so the pack needs **no** `(-а)` bracket forms, no `пользователь/пользовательница` doubling, and no passive-voice contortions. | `CONFIGURATION.md:9` ("Настройки стоит поменять, если **вы хотите**:"), `TROUBLESHOOTING.md:103` ("Если **вы работаете** через публичный домен") |
+| Third-party subjects stay neutral | Refer to the reader's counterpart by role (`тот, кто держит сервер`), not by gendered noun. | `CONFIGURATION.md:61` ("разрешение от того, кто держит сервер") |
+| `ты` only inside quoted user utterances | The single legitimate `ты` in the pack is an example query the **user speaks to Professor Mari** — informal address to the assistant, not to the reader. Do not generalize it. | `home/professor-mari.md:131` (`"что ты помнишь?"`) |
+| **Professor Mari is feminine** | Referred to as `она` / `ее`; the Latin name itself never declines. | `home/professor-mari.md:3` ("где **ее** найти, что **она** умеет") |
+| **`Marinara` takes feminine agreement** | When the bare product name is the grammatical subject, verbs agree feminine (`Marinara сама выбирает`, `Marinara хранит`). ~59 such constructions. | `CONFIGURATION.md:20` ("Marinara **сама** выбирает"), `CONFIGURATION.md:158` ("Marinara **хранит** данные") |
+
+---
+
+## 2. Product, feature & mode names
+
+**The frozen-name rule.** Product, mode, agent and feature names **stay in Latin script and never
+decline**. A Cyrillicized or declined name breaks the docs viewer's literal-substring search, which
+is why this is a hard rule rather than a stylistic preference (PR #4281).
+
+- Verified: **0** Cyrillicized product-name residuals pack-wide (`Маринар*`, `Термукс`, `Андроид`,
+  `Ноудл`, `СиллиТаверн` — all zero), and **0** Latin stems carrying a Cyrillic case suffix.
+
+**The carrier-noun rule.** Because the name cannot decline, a **Russian carrier noun takes the
+case** and the frozen name sits behind it in the nominative.
+
+| Do | Never |
+|---|---|
+| `в приложении Marinara Engine` | `в Маринаре` |
+| `сервер Marinara` / `установка Marinara` | `Marinar'ы`, `Marinarе` |
+| `каталог Pasta-Devs/Marinara-Agents` | any inflected repo name |
+| `персонажи NPC` / `персонаж NPC` | `НПС`, `неписи` |
+| `в скопированном отчете Support Diagnostics` | `в Support Diagnostics'е` |
+
+- 103 instances of the `в приложении Marinara …` carrier form. Evidence: `CONFIGURATION.md:3`,
+  `FAQ.md:3`, `chats/branches.md:3`.
+- Carrier + Latin `NPC`: `game/party-and-npcs.md:1` (`# Game Mode: отряд и персонажи NPC`),
+  `:79`, `:95`. `NPC` appears **47×** in Latin (43 as the standalone word, 4 inside the plural
+  `NPCs`); the carrier form `персонаж NPC` accounts for 25 of them. `НПС` **0×** — ban holds.
+
+**What stays English (never translated, never transliterated):**
+
+| Class | Members (as they appear) |
+|---|---|
+| Product & shell | `Marinara`, `Marinara Engine`, `Noodle`, `Professor Mari`, `Termux`, `Docker`, `Android`, `Windows`, `Linux`, `Node.js`, `Tailscale`, `SillyTavern`, `ComfyUI`, `Spotify`, `Home Assistant`, `OpenAI` |
+| Chat modes | `Conversation`, `Roleplay`, `Game Mode` (and bare `Game`) |
+| Agents & packages | `Storyboard`, `Illustrator`, `Music DJ`, `World Maps`, `Knowledge Router`, `Local Model`, `Agent Suite` |
+| Acronyms | `API`, `JSON`, `CSS`, `HUD`, `GM`, `GIF`, `PWA`, `HP`, `MP`, `CSRF`, `SSRF` |
+| UI controls & panels | every bold label — see §6 |
+
+**Glossed-on-first-use, then bare.** A frozen name that is not self-evident gets a one-time
+Russian explanation on first use in that document, then runs bare:
+
+- `HUD – это heads-up display, экранная панель` — `agents/agents-overview.md:50`
+- `Ключ API – это секретный код от провайдера` — `TROUBLESHOOTING.md:128`
+- `Эмбеддинг – это числовое представление текста` — `TROUBLESHOOTING.md:164`
+- `Токен – это небольшой кусочек текста` — `lorebooks/token-budgets.md:5`
+- `PWA (Progressive Web App – сайт, который можно установить как приложение)` — `FAQ.md:43`
+
+Note the gloss connector is ` – это ` (spaced en dash + `это`), not a colon and not an em dash.
+
+**Articles / determiners:** Russian has none. Do **not** import English `the`/`a` as `данный`,
+`указанный`, or `этот` unless the demonstrative is genuinely contrastive. The pack writes
+`Ветка – это копия чата`, not `Ветка – это данная копия чата` (`chats/branches.md:7`).
+
+---
+
+## 3. Core terminology
+
+Banned alternates are **defect classes**: a reviewer finding one *used for this concept* should
+treat it as a regression, not a synonym choice. The whole point of the single-rendering rule is that
+the docs viewer's search is literal-substring — two renderings of one concept split the result set.
+
+> **Read this before grepping for a banned alternate.** A ban is **sense-scoped**, never
+> word-scoped. Most banned alternates are ordinary, correct pack vocabulary in some *other* sense,
+> and several are among the most common words in the pack. Grepping the bare word does not find
+> defects — it finds the pack doing its job. The measured false-positive load, whole-tree:
+>
+> | Banned alternate | Occurrences | What they actually are |
+> |---|---|---|
+> | `вариант` | 299 | **option / choice** (`три варианта действий`) — never "swipe" |
+> | `запрос` | 241 | HTTP/provider **request**, `по запросу` — never "prompt" |
+> | `удаление` | 186 | ordinary **deletion** of data — never "eviction" |
+> | `элемент` | 178 | `элементы управления` = UI **controls**, list items — never "widget" |
+> | `лорбука` | 150 | the **genitive of masculine `лорбук`** — correct, see §6 |
+> | `шаг` | 128 | a numbered **step** in an instruction — never "Game Mode turn" |
+> | `группа` | 128 | lorebook **groups** and general grouping — never "party" |
+> | `сервис` | 105 | an external **AI service** — never "provider" (the configured entity) |
+> | `подсказка` | 103 | **tooltip** (`всплывающая подсказка`, 35×), **placeholder** (`подсказка в поле`, 10×), **hint/tip** — never "prompt" |
+> | `аватар` | 109 | the **avatar image** (`Roleplay Avatars`, `круг аватара`) — never "persona" |
+> | `пункт` | 70 | menu / list **item** — never "lorebook entry" |
+> | `заметка` | 67 | a user's or agent's **note** — never "saved memory" |
+> | `помощник` | 56 | the **definitional gloss** for agent — see the agent row |
+> | `off` | 41 | the **verbatim UI state** `**off**` — the ban covers the Russian default column only |
+> | `ассистент` | 40 | the **assistant message role** and Professor Mari — see the agent row |
+> | `реплика` | 34 | **in-fiction speech** in quotes — never "message" |
+> | `знак` | 21 | punctuation **mark**, the tic-tac-toe **mark** — never "token" |
+> | `вложение` | 21 | file **attachment** — never "embedding" |
+> | `эпизод` | 21 | the **Storyboard episode** — never "scene" |
+> | `встраивание` | 16 | an agent's **pipeline phase** (`способ встраивания`) — never "embedding" |
+> | `пост` | 13 | a **Noodle post** — never "chat message" |
+> | `векторизация` | 13 | the **act** of vectorizing a lorebook — see the embedding row |
+> | `картинка персонажа` | 13 | the **avatar** (`characters/creating-and-editing-characters.md:89`) — never "sprite" |
+> | `диалог` | 10 | **dialogue box** (`Game Dialogue Display`) — never "chat" |
+> | `переписка` | 10 | messaging **as prose description** — never the term for "chat" |
+> | `соединение` | 5 | a **network/physical** connection — never a configured provider connection |
+> | `круг` | 3 | `круг аватара` = avatar **circle** — never "combat round" |
+> | `буфер` | 2 | `буфер обмена` = **clipboard** — never "cache" |
+> | `alter ego` | 1 | inside the verbatim UI label `**Inspired alter ego (Hinted)**`, `noodle/settings.md:28` |
+> | `индексация` | 1 | graph **indexing** in a dev doc — never "vectorization" |
+>
+> The **rest of the banned alternates are genuinely absent (0×) and safe to grep bare**: `кэш`,
+> `НПС`, `непись`, `НИП`, `учетная запись`, `затравка`, `лексема`, `предустановка`, `шаблон
+> настроек`, `книга знаний`, `книга лора`, `предание`, `мифология`, `чар`, `герой`, `профиль
+> пользователя`, `беседа`, `чат группы`, `мультичат`, `смахивание`, `отслеживатель`, `следилка`,
+> `мини-приложение`, `поставщик`, `лаунчер`, `стартер`, `накатить`, `ветка выпусков`, `релиз-канал`,
+> `бранч`, `чекаут`, `вейк-лок`, `аккумулятор`, `энергосбережение`, `резидентно`, `ОЗУ`, `выселение`,
+> `бэкап`, `дамп`, `снапшот`, `слепок`, `срез`, `коннекшн`, `чарактер-кард`, `реквизиты`, `данные для
+> входа`, `хаб-запись`, `узловая запись`, `бюджет токенов`, `косая команда`, `ролл`, `кидание`,
+> `пати`, `вайтлист`, `переменная среды`, `энв`, `неограниченно`, `таймаут`.
+>
+> So the split is: **the 30 words in the table need a sense check before you call anything a defect;
+> the other 58 are clean mechanical checks.**
+
+Where a banned alternate appears in the table above, its ban is **narrow** even if the cell below
+does not repeat the restriction — check the count and sense there first. This applies in particular
+to `вариант` (swipe), `шаг` (turn), `группа` (party), `сервис` (provider), `заметка` (memory item)
+and `удаление` (eviction), all of which are common, correct words elsewhere in the pack.
+
+| English term | This pack's term | Banned alternates | Evidence |
+|---|---|---|---|
+| prompt | **промпт** (declines), 581× | подсказка, запрос, затравка — **for the prompt sense only** | `CONFIGURATION.md:37`; `chats/peek-prompt.md:70`. The pack draws the line itself at `settings/settings-overview.md:44`: "меняет элементы управления и **подсказки** приложения, но не **промпты** для модели" |
+| tooltip | **всплывающая подсказка** (bare **подсказка** once the tooltip is in view) | тултип, всплывающий текст | `chats/branches.md:38`, `chats/group-chats.md:43`, `game/dice-and-skill-checks.md:29` — 35× in the full form |
+| placeholder text | **подсказка в поле** | плейсхолдер, заполнитель | `characters/sprites.md:33`, `chats/connected-chats.md:83`, `REMOTE_ACCESS.md:190` |
+| token | **токен** (declines) | лексема, знак | `lorebooks/token-budgets.md:5` |
+| preset | **пресет** (declines) | предустановка, шаблон настроек | `CONFIGURATION.md:185`. **Not** `профиль настроек` — that is a different feature, next row |
+| settings profile | **профиль настроек** | пресет (that is the prompt preset), профиль чата | `chats/settings-profiles.md` (whole guide); `:14` states the relationship: "пресет промпта – лишь один из элементов профиля настроек"; also `chats/managing-chats.md:29`, `chats/group-chats.md:118` |
+| lorebook | **лорбук** (declines, **masculine**) | книга знаний, книга лора | `FAQ.md:101`. The 150 hits for `лорбука` are the **genitive singular** and are correct; what is banned is treating it as a feminine **nominative** (§6) |
+| lore | **лор** (declines) | предание, мифология | `lorebooks/entries.md:155` ("подтягивать связанный лор") |
+| character card | **карточка персонажа** | карта персонажа, чарактер-кард | `agents/approvals-and-agent-suite.md:38` |
+| character | **персонаж** | чар, герой | `CONFIGURATION.md:18` |
+| persona | **персона** (declines) | профиль пользователя, alter ego; `аватар` (reserved for the **avatar image** — `appearance/appearance-settings.md:88`, `characters/creating-and-editing-characters.md:15`) | `FAQ.md:103` (`**Linked Personas** (связанные персоны)`) |
+| chat | **чат** (declines) | беседа; `диалог` (reserved for the **dialogue box** — `appearance/appearance-settings.md:100`, `Game Dialogue Display`); `переписка` (fine as descriptive prose for messaging, e.g. `FAQ.md:53`, but never as the term) | `CONFIGURATION.md:148` |
+| group chat | **групповой чат** | чат группы, мультичат | `characters/creating-and-editing-characters.md:57` |
+| message | **сообщение** | реплика (reserved for in-fiction speech, `appearance/appearance-settings.md:66`), пост (reserved for **Noodle posts**, `noodle/overview.md:47`) | `FAQ.md:121` |
+| swipe | **свайп** (declines) | смахивание, вариант (bare) | `chats/branches.md:25` (glossed once: `свайпами (альтернативными вариантами ответа)`) |
+| agent | **агент** (declines) | бот (reserved: AI card-game players, `conversation/table-games.md:49`), отслеживатель | `CONFIGURATION.md:29`. **`помощник` is not banned** — it is the pack's own definitional gloss for an agent and appears in the guide's H1: `agents/agents-overview.md:1` (`# Агенты: помощники ИИ в чатах`), `:7`, `agents/built-in-agents.md:7`. Use it to *explain* an agent, never as the standalone term |
+| assistant (message role) | **ассистент** | — | `agents/built-in-agents.md:17`, `:45`, `:210` (`сообщений пользователя и ассистента`). The same word is also correct for Professor Mari as an assistant persona: `characters/creating-and-editing-characters.md:159` (`персонаж-ассистент`), `conversation/profiles.md:32`. It is **not** a synonym for `агент` |
+| tracker | **трекер** (declines) | отслеживатель, следилка | `agents/agents-overview.md:50` (`**Manual Trackers**`); `appearance/appearance-settings.md:67` |
+| widget | **виджет** (declines) | мини-приложение | `game/hud-widgets.md:1` (`# Game Mode: виджеты панели HUD`), `:7`, `:9`; `characters/colors-and-stats.md:71`. 86× pack-wide — but **0× in `agents/agents-overview.md`**, which is about agents, not widgets |
+| sprite | **спрайт** (declines) | картинка персонажа (that phrase means something else) | `CONFIGURATION.md:213` |
+| connection (configured provider) | **подключение** | коннекшн; `соединение` (reserved for a **network/physical** link — `conversation/calls.md:20`, `development/personal-extensions.md:55`) | `CONFIGURATION.md:263` |
+| provider | **провайдер** (declines) | поставщик, сервис | `CONFIGURATION.md:18` |
+| embedding (the object) | **эмбеддинг** (declines) | вложение, встраивание | `CONFIGURATION.md:208`; glossed at `TROUBLESHOOTING.md:164` and `lorebooks/semantic-search.md:11` |
+| vectorize / vectorization (the action) | **векторизовать** / **векторизация** | эмбеддить, индексация | `agents/knowledge-sources.md:89` (`векторизуйте лорбук`; `при векторизации`), `connections/local-model.md:151`. 13× — this is a **separate, attested term**, not a banned rendering of *embedding* |
+| launcher / launch script | **скрипт запуска** (56×) | лаунчер, стартер | `CONFIGURATION.md:276`, `TROUBLESHOOTING.md:324`; declined form at `CONFIGURATION.md:274` (`в скриптах запуска`). `программа запуска` survives 4× — see residual F |
+| update (verb) / apply | **применить обновление**, n. **применение обновления** | накатить, установить обновление (for the in-app Apply action) | `CONFIGURATION.md:238`; `UPGRADING.md:158` |
+| release channel | **канал выпусков** | ветка выпусков, релиз-канал | `UPGRADING.md:128` |
+| branch (chat) | **ветка** | ответвление (used only as a loose descriptor), форк | `chats/branches.md:1`, `:7` |
+| branch (git / repo) | **ветка** (same word — context disambiguates) | бранч | `CONFIGURATION.md:316` (`официальная ветка docs-i18n`) |
+| checkout (working tree) | **рабочая копия** | чекаут, выгрузка | `TROUBLESHOOTING.md:39` |
+| wake lock | **блокировка сна** | вейк-лок, удержание пробуждения | `TROUBLESHOOTING.md:324` |
+| battery optimization | **оптимизация батареи** | оптимизация аккумулятора, энергосбережение | `TROUBLESHOOTING.md:326`, `:332` |
+| background activity / run in background | **фоновая активность** / **работать в фоне** | активность в фоновом режиме, бэкграунд | `TROUBLESHOOTING.md:326`, `:332` |
+| in memory / resident | **в памяти** (`держит в памяти`, `хранятся только в памяти`) | в оперативной памяти, резидентно, в ОЗУ | `CONFIGURATION.md:155`; `TROUBLESHOOTING.md:182`; `development/architecture-map.md:95` |
+| memory (the system) | **память** | воспоминания (that is the item, not the system) | `CONFIGURATION.md:156` |
+| memory (a saved item) | **воспоминание** | фрагмент памяти (used only in the counting phrase), заметка | `TROUBLESHOOTING.md:163`, `:166` |
+| Saved memories (prose) | **Сохраненные воспоминания** | Сохраненная память, Мои воспоминания | `home/professor-mari.md:114` — panel label itself stays **Memories**, `:121` |
+| eviction (from a bounded space) | verb **вытеснить**; noun **вытеснение**; "drop from memory" = **убрать из памяти** | выселение, выброс, удаление | verb: `chats/peek-prompt.md:70`, `lorebooks/token-budgets.md:5`, `lorebooks/entries.md:138`. **Noun: `CONFIGURATION.md:155`** (`значение 0 … отключает вытеснение`, rendering EN "disables eviction"). `убирается из памяти` on the same line renders EN "is dropped from memory" |
+| least-recently-used | **тот, к которому дольше всего не обращались** | LRU, давний, наименее используемый | `CONFIGURATION.md:155` — `чат, к которому дольше всего не обращались и в котором нет несохраненных изменений, убирается из памяти`, rendering EN `docs/CONFIGURATION.md:157` "the least-recently-used chat with no unsaved changes is dropped from memory". Reuse this relative-clause construction; do not coin a noun |
+| cache (n. / v.) | **кеш**, **кешировать**, **кешируется** | **кэш** (hard ban); `буфер` (reserved for `буфер обмена` = **clipboard**, `game/sessions-and-saves.md:30`) | `TROUBLESHOOTING.md:75`; `UPGRADING.md:147`; `CONFIGURATION.md:322` — `кэш` appears **0×** |
+| backup | **резервная копия** | бэкап, бекап, дамп | `CONFIGURATION.md:158`, `:16` |
+| snapshot | **снимок** (`снимок состояния`, `снимок пространства`) | слепок, срез, снапшот | `agents/hierarchical-maps.md:24`, `:103`; `agents/hierarchical-maps.md:488` |
+| extension (Marinara add-on) | **расширение** | дополнение (reserved for *add-on package* sense), плагин | `CONFIGURATION.md:57` (`### Внешние расширения`) |
+| account | **аккаунт** (declines) | **учетная запись** (banned), профиль | `agents/hierarchical-maps.md:35`, `:112`; 126 occurrences, 0 `учетная запись` |
+| credentials | **учетные данные** | реквизиты, данные для входа | `FAQ.md:47`; `TROUBLESHOOTING.md:294` — the `учетн-` stem survives here **only** in this sense |
+| NPC | **NPC** (Latin, undeclined) + carrier noun `персонаж NPC` | **НПС** (hard ban), неписи, НИП | `game/party-and-npcs.md:1`, `:79`, `:95` — `НПС` appears **0×** |
+| setting (fictional world) | **мир** | **сеттинг** (banned — 1 residual, see §7 residual C) | `FAQ.md:101`, `:105`; `agents/hierarchical-maps.md:35` |
+| turn (Game Mode) | **ход** | раунд (reserved for combat rounds), шаг | `game/getting-started.md:11` (`от хода к ходу`), `:104` |
+| every turn / each time (Mari, chat, lorebook) | **каждый раз** | каждый ход (Game-Mode-only word) | `home/professor-mari.md:127`, `:129`; `chats/chat-settings.md:30`; `lorebooks/entries.md:73` |
+| round (combat) | **раунд** | `круг` (reserved for `круг аватара` = the **avatar circle**, `characters/creating-and-editing-characters.md:15`) | `game/combat.md:9` |
+| hub entry (lorebook) | **запись-узел** / pl. **записи-узлы** | хаб-запись, узловая запись, родительская запись | `lorebooks/entries.md:153`, `:155`, `:324` |
+| entry (lorebook) | **запись** | статья; `пункт` (reserved for a **menu / list item** — `appearance/custom-css-themes.md:59`) | `FAQ.md:101` |
+| token budget / entry limit | **лимит токенов** / **лимит записей** | бюджет токенов, квота | `lorebooks/token-budgets.md:1`, `:3` |
+| slash command | **слеш-команда** | косая команда, команда со слешем | `chats/guided-and-impersonate.md:11`, `:96` |
+| scene | **сцена** | эпизод — **but** `эпизод` is the Storyboard agent's own unit (`game/storyboard.md:11`, `:14`, `:15`), so the ban covers the *narrative-scene* sense only | `roleplay/getting-started.md:108` |
+| dice roll / skill check | **бросок кубика** / **проверка навыка** | кидание, ролл, чек | `chats/slash-commands.md:82`; `agents/built-in-agents.md:226` |
+| party | **отряд** | группа (reserved for lorebook groups), пати | `game/party-and-npcs.md:1`; `game/sessions-and-saves.md:72` |
+| log (server) | **журнал** | лог, логи | `CONFIGURATION.md:14` (`подробность журнала сервера`), `:106`, `:217` |
+| environment variable | **переменная окружения** | переменная среды, энв | `CONFIGURATION.md:3` |
+| timeout | **тайм-аут** | таймаут (no hyphen), время ожидания | `CONFIGURATION.md:15`, `:205` |
+| allowlist | **список разрешенных адресов** (37×) | вайтлист, белый список | `FAQ.md:14`, `:37`; `CONFIGURATION.md:12`, `:134`. `белый список` survives 1× in a *fields* (not addresses) sense — residual G |
+| unset (default column) | **не задано** | пусто (reserved for EN "empty"), нет значения | `CONFIGURATION.md:238` — the **only** `не задано` in the table; contrast 18× `пусто` at `:124`, `:125`, `:127`, `:135-138`, `:154`, `:235`, `:244`, `:275`, `:292`, `:296`, `:297`, `:310`, `:317`, `:324`, `:325`; prose form `не задан` at `:118`, `:247` |
+| off (default column) | **выключено** (16×) | отключено, off — **in the default column**. In running prose `отключено` is fine for "is disabled" (`TROUBLESHOOTING.md:139`, 1×) | `CONFIGURATION.md:156` |
+| unlimited (default column) | **без ограничений** | неограниченно, ∞ | `CONFIGURATION.md:155` |
+
+### Terms carried from the 2026-09-01 mirror cycle
+
+These rows were decided during the same-day delta mirror and are reproduced here with the
+citations they shipped with:
+
+- **`least-recently-used` — CORRECTED, now verified.** The earlier cycles recorded this as
+  "no established LRU rendering, phrase it naturally". **That was a false negative.** The pack does
+  render it, at `CONFIGURATION.md:155` (the `MARINARA_MAX_RESIDENT_CHATS` row):
+  `чат, к которому дольше всего не обращались … убирается из памяти` — translating EN
+  `docs/CONFIGURATION.md:157` "the least-recently-used chat … is dropped from memory". The prescribed
+  phrasing and the shipped phrasing turn out to be the same string, so the guidance is unchanged, but
+  it is now an **in-pack term with a citation**, not an invention to be avoided.
+  The related `chats/managing-chats.md:97` (**Oldest** — `чаты, в которых активности не было дольше
+  всего`) is a *sort order*, a second, consistent use of the same construction.
+- **`eviction` as a noun — CORRECTED, now verified.** `вытеснение` **is** attested, on that same
+  line: `значение 0 (или незаданная переменная) отключает вытеснение` for EN "disables eviction".
+  The verb remains the more common form (3×) and is still the better default in running prose, but
+  the noun is a pack term and no longer needs rewriting away.
+- **Why both were missed.** The original greps (`давн*`, `вытесн*`, `выгруж*`, `из памяти`,
+  `кеш`, `обращал*`) *should* have hit — `CONFIGURATION.md:155` matches four of the six. A grep that
+  returns nothing on Cyrillic is the documented MSYS failure in §7 trap 2, and this is a concrete
+  instance of it producing a wrong glossary entry. **Re-run any negative finding through the Python
+  scanner before recording it as a ruling.**
+- **`unset` ≠ `empty`** — do **not** collapse the distinction. Re-verified this cycle and the
+  split is clean: the default column renders EN *empty* as `пусто` **18 times**, always for a
+  variable whose value is an empty **string** (`BASIC_AUTH_USER`, `SSL_CERT`, `GIPHY_API_KEY` …,
+  `CONFIGURATION.md:124`–`:325`), while `не задано` appears **exactly once**
+  (`CONFIGURATION.md:238`, `UPDATES_APPLY_DISABLED`) — a set/not-set **flag**. EN deliberately uses
+  a different word there, so `не задано` stays separate. Related non-literal defaults follow the
+  same lowercase-Russian-word pattern (`автоматически`, `встроенные значения`, `выключено`,
+  `без ограничений`).
+
+---
+
+## 4. Typography & punctuation
+
+| Rule | Detail | Evidence |
+|---|---|---|
+| **En dash `–` (U+2013) for тире** | Wherever Russian grammar wants a dash — subject/predicate copula, parenthetical, list intro — use the **en dash**, spaced on both sides. | 1762 occurrences; `CONFIGURATION.md:3`, `FAQ.md:101` |
+| **Em dash `—` (U+2014) is banned** | Pack-wide ban. 14 characters survive across 7 lines (6 Russian-prose lines + 1 by-design English literal) — see §7 residual A. | see §7 residual A |
+| Unspaced en dash = numeric range only | `5–3`, `23:00–07:00`. In prose the dash is always ` – `. | `agents/hierarchical-maps.md:4`, `:7`, `:430`; `noodle/settings.md:219`; 4 unspaced instances total, all ranges |
+| **Straight ASCII quotes only** | `"..."`. **No «ёлочки»**, no „нижние лапки", no curly `“ ” ‘ ’`. | `«»` **0×**, curly quotes **0×**; `TROUBLESHOOTING.md:330` (`"Opening chat..."`) |
+| **No non-breaking spaces** | U+00A0 appears **0×**. Do not introduce them for numeral+unit or preposition binding. | full character inventory: no U+00A0 |
+| **`е`, not `ё`** | One spelling per word keeps search deterministic. The sole allowed exceptions are **всё / всём / всё-таки** (14 conforming uses). Capital `Ё` appears **0×**. | 9 non-conforming words remain — see §7 residual B |
+| Thousands separator = **space**, in prose quantities only | `1 000 000`, `2 000`, `478 000`. Never `1,000`, never `1.000` (**0** of each — the ban holds). **Technical and config values stay bare**: `4096`, `8192`, `300000`, ports, hex. Only 6 separated numbers exist pack-wide, so treat this as a narrow prose rule, not a sweep target. | `extending/writing-personal-extensions.md:206`, `:221`, `:225`; `development/code-cleanup-audit.md:46` (`478 000`); `conversation/table-games.md:109`. Bare technical values: `noodle/settings.md:133`, `:160`; `agents/custom-agents.md:163`. **Inconsistency:** `conversation/table-games.md:109` carries `**1000**` and `1 000 000` in one row |
+| Decimal separator = **comma** in prose, **period** in code/values | Env-var values and code fences keep the literal ASCII form. | `CONFIGURATION.md:205` (`300000` (5 минут)) |
+| Percent | Numeral + `%` with **no space** (`100%`, `75%`, `40%`) for values and UI figures; spelled `процентов` when the sentence reads as prose. Both are in use; match the local sentence. | `characters/creating-and-editing-characters.md:57` (`от 0 до 100 процентов`); `lorebooks/entries.md:218` (`Probability 40%`) |
+| Sentence terminators | Full stop. Russian does not double punctuation; `!.` appears **0×**. The 2 hits for `?.` are JavaScript optional chaining inside code (`extending/personal-extensions.md:97`, `:107`) — not punctuation. | pack-wide |
+| **No exclamation marks in Russian prose** | **0** in Russian sentences. All 17 `!` outside code are inside **verbatim English UI strings** (`**Victory!**`, `**React quickly!**`, `**Import complete!**`, `"{winner} wins!"`) — reproduce those as the app renders them, but never write an exclamation in your own Russian. | `game/combat.md:70`, `:84`; `data/importing-from-sillytavern.md:78`; `conversation/table-games.md:73` |
+| **List mechanics** | Bullets are full sentences and end with a **period** — 2232 of 2865 bullets longer than 40 characters (78%). Bullets ending `)` (425) are label-gloss forms; `;` (102) appears in enumerations that continue one sentence across items. | `CONFIGURATION.md:11-16`; `agents/hierarchical-maps.md:35-40` (semicolon run) |
+| Colon before a list | Used when the stem is a genuine lead-in — **373 of 578 list intros (64%)**. A stem that is already a complete sentence takes a period instead. | colon: `CONFIGURATION.md:9` (`…если вы хотите:`), `:22` (`Жизненный цикл пакетов и их хранение:`), `chats/managing-chats.md:94`. Period (182 intros): `agents/agents-overview.md:71` (`Проверить можно так.`), `agents/built-in-agents.md:25` |
+| Ordered lists | `1.` `2.` `3.` with a period, imperative sentence per step. | `FAQ.md:9-31` |
+| Ellipsis in verbatim UI strings | Reproduce **byte-exact** what the app renders — **never normalize**. The pack ships **15** U+2026 and **45** verbatim ASCII `...` strings, and that mixture is very largely *correct*, because the app itself is mixed. It is mixed **per component, not per word**: `en.json` has `ui.chat.summarypopover.generating = 'Generating...'` next to `ui.layout.chatsidebar.generating = 'Generating…'`, and `ui.game.gamejournal.savingEntry = 'Saving...'` next to `editor.save.saving = 'Saving…'`. So you cannot infer the form from the word — **look up the specific key for the specific screen** before writing it. One genuine mismatch found — residual E. | `UPGRADING.md:135` (`**Switching…**` = `ui.panels.advancedsettings.switching`) vs `TROUBLESHOOTING.md:330` (`"Opening chat..."` = `ui.chat.chatarea.openingChat`) |
+| Menu-path separator | `→` (U+2192) is the majority form (80×). Two ASCII variants also ship — see §7 residual D. | `CONFIGURATION.md:31` (`**Settings** (настройки) **→ Advanced → Danger Zone**`) |
+
+---
+
+## 5. UI labels & glosses
+
+**The byte-exact rule.** The `ru` app locale (`packages/client/src/localization/locales/ru.json`)
+covers **132 of 9,123** English UI keys — **1.4%**. The overwhelming majority of Marinara's
+interface renders **in English** for a Russian reader. That is the reason the docs keep control
+names in English: a translated label in the docs would not match anything on screen.
+
+So: **UI control names stay in English, bold, byte-exact as rendered.**
+
+### Pattern A — interactive controls: bold EN + one-time parenthetical gloss
+
+The gloss is **lowercase Russian in parentheses**, given **once per document** on first mention;
+every later mention in that same document runs bare.
+
+```
+Агенты включаются внутри каждого чата, в выдвижной панели **Chat Settings** (настройки чата).
+```
+— `agents/agents-overview.md:37`
+
+Verified gloss-once behaviour: `agents/agents-overview.md` mentions **Chat Settings** 4 times and
+glosses it once; `chats/chat-settings.md` 5 times, glossed once; `agents/approvals-and-agent-suite.md`
+2 times, glossed once.
+
+More in-pack examples:
+
+| Label | Gloss | Where |
+|---|---|---|
+| `**Agents**` | (агенты) | `agents/agents-overview.md:3` |
+| `**Download Agents**` | (скачать агентов) | `agents/agents-overview.md:25` |
+| `**Review Agent Outputs**` | (проверять результаты агентов) | `agents/agents-overview.md:49` |
+| `**Debug mode**` | (режим отладки) | `agents/agents-overview.md:76` |
+| `**Release Channel**` | (канал выпусков) | `UPGRADING.md:128` |
+| `**Memories**` | (воспоминания) | `home/professor-mari.md:121` |
+| `**Token Budget**` | (лимит токенов) | `lorebooks/token-budgets.md:3` |
+| `**Manual Trackers**` | (ручные трекеры; только для чатов Roleplay) | `agents/agents-overview.md:50` |
+
+Gloss style: lowercase, no terminal punctuation inside the parentheses, imperative for verbs
+(`скачать агентов`, `проверять результаты агентов`), noun phrase for nouns.
+
+#### A bold label's parentheses are not always a gloss
+
+This matters for review and for QA check 14. A bold EN label takes **four** different kinds of
+parenthetical, and only the first is the once-per-document translation gloss:
+
+| Kind | Example | Repeatable? |
+|---|---|---|
+| **Translation gloss** | `**Session** (сессия)` — `game/sessions-and-saves.md:13` | **No** — once per document |
+| **Icon / locator** | `**Session** (иконка пера)` — `:16`, `:27`; `**Constant** (желтая точка)` — `lorebooks/entries.md:73` | Yes, as often as the reader needs to find the control |
+| **Default state** | `**Add as Prompt Section** (включено по умолчанию)` — `agents/built-in-agents.md:81`, `:97`, `:115`, `:133`, `:141`; `**Token Budget** (по умолчанию **2048**)` — `lorebooks/token-budgets.md:20` | Yes |
+| **Example / scope note** | `**Pools** (сначала HP и MP на 100 из 100)` — `characters/colors-and-stats.md:58`; `**Allow Noodle references** (для каждого чата)` — `noodle/settings.md:245` | Yes |
+
+A naive `**Label** (` regex conflates all four and reports 23 false "double glosses" (9 after
+filtering obvious default/icon wording). The pack's true repeat-translation count is **0**.
+
+### Pattern B — status and error strings: bold EN, **no gloss**
+
+Strings the app *emits* (rather than controls the user clicks) carry no parenthetical gloss. The
+surrounding Russian sentence explains them.
+
+- `**Untrusted request host**` — `TROUBLESHOOTING.md:103`
+- `**Save blocked: missing CSRF header**` — `TROUBLESHOOTING.md:114`
+- `**Waiting for vector**` — `TROUBLESHOOTING.md:163`
+- `**Embedding unavailable**` — `TROUBLESHOOTING.md:164`
+- `**No API connection configured for this chat**` — `TROUBLESHOOTING.md:128`
+- `**Server unreachable**`, `**Unreachable (request timed out)**` — `TROUBLESHOOTING.md:330`
+
+This precedent also avoids nesting a gloss inside a label that already carries its own parentheses.
+
+### Pattern C — long verbatim strings: straight double quotes, unbolded
+
+Multi-word sentences the app prints are quoted, not bolded:
+
+- `"Opening chat..."` — `TROUBLESHOOTING.md:330`
+- `"Update applied successfully. Please relaunch the app to use the new version."` — `UPGRADING.md:164`
+- `"Staging builds are pre-release tester builds. Back up your app data before applying them."` — `UPGRADING.md:133`
+- `"N commits behind"` — `UPGRADING.md:145`; `"vX.Y.Z available"` — `UPGRADING.md:144`
+
+### Never copy a gloss from `ru.json`
+
+The divergence is **measured and confirmed** (re-counted this cycle from
+`packages/client/src/localization/locales/ru.json`): of its 132 values, **12 contain `ё`**
+(`сохранённые`, `Загрузка…`, `Щёлкните`, `включённых`), **2** use `…` (U+2026), **1** uses an em
+dash (`connections.mediaSources.atlas.videoDefaultsNote`), and **0** use an en dash. Every one of
+those is a docs-pack violation.
+
+**`[recorded ruling]`** — the *precedence* decision: where the two disagree, the **docs style
+contract wins**. Glosses are written in the pack's own register (`е` not `ё`, en dash, straight
+quotes) and are **never** pasted from `ru.json`. The measurement above is verifiable; the ordering
+of the two contracts is a maintainer call the pack cannot show.
+
+### Feature names with no `ru` precedent
+
+An unbolded English feature name with no pack precedent stays Latin behind a carrier noun:
+`в скопированном отчете Support Diagnostics` (`TROUBLESHOOTING.md:330`).
+
+---
+
+## 6. Language-specific mechanics
+
+**Declension of loanwords.** Community-standard Cyrillic loanwords decline **normally**. Case
+endings are suffixes, so the searchable stem survives declension — this is why loanwords may
+decline while frozen Latin names may not.
+
+```
+промпт  → промпта, промпту, промптом, промпты, промптов
+токен   → токена, токенов, токенам
+пресет  → пресета, пресеты, пресетов
+лорбук  → лорбука, лорбуку, лорбуки, лорбуков, лорбукам
+чат     → чата, чату, чатом, чаты, чатов, чатам
+свайп   → свайпа, свайпами
+спрайт  → спрайта, спрайтов
+виджет / трекер / провайдер / эмбеддинг / аккаунт — likewise
+```
+
+**`лорбук` is masculine.** `большой лорбук`, `общего лорбука`, `в лорбуке`. Never treat it as
+feminine (`лорбука` as nominative). **`[recorded ruling]`** the form itself was adopted because it is
+the **RU SillyTavern community's own term** — the pack's readers arrive already using it (PR #4281).
+The pack confirms the term; the community-usage rationale is the recorded justification.
+
+**Compound nouns with a Latin head** hyphenate the Russian modifier and decline only the Russian
+part when the Russian part is the head:
+
+- `агенты-писатели`, `агенты-трекеры` (`agents/agents-overview.md:11`)
+- `записи-узлы` → gen. `записей-узлов`, prep. `на записях-узлах` (`lorebooks/entries.md:153`, `:155`, `:324`)
+- `слеш-команда` → instr. `слеш-командой` (`chats/guided-and-impersonate.md:96`)
+
+**Carrier-noun case selection.** The carrier takes whatever case the sentence needs; the Latin name
+never moves: `в приложении Marinara Engine` (prep.), `сервера Marinara` (gen.),
+`с сервером Marinara` (instr.), `каталог Pasta-Devs/Marinara-Agents` (acc.).
+
+**Genitive after quantities:** `33 пакета`, `5 новых сообщений`, `тысячи токенов подробностей`
+(`agents/agents-overview.md:11`, `TROUBLESHOOTING.md:166`, `lorebooks/entries.md:155`).
+
+**Aspect in instructions.** Steps use the **perfective** imperative (`Нажмите`, `Откройте`,
+`Задайте`) for a single completed action; the **imperfective** appears for habitual or ongoing
+behaviour (`держите выключенным`, `Управлять воспоминаниями можно`).
+
+**In-fiction content is not translated.**
+
+- Example lorebook **entry names, keys and content stay Latin/English** by design:
+  `**Count Vlad**`, `Primary Keys: \`Vlad\``,
+  `Content: \`The immortal count who rules Wallachia after dark…\`` (`lorebooks/entries.md:180-190`).
+  Where an entry *heading* is a descriptive Russian phrase (`**Слабость графа**`,
+  `lorebooks/entries.md:196`), its key/content fields still stay English.
+- **Literal-matching demonstrations stay English by design** — the whole point is that the
+  substring behaviour is visible: `ключевое слово \`Ash\` совпадает с "Ash", но не с "ashes" и не
+  с "cash"` (`lorebooks/entries.md:231`). Translating these destroys the demonstration.
+
+---
+
+## 7. QA checks & known traps
+
+### Tooling traps — read before writing any check
+
+1. **JavaScript `\w` does NOT match Cyrillic — even with the `/u` flag. `[verified 2026-09-01]`**
+   A validator built on `\w` reports a clean pack because it matched nothing at all. Reproduced:
+
+   ```
+   $ node -e "const t='промпт токен лорбук';
+              console.log(t.match(/\w+/gu));               // null
+              console.log(t.match(/[а-яё]+/gu));           // ['промпт','токен','лорбук']
+              console.log(t.match(/\p{Script=Cyrillic}+/gu)); // ['промпт','токен','лорбук']"
+   ```
+
+   Use `[а-яёА-ЯЁ]` or `\p{Script=Cyrillic}` with `/u`. Highest-value trap in the list, because the
+   failure mode is a **false pass**.
+
+2. **MSYS bash `$'\uXXXX'` does not expand — greps silently return nothing. `[verified 2026-09-01]`**
+   Reproduced against a file with a known-good ground truth of **2** em-dash lines
+   (`ru/agents/custom-agents.md`, counted in Python):
+
+   ```
+   $ printf '%s' $'—' | od -c        # ->  \   u   2   0   1   4   (six literal bytes)
+   $ grep -c $'—' ru/agents/custom-agents.md   # -> 0   WRONG (false pass)
+   $ grep -c '—'       ru/agents/custom-agents.md   # -> 2   correct (literal character)
+   ```
+
+   Also confirmed: MSYS `grep`/`sed` are **byte-oriented** for Cyrillic —
+   `grep -o '[А-Яа-я]\{4,\}'` emits truncated UTF-8, leaving dangling lead bytes (`0xD1`) mid-word,
+   so `-o` output, `[А-Яа-я]` classes, and `-P` lookarounds all mis-slice multibyte text.
+   **Run every Cyrillic check through a Python script reading UTF-8** (or ripgrep), never through
+   MSYS `grep -P` + `sed`. Paste the literal character rather than an escape.
+
+   **This trap has already cost this glossary two wrong entries** — the "no LRU rendering" and
+   "eviction noun unattested" findings in §3 were both false negatives produced this way. Treat any
+   *negative* Cyrillic finding as unproven until a Python scan confirms it.
+
+### Mechanical checks (each catches a real `ru` regression class)
+
+All counts below were re-measured 2026-09-01 with the UTF-8 Python scanner.
+
+| # | Check | Expected | Measured |
+|---|---|---|---|
+| 1 | Em dash `U+2014` outside English literal content | 0 | **6 prose lines / 13 chars** — residual A |
+| 2 | `ё` outside `всё`/`всём`/`всё-таки`; capital `Ё` | 0 | **9 words, 2 files**; `Ё` 0 — residual B |
+| 3 | `кэш` | 0 | **0** ✓ |
+| 4 | `учетная/учетную/учетной запись` | 0 (`учетные данные` allowed, 11×) | **0** ✓ |
+| 5 | `НПС`, `непись`, `НИП` | 0 | **0** ✓ |
+| 6 | `сеттинг` | 0 | **1** — residual C |
+| 7 | `«` `»` `“` `”` `‘` `’` `„` | 0 | **0** ✓ |
+| 8 | Non-breaking space `U+00A0` (also `U+3000`, `U+200B`, `U+200D`, `U+2011`, `U+2212`) | 0 | **0** each ✓ |
+| 9 | Mid-sentence capitalized `Вы` | 0 | **0** ✓ (39 sentence-initial are correct) |
+| 10 | Singular imperatives `Нажми`, `Открой`, `Задай`, `Выбери`; `ты`-family outside quoted user utterances | 0 | **0** imperatives; **1** legitimate quoted `ты` (`home/professor-mari.md:131`) ✓ |
+| 11 | Cyrillicized product names (`Маринар`, `Термукс`, `Андроид`, `Ноудл`, `СиллиТаверн`) | 0 | **0** ✓ |
+| 12 | Latin stem carrying a Cyrillic case suffix (`\b[A-Za-z]{3,}[а-яё]{1,4}\b`) | 0 | **0** ✓ |
+| 13 | Unspaced en dash outside numeric ranges | 0 | **0** ✓ (4 unspaced, all ranges) |
+| 14 | Bold EN label **translation-glossed** more than once in the same file | 0 | **0** ✓ — **but not naively greppable**, see §5 "A bold label's parentheses are not always a gloss" |
+| 15 | Structural parity vs `en/`: file count, headings, code fences, link targets, table shapes | 125/125 | **125/125 filenames match `docs/` exactly**, 0 extra, 0 missing ✓ |
+| 16 | Link text ↔ target H1 agreement | 0 paraphrases (PR #4281 drove this to zero; it degrades search ranking) | not re-run this cycle |
+| 17 | `программа запуска` (use `скрипт запуска`) | 0 | **4** — residual F |
+| 18 | `белый список` (use `список разрешенных адресов`) | 0 | **1** — residual G |
+| 19 | `1,000` / `1.000` thousands forms | 0 | **0** ✓ |
+| 20 | `таймаут` without hyphen | 0 | **0** ✓ (24 correct `тайм-аут`) |
+
+**Checks 3–13 and 17–20 are the safely greppable ones.** Do **not** build a check by grepping a
+banned alternate from the §3 table without its sense restriction — see the false-positive table at
+the top of §3.
+
+Check 15/16 are the pack-level gates PR #4281 ran via
+`node scripts/docs-i18n/build-manifest.mjs ru` + `validate-pack.mjs ru` and `pnpm regression:docs`.
+
+### Known pack residuals
+
+Documented, **not** silently fixed. Each is a real deviation from a rule above; fix them in a
+deliberate, reviewable change rather than as a drive-by.
+
+**A. Em dash `—` in Russian prose (6 lines, 13 characters, rule §4).**
+
+| Location | Count | Note |
+|---|---|---|
+| `TROUBLESHOOTING.md:260` | 1 | `чаты выглядят пустыми — данные по-прежнему лежат на диске` |
+| `TROUBLESHOOTING.md:417` | 1 | ``root с `SYS_ADMIN` — широкое повышение прав`` |
+| `agents/custom-agents.md:113` | 1 | `**Image Connection** — переопределяет подключение` |
+| `agents/custom-agents.md:114` | 1 | `**Camera button** — немедленно создает изображение` |
+| `development/file-storage.md:31` | **6** | one very long paragraph; the dashes head a run of appositive `— по чату; … — по персонажу; …` clauses. Rewriting it needs care, not a character swap |
+| `extending/personal-extensions.md:67` | **3** | `` `kind: "menu-item"` — действие в меню Extensions ``, plus two more in the `button` / `menu-item` / `panel` field run |
+
+`lorebooks/entries.md:189` holds the 14th em dash but is **not** a residual: it sits inside an
+English in-fiction `Content:` literal, which stays English by design (§6).
+
+**B. `ё` outside the allowed exceptions (9 words, 2 files, rule §4).**
+
+- `agents/built-in-agents.md:153` — `Ведёт`, `завершённые`
+- `agents/built-in-agents.md:155` — `передаёт`
+- `agents/built-in-agents.md:161` — `остаётся`, `сохранённым`
+- `prompts/macros.md:42`, `:74` — `её` (×2)
+- `prompts/macros.md:194` — `нулём`
+- `prompts/macros.md:236` — `своё`
+
+**C. `сеттинг` (1 occurrence, rule §3).**
+`agents/hierarchical-maps.md:112` — `для многоразовых фанатских миров, сеттингов кампаний,
+подземелий…`. The ruling is `setting → мир`; this line reaches for a second word to avoid repeating
+`миров` in the same clause. A fix must rewrite the clause, not just swap the word.
+
+**D. Menu-path separator is inconsistent (3 variants, rule §4).**
+`→` 80× (majority, correct), `->` 51×, `**X** > **Y**` 44×. Examples:
+`appearance/appearance-settings.md:3` (`**Settings -> Appearance**`),
+`extending/personal-extensions.md:180` (`**Settings** > **Advanced** > **Danger Zone**`),
+`CONFIGURATION.md:31` (`**Settings** (настройки) **→ Advanced → Danger Zone**`).
+Normalizing to `→` is a mechanical, low-risk sweep — but it edits ~95 lines, so it deserves its own
+change.
+
+**E. Ellipsis in verbatim UI strings — RESOLVED 2026-09-01 (rule §4).**
+
+The earlier ruling deferred this as "requires checking the app". It has now been checked, against
+`packages/client/src/localization/locales/en.json`. The app really does use both forms, and the pack
+is **correct nearly everywhere** — this was mostly a false alarm:
+
+| Pack string | Pack form | `en.json` key | App form | Verdict |
+|---|---|---|---|---|
+| `**Switching…**` `UPGRADING.md:135` | U+2026 | `ui.panels.advancedsettings.switching` | `Switching…` | ✓ |
+| `**Checking…**` `:139` | U+2026 | `settings.notifications.customSound.status.loading` | `Checking…` | ✓ |
+| `**Refreshing…**` `:182` | U+2026 | `ui.panels.advancedsettings.refreshing` | `Refreshing…` | ✓ |
+| `**Creating backup…**` `:27` | U+2026 | `ui.panels.advancedsettings.creatingBackup` | `Creating backup…` | ✓ |
+| `"Opening chat..."` `TROUBLESHOOTING.md:330` | ASCII | `ui.chat.chatarea.openingChat` | `Opening chat...` | ✓ |
+| `**Importing...**` `appearance/chat-backgrounds.md:28` | ASCII | `ui.botBrowser.detailview.importing` | `Importing...` | ✓ |
+| `**Search models…**` `connections/connecting-to-a-provider.md:34` | U+2026 | `ui.connections.connectioneditor.searchModels` | `Search models…` | ✓ |
+| `**Autosaving…**` `lorebooks/entries.md:31` | U+2026 | `ui.lorebooks.expandeddrawer.autosaving` | `Autosaving…` | ✓ |
+| `**Search entries…**` `lorebooks/entries.md:13` | U+2026 | `chat.settings.inlineLorebook.search` | `Search entries…` | ✓ |
+| **`**Updating...**` `UPGRADING.md:164`** | **ASCII** | `ui.panels.advancedsettings.updating` | **`Updating…`** | ✗ **defect** |
+
+**One real fix:** `UPGRADING.md:164` should read `**Updating…**` with U+2026. The context is
+unambiguous — the surrounding sentences document the **Apply Update** button on the Advanced
+Settings panel (`:151`, `:156`, `:164`), and every sibling progress string on that panel
+(`switching`, `refreshing`, `creatingBackup`) uses U+2026. The ASCII `Updating...` in `en.json`
+belongs to `ui.game.gamesessionhistory.updating`, a different screen.
+
+The rule itself stands and is now evidence-backed: **look the string up in `en.json`; never
+normalize the pack to one form.**
+
+One loose end left for a maintainer: several search placeholders are written with a trailing
+`...` in the pack (`**Search characters...**` `chats/group-chats.md:19`,
+`**Search conversations...**` `chats/managing-chats.md:92`) while the nearest `en.json` values
+(`search.panels.characters`) carry **no** ellipsis at all. The component may append one at render
+time. This needs a look at the running app, not at `en.json` — do not "fix" these from the locale
+file alone.
+
+**F. `программа запуска` for the launcher (4 occurrences, rule §3).**
+The pack's term is `скрипт запуска` (56×). These four reach for a different noun:
+`TROUBLESHOOTING.md:45` (a heading — `### Обновление программы запуска до pnpm 10.34.5`), `:47`,
+`:262`, `UPGRADING.md:186`. The heading is the awkward one: changing it changes an anchor, so
+check inbound links before editing.
+
+**G. `белый список` (1 occurrence, rule §3).**
+`development/personal-extensions.md:22` — `ограниченные поля из белого списка`. Note the pack term
+`список разрешенных адресов` is scoped to *addresses* and does not fit a **field** allowlist, so
+this needs a phrasing decision (`список разрешенных полей`?), not a find-and-replace.
+
+**H. Thousands separator applied inconsistently in one row (rule §4).**
+`conversation/table-games.md:109` carries `**1000**` and `1 000 000` in the same table row.
+
+---
+
+## Change log
+
+| Date | Change |
+|---|---|
+| 2026-09-01 | Second-generation glossary re-derived from the shipped pack, PR #4281, and the 2026-09-01 mirror-cycle notes, after the originals were lost to temp-directory cleanup. Added measured residual inventory (A–E), the `ru.json` 1.4%-coverage finding behind the byte-exact UI rule, and the LRU negative finding. |
+| 2026-09-01 | **Verification pass against the 125 shipped files.** Corrected two rulings that the pack contradicts: `least-recently-used` and the noun `вытеснение` are both **attested** at `CONFIGURATION.md:155` (the earlier "no precedent" findings were MSYS-grep false negatives). Resolved the ellipsis ruling against `en.json` — the pack is correct except `UPGRADING.md:164`. Added sense-scoping to §3 with a measured false-positive table, after finding that 30 of the 88 "banned" alternates are live pack vocabulary in other senses (`подсказка` 103×, `запрос` 241×, `лорбука` 150× genitive …). Removed the wrong bans on `профиль настроек` (a distinct feature), `помощник` (the pack's own gloss for *agent*) and `ассистент` (the message role); added rows for tooltip, placeholder, settings profile, assistant role, and vectorization. Upgraded both §7 tooling traps from recorded rulings to **verified** with reproductions. Fixed citations for `widget`, `log`, `allowlist`, gender-neutrality, and the thousands separator; corrected the capitalized-`Вы` count (2 → 39, all sentence-initial), the em-dash per-line counts, and the `§8` cross-references (residuals live in §7). Added residuals F–H and checks 17–20. |

--- a/glossaries/glossary-zh-hans.md
+++ b/glossaries/glossary-zh-hans.md
@@ -1,0 +1,532 @@
+# Simplified Chinese (`zh-hans`) — documentation-pack glossary
+
+## Provenance
+
+This is the **second-generation** glossary for the `zh-hans` documentation pack. The original
+working glossary from the pack's translation cycle was lost to temp-directory cleanup; this file
+was **re-derived on 2026-09-01** from, in authority order:
+
+1. **The shipped pack as it exists on `docs-i18n`** (125 `.md` files + `manifest.json`) — the
+   ground truth. Every prescriptive rule below was re-measured against it; terminology rows cite a
+   pack file and line.
+2. **The pack's shipping PR decision write-up** — Pasta-Devs/Marinara-Engine **PR #4435**
+   ("Simplified Chinese documentation pack"), plus the `zh-hans` convention bullet it added at
+   `CONTRIBUTING.md:242`.
+3. **The 2026-09-01 mirror-cycle notes** (`prd-notes-zh-hans.md`) — evidence-backed choices made
+   during the #5604 / #5720 / #5718 delta mirror, each carrying its own pack citation.
+4. **The app locale** `packages/client/src/localization/locales/zh-Hans.json` — consulted for
+   byte-exact UI strings, **not** used as a terminology authority (see §6.4).
+
+Rules are marked one of two ways:
+
+- **[V]** — verified against the pack as shipped, with a citation.
+- **[R]** — a **recorded maintainer/cycle ruling** carried forward from the original cycle. The
+  pack cannot show it (it is a process fact, a historical count, or a runtime behavior), so it is
+  preserved as-recorded rather than re-derived.
+
+Line numbers are as of the 2026-09-01 worktree state. Paths are pack-relative.
+
+---
+
+## 1. Register & address
+
+| # | Rule | Evidence |
+|---|---|---|
+| 1.1 | **[V]** Second person is **你**. **您 is banned outright** — zero occurrences across all 125 files. This is the modern mainland software register; 您 reads as customer-service deference and is wrong for a self-hosted tool. | `grep -r 您` → 0 hits, whole pack |
+| 1.2 | **[V]** Pronouns stay **sparse**. Chinese drops subjects; do not carry EN "you/your" across mechanically. Measured retention: EN docs contain **4,051** `you`/`your`; the pack contains **511** 你 over 312,388 CJK characters — roughly **13%** carry-through, about one 你 per 611 characters. Of those 511, 85 are 你的 and 38 are 你自己; **do not add 511 + 85**, 你的 is counted inside the 511. | `docs/**.md` vs pack char census |
+| 1.3 | **[V]** No honorific or polite-register openers: 您好, 请您, 敬请 — zero occurrences. Imperatives are bare (打开…, 设为…, 见…). | `CONFIGURATION.md:12–16`; `data/backup-and-restore.md:81` (要把…用 **Import Profile**) |
+| 1.4 | **[V]** Register is **plain technical mainland Chinese**, not literary and not 翻译腔. Colloquial-but-clean connectives are in-register and used freely: 就行, 直接, 顺手, 省得, 一句, 照常. | `chats/settings-profiles.md:3` (直接套用方案就行，不必从头再设一遍) |
+| 1.5 | **[V]** Gender-neutral by default — Chinese third person in text is 它 for software/agents and 角色 for in-fiction people. 他/她 appear only where the EN source refers to a specific gendered character (Professor Mari is 她). Never invent a gender for a UI actor. | `home/professor-mari.md:120` (她保存的记忆…); `agents/agents-overview.md` (智能体…它) |
+| 1.6 | **[R]** Four independent native-reader QA panels read every file end-to-end during the original cycle (~150 fixes: 翻译腔 rewrites, mistranslation catches, one profile-term unification), followed by a reconciliation pass resolving cross-panel conflicts with recorded rulings. Register decisions above are the settled output of that process. | recorded ruling (PR #4435 "Validation performed") |
+
+---
+
+## 2. Product, feature & mode names
+
+| # | Rule | Evidence |
+|---|---|---|
+| 2.1 | **[V]** Product names stay in **Latin script, never transliterated**: Marinara, Marinara Engine, Noodle, NoodleR, Professor Mari, Termux, Android, Node, Docker, Tailscale, SillyTavern, ComfyUI. Zero occurrences of 玛丽娜拉 / 马里纳拉 / 面条. | `CONFIGURATION.md:3`; `home/professor-mari.md` |
+| 2.2 | **[V]** The three **mode names stay English**: `Conversation`, `Roleplay`, `Game Mode`. On first mention per file they take a tight half-width gloss, then run bare. Gloss counts: **44 / 37 / 36**. The gloss is usually written on the **plain, unbolded** name per §5.2.b — `Conversation(对话模式)`, `Roleplay(角色扮演)`, `Game Mode(游戏模式)`; only 3 / 10 / 4 of those are bolded (**Conversation**(对话模式) etc.), and bolding is reserved for where the name is being introduced as a UI surface. | `FAQ.md:53–55` (bolded); `conversation/profiles.md:3`, `integrations/discord-mirror.md:3` (unbolded) |
+| 2.3 | **[V]** `Noodle` and `NoodleR` are never translated and never glossed. | `noodle/overview.md`; `FAQ.md:119` |
+| 2.4 | **[V]** Panel / editor / screen names that the app renders in English stay English in bold and take a gloss on first mention: **Character Editor**(角色编辑器), **Persona Editor**(用户角色编辑器), **Preset Editor**(预设编辑器), **Chat Settings**(聊天设置), **Connections**(连接), **Agents**(智能体). | `FAQ.md:101`; `conversation/profiles.md:11–12`; `prompts/presets.md:3` |
+| 2.5 | **[V]** Environment-variable names, file names, CLI commands, paths and code literals are **byte-exact and never translated**: `MARINARA_MAX_RESIDENT_CHATS`, `UPDATES_APPLY_DISABLED`, `termux-wake-lock`, `termux-tools`, `server-*.log`, `start.bat`, `.env`, `DATA_DIR`. | `CONFIGURATION.md:155`, `:238`; `TROUBLESHOOTING.md:326` |
+| 2.6 | **[V]** Navigation paths keep the English segment names and join them with `→` or `>` exactly as EN does; when a path is glossed, the **gloss** joins the Chinese segment names with `→`: **Settings → Advanced → Danger Zone**(设置 → 高级 → 危险区域). | `CONFIGURATION.md:31` |
+| 2.7 | **[V]** Version literals, release-tag forms and numeric identifiers are byte-exact half-width: `2.4.5`, `v2.3.1`, `pnpm@10.34.5`, `7860`. Full-width digits would silently break the in-app substring search. | `TROUBLESHOOTING.md:37`, `:47`; `CONFIGURATION.md:156` |
+| 2.8 | **[V]** `SillyTavern` stays Latin everywhere; the community nickname **酒馆** is sanctioned **exactly once**, as a parenthetical in the import guide's opening sentence, and appears nowhere else. | `data/importing-from-sillytavern.md:3` — `SillyTavern(社区常称“酒馆”)`; whole-pack count for 酒馆 = 1 |
+
+---
+
+## 3. Core terminology
+
+Every row is one term, one rendering, pack-wide — the in-app docs search is literal substring
+matching, so a synonym is a search miss.
+
+**How to read the "Banned alternates" column.** A ban is **sense-scoped**: the listed string is
+banned *as a rendering of that English term*, not as a string anywhere in the pack. Many banned
+alternates are ordinary Chinese words the pack uses freely in another sense (指令 = "instruction",
+标记 = "to mark", 信息 = "information", 镜像 = "Docker image"), and several are pure substring
+artifacts (词条 inside 关键词+条目, 复写 inside 回复+写). Where a banned string is attested in
+another sense, the count and that sense are given in parentheses so the C-checks in §7.1 are not
+read as failures. **A count of 0 means the string is genuinely absent pack-wide.**
+
+Rows whose banned alternate is genuinely competing with the prescribed term — i.e. the pack itself
+is inconsistent — are marked **⚠ residual** and carry a §7.4 entry with counts and file cites.
+
+| English term | Pack term | Banned alternates | Evidence |
+|---|---|---|---|
+| prompt | **提示词** (625) | 提示語 (0), 提示詞 (0), 提示文本 (0); 指令 (76 — but only as *prompt*: 指令 is the pack's own word for an **instruction** — 智能体指令, 引导指令, Maps 指令, CPU 指令) | `prompts/presets.md:3` |
+| token (LLM unit) | **Token**, capital T, Latin script, spaced from CJK | 令牌 (0), 词元 (0), 符元 (0); 标记 (140 — but only as *token*: 标记 is the pack's verb "to mark/tag" and its noun for a **map marker**) | `FAQ.md:105` — `Token(模型切分文本的最小单位)`; `chats/messages.md:95` |
+| token budget | **Token 预算** | 令牌预算 (0) | `lorebooks/linking-to-characters.md:101` |
+| token (auth/API credential) | **Token** in Latin, or **密钥** for "key" | 令牌 (0). Note the one lowercase exception: `characters/bot-browser.md:175` writes `token 或 cookie 值` in Chinese prose. Elsewhere lowercase `token` only appears inside code, file names and verbatim EN labels. | `characters/bot-browser.md:175`; `FAQ.md:65` (API 密钥) |
+| preset (prompt preset) | **预设** / **提示词预设** (224 / 36) | 配置文件 (0), 方案 (that is a *settings profile*); 预置 (6 — but only as *preset*: 预置 is the pack's adjective for "bundled/preconfigured", 包内预置的链路) | `prompts/presets.md:3`; `chats/settings-profiles.md:9` |
+| settings profile | **设置方案** (18; short form 方案) | 设置预设 (0), 设置档案 (0), 配置文件 (0) | `chats/settings-profiles.md:1`, `:3` |
+| lorebook | **世界书** (568) | 世界書 (0 — traditional; breaks search), 知识书 (0), 设定集 (0), 传说书 (0) | `FAQ.md:105`; `lorebooks/overview.md` |
+| lorebook entry | **条目** (515) | 词条 (0 — the 2 grep hits are substrings of 关键词+条目 and 关键词+条件); 项目 (30 — but only as *entry*: 项目 is "project" (项目根目录) and generic "item" (图库项目)) | `lorebooks/entries.md:13` |
+| character card | **角色卡** (199) | 角色檔 (0). **人物卡 is NOT banned** — see the next row; it is a different EN term. | `FAQ.md:101` |
+| character sheet (Game Mode party stat block, EN **Sheet**) | **人物卡** (17) | 角色卡 (that is the *character card*) | `game/party-and-npcs.md:23` — 人物卡…和角色卡是两回事; `:39` **Regenerate Sheet**(重新生成人物卡); `:43` **Edit Sheet**(编辑人物卡); `:45` **Sheet Details**(人物卡详情); `:50` **Save Sheet**(保存人物卡) |
+| character | **角色** (2,046) | 人設 (0); 人物 (21 — 17 of them inside 人物卡 above, and 4 in `development/hierarchical-locations-prd-v3.md` meaning "figures visible in an image": 出镜人物) | `characters/creating-and-editing-characters.md:3` |
+| persona (the user's own card) | **用户角色** (443) | **人设** — this is what the *app UI* uses (218 hits in `zh-Hans.json`) and it is **banned in docs**; also 角色扮演身份, 个人形象 | `FAQ.md:107` — **Linked Personas**(关联用户角色); `characters/personas.md:97` |
+| chat | **聊天** (1,910) | 对话 (reserved for the Conversation mode gloss), 会话 (reserved for Game sessions) | `chats/managing-chats.md:3` |
+| group chat | **群聊** (64) | 团体聊天 (0), 多人对话 (0) | `chats/group-chats.md:77` |
+| message | **消息** (802) | 讯息 (0), 留言 (0); 信息 (112 — but only as *message*: 信息 is "information" — 接入信息, 登录信息, 报错信息, 诊断信息) | `chats/messages.md:1` |
+| swipe | **swipe** when quoting the UI label; **备选回复** (96) in Chinese prose | 划动 (0); 滑动 (3 — but only as *swipe the feature*: 滑动 is the literal finger gesture, 向左滑动 / 触屏滑动) | `chats/messages.md:60` — **Previous swipe**(上一条备选回复) |
+| regenerate | **重新生成** (67) | 重生 (0); 再生成 (0 — the 1 grep hit is 再 + 生成, "generate again") | `chats/messages.md:1` |
+| greeting / first message | **开场白** (9) — ⚠ **residual**, see §7.4 **R-8** | 招呼语 (0); 问候语 (4 — a genuinely competing rendering of the same EN "greeting", not a different sense) | `FAQ.md:101`; `characters/creating-and-editing-characters.md:73` — **Dialogue & Greetings**(对白与开场白) |
+| agent | **智能体** (766) | **代理** — reserved for network *proxy*, never for agents; also 助手 (0 as *agent*), 代理人 (0), 特工 (0) | `FAQ.md:115`; `agents/agents-overview.md:1` |
+| tracker (agent) | **追踪器** (85) | 跟踪器 (0), 追蹤器 (0) | `agents/agents-overview.md:50` |
+| proxy (network) | **代理** (26) — only ever this sense | — | `REMOTE_ACCESS.md:150`; `CONFIGURATION.md:135` (反向代理) |
+| connection | **连接** (775) | 联接 (0), 链接 (reserved for hyperlinks); 连线 (1 — but only as *connection*: `media/comfyui.md:101` 节点连线 is ComfyUI node wiring) | `FAQ.md:65` |
+| provider | **服务商** (364) | 供应商 (0), 提供商 (0); 厂商 (3 — but only as *provider*: 厂商 is the device **OEM** — 手机厂商, `TROUBLESHOOTING.md:324`, `:326`, `:330`) | `FAQ.md:65` |
+| API key | **API 密钥** (103) | API 金鑰 (0), 接口密码 (0) | `FAQ.md:65` |
+| launcher (the shell start script) | **启动脚本** (81) | 启动程序, 载入器 | `CONFIGURATION.md:155` (Termux 启动脚本); `CONFIGURATION.md:88` |
+| launcher (the updater component that gates downgrades) | **启动器** (8) | — (see §7.4 residual R-5 on the two-form split) | `TROUBLESHOOTING.md:262`; `UPGRADING.md:186` |
+| update (noun/verb) | **更新** (297) | 升级 (reserve for "upgrade" headings) | `installation/windows.md:190` |
+| apply (an **update**) | **应用更新** / **应用** (13) | 套用, 施加 — **scoped to the update sense only**. 套用 (27) is the pack's established verb for applying a **settings profile, preset or map template** (`chats/settings-profiles.md:3` 直接套用方案就行; `:30` ## 套用方案), and 施加 (5) is for applying a **penalty or status effect** (施加惩罚, 施加增益). Neither is a defect. | `installation/windows.md:204` — **Apply Update**(应用更新); `CONFIGURATION.md:238` |
+| release channel | **发布通道** (6) | 发行通道 (0 here — this is the *app locale's* term, see §5.4), 频道 (that is a Discord channel), 渠道 (0) | `CONFIGURATION.md:237`; `installation/windows.md:201` |
+| channel (Discord / media) | **频道** (10) | 通道 | `integrations/discord-mirror.md:3` |
+| channel (audio bus, alpha, map link) | **通道** | 频道 | `media/tts-setup.md:150`; `characters/sprites.md:76` |
+| checkout (a git working tree) | **仓库** (58) | 检出 (0), 工作树 (0), 签出 (0 — the 2 grep hits are 标签 + 出现) | `TROUBLESHOOTING.md:39` — "如果仓库本身没法更新"; `CONFIGURATION.md:238` |
+| loopback | **环回** (32) | 回环 (0), 本地回送 (0) | `CONFIGURATION.md:114` — 环回（loopback） |
+| wake lock | **唤醒锁** (2) | 唤醒锁定 (0), 屏幕锁 (0) | `TROUBLESHOOTING.md:324` |
+| battery optimization | **电池优化** (2) | 省电优化 (0), 电量优化 (0) | `TROUBLESHOOTING.md:326` |
+| run in the background | **后台运行** (3) | 背景运行 (0) | `TROUBLESHOOTING.md:326` |
+| background activity (the Android setting) | **后台活动** — deliberately distinct from 后台运行, mirroring EN's own distinction | 后台运行 (that is the *other* term) | `TROUBLESHOOTING.md:332` |
+| frozen (cached-app freezer) | **冻结**; the freezer itself is **缓存应用冻结器** | 卡死, 挂起 (used for "suspends", not "frozen") | `TROUBLESHOOTING.md:330` |
+| memory (RAM) | **内存** (27) | 记忆体 (0), 存储器 (0) | `CONFIGURATION.md:155` |
+| in memory / resident | **保留在内存里**, **载入内存** | 驻留内存 (0); 常驻 (6 — but only as *RAM-resident*: 常驻 is the gloss for the lorebook/memory **Persistent** flag, `home/professor-mari.md:127` **Persistent**(常驻，见下文), and 常驻角色 "recurring character") | `CONFIGURATION.md:155`; `development/file-storage.md:39` |
+| eviction (drop from memory) | **从内存中移出（不会从磁盘删除）** | 逐出 (0), 淘汰 (0), 驱逐 (0) | `CONFIGURATION.md:155` |
+| least-recently-used | **最久未使用** | 最近最少使用 (0 — rejected as textbook jargon for a table cell), LRU (0) | `CONFIGURATION.md:155` |
+| VRAM | **显存** (22) | 视频内存 (0) | `game/ltx-2-3-storyboards.md:40` |
+| memory (the agent feature) | **记忆** (123); the feature is **Memory Recall**(记忆功能) (15) | 内存 (that is RAM); 记忆召回 (0 — the *app locale's* term, see §5.4); 回忆 (9 — but only as the **noun**: 回忆 is the pack's **verb** "to recall", 回忆到的记忆 / 回忆不出来, and a "flashback" in `roleplay/scenes.md:7`) | `FAQ.md:127`; `agents/memory.md` |
+| unsaved changes | **未保存的改动** (6) | 未保存的更改 (0) | `CONFIGURATION.md:155`; `agents/approvals-and-agent-suite.md` |
+| cache (noun/verb) | **缓存** (49) | 快取 (0); 暂存 (2 — but only as *cache*: 暂存 is git **stash**, `installation/windows.md:192` 把它们暂存起来，更新完再放回去) | `agents/approvals-and-agent-suite.md:95`; `:3` — **Cached prompt injections**(缓存的提示词注入) |
+| backup | **备份** (96); full archive = **完整备份** (7) | 备存 (0), 备分 (0 — the 2 grep hits are 设备 + 分配) | `data/backup-and-restore.md:9` — **Download Backup**(下载备份) |
+| snapshot | **快照** (108) | 截图 (that is a screenshot, 1 hit, correct); 镜像 (59 — but only as *snapshot*: 镜像 is the pack's established term for a **Docker/container image** and for the verb "to mirror", `installation/containers.md:14`, `integrations/discord-mirror.md:3`) | `development/file-storage.md:7`, `:51` |
+| profile (portable account archive: Export/Import Profile) | **档案** (60) | 配置文件 (0), 个人资料 (that is the social profile), 存档 (that is a Game save) | `data/backup-and-restore.md:10` — **Export Profile**(导出档案) |
+| profile (Conversation / Noodle social profile) | **个人资料** (26) | 档案 (that is the account archive); 简介 (8 — but only as *profile*: 简介 is the gloss for the Noodle **Bio** field, `noodle/overview.md:90` **Bio**(简介)) | `conversation/profiles.md:1`, `:3`; `noodle/overview.md:88` |
+| save / save file (Game Mode) | **存档** (20) | 档案 (that is the account archive), 保存点 (0) | `game/sessions-and-saves.md:1` — Game Mode：会话与存档 |
+| session | **会话** (102) | 场次 (0), 对话 (reserved for the Conversation gloss) | `game/sessions-and-saves.md:1`; `TROUBLESHOOTING.md:324` (服务器会话) |
+| extension | **扩展** (190); the feature is **个人扩展** (15) but the product name **Personal Extension(s)** stays Latin | 外挂 (0), 擴充 (0); 插件 (8 — but only as *extension*: 插件 is the gloss for the **Addons** settings section, `CONFIGURATION.md:59` **Settings → Addons**(插件), and for a native/Vite **plugin**) | `extending/personal-extensions.md:1`, `:3`; `data/backup-and-restore.md:10` |
+| NPC | **NPC**, Latin, uppercase; glossed on first mention per file, in two attested forms — `NPC(玩家之外的角色)` and `非玩家角色（NPC，即玩家之外的角色）` | 路人 (0); 非玩家角色 **as a running term** (used once, only as that first-mention expansion) | `game/party-and-npcs.md:1`, `:3`; `game/getting-started.md:11` |
+| GM / game master | **游戏主持人（GM）** (27) on first mention, **GM** after | 主持人 as a standalone term (0), 地下城主 (0) | `FAQ.md:55`; `game/party-and-npcs.md:106` |
+| sprite | **立绘** (224) | 精灵图 (0), 立繪 (0), 角色图 (0 as *sprite* — the 20 grep hits are all 角色图库 / 角色图片 / 角色图像 / 角色图包) | `FAQ.md:54`; `characters/sprites.md` |
+| narrator / narration | **旁白** (25) — ⚠ **residual**, see §7.4 **R-9** | 解说 (3 — but only as *narrator*: 解说 is the gloss for the table-games **Announcer** role, `conversation/table-games.md:135`); 叙述者 (3 — a genuinely competing rendering, all in `roleplay/combat-encounters.md:34`–`:35`) | `chats/group-chats.md:77`; `appearance/card-css-theming.md:147` |
+| branch (chat branch) | **分支** (178) | 分岔 (0); 支线 (5 — but only as *chat branch*: 支线 is the narrative side-branch — **Party Arcs**(队伍支线), 场景支线) | `chats/branches.md:1` |
+| keyword (lorebook trigger) | **关键词** (160) | 关键字 (0), 触发词 (0) | `agents/custom-agents.md:3` |
+| macro | **宏** (142) | 巨集 (0), 宏指令 (0) | `prompts/macros.md` |
+| slash command | **斜杠命令** (26) | 斜線指令 (0); 命令行 (6 — but only as *slash command*: 命令行 is "command line", 命令行工具（CLI）) | `chats/slash-commands.md`; `development/optional-agent-packages.md:124` |
+| regex / regex script | **正则** (52) / **正则脚本** (37); the UI label `Regex` stays Latin | 正規表示式 (0), 规则表达式 (0) | `extending/regex-scripts.md:7` — Regex 是“regular expression”（正则表达式）的缩写 |
+| tool / function calling | **工具** (333); function calling = **函数调用** (11) | 功能 as a rendering of *tool* (0), 函式 (0) | `agents/custom-agents.md:137` |
+| completion | **补全** (6) | 完成 as a rendering of *completion* (0), 完稿 (0) | `chats/messages.md:95` (补全 Token 数) |
+| streaming | **流式** / **流式输出** (29) | 串流 (0), 实时输出 (0) | `chats/sending-and-streaming.md:1` |
+| override | **覆盖** (125) | 覆寫 (0), 复写 (0 — the 6 grep hits are all 回复 + 写, e.g. 回复写完) | `agents/custom-agents.md:162` — **Connection Override**(连接覆盖) |
+| empty (default-column value) | **空** | 未设置 (that is the *other* value) | `CONFIGURATION.md:154` (`ENCRYPTION_KEY` \| 空) |
+| unset (default-column value) | **未设置** (6) | 空 (that is the *other* value), 无 | `CONFIGURATION.md:238` (`UPDATES_APPLY_DISABLED` \| 未设置); prose at `CONFIGURATION.md:277` |
+| off (default-column value) | **关闭** (238) | 关 (0 standalone), 停用 (0) | `CONFIGURATION.md:156` (`MARINARA_EAGER_STORAGE` \| 关闭) |
+| unlimited ("set 0 for unlimited") | **不限** (5 in this sense) is the pack's dominant prose form; **无限制** (1) and **不限制** (2) also occur — ⚠ **residual**, see §7.4 **R-7**. In a config table's default column the attested form is `` `0` ``(无限制). | 无限 as a standalone rendering (0 in this sense) | `lorebooks/token-budgets.md:20`, `:36`; `lorebooks/overview.md:90` (不限); `CONFIGURATION.md:155` — `` `0` ``(无限制) |
+
+### 3.1 The four-way "profile" split
+
+**[V]** EN "profile" lands on **four** distinct Chinese terms. The original cycle recorded this as
+a *three-way* split (ruling **[R]**); the shipped pack shows four, and the pack governs:
+
+| EN sense | Term | Where |
+|---|---|---|
+| portable account archive (Export/Import Profile, `marinara-profile.json`) | **档案** | `data/backup-and-restore.md:10`, `:72`; `CONFIGURATION.md:245` |
+| a character's/persona's Conversation & Noodle social profile (display name, about-me) | **个人资料** | `conversation/profiles.md:1`; `noodle/overview.md:88` |
+| a named, reusable bundle of chat settings ("settings profile") | **设置方案** | `chats/settings-profiles.md:1` |
+| a Game Mode save | **存档** | `game/sessions-and-saves.md:1` |
+
+Never swap these. 档案 in a Game Mode context, or 存档 in a backup context, is a bug.
+
+---
+
+## 4. Typography & punctuation
+
+### 4.1 Script and width
+
+| # | Rule | Evidence |
+|---|---|---|
+| 4.1.1 | **[V]** **Simplified characters only.** A scan of 216 unambiguously traditional-only forms (們個這來時對開關實現後點於為將學會體發動與並書據絡經過準備聯繫緩衝擊選擇檔軟訊資製視圖傳儲執覽權誤碼註釋讀寫參變陣迴語範輸畫顯單鈕捲標籤頁欄屬繼緒瀏戶請應憑證簽雜亂裡著妳佔說話認識誰讓訪載離網絡電腦…) returns **0 distinct forms, 0 occurrences** across all 125 files. The sense-split pairs are clean too: 裡 = 0, 著 = 0, 妳 = 0, 佔 = 0, 檔 = 0, 說 = 0, 個 = 0, 們 = 0, 時 = 0, 後 = 0. **Build the scan list carefully** — every form must have a *distinct* simplified counterpart. Shared forms (器 硬 料 窗 用 方 行 果 除 法 回 型 性 索 素 繁 厚 明 容 查 列 境 函 照 警 象 累 返 翻 紫 …) are identical in both scripts and will report thousands of false hits (see §7.3 **T1**). | whole-pack scan |
+| 4.1.2 | **[V]** **All Latin letters and digits are half-width ASCII.** Zero characters in U+FF10–FF19 / U+FF21–FF3A / U+FF41–FF5A. Full-width ７８６０ would never match a search for `7860`. | whole-pack scan |
+| 4.1.3 | **[V]** Text is **NFC-normalized**; every file round-trips through `unicodedata.normalize("NFC", …)` unchanged. | whole-pack scan |
+| 4.1.4 | **[V]** **No ideographic space** (U+3000) and **no NBSP** (U+00A0, U+2007, U+202F): 0 occurrences. Also 0 zero-width joiners/non-joiners (U+200D, U+200B), 0 bidi marks (U+200E) and 0 BOMs (U+FEFF). Separation is always a plain half-width space. | whole-pack scan |
+| 4.1.5 | **[V]** CJK punctuation is full-width: ，(10,573) 。(13,643) 、(4,292) ；(442) ：(2,600) ？(35). **！ is not used at all** (0) — the EN docs' exclamation-free register carries over. | `CONFIGURATION.md`, whole-pack census |
+
+### 4.2 The two-case parenthesis rule
+
+**[V]** Parenthesis width is decided by **what precedes the opening paren, never by what is inside
+it**. This is the single most load-bearing typography rule in the pack.
+
+The classifier is the immediately preceding character, with one refinement: when that character is
+a bold close `**` or a closing `)`, look at the **span it closes** — an English label behaves as
+Latin (half-width), a Chinese span behaves as CJK (full-width). Never look at the gloss.
+
+Counts below are of **conforming** parens (prose only, code fences excluded); the non-conforming
+ones are itemised in §7.4 **R-1**.
+
+| Preceding character | Paren | Count | Example |
+|---|---|---|---|
+| Latin letter or digit | half-width `( )`, tight | 437 | `Token(模型切分文本的最小单位)` — `FAQ.md:105` |
+| bold close `**`, **English** bold content | half-width `( )`, tight | 2,111 | `**Export Profile**(导出档案)` — `data/backup-and-restore.md:10` |
+| bold close `**`, **Chinese** bold content | full-width `（ ）` — the bold is Chinese prose, so the CJK rule applies | 2 (against 3 half-width; see §7.4 **R-10**) | `初始处于**禁用**（关闭）状态` — `home/professor-mari.md:120` |
+| inline-code close `` ` `` | half-width `( )`, tight | 64 | `` `0` ``(无限制) — `CONFIGURATION.md:155` |
+| a Chinese character | full-width `（ ）` | 471 | `环回（loopback）` — `CONFIGURATION.md:114` |
+| a preceding **Chinese gloss's** `)` | full-width `（ ）` | 16 | `**Chat Settings**(聊天设置)（齿轮图标）` — `agents/approvals-and-agent-suite.md:12` |
+| a preceding **English label's own** `)` | half-width `( )` — the label is byte-exact per §5.1, so its `)` counts as Latin | 2 | `Covers (Blinds & Garage)(遮挡设备：窗帘与车库门)` — `integrations/home-assistant.md:119`, `:124` |
+| CJK punctuation (。 ” 、) | full-width `（ ）` | 2 | `…改成 **Constant**。（不带关键词的条目…）` — `lorebooks/entries.md:366` |
+
+Corollaries:
+
+- **4.2.a [V]** A markdown link's `](` is not a paren for this purpose — it is always ASCII (941
+  instances).
+- **4.2.b [V]** Verbatim English quoted from the app is **exempt**: whatever parens the app's own
+  string contains stay byte-exact, e.g. **Unreachable (request timed out)** keeps its half-width
+  paren *and* its space, inside CJK prose. `TROUBLESHOOTING.md:330`
+- **4.2.c [V]** 14 in-pack violations survive; see §7.4 residual **R-1**.
+
+### 4.3 Close-side spacing after a gloss — the §4(e) rule
+
+**[V]** Measured over 2,101 `**Label**(Chinese gloss)` instances:
+
+| What follows `)` | Treatment | Count |
+|---|---|---|
+| anything that is not CJK punctuation — Chinese prose, a table pipe `\|`, `→`, `/`, `>` | **one half-width space**, then it | 1,185 (of which 1,127 are Chinese prose) |
+| CJK punctuation (。，、：；？”) or a closing `）` | **no space** | 887 (879 + 8 closing `）`) |
+| a chained full-width `（…）` aside | **no space** | 16 |
+| end of line / list item | nothing | 9 |
+| *(violations: CJK prose with no space)* | — | 4 (§7.4 **R-2**) |
+
+Example of both halves in one line: `**Export Profile**(导出档案) 生成的文件更轻，…（角色、…）。`
+— `data/backup-and-restore.md:10`.
+
+### 4.4 CJK ↔ Latin spacing
+
+**[V]** **Exactly one half-width space** separates a CJK character from an adjacent Latin
+letter or digit, in both directions. Measured: 7,202 `Latin␠CJK` and 6,326 `CJK␠Latin`
+adjacencies, and **zero** tight adjacencies of either kind across the whole pack. This holds for
+inline code, bold labels, product names and version literals alike: `Token 数`, `Marinara 会自动…`,
+`pnpm 10.34.5 的…`.
+
+The space is *not* inserted between CJK and a full-width punctuation mark, and never before
+，。、；：？.
+
+### 4.5 Quotes
+
+| # | Rule | Evidence |
+|---|---|---|
+| 4.5.1 | **[V]** Chinese-prose quoting uses **curly “ ”** (GB/T 15834): 414 pairs, perfectly balanced. **‘ ’ is unused** (0), and 「」《》 are unused (0). | `CONFIGURATION.md:7` — “让多台设备访问同一个服务器” |
+| 4.5.2 | **[V]** A quoted **English UI string** also sits inside the pack's curly “ ”, but the string itself is **byte-exact** — including its own ellipsis character. 312 of the 414 quoted spans are pure ASCII English. | `UPGRADING.md:164` — “Update applied successfully. Please relaunch the app to use the new version.” |
+| 4.5.3 | **[V]** Straight ASCII `"` survives **only when the quote marks are part of the string the app renders**: `Theme "My Theme" saved and activated.`, `Delete "your connection name"?`, `-tag:"tag name"`, `Use "🔞 Popular NSFW" sort…`. Exactly **14** such spans exist in prose pack-wide (there are 360 more inside code fences and inline code, which this rule does not govern). Never use straight quotes for the pack's own quoting. | `appearance/custom-css-themes.md:29`; `connections/organizing-connections.md:47`; `characters/library-organization.md:22`, `:68`, `:93`; `characters/bot-browser.md:85`; `connections/local-model.md:185`; `development/optional-agent-packages.md:61` (×4), `:67`; `media/scene-video.md:159`, `:163` |
+| 4.5.4 | **[R]** The original cycle resolved the quote-style question into a principled **301 / 12** split (curly for the pack's own quoting; straight only where the rendered string owns the marks). Today's re-measurement gives **414 curly pairs / 14 straight prose spans** — the *rule* is unchanged; the historical counts are recorded, not re-derivable. | recorded ruling (PR #4435); re-measured 2026-09-01 |
+
+### 4.6 The quoted-sentence terminator ruling
+
+**[V]** When a quoted string already carries its own terminal punctuation (`.`/`!`/`?`), **no
+outer 。 is added after the closing ”**. Measured: **0 violations** pack-wide.
+
+- quoted **sentence** → `”` then end-of-line (62), a continuing Chinese clause (68), or ，(12) —
+  never 。 (0). `UPGRADING.md:172` — …会看到：“Could not check for updates. Try again later.”这通常是…
+- quoted **term/fragment** (no internal terminator) → the outer 。 is added normally (73).
+  `TROUBLESHOOTING.md:145` — …“修复”。
+
+Mechanical check: `grep -rP '[.!?。？]”。'` must return zero.
+
+### 4.7 Dashes, ellipses, separators
+
+| # | Rule | Evidence |
+|---|---|---|
+| 4.7.1 | **[V]** The Chinese dash is the **doubled em dash ——**, set **tight** (no surrounding spaces), and it is rare: 2 occurrences pack-wide. Use it only where EN uses a dash to pivot a sentence. | `TROUBLESHOOTING.md:260` — 聊天看起来是空的——数据仍在磁盘上; `TROUBLESHOOTING.md:330` |
+| 4.7.2 | **[V]** A **single spaced em dash `—`** appears **3 times**, only inside content byte-inherited from EN (two list-item dashes, one quoted English card description). Do not author one in Chinese prose. | `agents/custom-agents.md:113`, `:114`; `lorebooks/entries.md:189` |
+| 4.7.3 | **[V]** Ellipsis follows the **string being quoted**, never a house style: `…` (U+2026) where the app renders U+2026 (**Creating backup…**, **Saving…**), and ASCII `...` where the app renders ASCII (“正在打开聊天...”, key `ui.chat.chatarea.openingChat`). | `UPGRADING.md:27`; `TROUBLESHOOTING.md:330` |
+| 4.7.4 | **[V]** `·` (U+00B7) and `–` (U+2013) appear once each and are inherited from EN table cells, not authored. `–` at `noodle/settings.md:219` is a **drift** from EN's ASCII hyphen (§7.4 **R-3**). | `INSTALLATION.md:14`; `noodle/settings.md:219` |
+
+### 4.8 Headings, lists, tables
+
+| # | Rule | Evidence |
+|---|---|---|
+| 4.8.1 | **[V]** Headings are **translated into Chinese** and take **no terminal 。** (0 of 1,861). Question headings take **？** (24). A heading that names a UI surface keeps the English name: `## Agents 面板`. | `agents/agents-overview.md:21`; `FAQ.md:49` |
+| 4.8.2 | **[V]** A heading that pairs a scope with a topic uses a **full-width ：**: `# Game Mode：会话与存档`, `### Windows：构建 shared 包时提示 …`. | `game/sessions-and-saves.md:1`; `TROUBLESHOOTING.md:35` |
+| 4.8.3 | **[V]** Heading **level structure is identical to EN**, in order — 123 of 125 files match exactly (the 2 deltas are EN drift, §7.4 **R-4**). | structural diff vs `docs/` |
+| 4.8.4 | **[V]** Of 4,644 list items: **3,774** are full sentences ending with **。**; **480** are a label plus a gloss ending at the closing `)` with no terminator; **119** are members of a semicolon series ending with **；**. The remaining 271 are fragments, bare labels and table-like rows. | `FAQ.md:53–55`; `agents/custom-agents.md:162` |
+| 4.8.5 | **[V]** Table cells that are sentences end with **。**; the header row and column count mirror EN exactly. The pack writes cells with a **single space** on each side (`\| x \| y \| z \|`) and does **not** column-align them to equal width the way the EN source does — 0 column-aligned tables pack-wide. Match the surrounding file, not the EN source. | `CONFIGURATION.md:150–156` vs `docs/CONFIGURATION.md:124–131` |
+| 4.8.6 | **[V]** **Code fences are byte-identical to EN** — content, language tag and all. 123 of 125 files match exactly; the 2 deltas are EN drift (§7.4 **R-4**). Never translate anything inside a fence, including comments. | fence diff vs `docs/` |
+| 4.8.7 | **[V]** **Link targets are byte-identical to EN**, in order — 120 of 125 files match exactly. Link *text* is translated. The 5 deltas are all mirror lag (EN gained one link each), not retargeting: `CONFIGURATION.md`, `agents/built-in-agents.md`, `characters/creating-and-editing-characters.md`, `extending/personal-extensions.md`, `media/tts-setup.md` — see §7.4 **R-4**. | link diff vs `docs/` |
+
+---
+
+## 5. UI labels & glosses
+
+### 5.1 The byte-exact rule
+
+**[V]** Any string the app actually renders is reproduced **byte-exact**, in English, whenever the
+app renders it in English — including capitalization, internal punctuation, its own parentheses,
+its own quote marks and its own ellipsis character. Bold if EN bolds it; plain if EN does not.
+
+`TROUBLESHOOTING.md:330` carries all three cases in one paragraph:
+**Server unreachable** (bold, EN-only string, no gloss), **Unreachable (request timed out)** (bold,
+EN-only, half-width paren preserved inside CJK prose), and “正在打开聊天...” (translated in
+`zh-Hans.json` as `ui.chat.chatarea.openingChat`, so quoted in Chinese with the label's own ASCII
+dots).
+
+### 5.2 The gloss pattern
+
+**[V]** `**English Label**(中文释义)` — bold English, tight half-width paren, Chinese gloss, then
+§4.3 close-side spacing. **2,103 of 6,688** bold spans carry a Chinese gloss (2,101 with a
+half-width paren, 2 with a full-width one — the §7.4 **R-1** violations). A further 26 bold spans are
+followed by a paren whose contents are **not** Chinese (a number, an EN mode name, a unit); those
+are not glosses.
+
+- **5.2.a [V] Gloss on first mention per file, then run bare.** **763** English labels repeat within
+  a file and are glossed at least once. Of those, **702 (92%)** are glossed on the first occurrence
+  only — the target pattern. The rest split two ways: **18** repeat the gloss on a later occurrence
+  as well, and **43** are glossed *once but not on the first occurrence* (the label first appears
+  bare, then picks up a gloss later — e.g. `agents/memory.md` **Backfill** bare at `:149`, glossed
+  at `:166`). Do not gloss every occurrence, and put the gloss on the **first** one.
+- **5.2.b [V] Plain (unbolded) Latin UI names take the same tight gloss**: `Chat Settings(聊天设置)`,
+  `Support Diagnostics(支持诊断信息)`. `FAQ.md:61`; `TROUBLESHOOTING.md:330`
+- **5.2.c [V] Bold spans whose content is already Chinese are not glossed** — **312 of 314**. The 2
+  exceptions are not glosses but **parenthetical asides** in Chinese, and they take the full-width
+  paren the CJK rule calls for: `home/professor-mari.md:120` 初始处于**禁用**（关闭）状态 and `:127`
+  简短**索引**（只有标题和一行描述）. Never write `**中文**(中文)` as if it were a gloss.
+- **5.2.d [V] Status / error sentences are not glossed.** Of 67 bold spans that are full English
+  sentences ending in `.`/`!`/`?`, **58 carry no gloss**; the **9** that do are all progress or
+  placeholder strings (**Preparing context...**(准备上下文), **Search characters...**(搜索角色)),
+  which are labels, not messages. An EN-only error string stands alone: **Save blocked: missing
+  CSRF header** (`REMOTE_ACCESS.md:209`, `TROUBLESHOOTING.md:114`), **Server unreachable**
+  (`TROUBLESHOOTING.md:330`). Glossed set: `chats/sending-and-streaming.md:80`–`:86`, `:135`;
+  `chats/group-chats.md:19`
+- **5.2.e [V] Long navigation paths are glossed as a whole**, arrows and all:
+  **Settings → Advanced → Danger Zone**(设置 → 高级 → 危险区域). `CONFIGURATION.md:31`
+
+### 5.3 Untranslated labels
+
+**[V]** When the app renders a label in English for *every* locale, the pack keeps it English and
+either glosses it (if it is a clickable control) or leaves it bare (if it is a status/error
+string — §5.2.d). It is **never** replaced with a Chinese translation, because the reader has to
+find that exact string on screen.
+
+### 5.4 The locale file is a source, not an authority
+
+**[V] and [R].** `packages/client/src/localization/locales/zh-Hans.json` is consulted for two
+things only: (a) whether a given label is translated in the app at all, and (b) if it is, its
+byte-exact Chinese string for quoting. It is **not** the terminology authority for glosses.
+
+Measured (2026-09-01, over the 2,101 `**EN Label**(中文)` glosses of §5.2): **1,804** of those labels
+appear verbatim as a string in `en.json` and have a `zh-Hans.json` translation. Of those,
+**1,281 (71%)** reproduce the app's Chinese string exactly and **523 diverge**. The divergences are
+deliberate house terms, and the pack wins:
+
+| Label | App locale (`zh-Hans.json`) | Pack gloss |
+|---|---|---|
+| Persona / Linked Personas | 人设 / 关联人设 (218 occurrences across 207 of the 8,706 strings; 用户角色 appears in 0) | **用户角色** (443) |
+| Memory Recall | 记忆召回 | **记忆功能** |
+| Conversation | 对话 | **对话模式** |
+| Release Channel | 发行通道 | **发布通道** |
+| Import Profile | 导入资料 | **导入档案** |
+| Full page access | 完整页面访问 | **整页访问** |
+| Text to Speech | 文本转语音 | **语音合成** |
+| Ask Professor Mari | 询问 Mari 教授 | **问问 Professor Mari** (the locale translates the product name; the pack does not — §2.1 wins) |
+| Replay Tutorial | 重播教程 | **重看教程** |
+
+A gloss that differs from `zh-Hans.json` is therefore **not automatically a bug** — check §3
+first. (The 人设/用户角色 divergence is a real cross-surface trap; see §7.4 **R-6**.)
+
+---
+
+## 6. Language-specific mechanics
+
+| # | Rule | Evidence |
+|---|---|---|
+| 6.1 | **[V]** **CJK-initial link text takes no space against preceding Chinese prose.** A markdown link whose visible text starts with a Chinese character is written tight against the CJK character or CJK punctuation before it: of 660 CJK-initial link texts, **306 sit directly after CJK/CJK punctuation and all 306 are tight — 0 spaced**. (The other 354 start a line, a list item or a table cell, where the question does not arise.) `见[连接 AI 服务商](…)`, `想看带示例的分步说明，读[远程访问：…](…)`. | `CONFIGURATION.md:18`, `:110`, `:166` |
+| 6.2 | **[V]** **Latin-initial link text takes the normal §4.4 space** — the CJK↔Latin rule looks *through* the `[`: `…看 [Marinara Engine 故障排查](TROUBLESHOOTING.md)`. Of 280 Latin-initial link texts, **106 sit after CJK prose and all 106 take the space — 0 tight**. | `FAQ.md:39`, `:45` |
+| 6.3 | **[V]** Chinese has no plural morphology and no articles — do not carry EN's *a/the/s*. EN "the least-recently-used chat with no unsaved changes" becomes 最久未使用、且没有未保存改动的那个聊天; the definite article surfaces (only when needed) as 那个/这个, not as a fixed particle. | `CONFIGURATION.md:155` |
+| 6.4 | **[V]** Enumerations use the **、 (ideographic comma)** between items and **，** between clauses: 角色、聊天、用户角色、世界书、预设和各项设置。 Never `、` before 和/或 — the last item joins with 和/或 directly. | `FAQ.md:153`; `CONFIGURATION.md:22` |
+| 6.5 | **[V]** Measure words are used naturally and are not mechanical: 一份档案, 一本世界书, 一张角色卡, 一条消息, 一个聊天, 一段文字. 一个 appears 1,879 times; do not default to it where a specific classifier reads better. | `data/backup-and-restore.md:10` (一份便携副本); `FAQ.md:105` (一组世界设定条目) |
+| 6.6 | **[V]** Locative 里 (never 裡) for "in/inside": `.env` 里, 应用里, 聊天里. | `CONFIGURATION.md:18`, `:78` |
+| 6.7 | **[V]** Chinese compounds do **not** take an internal space, and a Latin token inside a compound keeps its §4.4 spaces on both sides: `Token 预算`, `Discord 频道`, `Termux 启动脚本`, `Basic Auth 与 IP 允许列表`. | `lorebooks/token-budgets.md:1`; `CONFIGURATION.md:331` |
+| 6.8 | **[V]** Prefer active, verb-first constructions over 被-passives and 进行-nominalizations. 进行 appears **37 times**, and almost all of it is legitimate: the aspectual 进行中/进行时 "in progress, while running" (通话进行中, 游戏进行时, 正在进行的生成) and 进行 as a full main verb (进行遭遇战, 打开一个角色…进行编辑). Only a couple are the light-verb nominalization to avoid — `development/file-storage.md:33` 根据所有权键**进行**百分号编码 and `data/where-data-is-stored.md:21` 从旧存储**进行**一次性升级; prefer 按…编码 / 从旧存储一次性升级. 被 (282) is used only for genuine passives (被冻结, 被跳过, 被拒绝). | whole-pack scan; `TROUBLESHOOTING.md:330` |
+| 6.9 | **[V]** Chinese-language quotes attributed to a character or to the user are written in Chinese inside “ ”, with 、 separating alternatives: 也可以直接问她：“你记得哪些事？”、“把我那条世界书格式的记忆改一下，…”. | `home/professor-mari.md:131` |
+
+---
+
+## 7. QA checks & known traps
+
+### 7.1 Mechanical checks (run all of these before pushing a `zh-hans` change)
+
+| # | Check | Expected |
+|---|---|---|
+| C1 | `您` count | **0** — 您 is banned (§1.1) |
+| C2 | Traditional-character scan over the 216-form list in §4.1.1 | **0 distinct forms, 0 occurrences.** Build the list from forms that have a *distinct* simplified counterpart; a list contaminated with shared forms (器 硬 料 窗 用 方 行 果 除 法 回 型 性 索 素 繁 …) reports thousands of bogus hits |
+| C3 | Full-width alnum scan U+FF10–FF19 / U+FF21–FF3A / U+FF41–FF5A | **0** — full-width digits break the in-app search (§4.1.2) |
+| C4 | `U+3000` / `U+00A0` / `U+2007` / `U+202F` / `U+200B` / `U+200D` / `U+FEFF` scan | **0** (§4.1.4) |
+| C5 | NFC round-trip per file | **byte-identical** (§4.1.3) |
+| C6 | `“` count == `”` count, per file and pack-wide | balanced (414 today; 0 unbalanced files) |
+| C7 | regex `[.!?。？]”。` | **0** — the quoted-sentence ruling (§4.6) |
+| C8 | Tight CJK↔Latin adjacency: `[一-鿿][A-Za-z0-9]` and the reverse | **0** (§4.4) |
+| C9 | Paren-width classifier: for every `(` / `（` outside code fences, classify the preceding character per §4.2 | 14 known violations, no new ones (§7.4 **R-1**) |
+| C10 | Gloss close-side spacing per §4.3 | 4 known violations, no new ones (§7.4 **R-2**) |
+| C11 | Code-fence content vs the EN file it mirrors | byte-identical (§4.8.6) |
+| C12 | Heading-level sequence vs EN; link-target list vs EN | identical (§4.8.3, §4.8.7) |
+| C13 | Bold-span count per file vs EN | equal (§7.2) |
+| C14 | `node scripts/docs-i18n/build-manifest.mjs <pack-dir>` then `node scripts/docs-i18n/validate-pack.mjs <pack-dir>` | passes; manifest hashes refreshed. **[R]** — required by `CONTRIBUTING.md:244`, not observable from pack content alone |
+| C15 | **[R]** Runtime search probe on a smoke server: search 世界书 → many guides; search the traditional 世界書 → **0 results**. This probe is *why* C2 exists; the pack alone shows only the 0-occurrence half of it. | recorded ruling (PR #4435) |
+| C16 | Sense-scoped term scan: for every §3 row, count the prescribed term **and** each banned alternate | Match the §3 counts. A banned alternate carrying a parenthesised count in §3 is **expected**, not a failure — read its noted sense before "fixing" anything, and never regex a ban without checking for substring artifacts (词条, 复写, 签出, 备分, 再生成, 角色图 are all 0 in their banned sense). The only rows that should ever move are the ⚠ residuals **R-7** (unlimited), **R-8** (greeting), **R-9** (narrator) |
+
+### 7.2 Bold parity — how to run it honestly
+
+**[V] and [R].** The cycle ruling is **strict bold-span parity with EN**: the pack may translate a
+bold span's content but may never add or drop one. (**[R]**: 80 translator-added bolds were removed
+across 36 drifted files during the original normalization — a process fact the pack cannot show.)
+
+Re-measured 2026-09-01 against current `staging`: **115 of 125** files have identical bold-span
+counts. All 10 deltas were traced and **none is a translation defect** — each is EN content that
+changed after the pack's last mirror:
+
+| File | EN / ZH bolds | EN last touched |
+|---|---|---|
+| `agents/hierarchical-maps.md` | 204 / 218 | 2026-08-04 |
+| `FAQ.md` | 130 / 121 | 2026-08-21 |
+| `characters/galleries.md` | 48 / 40 | 2026-08-03 |
+| `noodle/overview.md` | 69 / 66 | 2026-08-09 |
+| `agents/built-in-agents.md` | 197 / 195 | 2026-08-22 |
+| `game/storyboard.md` | 144 / 142 | 2026-08-15 |
+| `roleplay/hud-and-trackers.md` | 86 / 84 | 2026-08-17 |
+| `characters/personas.md` | 132 / 133 | 2026-08-04 |
+| `extending/personal-extensions.md` | 19 / 18 | 2026-08-14 |
+| `home/professor-mari.md` | 60 / 61 | 2026-08-16 |
+
+Worked examples: `characters/galleries.md` is missing 8 bolds because EN commit `cd22b2057` split
+one paragraph into a bulleted list the pack has not mirrored yet; `characters/personas.md` has one
+*extra* bold (**Character Tracker**) because EN line 127 was rewritten to "Tracker agents do not
+update them"; `home/professor-mari.md` has one extra (**Professor Mari 在线状态指示器**) because the
+EN sentence it translated has since been removed.
+
+**Therefore: always run C13 against the EN revision the pack was mirrored from, not against tip.**
+A count delta is a mirror-lag signal first and a parity bug second.
+
+### 7.3 Tooling traps
+
+- **T1 [V]** `grep` under Git Bash/MSYS mis-handles full-width character classes — `grep -o "[０-９]"`
+  reported 796,725 bogus hits on this pack. Do all Unicode-class scans in Python with explicit
+  codepoint ranges, not with shell `grep` character classes.
+- **T2 [V]** Python on this machine defaults stdout to cp1252 and will `UnicodeEncodeError` on ，or
+  （. Prefix every analysis command with `PYTHONIOENCODING=utf-8`.
+- **T3 [V]** `grep -c` over a byte-oriented pattern returns per-file counts that look like matches
+  even when the pattern never matched (the NBSP scan reported 125 "files" before being redone in
+  Python). Confirm any zero/nonzero result with a second method before writing it into a rule.
+- **T4 [R]** Committed git blobs were re-hashed against the manifest during the shipping cycle
+  (9 packs × 124 files, 0 mismatches). Rebuild the manifest after *any* pack edit or the download
+  verification fails at runtime.
+- **T5 [V]** **`\w` does not match Chinese.** In JavaScript (and in Python without `re.UNICODE`
+  semantics for byte patterns), `\w` is `[A-Za-z0-9_]` — it matches **zero** characters of this
+  pack's 312,388 CJK characters, so `\b`, `\w+` and `\W` word-boundary logic silently no-op on
+  Chinese text. This matters twice: when writing scan scripts for the pack, and when documenting
+  `extending/regex-scripts.md` for readers, whose CJK patterns need explicit codepoint ranges
+  (`[一-鿿]`) or lookarounds instead. The same trap is recorded for `ru` (Cyrillic) — do
+  not drop it from either glossary.
+- **T6 [V]** In Python, `'' in '(（'` is **True**. A "is the next character a paren?" test written as
+  `line[i:i+1] in '(（'` therefore counts every **end-of-line** bold span as glossed. This inflated
+  a draft of the §5.2.d count from 9 to 16 before it was caught. Guard the empty case explicitly.
+
+### 7.4 Known pack residuals
+
+These are **documented, not silently fixed** — the shipped pack is the ground truth, and changing
+them is a separate, deliberate change.
+
+- **R-1 — 14 paren-width violations of §4.2.**
+  Full-width where half-width is expected (preceding token is Latin/bold-EN/inline-code): 5 in
+  `agents/built-in-agents.md:159` (（默认使用 Agent 连接）、（20）、（10）、（5）、（3） after English bold
+  labels), 1 in `characters/galleries.md:73` (**Copy image reference**（链接图标）), 1 in
+  `characters/galleries.md:89` (`id（…`), 3 in `development/optional-agent-packages.md:69` (after
+  inline-code closes).
+  Half-width where full-width is expected (preceding token is CJK): 4, all in
+  `development/optional-agent-packages.md:26` (×2), `:59`, `:67`.
+  `development/optional-agent-packages.md` is the hotspot — 7 of the 14.
+- **R-2 — 4 missing close-side spaces (§4.3).** `agents/built-in-agents.md:250`
+  (**Touch Sensitivity**(触感强度)选项), `integrations/haptic-feedback.md:11`
+  (**Agents**(智能体)之一), `:80` (**Touch sensitivity**(触感强度)控件) and `:94`
+  (**Incidental contact**(无意触碰)开关). `integrations/haptic-feedback.md` holds 3 of the 4.
+- **R-3 — one dash drift.** `noodle/settings.md:219` renders EN's `23:00-07:00` as `23:00–07:00`
+  (U+2013). A literal search for the EN range string misses. Single occurrence.
+- **R-4 — mirror lag, not defects.** Structural deltas against current `staging` EN, all caused by
+  EN moving after the last mirror:
+  - **code fences (2 files)** — `TROUBLESHOOTING.md` (EN bumped `pnpm@10.33.2`→`10.34.5` in two
+    fences), `game/ltx-2-3-storyboards.md` (EN renamed a pipeline step to "Narration Passthrough").
+  - **heading structure (2 files)** — `FAQ.md`, `prompts/macros.md` (one EN heading each added).
+  - **link targets (5 files)** — `CONFIGURATION.md`, `agents/built-in-agents.md`,
+    `characters/creating-and-editing-characters.md`, `extending/personal-extensions.md`,
+    `media/tts-setup.md` (EN gained one link each).
+  - **bold-span counts (10 files)** — the table in §7.2.
+
+  Fold these into the next mirror cycle rather than patching in isolation.
+- **R-5 — the launcher two-form split.** 启动脚本 (81) is the shell start script; 启动器 (8) is the
+  updater/downgrade-guard component. Both are attested and the split is coherent, but it is *not*
+  a rule the EN source distinguishes — EN says "launcher" for both. Treat 启动脚本 as the default and
+  only reach for 启动器 where the pack already does (`TROUBLESHOOTING.md:47`, `:49`, `:262`;
+  `UPGRADING.md:186`).
+- **R-6 — persona is 用户角色 in docs, 人设 in the app.** The docs pack uses 用户角色 (443) and never
+  人设 (0); the shipped UI uses 人设 (218 occurrences across 207 of the 8,706 strings in
+  `zh-Hans.json`, which itself contains 用户角色 zero times). A reader who reads "人设" on
+  screen and searches the docs for it finds **nothing**. This is a genuine cross-surface
+  inconsistency. Do not "fix" it inside the pack — it needs a decision about which surface moves.
+- **R-7 — "unlimited" has three renderings.** EN "set 0 for unlimited" lands on **不限** at
+  `lorebooks/token-budgets.md:20` and `:36` and `lorebooks/overview.md:90` (plus the same sense as
+  不限次数 at `lorebooks/entries.md:119` and 不限深度 at `extending/regex-scripts.md:128` — 5 in all),
+  on **不限制** at `lorebooks/linking-to-characters.md:101`, and on **无限制** in the config table
+  cell `CONFIGURATION.md:155` (`` `0` ``(无限制)). Two files in the same lorebook-budget cluster
+  disagree with each other, and a reader searching 无限制 finds the config table and misses every
+  lorebook page. 不限 is the majority form; 无限制 and 不限制 are the outliers. Do not settle this by
+  preference — it needs the C15 search probe and a recorded ruling.
+- **R-8 — "greeting" has two renderings.** EN "greeting(s)" is **开场白** (9) everywhere it means a
+  character card's first message (`FAQ.md:101`, `characters/creating-and-editing-characters.md:73`
+  **Dialogue & Greetings**(对白与开场白), `:76`, `characters/import-export.md:5`,
+  `characters/bot-browser.md:5`), but **问候语** (4) in two files that mirror the same EN word:
+  `characters/galleries.md:71` (the heading, EN "Reuse a gallery image in messages and greetings")
+  and `:73`, and `chats/sending-and-streaming.md:54` and `:56`. A reader searching 开场白 will not
+  find the gallery-reuse guide. 开场白 is the established term; 问候语 is the drift.
+- **R-9 — "narrator" has two renderings.** **旁白** (25) is the pack-wide term for narration and the
+  narrator voice (`FAQ.md:54`, `chats/group-chats.md:77` **Merged (Narrator)**(合并叙述),
+  `appearance/card-css-theming.md:147`). **叙述者** (3) appears only in
+  `roleplay/combat-encounters.md:34`–`:35`, for the narrating perspective (**Omniscient**(全知),
+  **Limited**(限知)). Arguably a persona-vs-text distinction, but it is not one EN makes and it is
+  confined to one file. Unrelated: 解说 (3) is *not* part of this — it is the sanctioned gloss for
+  the table-games **Announcer** role.
+- **R-10 — 3 Chinese bold spans take a half-width paren.** Against the §4.2 rule that a Chinese bold
+  close takes full-width `（ ）` (attested twice, `home/professor-mari.md:120`, `:127`), three
+  spans use the half-width form: `agents/hierarchical-maps.md:421` (**(copy)**, **(copy N)**) and
+  `roleplay/combat-encounters.md:48` (**(You)**). All three are byte-exact English strings the app
+  renders, so they are arguably §4.2.b exemptions rather than defects — but the classifier flags
+  them, so they are recorded here rather than silently excluded.
+
+### 7.5 Standing process rulings
+
+- **P1 [R]** Never change an established term without re-running the runtime search probe (C15) on
+  a smoke server. The pack's search is literal substring matching; a synonym introduced in one file
+  silently partitions the result set.
+- **P2 [R]** Terminology decisions were reconciled across four native-reader panels with recorded
+  rulings. A new proposal that reopens a settled term needs a stated reason, not a preference.
+- **P3 [R]** The docs pack's term wins over the app locale (§5.4). If they should converge, that is
+  an Engine-side locale change, not a pack edit.
+- **P4 [R]** Do not fix unrelated pre-existing issues while mirroring a delta; the diff scoped to
+  `zh-hans/` must show only the intended hunks. Residuals in §7.4 belong to a dedicated cleanup.


### PR DESCRIPTION
## Linked issue

No linked issue — this implements the standing proposal (raised during earlier pack cycles) to commit the translation glossaries to the `docs-i18n` branch itself. Maintainer-side impetus: the working glossaries have now been destroyed twice by machine temp-directory cleanup, the second time unrecoverably.

## Why this change

Each language pack shipped with a working glossary — the register, terminology, typography, UI-label, and QA conventions that make 125 docs per language internally consistent. Those glossaries lived in a temporary workspace: the first loss (2026-08-15) was recovered byte-exact by mining old agent transcripts; the second loss took the transcripts too, and the originals are gone. Small mirror PRs can lean on in-pack precedent, but any future full cycle (Arabic especially) would have started from zero. Committing the glossaries next to the packs they govern ends the failure mode and puts them in front of every future contributor.

## What changed

- **`glossaries/glossary-<lang>.md` × 10** (es, de, fr, pt-br, pl, ru, ja, ko, zh-hans, hi) — second-generation glossaries, re-derived from three sources in authority order: the shipped packs (ground truth — every terminology row cites an in-pack evidence file; 89–173 verified rules per language), each pack's original PR decision write-up (#4100/#4157/#4191/#4229/#4235/#4281/#4345/#4374/#4435/#4471), and the terminology notes from today's mirror cycle (#5723). Each glossary then passed an independent verification pass that grep-audited every prescriptive claim against the pack — including that banned alternates are actually absent and that typography claims hold at the character level — applying 22–64 corrections per language. Rules carried from the lost originals that the pack cannot evidence are explicitly marked as **recorded rulings**; where a pack is internally inconsistent, the glossary documents it as a **known pack residual** (with counts and file cites) instead of pretending, leaving fixes for deliberate sweeps.
- **`glossaries/glossary-ar-draft.md`** — preserves the Arabic conventions from the RTL viewer scoping report (also lost): the orthography rules that need native QA from file 1 (hamza carriers, ة/ه, ي/ى), the ASCII-digit and backtick mandates with their renderer-level reasons, and the viewer facts #4489 shipped. Clearly marked as a pack-less draft; the ar cycle stays held.
- **`glossaries/README.md`** — ground rules: the pack is the ground truth; precedent-setting pack changes update the glossary in the same commit; the folder is contributor documentation only.
- **Branch `README.md`** — the update-a-pack recipe now starts with "read the glossary" and ends with the same-commit rule.

The `glossaries/` folder sits outside every pack directory: no manifest lists it, the app never downloads it, and pack size is unaffected.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- No pack content or manifest changed — `git diff --stat` is the 12 new files under `glossaries/` plus the README recipe edit. Nothing here affects the app, downloads, or validation.
- All ten glossaries follow the same 8-section structure (provenance → register → names → terminology table → typography → UI labels → mechanics → QA traps), so cross-language comparison is mechanical.
- The verification passes surfaced a handful of genuine maintainer calls, documented inside the relevant glossaries as open residuals rather than decided unilaterally — notably: de's single `Ratenlimit` false friend (replacement term undecided), fr's three-way naming split for image placeholders, pt-br's prose `checkout` (ledger said banned, pack is consistently English — the glossary describes the pack and flags the conflict), and pt-br's missing `sourceCommit` in its manifest (needs a rebuild with `--source-commit` someday).
- **Please verify manually:** skim one glossary in your language(s) of comfort for tone/accuracy if desired; the terminology tables are the load-bearing part.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

Contributor documentation on the `docs-i18n` branch only — no user-facing docs, no CHANGELOG (the branch carries none). Optional follow-up: a one-line pointer to `glossaries/` from `CONTRIBUTING.md § Translated documentation` on `staging` could ride any future staging PR.

## UI evidence (if applicable)

Not applicable — contributor documentation only; nothing is rendered in the app.
