### PR TITLE
[NOTICE] Outside contributors: please hold new pull requests until ~September 16

### DIFF
--- a/.github/OUTSIDE-PR-HOLD-NOTICE.md
+++ b/.github/OUTSIDE-PR-HOLD-NOTICE.md
@@ -1,0 +1,9 @@
+# Notice: outside pull requests are on hold until ~September 16, 2026
+
+If you are not a Pasta-Devs member, please hold off on opening new pull requests until @SpicyMarinara returns from vacation.
+
+Only @SpicyMarinara can approve and merge pull requests from outside contributors (enforced by the required "Owner approval for outside contributors" check - there is no bypass). Until she is back, outside PRs cannot be merged and each submission still consumes CI minutes and CodeRabbit review quota.
+
+Bug reports and feature requests in Issues remain very welcome - a Pasta-Devs member can often land the fix without waiting.
+
+See the announcement issue for details. This file is removed when the hold lifts.


### PR DESCRIPTION
﻿**TL;DR: If you are not a Pasta-Devs member, please hold off on opening new pull requests until @SpicyMarinara returns from vacation (around September 16).**

## Why

Only @SpicyMarinara has the rights to approve and merge pull requests from outside contributors. This is enforced by the repository's required "Owner approval for outside contributors" check - no other maintainer can satisfy it, and there is no bypass. She is on vacation for roughly the next two weeks.

Until she is back:

- Outside PRs cannot be merged, no matter how good they are - they will sit unmergeable in the queue.
- Every submission still consumes CI minutes and CodeRabbit review quota, which delays the reviews the team can actually act on and is already causing workflow delays.

## What you can still do

- **Bug reports and feature requests in Issues are very welcome.** They cost no review quota, and a Pasta-Devs member can often land the fix without waiting - a recent report went from issue to merged-track fix the same day (#5756).
- Keep your work on a branch in your fork and open the PR once the hold lifts.

Already-open outside PRs will be handled case-by-case - see #5757 for an example of a fix adopted by a member (with full credit preserved) so it did not have to wait.

This notice will be closed when the hold lifts. Thank you for your patience, and sorry for the inconvenience - the contributions themselves are appreciated.

---

*This is a placeholder PR kept in **draft** so the notice is visible at the top of the pull request list (drafts do not trigger CodeRabbit reviews). It is not meant to be merged - it will be closed when the hold lifts. The announcement issue is #5779.*

