### PR TITLE
test(ui): fix the flaky preset accent spec by waiting for the editor dirty flag

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -116,6 +116,28 @@ async function readCssVariableColor(page: Page, variableName: string) {
   }, variableName);
 }
 
+/**
+ * Detail editors mirror their unsaved-changes flag into the UI store, and the
+ * header's back button branches on it: while the flag is still false the
+ * click CLOSES the editor instead of raising the unsaved warning, unmounting
+ * the very shell the following assertions look inside (#5788). Waiting for
+ * the app's own signal turns "typed, so it must be dirty by now" into a
+ * deterministic wait. A timeout here is a real defect - the edit never
+ * registered - not a flake.
+ */
+async function waitForEditorDirty(page: Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(async () => {
+        const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
+          useUIStore: { getState: () => { editorDirty: boolean } };
+        };
+        return useUIStore.getState().editorDirty;
+      }),
+    )
+    .toBe(true);
+}
+
 async function readScopedCssVariableColor(scope: Locator, variableName: string) {
   return scope.evaluate((element, name) => {
     const probe = document.createElement("span");
@@ -8409,9 +8431,12 @@ test("preset import and save-export feedback follow the active accent", async ({
     await editor.getByTitle("Save current edits before exporting", { exact: true }).click();
     const exportDialog = page.getByRole("dialog", { name: /Save before exporting/u });
     await expect(exportDialog).toBeVisible();
+    // The "Changes saved" toast auto-dismisses after 1500ms, so the accent is
+    // read BEFORE the save is triggered: a round trip spent here would come
+    // straight out of the window the visibility assertion has to catch it in.
+    const expectedEditorAccent = await readScopedCssVariableColor(editor, "--marinara-editor-accent");
     await exportDialog.getByRole("button", { name: "Save and export", exact: true }).click();
 
-    const expectedEditorAccent = await readScopedCssVariableColor(editor, "--marinara-editor-accent");
     const savedFeedback = editor.getByText("Changes saved", { exact: true });
     await expect(savedFeedback).toBeVisible();
     await expect(savedFeedback).toHaveCSS("color", expectedEditorAccent);
@@ -8421,6 +8446,7 @@ test("preset import and save-export feedback follow the active accent", async ({
     });
 
     await titleInput.fill(`Unsaved Theme Feedback ${suffix}`);
+    await waitForEditorDirty(page);
     await editor.locator(".mari-editor-header-main > button").first().click();
     const unsavedFeedback = editor.getByText("You have unsaved changes.", { exact: true }).locator("..");
     await expect(unsavedFeedback).toBeVisible();


### PR DESCRIPTION
## Linked issue

Closes #5788

## Why this change

- This spec has failed on `mobile-webkit` across at least three unrelated PRs (#5755, #5787, and one full-matrix rerun), each time costing a rerun cycle on work that never touched the preset surface. It is the single most disruptive flake in the suite right now.
- The issue text (which I filed) guessed at "a toast that unmounts between the click and the assertion". The CI log says otherwise: the mechanism is not a vanishing toast but the editor closing itself, which is worth correcting on the record since the wrong guess would have produced a fix that changed nothing.

## What the failure actually is

The failing assertion is the **unsaved-changes warning**, and the error is `element(s) not found` rather than a visibility timeout:

```
Locator: locator('.mari-editor-shell').getByText('You have unsaved changes.', { exact: true }).locator('..')
Error: element(s) not found
  8377 |  await editor.locator(".mari-editor-header-main > button").first().click();
> 8379 |  await expect(unsavedFeedback).toBeVisible();
```

The editor's back button branches on the dirty flag (`PresetEditor.tsx`):

```ts
const handleClose = useCallback(() => {
  if (dirty) { setShowUnsavedWarning(true); return; }
  closePresetDetail();          // ← closes outright, unmounting .mari-editor-shell
}, [dirty, closePresetDetail]);
```

So the spec's `fill()` → immediate `click()` is a race against the app committing the edit. When the dirty flag has not registered yet, the click takes the **not-dirty** branch: the editor closes, the whole shell unmounts, and the following assertion finds nothing at all — exactly the reported error, and exactly why a rerun "fixes" it. `setDirty(false)` exists in only one place (the save handler), so a stale flag at click time is the only path to this failure.

## What changed

- **New `waitForEditorDirty(page)` helper**: detail editors mirror their unsaved-changes flag into the UI store (`editorDirty` — documented there as "True when any open detail editor has unsaved changes"), which is the same flag the back button branches on. The spec now waits for the app's own signal instead of assuming a keystroke is already committed. Note the failure semantics improve too: if the edit genuinely never registers, this now fails deterministically at the wait with a clear cause, instead of intermittently three assertions later.
- **Deliberately not applied to the lorebook spec.** `Lorebook vectorization saves pending eligibility settings first` runs the same fill → back-button → expect-warning shape against the same store flag, so it looked like the same latent flake. It isn't: that flow edits the field earlier and cancels out of a dialog without saving (the spec asserts the save count is unchanged), so the editor is *already* dirty by the time it clicks back. A wait there would pass instantly and protect nothing, so it is left alone rather than added as decoration.
- **Pre-read the accent before triggering the save** in the preset spec. The "Changes saved" toast auto-dismisses after 1500ms (`setTimeout(() => setShowSaved(false), 1500)`), and the spec was spending a `page.evaluate` round trip inside that window before asserting the toast is visible. That is a second, latent flake of the same family in the same test; reading the accent first costs nothing and removes it.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `npx tsc --noEmit -p tsconfig.json` (the `check:e2e-types` leg) and Prettier both pass.
- The preset spec was run locally with the fix: **13 consecutive passes on `mobile-webkit`** (8 + 5 across two runs) and **3 on `desktop-chromium`**, since the spec runs on all three projects.
- **Honest limitation**: I could not reproduce the failure locally — it passed 6/6 before the fix on this machine, because the race needs a loaded CI shard where the app is slower to commit than Playwright is to click. The diagnosis therefore rests on the CI log's own evidence (the failing locator plus the `handleClose` branch that is the only way to produce it), not on a local red-to-green transition. The real proof will be this spec staying green across the matrix over the coming weeks.
- No CHANGELOG entry: test-only changes here don't take one (matching e.g. `b2c412e4a`, `34d1f7f41`).

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable — end-to-end test changes only, no product code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by waiting for unsaved editor changes to be recognized before navigating away.
  * Updated export-flow checks to capture the editor’s accent color before saving, improving validation of the saved result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->