### PR TITLE
fix(connections): read NanoGPT model limits from its detailed catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- NanoGPT connections now read each model's context window and output limit from the provider catalog, so the model picker and the auto-filled Max Context Window show real values instead of 0 for models that are not covered by the built-in aggregator fallback (#5770).
 - Lorebook entries are no longer inserted twice when a preset has more than one lorebook marker (#5716): each world-info position (Before / After) is now placed by the first marker that covers it, so a second "Lorebook Marker (All)" placeholder - or an "All" marker following a "Before" marker - no longer repeats the same entries in the prompt.
 - Mobile connection drag previews now retain the configured Chat Chrome Text Color, and the Roleplay quick switcher context progress bar follows Accent Color (#5758).
 - Professor Mari can no longer answer her own permission question (#5748): once she asks whether to apply a change, that question is binding for the rest of the run - any edit she stages afterwards is held behind the Accept action instead of executing, and a hidden follow-up edit is refused with guidance. Previously an ask that rode alongside an `apply:false` preview left the engine nothing to hold, so she could pivot to applying unasked one round later ("to show you the review card"). Dry-run previews now tell her, truthfully, that the user cannot see them, and "propose your edits" maps to one described-and-held proposal instead of a preview plus a second full generation.

--- a/packages/shared/src/constants/providers.ts
+++ b/packages/shared/src/constants/providers.ts
@@ -136,7 +136,8 @@ export const PROVIDERS: Record<APIProvider, ProviderDefinition> = {
     id: "nanogpt",
     name: "NanoGPT",
     defaultBaseUrl: "https://nano-gpt.com/api/v1",
-    modelsEndpoint: "/models",
+    // Detailed catalog: the plain one omits context_length and max_output_tokens.
+    modelsEndpoint: "/models?detailed=true",
     supportsStreaming: true,
     usesAuthHeader: true,
     apiKeyHeader: null,


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5770

## Why this change

- NanoGPT connections report `Context: 0` and `Max Output: 0` for most models, so Max Context Window is never auto-filled and users have to guess the limit by hand. On `inception/mercury-2.5-preview` the real window is 260K, and a user who typed 128K was silently losing half of it.
- `model-lists.ts` already declares the intent — `nanogpt: []` with the comment "models fetched dynamically via API" — but the request Marinara sends is NanoGPT's plain catalog, whose entries carry only `id`, `object`, `created` and `owned_by`. There are no limits in that response to read.
- Today only models whose unqualified id also exists in the built-in aggregator fallback (OpenAI, Anthropic, Google, DeepSeek, MiMo, Moonshot, Z.AI, xAI) resolve limits. Every other vendor resolves to zero, and the only alternative to this fix is adding vendors to a static list by hand, which is what the aggregator design deliberately avoids.

## What changed

- `packages/shared/src/constants/providers.ts`: NanoGPT's `modelsEndpoint` now requests the detailed catalog (`/models?detailed=true`). No other provider is affected.
- No parsing change: `readOpenAICompatibleModelLimits` in `connections.routes.ts` already reads `context_length` and `max_output_tokens`, which are exactly the fields the detailed catalog adds.
- The detailed catalog also supplies `name`, so the model dropdown stops rendering the id twice (`inception/mercury-2.5-preview (inception/mercury-2.5-preview)` becomes `Mercury 2.5 Preview`).
- CHANGELOG entry under `[Unreleased] → Fixed`.

Measured, on the current catalog of 622 models: 609 now resolve a context window and 597 an output limit, against none before.

Notes for reviewers:

- The detailed catalog is larger — 60 KB against 7.6 KB on the wire with compression, 675 KB against 58 KB decoded, and about 0.8 s slower per fetch. Both figures sit well under the 5 MiB cap on the model-list request.
- The same field also feeds the connection test, whose response cap is 2 MiB rather than 5 MiB. The current response is 675 KB, so there is roughly a threefold margin, but the catalog grows over time. If reviewers prefer to remove that exposure, the connection test can keep using the plain catalog since it only checks credentials; that would need a separate field or a special case in the URL builder, so it is deliberately not in this PR.
- Putting a query string in a field named `modelsEndpoint` is new for this file: every other provider uses a bare path. Both consumers concatenate the value onto a base URL with trailing slashes stripped, and both produce a valid URL. Happy to move it to a dedicated field if the convention matters more than the diff size.
- NanoGPT ignores unknown query parameters and answers with the plain catalog, so if the flag ever disappears upstream this degrades to today's behavior instead of breaking the model list.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Verified in a desktop browser against a real NanoGPT connection, on this branch:

- **Fetch Models from API** on a NanoGPT text connection loads the catalog as before.
- `inception/mercury-2.5-preview` now reports `Context: 260K` and `Max Output: 65536`, where it previously reported `Context: 0  Max Output: 0`.
- The model dropdown renders `Mercury 2.5 Preview` instead of repeating the id twice.
- **Max Context Window** is auto-filled from the selected model instead of staying at a hand-typed value.
- **Test connection** still succeeds on the same connection, which is the path that also uses this endpoint.
- An untouched provider (OpenRouter) still lists models and limits exactly as before.

`pnpm check` passes locally on this branch (impeccable, localization, format, lint, e2e types, build).

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)
<img width="752" height="355" alt="image" src="https://github.com/user-attachments/assets/a44d1315-519f-4f5b-884a-6b59cc937728" />
<img width="742" height="214" alt="image" src="https://github.com/user-attachments/assets/0da56299-5eae-4b64-bf4b-cab4558acad0" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed NanoGPT model connections so context window and output limits are populated with accurate values.
  * The model picker and automatically filled Max Context Window field no longer display 0 for supported models.
* **Documentation**
  * Added an Unreleased changelog entry describing the NanoGPT connection fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->