### PR TITLE
fix: sync Home Widgets chrome toggles per installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Added Claude Fable 5.1 and Claude Mythos 5.1 support for Anthropic connections, including their 1M-token context windows, 128k output limits, adaptive-thinking behavior, and automatic fallback when a preset requests unsupported forced tool use (#5735, #5737).
 - Added Home Widgets settings to control the URL bar and desktop or mobile bookmarks on other tabs.
+- Home Widgets URL bar and bookmark toggles now save per installation and apply across browsers and devices connected to that installation.
 - Added character cards to Persona selection so you can play as any saved character in Conversation and Roleplay setup or an active chat.
 - Added an opt-in setting to show character identities in Persona pickers, with collapsed folder navigation and identity transition notices.
 

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -1265,6 +1265,9 @@ function normalizePersistedMainSurface(persisted: Record<string, unknown>) {
  */
 export function pickSyncedSettings(state: UIState) {
   return {
+    showHomeBrowserAddressBar: state.showHomeBrowserAddressBar,
+    showHomeBrowserDesktopBookmarksOnOtherTabs: state.showHomeBrowserDesktopBookmarksOnOtherTabs,
+    showHomeBrowserMobileBookmarksOnOtherTabs: state.showHomeBrowserMobileBookmarksOnOtherTabs,
     sidebarOpen: state.sidebarOpen,
     sidebarWidth: state.sidebarWidth,
     trackerPanelEnabled: state.trackerPanelEnabled,

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -7312,10 +7312,28 @@ assert.match(
 );
 const projectionState = {
   ...useUIStore.getState(),
+  showHomeBrowserAddressBar: false,
+  showHomeBrowserDesktopBookmarksOnOtherTabs: false,
+  showHomeBrowserMobileBookmarksOnOtherTabs: false,
   enterToSendGame: false,
   enterToSendProfessorMari: false,
   chatHelpSeenModes: ["game"] as ChatMode[],
 };
+assert.equal(
+  pickSyncedSettings(projectionState).showHomeBrowserAddressBar,
+  false,
+  "Home URL bar visibility must be saved per installation",
+);
+assert.equal(
+  pickSyncedSettings(projectionState).showHomeBrowserDesktopBookmarksOnOtherTabs,
+  false,
+  "Home desktop bookmark visibility must be saved per installation",
+);
+assert.equal(
+  pickSyncedSettings(projectionState).showHomeBrowserMobileBookmarksOnOtherTabs,
+  false,
+  "Home mobile bookmark visibility must be saved per installation",
+);
 assert.equal(
   pickSyncedSettings(projectionState).enterToSendGame,
   false,


### PR DESCRIPTION
$## Linked issue\n\nCloses #5761\n\n## Why this change\n\n- Home Widgets URL bar and bookmark toggles were saved only in browser-local Zustand state. Users expected these installation settings to apply across browsers and devices.\n\n## What changed\n\n- Added the URL bar visibility setting to the server-synced UI settings projection.\n- Added desktop and mobile other-tab bookmark visibility to the same projection.\n- Added regression assertions for all three values.\n- Added the required Unreleased changelog entry.\n\n## Validation\n\n- [ ] `pnpm check` passes locally\n- [ ] Container (Docker / Podman) built and ran without issue\n- [ ] Ran the app, clicked through the changes manually\n- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)\n- [ ] Above manual verification completed (describe below)\n- [ ] Read and followed `CONTRIBUTING.md`\n\n### Manual verification notes\n\n- Automated validation completed. Browser, container, and manual verification remain for the human contributor.\n\n## Docs and release impact\n\n- [ ] No docs changes needed\n- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed\n- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)\n- [ ] Version/release files updated (only if this PR includes a version bump)\n\n## UI evidence (if applicable)\n\n- Manual browser evidence is still required for this UI setting change.\n\n## Proof\n\n- `pnpm check` reached the client build but exceeded the initial 120-second command limit.\n- `pnpm build` passed with the extended timeout.\n- Focused open-issue regression passed.\n- `pnpm lint` passed.\n- Prettier and localization checks passed.\n\n<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Home browser address-bar and bookmark visibility preferences now sync across browsers and devices connected to the same installation.
  - These preferences are saved per installation and persist between sessions.

- **Tests**
  - Added regression coverage to verify synchronization of Home browser display settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->