### PR TITLE
feat: support Claude Mythos 5.1 on Anthropic connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added Claude Mythos 5.1 support for Anthropic connections, including its 1M-token context window, 128k output limit, adaptive-thinking behavior, and automatic fallback when a preset requests unsupported forced tool use (#5735).
 - Added Home Widgets settings to control the URL bar and desktop or mobile bookmarks on other tabs.
 - Added character cards to Persona selection so you can play as any saved character in Conversation and Roleplay setup or an active chat.
 - Added an opt-in setting to show character identities in Persona pickers, with collapsed folder navigation and identity transition notices.

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -205,6 +205,7 @@ export const ANTHROPIC_MODELS: KnownModel[] = [
   { id: "claude-opus-5", name: "claude-opus-5", context: 1000000, maxOutput: 128000 },
   { id: "claude-sonnet-5", name: "claude-sonnet-5", context: 1000000, maxOutput: 128000 },
   { id: "claude-fable-5", name: "claude-fable-5", context: 1000000, maxOutput: 128000 },
+  { id: "claude-mythos-5-1", name: "claude-mythos-5-1 (limited access)", context: 1000000, maxOutput: 128000 },
   { id: "claude-mythos-5", name: "claude-mythos-5 (limited access)", context: 1000000, maxOutput: 128000 },
   { id: "claude-opus-4-8", name: "claude-opus-4-8", context: 1000000, maxOutput: 128000 },
   { id: "claude-opus-4-7", name: "claude-opus-4-7", context: 1000000, maxOutput: 128000 },

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -848,6 +848,16 @@ assert.equal(
   "mythos",
 );
 assert.deepEqual(anthropicMythosBody.tool_choice, { type: "auto" });
+const anthropicMythos51Body: Record<string, unknown> = { thinking: { type: "adaptive" } };
+assert.equal(
+  applyAnthropicToolChoice(anthropicMythos51Body, {
+    model: "claude-mythos-5-1",
+    toolChoice: "required",
+    tools: [testToolDefinition],
+  }),
+  "mythos",
+);
+assert.deepEqual(anthropicMythos51Body.tool_choice, { type: "auto" });
 const anthropicAutomaticBody: Record<string, unknown> = {
   tool_choice: { type: "any", disable_parallel_tool_use: true },
 };
@@ -864,6 +874,12 @@ assert.equal(supportsAnthropicThinkingDisable("claude-sonnet-5"), true);
 assert.equal(supportsAnthropicThinkingDisable("claude-opus-5"), true);
 assert.equal(supportsAnthropicThinkingDisable("claude-fable-5"), false);
 assert.equal(isClaudeAdaptiveOnlyNoSamplingModel("claude-opus-5"), true);
+assert.equal(isClaudeAdaptiveOnlyNoSamplingModel("claude-mythos-5-1"), true);
+assert.equal(supportsAnthropicThinkingDisable("claude-mythos-5-1"), false);
+assert.equal(shouldSuppressUnknownModelParameters("anthropic", "claude-mythos-5-1"), false);
+const mythos51 = findKnownModel("anthropic", "claude-mythos-5-1");
+assert.equal(mythos51?.context, 1_000_000);
+assert.equal(mythos51?.maxOutput, 128_000);
 const opus5 = findKnownModel("anthropic", "claude-opus-5");
 assert.equal(opus5?.context, 1_000_000);
 assert.equal(opus5?.maxOutput, 128_000);


### PR DESCRIPTION
## Linked issue

Closes #5735

## Why this change

- Anthropic connections currently treat Claude Mythos 5.1 as unknown, so Marinara does not expose its documented limits or consistently apply known-model request behavior.

## What changed

- Registered claude-mythos-5-1 for native Anthropic connections with its documented 1M-token context window and 128k output limit.
- Reused the existing Mythos compatibility path: adaptive-only reasoning, no unsupported thinking-disable request, no sampling parameters, and automatic tool choice when a preset asks for a forced call.
- Added exact-ID provider regression coverage and an Unreleased changelog entry.

## Validation

- [ ] pnpm check passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed CONTRIBUTING.md

Automated evidence:

- pnpm check: passed locally.
- pnpm build:shared && node ./scripts/run-regressions.mjs --filter scripts/regressions/provider-compat.regression.ts: 1/1 passed.
- Regression confirms claude-mythos-5-1 is known at 1M/128k, remains adaptive-only, rejects thinking disable, and converts required tool choice to auto.

### Manual verification notes

- The local client and server started successfully.
- No controllable browser was available in this session, so the model-picker click-through was not claimed.
- A live completion was not attempted because Claude Mythos 5.1 requires Project Glasswing approval and credentials.
- Manually verify the model appears under an Anthropic connection as claude-mythos-5-1 (limited access).
- Manually verify an approved Project Glasswing account can complete a text request.
- Manually verify a forced-tool preset falls back to automatic tool choice instead of receiving an Anthropic 400 response.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the docs-i18n branch updated to match, or a docs-i18n follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

The provider reference does not enumerate individual model IDs, so no user-facing docs change is needed. CHANGELOG.md is updated. No release metadata changed.

## UI evidence (if applicable)

- No new component or layout. The existing model picker renders the shared model catalog entry.

## Source

- Anthropic migration guide: https://platform.claude.com/docs/en/models/fable-5-1/migration-guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the limited-access Claude Mythos 5.1 model in Anthropic connections.
  * Supports a 1M-token context window and up to 128K output tokens.
  * Enables adaptive thinking and automatically falls back when forced tool use is unsupported.

* **Bug Fixes**
  * Improved compatibility for tool selection and model-specific request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->