### PR TITLE
Fix mobile Roleplay action state and Peek Prompt separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Mobile message-action icons no longer keep an iPhone-only hover color after being tapped, and Peek Prompt now shows a readable middle dot between its section and estimated-token totals (#5825).
 - Mobile chat overlays stay usable around the software keyboard: focused toolbar menus remain inside the visible viewport while editing, and chats with Echo Chamber leave enough top scroll clearance to keep Load More tappable below its collapsed window (#5817, #5822).
 - The button that applies changes Mari is holding for your approval is no longer labelled as a suggestion (#5820). It sat under the caption "Suggestions only. Pick one, or type your own.", which told you the one control that applies her pending edits was optional - so it looked like she had quietly done nothing. The row now says she is waiting for approval and that nothing has been changed yet, and a "Don't apply" button sits next to Accept so declining is a click rather than a typed sentence.
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2092,27 +2092,29 @@ test("mobile Roleplay Peek prompt keeps its tapped action visible and labels pro
 }, testInfo) => {
   test.skip(!testInfo.project.name.includes("mobile"), "The sticky action state is mobile-only.");
 
-  const chatResponse = await page.request.post("/api/chats", {
-    data: { name: "Mobile Roleplay Peek Prompt Smoke", mode: "roleplay", characterIds: [] },
-  });
-  expect(chatResponse.ok(), await chatResponse.text()).toBeTruthy();
-  const chat = (await chatResponse.json()) as { id: string };
-  const messageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
-    data: {
-      role: "assistant",
-      content: "A mobile prompt action remains within reach.",
-      extra: {
-        cachedPrompt: [
-          { role: "system", content: "Stay in character." },
-          { role: "user", content: "Continue the scene." },
-        ],
-      },
-    },
-  });
-  expect(messageResponse.ok(), await messageResponse.text()).toBeTruthy();
-  const message = (await messageResponse.json()) as { id: string };
-
+  let chatId: string | null = null;
   try {
+    const chatResponse = await page.request.post("/api/chats", {
+      data: { name: "Mobile Roleplay Peek Prompt Smoke", mode: "roleplay", characterIds: [] },
+    });
+    expect(chatResponse.ok(), await chatResponse.text()).toBeTruthy();
+    const chat = (await chatResponse.json()) as { id: string };
+    chatId = chat.id;
+    const messageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
+      data: {
+        role: "assistant",
+        content: "A mobile prompt action remains within reach.",
+        extra: {
+          cachedPrompt: [
+            { role: "system", content: "Stay in character." },
+            { role: "user", content: "Continue the scene." },
+          ],
+        },
+      },
+    });
+    expect(messageResponse.ok(), await messageResponse.text()).toBeTruthy();
+    const message = (await messageResponse.json()) as { id: string };
+
     await prepareFreshClient(page);
     await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
     await page.goto("/");
@@ -2146,7 +2148,7 @@ test("mobile Roleplay Peek prompt keeps its tapped action visible and labels pro
       contentType: "image/png",
     });
   } finally {
-    await bestEffortDelete(page.request, `/api/chats/${chat.id}?force=true`);
+    if (chatId) await bestEffortDelete(page.request, `/api/chats/${chatId}?force=true`);
   }
 });
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2086,6 +2086,69 @@ test("mobile Roleplay context and edit controls keep their chrome and space", as
   }
 });
 
