### PR TITLE
fix(ui): move agent bulk connection action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Allowed trusted backend scheduler calls to execute their own capability routes without a browser `X-Admin-Secret`, while keeping external package route requests protected.
 - Prevented profile preview tokens from being sent over non-local HTTP connections.
 - Moved the desktop right-panel resize hit area away from the main chat scrollbar.
+- Moved the agent connection bulk assignment control from the Agents panel to Connections -> Defaults -> Agents.
 
 ### Added
 

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -17,7 +17,6 @@ import {
   Download,
   Check,
   FolderPlus,
-  Loader2,
   ArrowUpDown,
   ShieldCheck,
   TriangleAlert,
@@ -30,14 +29,9 @@ import {
   useDeleteAgent,
   useAgentImportPolicy,
   useImportAgent,
-  useUpdateAgent,
-  useUpdateAgentByType,
   useUploadAgentImage,
   type AgentConfigRow,
 } from "../../hooks/use-agents";
-import { useConnections } from "../../hooks/use-connections";
-import { appendLocalSidecarConnectionOption, type ConnectionProviderLike } from "../../lib/connection-filters";
-import { useSidecarStore } from "../../stores/sidecar.store";
 import {
   useCapabilityAgentRegistry,
   useCapabilityCatalog,
@@ -228,13 +222,6 @@ export function AgentsPanel() {
   const { data: capabilityCatalog } = useCapabilityCatalog();
   const createAgent = useCreateAgent();
   const importAgent = useImportAgent();
-  const updateAgent = useUpdateAgent();
-  const updateAgentByType = useUpdateAgentByType();
-  const { data: connectionsList } = useConnections();
-  const sidecarModelDownloaded = useSidecarStore((state) => state.modelDownloaded);
-  const sidecarModelDisplayName = useSidecarStore((state) => state.modelDisplayName);
-  const [bulkConnectionId, setBulkConnectionId] = useState("");
-  const [bulkAssigning, setBulkAssigning] = useState(false);
   const { data: agentImportPolicy, isLoading: agentImportPolicyLoading } = useAgentImportPolicy();
   const deleteAgent = useDeleteAgent();
   const uninstallCapabilityPackage = useUninstallCapabilityPackage();
@@ -347,64 +334,6 @@ export function AgentsPanel() {
     () => availableBuiltInAgents.filter((agent) => !deletedBuiltInTypes.has(agent.id)),
     [availableBuiltInAgents, deletedBuiltInTypes],
   );
-  // Bulk connection assignment (#5539): connection options plus the sidecar
-  // pseudo-connection, mirroring the per-agent picker in the Agent editor.
-  // The connections endpoint is untyped at the hook; the loose structural
-  // ConnectionProviderLike shape is what the filter helpers are built for.
-  const bulkConnectionOptions = useMemo(
-    () =>
-      appendLocalSidecarConnectionOption(
-        (connectionsList ?? []) as ConnectionProviderLike[],
-        import.meta.env.VITE_MARINARA_LITE !== "true" && sidecarModelDownloaded,
-        sidecarModelDisplayName,
-      ),
-    [connectionsList, sidecarModelDownloaded, sidecarModelDisplayName],
-  );
-  const customAgentConfigs = useMemo(
-    () => visibleAgentConfigs.filter((config) => !builtInAgentIds.has(config.type)),
-    [visibleAgentConfigs, builtInAgentIds],
-  );
-  const bulkAssignTargetCount = visibleBuiltInAgents.length + customAgentConfigs.length;
-
-  const handleBulkAssignConnection = async () => {
-    if (bulkAssigning || bulkAssignTargetCount === 0) return;
-    const nextConnectionId = bulkConnectionId || null;
-    const optionName = bulkConnectionId
-      ? (bulkConnectionOptions.find((option) => option.id === bulkConnectionId)?.name ?? bulkConnectionId)
-      : localizeUi("ui.panels.agentspanel.bulkConnectionAgentDefault");
-    const confirmed = await showConfirmDialog({
-      title: localizeUi("ui.panels.agentspanel.bulkConnectionApply"),
-      message: localizeUi("ui.panels.agentspanel.bulkConnectionConfirm", {
-        value1: String(bulkAssignTargetCount),
-        value2: optionName,
-      }),
-    });
-    if (!confirmed) return;
-    setBulkAssigning(true);
-    try {
-      // By type for installed package agents (creates missing config rows);
-      // by id for custom agents, which exist only as config rows. PATCH only
-      // the connection so agent settings are never clobbered.
-      await Promise.all([
-        ...visibleBuiltInAgents.map((agent) =>
-          updateAgentByType.mutateAsync({ agentType: agent.id, connectionId: nextConnectionId }),
-        ),
-        ...customAgentConfigs.map((config) =>
-          updateAgent.mutateAsync({ id: config.id, connectionId: nextConnectionId }),
-        ),
-      ]);
-      toast.success(
-        localizeUi("ui.panels.agentspanel.bulkConnectionDone", {
-          value1: String(bulkAssignTargetCount),
-          value2: optionName,
-        }),
-      );
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : localizeUi("ui.panels.agentspanel.bulkConnectionFailed"));
-    } finally {
-      setBulkAssigning(false);
-    }
-  };
   // Custom agents = DB entries whose type doesn't match any built-in
   const customAgents = useMemo(
     () =>
@@ -1147,36 +1076,6 @@ export function AgentsPanel() {
           title={localizeUi("ui.panels.agentspanel.selectAgents")}
         >
           <Check size="0.8125rem" />
-        </button>
-      </div>
-
-      <div className="flex items-center gap-2">
-        <select
-          value={bulkConnectionId}
-          onChange={(event) => setBulkConnectionId(event.target.value)}
-          disabled={bulkAssigning || bulkAssignTargetCount === 0}
-          className="mari-chrome-field h-8 min-w-0 flex-1 px-2 py-0 text-[0.6875rem]"
-          aria-label={localizeUi("ui.panels.agentspanel.bulkConnectionLabel")}
-        >
-          <option value="">{localizeUi("ui.panels.agentspanel.bulkConnectionAgentDefault")}</option>
-          {bulkConnectionOptions.map((connection) => (
-            <option key={connection.id ?? ""} value={connection.id ?? ""}>
-              {connection.name}
-            </option>
-          ))}
-        </select>
-        <button
-          type="button"
-          onClick={() => void handleBulkAssignConnection()}
-          disabled={bulkAssigning || bulkAssignTargetCount === 0}
-          className="mari-chrome-control mari-chrome-control--small h-8 min-h-0 shrink-0 px-2 text-[0.6875rem]"
-          title={localizeUi("ui.panels.agentspanel.bulkConnectionLabel")}
-        >
-          {bulkAssigning ? (
-            <Loader2 size="0.75rem" className="animate-spin" />
-          ) : (
-            localizeUi("ui.panels.agentspanel.bulkConnectionApply")
-          )}
         </button>
       </div>
 

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -32,7 +32,7 @@ import {
 } from "../../hooks/use-connection-folders";
 import { handleFolderRenameKeyDown, useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { useTouchFolderDrag } from "../../hooks/use-touch-folder-drag";
-import { useAgentConfigs, useCreateAgent, useUpdateAgent } from "../../hooks/use-agents";
+import { useAgentConfigs, useCreateAgent, useUpdateAgent, useUpdateAgentByType } from "../../hooks/use-agents";
 import {
   selectVisibleTrackerCapabilityAgents,
   useCapabilityAgentRegistry,
@@ -43,7 +43,10 @@ import { useUIStore, type ConnectionPanelSort } from "../../stores/ui.store";
 import { GEMMA_RESTART_MESSAGE, useSidecarStore } from "../../stores/sidecar.store";
 import {
   LOCAL_SIDECAR_CONNECTION_ID,
+  BUILT_IN_AGENTS,
   getDefaultAgentPrompt,
+  isAgentConfigDeleted,
+  isRetiredBuiltInAgentId,
   type ConnectionFolder,
   type SidecarSpeechModelId,
   type SidecarSpeechRuntimeDiagnostics,
@@ -807,6 +810,9 @@ function ConnectionDefaultPair({
   fallbackModelLabel,
   includeLocalSidecar,
   showPaidConnectionWarningToggle = false,
+  onApplyToAllAgents,
+  applyingToAllAgents = false,
+  canApplyToAllAgents = true,
 }: {
   title: string;
   icon: ReactNode;
@@ -820,6 +826,9 @@ function ConnectionDefaultPair({
    *  writes the sidecar config's useAsAgentsDefault instead. */
   includeLocalSidecar?: boolean;
   showPaidConnectionWarningToggle?: boolean;
+  onApplyToAllAgents?: () => void;
+  applyingToAllAgents?: boolean;
+  canApplyToAllAgents?: boolean;
 }) {
   const { t: localizeUi } = useUiTranslation();
   const openConnectionDetail = useUIStore((state) => state.openConnectionDetail);
@@ -974,6 +983,21 @@ function ConnectionDefaultPair({
               help={localizeUi("ui.panels.connectiondefaultssection.showPaidConnectionWarningHelp")}
             />
           )}
+          {onApplyToAllAgents && (
+            <button
+              type="button"
+              onClick={onApplyToAllAgents}
+              disabled={applyingToAllAgents || updateConnection.isPending || !canApplyToAllAgents}
+              className="mari-chrome-control mari-chrome-control--small w-fit text-[0.6875rem]"
+              title={localizeUi("ui.panels.agentspanel.bulkConnectionLabel")}
+            >
+              {applyingToAllAgents ? (
+                <Loader2 size="0.75rem" className="animate-spin" />
+              ) : (
+                localizeUi("ui.panels.agentspanel.bulkConnectionApply")
+              )}
+            </button>
+          )}
         </div>
       </div>
     </div>
@@ -1006,6 +1030,72 @@ function ConnectionDefaultsSection({ connectionsList }: { connectionsList: Conne
     () => connectionsList.filter((connection) => connection.provider === "audio"),
     [connectionsList],
   );
+  const { data: agentConfigs } = useAgentConfigs();
+  const { data: capabilityAgents } = useCapabilityAgentRegistry();
+  const updateAgent = useUpdateAgent();
+  const updateAgentByType = useUpdateAgentByType();
+  const sidecarAsAgentsDefault = useSidecarStore((state) => state.config.useAsAgentsDefault);
+  const sidecarModelDisplayName = useSidecarStore((state) => state.modelDisplayName);
+  const [applyingToAllAgents, setApplyingToAllAgents] = useState(false);
+  const agentConnection =
+    languageConnections.find((connection) => isEnabledConnectionRole(connection.defaultForAgents)) ?? null;
+  const effectiveAgentConnectionId = sidecarAsAgentsDefault
+    ? LOCAL_SIDECAR_CONNECTION_ID
+    : (agentConnection?.id ?? null);
+  const agentConnectionName = sidecarAsAgentsDefault
+    ? createLocalSidecarConnectionOption(sidecarModelDisplayName).name
+    : (agentConnection?.name ?? localizeUi("ui.panels.agentspanel.bulkConnectionAgentDefault"));
+  const builtInAgentIds = useMemo(() => new Set((capabilityAgents ?? []).map((agent) => agent.id)), [capabilityAgents]);
+  const visibleBuiltInAgents = useMemo(
+    () =>
+      BUILT_IN_AGENTS.filter((agent) => builtInAgentIds.has(agent.id)).filter(
+        (agent) => !isAgentConfigDeleted((agentConfigs ?? []).find((config) => config.type === agent.id)?.settings),
+      ),
+    [agentConfigs, builtInAgentIds],
+  );
+  const customAgentConfigs = useMemo(
+    () =>
+      (agentConfigs ?? []).filter(
+        (config) =>
+          !builtInAgentIds.has(config.type) &&
+          !isRetiredBuiltInAgentId(config.type) &&
+          !isAgentConfigDeleted(config.settings),
+      ),
+    [agentConfigs, builtInAgentIds],
+  );
+  const handleApplyToAllAgents = async () => {
+    const targetCount = visibleBuiltInAgents.length + customAgentConfigs.length;
+    if (applyingToAllAgents || targetCount === 0) return;
+    const confirmed = await showConfirmDialog({
+      title: localizeUi("ui.panels.agentspanel.bulkConnectionApply"),
+      message: localizeUi("ui.panels.agentspanel.bulkConnectionConfirm", {
+        value1: String(targetCount),
+        value2: agentConnectionName,
+      }),
+    });
+    if (!confirmed) return;
+    setApplyingToAllAgents(true);
+    try {
+      await Promise.all([
+        ...visibleBuiltInAgents.map((agent) =>
+          updateAgentByType.mutateAsync({ agentType: agent.id, connectionId: effectiveAgentConnectionId }),
+        ),
+        ...customAgentConfigs.map((config) =>
+          updateAgent.mutateAsync({ id: config.id, connectionId: effectiveAgentConnectionId }),
+        ),
+      ]);
+      toast.success(
+        localizeUi("ui.panels.agentspanel.bulkConnectionDone", {
+          value1: String(targetCount),
+          value2: agentConnectionName,
+        }),
+      );
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : localizeUi("ui.panels.agentspanel.bulkConnectionFailed"));
+    } finally {
+      setApplyingToAllAgents(false);
+    }
+  };
 
   return (
     <section
@@ -1063,6 +1153,9 @@ function ConnectionDefaultsSection({ connectionsList }: { connectionsList: Conne
             fallbackModelLabel="No model set"
             includeLocalSidecar
             showPaidConnectionWarningToggle
+            onApplyToAllAgents={() => void handleApplyToAllAgents()}
+            applyingToAllAgents={applyingToAllAgents}
+            canApplyToAllAgents={visibleBuiltInAgents.length + customAgentConfigs.length > 0}
           />
           <ConnectionDefaultPair
             title={localizeUi("ui.panels.connectiondefaultssection.images")}

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -1030,7 +1030,7 @@ function ConnectionDefaultsSection({ connectionsList }: { connectionsList: Conne
     () => connectionsList.filter((connection) => connection.provider === "audio"),
     [connectionsList],
   );
-  const { data: agentConfigs } = useAgentConfigs();
+  const { data: agentConfigs, isLoading: agentConfigsLoading, isError: agentConfigsError } = useAgentConfigs();
   const {
     data: capabilityAgents,
     isLoading: capabilityAgentsLoading,
@@ -1039,10 +1039,14 @@ function ConnectionDefaultsSection({ connectionsList }: { connectionsList: Conne
   const updateAgent = useUpdateAgent();
   const updateAgentByType = useUpdateAgentByType();
   const sidecarAsAgentsDefault = useSidecarStore((state) => state.config.useAsAgentsDefault);
+  const sidecarModelDownloaded = useSidecarStore((state) => state.modelDownloaded);
   const sidecarModelDisplayName = useSidecarStore((state) => state.modelDisplayName);
   const [applyingToAllAgents, setApplyingToAllAgents] = useState(false);
   const capabilityAgentRegistryReady =
     !capabilityAgentsLoading && !capabilityAgentsError && capabilityAgents !== undefined;
+  const agentConfigsReady = !agentConfigsLoading && !agentConfigsError && agentConfigs !== undefined;
+  const agentAssignmentReady =
+    capabilityAgentRegistryReady && agentConfigsReady && (!sidecarAsAgentsDefault || sidecarModelDownloaded);
   const agentConnection =
     languageConnections.find((connection) => isEnabledConnectionRole(connection.defaultForAgents)) ?? null;
   const effectiveAgentConnectionId = sidecarAsAgentsDefault
@@ -1071,7 +1075,7 @@ function ConnectionDefaultsSection({ connectionsList }: { connectionsList: Conne
   );
   const handleApplyToAllAgents = async () => {
     const targetCount = visibleBuiltInAgents.length + customAgentConfigs.length;
-    if (applyingToAllAgents || !capabilityAgentRegistryReady || targetCount === 0) return;
+    if (applyingToAllAgents || !agentAssignmentReady || targetCount === 0) return;
     const confirmed = await showConfirmDialog({
       title: localizeUi("ui.panels.agentspanel.bulkConnectionApply"),
       message: localizeUi("ui.panels.agentspanel.bulkConnectionConfirm", {
@@ -1163,9 +1167,7 @@ function ConnectionDefaultsSection({ connectionsList }: { connectionsList: Conne
             showPaidConnectionWarningToggle
             onApplyToAllAgents={() => void handleApplyToAllAgents()}
             applyingToAllAgents={applyingToAllAgents}
-            canApplyToAllAgents={
-              capabilityAgentRegistryReady && visibleBuiltInAgents.length + customAgentConfigs.length > 0
-            }
+            canApplyToAllAgents={agentAssignmentReady && visibleBuiltInAgents.length + customAgentConfigs.length > 0}
           />
           <ConnectionDefaultPair
             title={localizeUi("ui.panels.connectiondefaultssection.images")}

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -1031,12 +1031,18 @@ function ConnectionDefaultsSection({ connectionsList }: { connectionsList: Conne
     [connectionsList],
   );
   const { data: agentConfigs } = useAgentConfigs();
-  const { data: capabilityAgents } = useCapabilityAgentRegistry();
+  const {
+    data: capabilityAgents,
+    isLoading: capabilityAgentsLoading,
+    isError: capabilityAgentsError,
+  } = useCapabilityAgentRegistry();
   const updateAgent = useUpdateAgent();
   const updateAgentByType = useUpdateAgentByType();
   const sidecarAsAgentsDefault = useSidecarStore((state) => state.config.useAsAgentsDefault);
   const sidecarModelDisplayName = useSidecarStore((state) => state.modelDisplayName);
   const [applyingToAllAgents, setApplyingToAllAgents] = useState(false);
+  const capabilityAgentRegistryReady =
+    !capabilityAgentsLoading && !capabilityAgentsError && capabilityAgents !== undefined;
   const agentConnection =
     languageConnections.find((connection) => isEnabledConnectionRole(connection.defaultForAgents)) ?? null;
   const effectiveAgentConnectionId = sidecarAsAgentsDefault
@@ -1065,7 +1071,7 @@ function ConnectionDefaultsSection({ connectionsList }: { connectionsList: Conne
   );
   const handleApplyToAllAgents = async () => {
     const targetCount = visibleBuiltInAgents.length + customAgentConfigs.length;
-    if (applyingToAllAgents || targetCount === 0) return;
+    if (applyingToAllAgents || !capabilityAgentRegistryReady || targetCount === 0) return;
     const confirmed = await showConfirmDialog({
       title: localizeUi("ui.panels.agentspanel.bulkConnectionApply"),
       message: localizeUi("ui.panels.agentspanel.bulkConnectionConfirm", {
@@ -1076,7 +1082,7 @@ function ConnectionDefaultsSection({ connectionsList }: { connectionsList: Conne
     if (!confirmed) return;
     setApplyingToAllAgents(true);
     try {
-      await Promise.all([
+      const results = await Promise.allSettled([
         ...visibleBuiltInAgents.map((agent) =>
           updateAgentByType.mutateAsync({ agentType: agent.id, connectionId: effectiveAgentConnectionId }),
         ),
@@ -1084,6 +1090,8 @@ function ConnectionDefaultsSection({ connectionsList }: { connectionsList: Conne
           updateAgent.mutateAsync({ id: config.id, connectionId: effectiveAgentConnectionId }),
         ),
       ]);
+      const rejected = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
+      if (rejected) throw rejected.reason;
       toast.success(
         localizeUi("ui.panels.agentspanel.bulkConnectionDone", {
           value1: String(targetCount),
@@ -1155,7 +1163,9 @@ function ConnectionDefaultsSection({ connectionsList }: { connectionsList: Conne
             showPaidConnectionWarningToggle
             onApplyToAllAgents={() => void handleApplyToAllAgents()}
             applyingToAllAgents={applyingToAllAgents}
-            canApplyToAllAgents={visibleBuiltInAgents.length + customAgentConfigs.length > 0}
+            canApplyToAllAgents={
+              capabilityAgentRegistryReady && visibleBuiltInAgents.length + customAgentConfigs.length > 0
+            }
           />
           <ConnectionDefaultPair
             title={localizeUi("ui.panels.connectiondefaultssection.images")}

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -1045,13 +1045,16 @@ function ConnectionDefaultsSection({ connectionsList }: { connectionsList: Conne
   const capabilityAgentRegistryReady =
     !capabilityAgentsLoading && !capabilityAgentsError && capabilityAgents !== undefined;
   const agentConfigsReady = !agentConfigsLoading && !agentConfigsError && agentConfigs !== undefined;
-  const agentAssignmentReady =
-    capabilityAgentRegistryReady && agentConfigsReady && (!sidecarAsAgentsDefault || sidecarModelDownloaded);
   const agentConnection =
     languageConnections.find((connection) => isEnabledConnectionRole(connection.defaultForAgents)) ?? null;
   const effectiveAgentConnectionId = sidecarAsAgentsDefault
     ? LOCAL_SIDECAR_CONNECTION_ID
     : (agentConnection?.id ?? null);
+  const agentAssignmentReady =
+    capabilityAgentRegistryReady &&
+    agentConfigsReady &&
+    effectiveAgentConnectionId !== null &&
+    (!sidecarAsAgentsDefault || sidecarModelDownloaded);
   const agentConnectionName = sidecarAsAgentsDefault
     ? createLocalSidecarConnectionOption(sidecarModelDisplayName).name
     : (agentConnection?.name ?? localizeUi("ui.panels.agentspanel.bulkConnectionAgentDefault"));
@@ -1075,7 +1078,8 @@ function ConnectionDefaultsSection({ connectionsList }: { connectionsList: Conne
   );
   const handleApplyToAllAgents = async () => {
     const targetCount = visibleBuiltInAgents.length + customAgentConfigs.length;
-    if (applyingToAllAgents || !agentAssignmentReady || targetCount === 0) return;
+    if (applyingToAllAgents || !agentAssignmentReady || effectiveAgentConnectionId === null || targetCount === 0)
+      return;
     const confirmed = await showConfirmDialog({
       title: localizeUi("ui.panels.agentspanel.bulkConnectionApply"),
       message: localizeUi("ui.panels.agentspanel.bulkConnectionConfirm", {


### PR DESCRIPTION
## Linked issue
Closes #5828

## Why this change
The Agents sidepanel duplicated the connection default workflow with its own selector and bulk action. Users should manage the default connection and its bulk application from Connections -> Defaults -> Agents.

## What changed
- Removed the connection selector and Apply to all action from the Agents sidepanel.
- Added Apply to all under Connections -> Defaults -> Agents.
- Applied the selected default connection to visible built-in and custom agents without changing other agent settings.
- Kept local sidecar support.
- Added the change to CHANGELOG.md.

## Validation
- [ ] pnpm check passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed CONTRIBUTING.md

### Manual verification notes
- Local CodeRabbit review completed.
- Full pnpm check completed locally.
- Browser, container, and mobile manual verification remain for the maintainer.

## Docs and release impact
- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the docs-i18n branch updated to match, or a [docs-i18n] follow-up issue opened
- [ ] Version/release files updated

## UI evidence
Not attached. Manual browser evidence remains pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option in **Connections → Defaults → Agents** to apply the selected default connection to all visible built-in and custom agents.
  - Added confirmation prompts before bulk assignment, with success or failure notifications.
- **Changes**
  - Moved bulk connection assignment controls from the **Agents** panel to the connection defaults section.
  - The Agents panel no longer provides bulk connection assignment controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->