### PR TITLE
feat: support Claude Fable 5.1 on Anthropic connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
-- Added Claude Mythos 5.1 support for Anthropic connections, including its 1M-token context window, 128k output limit, adaptive-thinking behavior, and automatic fallback when a preset requests unsupported forced tool use (#5735).
+- Added Claude Fable 5.1 and Claude Mythos 5.1 support for Anthropic connections, including their 1M-token context windows, 128k output limits, adaptive-thinking behavior, and automatic fallback when a preset requests unsupported forced tool use (#5735, #5737).
 - Added Home Widgets settings to control the URL bar and desktop or mobile bookmarks on other tabs.
 - Added character cards to Persona selection so you can play as any saved character in Conversation and Roleplay setup or an active chat.
 - Added an opt-in setting to show character identities in Persona pickers, with collapsed folder navigation and identity transition notices.

--- a/packages/server/src/services/llm/providers/anthropic.provider.ts
+++ b/packages/server/src/services/llm/providers/anthropic.provider.ts
@@ -141,7 +141,7 @@ function formatAnthropicTools(tools: LLMToolDefinition[] | undefined): Array<Rec
 export function applyAnthropicToolChoice(
   body: Record<string, unknown>,
   options: Pick<ChatOptions, "model" | "toolChoice" | "tools">,
-): "applied" | "manual-thinking" | "mythos" | "none" {
+): "applied" | "manual-thinking" | "automatic-only" | "none" {
   if (!options.tools?.length) {
     delete body.tool_choice;
     return "none";
@@ -156,9 +156,10 @@ export function applyAnthropicToolChoice(
     return "none";
   }
 
-  if (options.model.toLowerCase().includes("mythos")) {
+  const model = options.model.toLowerCase();
+  if (model.includes("mythos") || model === "claude-fable-5-1") {
     setToolChoiceType("auto");
-    return "mythos";
+    return "automatic-only";
   }
   const thinking = isRecord(body.thinking) ? body.thinking : null;
   if (thinking?.type === "enabled") {
@@ -424,8 +425,11 @@ export class AnthropicProvider extends BaseLLMProvider {
       logger.warn(
         "Anthropic manual extended thinking does not support forced tool use; falling back to automatic tool choice",
       );
-    } else if (toolChoiceResult === "mythos") {
-      logger.warn("Claude Mythos does not support forced tool use; falling back to automatic tool choice");
+    } else if (toolChoiceResult === "automatic-only") {
+      logger.warn(
+        "Claude model %s does not support forced tool use; falling back to automatic tool choice",
+        options.model,
+      );
     }
 
     const response = await llmFetch(url, {

--- a/packages/server/src/services/llm/providers/anthropic.provider.ts
+++ b/packages/server/src/services/llm/providers/anthropic.provider.ts
@@ -13,7 +13,11 @@ import {
   type LLMToolDefinition,
   type LLMUsage,
 } from "../base-provider.js";
-import { isClaudeAdaptiveOnlyNoSamplingModel, shouldSuppressUnknownModelParameters } from "@marinara-engine/shared";
+import {
+  findKnownModel,
+  isClaudeAdaptiveOnlyNoSamplingModel,
+  shouldSuppressUnknownModelParameters,
+} from "@marinara-engine/shared";
 import { logger } from "../../../lib/logger.js";
 
 const DEFAULT_CACHING_AT_DEPTH = 5;
@@ -72,7 +76,10 @@ function applyAdaptiveThinkingConfig(
   body.thinking = { type: "adaptive", display: "summarized" };
   body.output_config = { effort: options.reasoningEffort ?? "high" };
   if (typeof visibleMaxTokens === "number" && Number.isFinite(visibleMaxTokens) && visibleMaxTokens > 0) {
-    body.max_tokens = Math.floor(visibleMaxTokens) + resolveAdaptiveThinkingHeadroom(options, visibleMaxTokens);
+    const requestedMaxTokens =
+      Math.floor(visibleMaxTokens) + resolveAdaptiveThinkingHeadroom(options, visibleMaxTokens);
+    const modelMaxOutput = findKnownModel("anthropic", options.model)?.maxOutput;
+    body.max_tokens = modelMaxOutput ? Math.min(requestedMaxTokens, modelMaxOutput) : requestedMaxTokens;
   }
 }
 

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -204,6 +204,7 @@ export const OPENAI_MODELS: KnownModel[] = [
 export const ANTHROPIC_MODELS: KnownModel[] = [
   { id: "claude-opus-5", name: "claude-opus-5", context: 1000000, maxOutput: 128000 },
   { id: "claude-sonnet-5", name: "claude-sonnet-5", context: 1000000, maxOutput: 128000 },
+  { id: "claude-fable-5-1", name: "claude-fable-5-1", context: 1000000, maxOutput: 128000 },
   { id: "claude-fable-5", name: "claude-fable-5", context: 1000000, maxOutput: 128000 },
   { id: "claude-mythos-5-1", name: "claude-mythos-5-1 (limited access)", context: 1000000, maxOutput: 128000 },
   { id: "claude-mythos-5", name: "claude-mythos-5 (limited access)", context: 1000000, maxOutput: 128000 },

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -845,7 +845,7 @@ assert.equal(
     toolChoice: "required",
     tools: [testToolDefinition],
   }),
-  "mythos",
+  "automatic-only",
 );
 assert.deepEqual(anthropicMythosBody.tool_choice, { type: "auto" });
 const anthropicMythos51Body: Record<string, unknown> = { thinking: { type: "adaptive" } };
@@ -855,9 +855,29 @@ assert.equal(
     toolChoice: "required",
     tools: [testToolDefinition],
   }),
-  "mythos",
+  "automatic-only",
 );
 assert.deepEqual(anthropicMythos51Body.tool_choice, { type: "auto" });
+const anthropicFableBody: Record<string, unknown> = { thinking: { type: "adaptive" } };
+assert.equal(
+  applyAnthropicToolChoice(anthropicFableBody, {
+    model: "claude-fable-5",
+    toolChoice: "required",
+    tools: [testToolDefinition],
+  }),
+  "applied",
+);
+assert.deepEqual(anthropicFableBody.tool_choice, { type: "any" });
+const anthropicFable51Body: Record<string, unknown> = { thinking: { type: "adaptive" } };
+assert.equal(
+  applyAnthropicToolChoice(anthropicFable51Body, {
+    model: "claude-fable-5-1",
+    toolChoice: "required",
+    tools: [testToolDefinition],
+  }),
+  "automatic-only",
+);
+assert.deepEqual(anthropicFable51Body.tool_choice, { type: "auto" });
 const anthropicAutomaticBody: Record<string, unknown> = {
   tool_choice: { type: "any", disable_parallel_tool_use: true },
 };
@@ -874,6 +894,12 @@ assert.equal(supportsAnthropicThinkingDisable("claude-sonnet-5"), true);
 assert.equal(supportsAnthropicThinkingDisable("claude-opus-5"), true);
 assert.equal(supportsAnthropicThinkingDisable("claude-fable-5"), false);
 assert.equal(isClaudeAdaptiveOnlyNoSamplingModel("claude-opus-5"), true);
+assert.equal(isClaudeAdaptiveOnlyNoSamplingModel("claude-fable-5-1"), true);
+assert.equal(supportsAnthropicThinkingDisable("claude-fable-5-1"), false);
+assert.equal(shouldSuppressUnknownModelParameters("anthropic", "claude-fable-5-1"), false);
+const fable51 = findKnownModel("anthropic", "claude-fable-5-1");
+assert.equal(fable51?.context, 1_000_000);
+assert.equal(fable51?.maxOutput, 128_000);
 assert.equal(isClaudeAdaptiveOnlyNoSamplingModel("claude-mythos-5-1"), true);
 assert.equal(supportsAnthropicThinkingDisable("claude-mythos-5-1"), false);
 assert.equal(shouldSuppressUnknownModelParameters("anthropic", "claude-mythos-5-1"), false);

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -1057,6 +1057,17 @@ assert.equal(
     assert.equal("temperature" in disabledBody, false);
     assert.equal("top_k" in disabledBody, false);
     assert.equal("top_p" in disabledBody, false);
+
+    await collectProviderOutput(provider, {
+      model: "claude-fable-5-1",
+      stream: false,
+      maxTokens: 128_000,
+      captureReasoning: true,
+      reasoningEffort: "max",
+    });
+    const fableMaxOutputBody = anthropicRequestBodies[2];
+    assert.ok(fableMaxOutputBody);
+    assert.equal(fableMaxOutputBody.max_tokens, 128_000);
   } finally {
     await new Promise<void>((resolve, reject) => anthropicServer.close((error) => (error ? reject(error) : resolve())));
   }


### PR DESCRIPTION
## Linked issue

Closes #5737

## Why this change

- Claude Fable 5.1 was omitted from the preceding Claude 5.1 support work, leaving the ordinary non-gated model unknown to native Anthropic connections.

## What changed

- Register `claude-fable-5-1` on native Anthropic connections with its 1M context window and 128k output limit.
- Apply its documented automatic-only tool-choice behavior while preserving Claude Fable 5 required-tool behavior.
- Add exact-model regression coverage for model discovery, adaptive thinking, parameter handling, and tool choice.
- Update the Unreleased changelog entry.

## Validation

- [ ] pnpm check passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed CONTRIBUTING.md

### Automated evidence

- `pnpm build:shared && node ./scripts/run-regressions.mjs --filter scripts/regressions/provider-compat.regression.ts` — passed (1/1).
- `pnpm check` — passed, including formatting, lint, localization, type checks, and production builds.

### Manual verification notes

A live Anthropic request was not made locally because no provider credential is available in the test environment. Please manually verify:

- Claude Fable 5.1 appears under an Anthropic connection.
- A Fable 5.1 text request succeeds.
- A forced-tool preset falls back to automatic tool choice instead of receiving an Anthropic 400 response.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the docs-i18n branch updated to match, or a docs-i18n follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing provider documentation enumerates individual Anthropic model IDs; the changelog is updated. No version bump is included.

## UI evidence (if applicable)

Existing model-picker presentation only; no new UI component, copy, or layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Claude Fable 5.1 with a 1M-token context window and 128k output limit.
  - Expanded Anthropic model support to include Claude Fable 5.1 alongside Claude Mythos 5.1.
  - Added adaptive-thinking support and automatic fallback when forced tool use is unavailable.

- **Bug Fixes**
  - Improved tool-choice handling and fallback messaging across supported Anthropic models.
  - Prevented requests from exceeding supported output limits.
  - Improved Claude Fable 5.1 compatibility, including reasoning and parameter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->