+test("mobile Roleplay Peek prompt keeps its tapped action visible and labels prompt totals clearly", async ({
+  page,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.includes("mobile"), "The sticky action state is mobile-only.");
+
+  const chatResponse = await page.request.post("/api/chats", {
+    data: { name: "Mobile Roleplay Peek Prompt Smoke", mode: "roleplay", characterIds: [] },
+  });
+  expect(chatResponse.ok(), await chatResponse.text()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+  const messageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
+    data: {
+      role: "assistant",
+      content: "A mobile prompt action remains within reach.",
+      extra: {
+        cachedPrompt: [
+          { role: "system", content: "Stay in character." },
+          { role: "user", content: "Continue the scene." },
+        ],
+      },
+    },
+  });
+  expect(messageResponse.ok(), await messageResponse.text()).toBeTruthy();
+  const message = (await messageResponse.json()) as { id: string };
+
+  try {
+    await prepareFreshClient(page);
+    await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
+    await page.goto("/");
+    await page.evaluate(async () => {
+      const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
+        useUIStore: { getState: () => { setChatChromeTextColor: (value: string) => void } };
+      };
+      useUIStore.getState().setChatChromeTextColor("#14b8a6");
+    });
+
+    const messageRow = page.locator(`[data-message-id="${message.id}"]`);
+    await messageRow.scrollIntoViewIfNeeded();
+    await messageRow.dispatchEvent("click");
+    const peekPrompt = messageRow.getByRole("button", { name: "Peek prompt", exact: true });
+    const copy = messageRow.getByRole("button", { name: "Copy", exact: true });
+    await expect(peekPrompt).toBeVisible();
+    await expect(copy).toBeVisible();
+    const actionColor = await readCssVariableColor(page, "--marinara-chat-message-action-text");
+    await expect(peekPrompt).toHaveCSS("color", actionColor);
+
+    await peekPrompt.tap();
+    await expect(page.getByRole("heading", { name: "Assembled Prompt" })).toBeVisible();
+    await expect(page.getByText(/^2 sections · ~\d+ tokens$/u)).toBeVisible();
+    await expect(page.getByText(/&middot;/u)).toHaveCount(0);
+    await expect(peekPrompt).toBeAttached();
+    await expect(peekPrompt).toHaveCSS("color", actionColor);
+    await expect(copy).toHaveCSS("color", actionColor);
+
+    await testInfo.attach(`mobile-roleplay-peek-prompt-${testInfo.project.name}.png`, {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+  } finally {
+    await bestEffortDelete(page.request, `/api/chats/${chat.id}?force=true`);
+  }
+});
+
 test("mobile Conversation editing exposes the final line before text changes", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("mobile"), "The mobile message-editor scroll buffer is mobile-only.");
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -204,8 +204,9 @@ async function openEditorSection(editor: Locator, label: string) {
   const navigation = editor.getByRole("navigation", { name: "Editor sections" });
   const desktopRail = editor.locator(".mari-editor-tab-rail");
   await expect
-    .poll(async () =>
-      (await compactMenuButton.isVisible()) || (await navigation.isVisible()) || (await desktopRail.isVisible()),
+    .poll(
+      async () =>
+        (await compactMenuButton.isVisible()) || (await navigation.isVisible()) || (await desktopRail.isVisible()),
     )
     .toBe(true);
   if (await compactMenuButton.isVisible()) {
@@ -19687,9 +19688,7 @@ test("mobile chat composer follows the visual viewport above the software keyboa
       .poll(() =>
         page.evaluate(() => ({
           height: getComputedStyle(document.documentElement).getPropertyValue("--mari-visual-viewport-height").trim(),
-          top: getComputedStyle(document.documentElement)
-            .getPropertyValue("--mari-visual-viewport-offset-top")
-            .trim(),
+          top: getComputedStyle(document.documentElement).getPropertyValue("--mari-visual-viewport-offset-top").trim(),
         })),
       )
       .toEqual({ height: "360px", top: `${iosFocusPageTop}px` });

--- a/packages/client/src/components/chat/MessageActionButton.tsx
+++ b/packages/client/src/components/chat/MessageActionButton.tsx
@@ -42,7 +42,7 @@ export function MessageActionButton({
       tabIndex={tabIndex}
       className={cn(
         "inline-flex h-[1.7em] w-[1.7em] shrink-0 items-center justify-center rounded-md p-0 text-[0.8125rem] leading-none transition-all active:scale-90 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-30",
-        "text-[var(--marinara-chat-message-action-text)] hover:bg-[var(--marinara-chat-message-action-bg-hover)] hover:text-[var(--marinara-chat-message-action-text-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]",
+        "text-[var(--marinara-chat-message-action-text)] [@media(pointer:fine)]:hover:bg-[var(--marinara-chat-message-action-bg-hover)] [@media(pointer:fine)]:hover:text-[var(--marinara-chat-message-action-text-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]",
         className,
       )}
     >

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -4004,7 +4004,7 @@
   "ui.chat.peekpromptmodal.cacheWrite": "cache write",
   "ui.chat.peekpromptmodal.closeAssembledPrompt": "Close assembled prompt",
   "ui.chat.peekpromptmodal.estTokens": "est. tokens",
-  "ui.chat.peekpromptmodal.middot": "&middot; ~",
+  "ui.chat.peekpromptmodal.middot": "· ~",
   "ui.chat.peekpromptmodal.note": "Note:",
   "ui.chat.peekpromptmodal.section": "section",
   "ui.chat.personapicker.characterSource": "Character",

--- a/packages/client/src/localization/locales/zh-Hans.json
+++ b/packages/client/src/localization/locales/zh-Hans.json
@@ -3722,7 +3722,7 @@
   "ui.chat.peekpromptmodal.cacheWrite": "写入缓存",
   "ui.chat.peekpromptmodal.closeAssembledPrompt": "关闭组装后的提示词",
   "ui.chat.peekpromptmodal.estTokens": "估算 token",
-  "ui.chat.peekpromptmodal.middot": "&middot; 约",
+  "ui.chat.peekpromptmodal.middot": "· 约",
   "ui.chat.peekpromptmodal.note": "注意：",
   "ui.chat.peekpromptmodal.section": "个部分",
   "ui.chat.personapicker.noMatchingPersonas": "没有匹配的人设。",


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #5825

## Why this change

- On iPhone, WebKit can retain a tapped Roleplay message action's hover styling, causing that one icon to disappear under some chat-chrome color combinations.
- Peek Prompt renders the HTML entity name `&middot;` as user-facing text instead of showing a readable separator.

## What changed

- Add a mobile WebKit regression for the tapped Peek Prompt action and assembled-prompt totals.
- Restrict message-action hover colors to devices with real hover support.
- Replace the escaped entity label with a visible middle-dot separator.

## Validation

- `pnpm check`
- `pnpm exec playwright test -c playwright.config.ts e2e/core-flows.e2e.ts --project mobile-webkit --grep "mobile Roleplay Peek prompt keeps"`
- `pnpm exec playwright test -c playwright.config.ts e2e/core-flows.e2e.ts --project mobile-chromium --grep "mobile Roleplay Peek prompt keeps"`

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify on iPhone that tapping Peek Prompt leaves its message action visible after the prompt viewer opens and closes.
- Manually verify Peek Prompt displays `sections · ~tokens` without an HTML entity name.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- The passing mobile Chromium and WebKit regression runs captured the open Peek Prompt over a still-visible action row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed mobile message-action icons retaining hover colors after being tapped.
  - Improved Peek Prompt totals formatting with a readable middle dot separator between sections and estimated tokens.
  - Ensured Peek Prompt actions remain attached and retain their color after tapping on mobile devices.
- **Localization**
  - Updated English and Simplified Chinese separators to use the correct middle dot character.
- **Tests**
  - Added mobile end-to-end coverage for Peek Prompt behavior, action colors, and totals formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->