### PR TITLE
feat: move Noodle image settings to package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- Moved Noodle and Slurp image canvas settings out of Engine Settings and into their respective package settings.
+
 - Fixed PNG metadata decompression, Nano Banana full-body image requests, GPT Image 2 OpenRouter routing, capability swipe timestamps, and bounded import uploads.
 - Allowed trusted backend scheduler calls to execute their own capability routes without a browser `X-Admin-Secret`, while keeping external package route requests protected.
 - Prevented profile preview tokens from being sent over non-local HTTP connections.

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -7217,7 +7217,7 @@ test("legacy browser records are cleaned while extension imports stay locked", a
         };
       }),
     )
-    .toEqual({ version: 98, hasExtensionRecords: false, hasCleanupFlag: false });
+    .toEqual({ version: 99, hasExtensionRecords: false, hasCleanupFlag: false });
 
   expect(
     await page.evaluate(

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -899,14 +899,6 @@ const SETTINGS_SEARCHABLE_CONTROLS: readonly SettingsSearchableControlMeta[] = [
     kind: "Input",
   },
   {
-    id: "image-noodle-size",
-    sectionId: "image-generation",
-    label: "Noodle image size",
-    description: "Set default Noodle timeline image dimensions.",
-    aliases: ["image", "resolution", "canvas", "noodle", "timeline"],
-    kind: "Input",
-  },
-  {
     id: "image-game-size",
     sectionId: "image-generation",
     label: "Game scene image size",
@@ -3967,9 +3959,6 @@ function ImageGenerationSettings() {
   const imageIllustrationWidth = useUIStore((s) => s.imageIllustrationWidth);
   const imageIllustrationHeight = useUIStore((s) => s.imageIllustrationHeight);
   const setImageIllustrationDimensions = useUIStore((s) => s.setImageIllustrationDimensions);
-  const imageNoodleWidth = useUIStore((s) => s.imageNoodleWidth);
-  const imageNoodleHeight = useUIStore((s) => s.imageNoodleHeight);
-  const setImageNoodleDimensions = useUIStore((s) => s.setImageNoodleDimensions);
   const imageGameWidth = useUIStore((s) => s.imageGameWidth);
   const imageGameHeight = useUIStore((s) => s.imageGameHeight);
   const setImageGameDimensions = useUIStore((s) => s.setImageGameDimensions);
@@ -4005,14 +3994,6 @@ function ImageGenerationSettings() {
           width={imageIllustrationWidth}
           height={imageIllustrationHeight}
           onCommit={setImageIllustrationDimensions}
-        />
-        <ImageDimensionRow
-          controlId="image-noodle-size"
-          label={localizeUi("settings.controls.noodleGeneration.label")}
-          help={localizeUi("settings.controls.noodleGeneration.help")}
-          width={imageNoodleWidth}
-          height={imageNoodleHeight}
-          onCommit={setImageNoodleDimensions}
         />
         <ImageDimensionRow
           controlId="image-game-size"

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -2610,7 +2610,7 @@ export const useUIStore = create<UIState>()(
     {
       name: "marinara-engine-ui",
       // v97 -> v98: add Home browser chrome visibility settings.
-      version: 98,
+      version: 99,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -742,8 +742,6 @@ interface UIState {
   imageBackgroundHeight: number;
   imageIllustrationWidth: number;
   imageIllustrationHeight: number;
-  imageNoodleWidth: number;
-  imageNoodleHeight: number;
   imageGameWidth: number;
   imageGameHeight: number;
   imagePortraitWidth: number;
@@ -1088,7 +1086,6 @@ interface UIState {
   setReviewImagePromptsBeforeSend: (v: boolean) => void;
   setImageBackgroundDimensions: (width: number, height: number) => void;
   setImageIllustrationDimensions: (width: number, height: number) => void;
-  setImageNoodleDimensions: (width: number, height: number) => void;
   setImageGameDimensions: (width: number, height: number) => void;
   setImagePortraitDimensions: (width: number, height: number) => void;
   setImageSelfieDimensions: (width: number, height: number) => void;
@@ -1310,8 +1307,6 @@ export function pickSyncedSettings(state: UIState) {
     imageBackgroundHeight: state.imageBackgroundHeight,
     imageIllustrationWidth: state.imageIllustrationWidth,
     imageIllustrationHeight: state.imageIllustrationHeight,
-    imageNoodleWidth: state.imageNoodleWidth,
-    imageNoodleHeight: state.imageNoodleHeight,
     imageGameWidth: state.imageGameWidth,
     imageGameHeight: state.imageGameHeight,
     imagePortraitWidth: state.imagePortraitWidth,
@@ -1528,8 +1523,6 @@ export const useUIStore = create<UIState>()(
       imageBackgroundHeight: 720,
       imageIllustrationWidth: 896,
       imageIllustrationHeight: 1280,
-      imageNoodleWidth: 1024,
-      imageNoodleHeight: 1536,
       imageGameWidth: 1280,
       imageGameHeight: 720,
       imagePortraitWidth: 1024,
@@ -2288,11 +2281,6 @@ export const useUIStore = create<UIState>()(
           imageIllustrationWidth: clampImageDimension(width),
           imageIllustrationHeight: clampImageDimension(height),
         }),
-      setImageNoodleDimensions: (width, height) =>
-        set({
-          imageNoodleWidth: clampImageDimension(width),
-          imageNoodleHeight: clampImageDimension(height),
-        }),
       setImageGameDimensions: (width, height) =>
         set({
           imageGameWidth: clampImageDimension(width),
@@ -2667,6 +2655,19 @@ export const useUIStore = create<UIState>()(
         };
       }),
       migrate: (persisted: any, version: number) => {
+        if (version <= 98 && (persisted.imageNoodleWidth !== undefined || persisted.imageNoodleHeight !== undefined)) {
+          try {
+            localStorage.setItem(
+              "marinara:noodle:legacy-image-size",
+              JSON.stringify({
+                width: persisted.imageNoodleWidth,
+                height: persisted.imageNoodleHeight,
+              }),
+            );
+          } catch {
+            // Package settings use their defaults if browser storage is unavailable.
+          }
+        }
         if (version <= 97) {
           if (persisted.showHomeBrowserAddressBar === undefined) persisted.showHomeBrowserAddressBar = true;
           if (persisted.showHomeBrowserDesktopBookmarksOnOtherTabs === undefined) {
@@ -3194,11 +3195,6 @@ export const useUIStore = create<UIState>()(
         if (version <= 88 && persisted.reduceAmbientEffects === undefined) {
           persisted.reduceAmbientEffects = false;
         }
-        // v89 -> v90: give Noodle timeline images their own provider-compatible canvas.
-        if (version <= 89) {
-          if (persisted.imageNoodleWidth === undefined) persisted.imageNoodleWidth = 1024;
-          if (persisted.imageNoodleHeight === undefined) persisted.imageNoodleHeight = 1536;
-        }
         // v90 -> v91: make the Home navigation assistant an explicit, default-on preference.
         if (version <= 90 && persisted.professorMariNavigationEnabled === undefined) {
           persisted.professorMariNavigationEnabled = true;
@@ -3328,8 +3324,6 @@ export const useUIStore = create<UIState>()(
         imageBackgroundHeight: state.imageBackgroundHeight,
         imageIllustrationWidth: state.imageIllustrationWidth,
         imageIllustrationHeight: state.imageIllustrationHeight,
-        imageNoodleWidth: state.imageNoodleWidth,
-        imageNoodleHeight: state.imageNoodleHeight,
         imageGameWidth: state.imageGameWidth,
         imageGameHeight: state.imageGameHeight,
         imagePortraitWidth: state.imagePortraitWidth,

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -2609,7 +2609,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      // v97 -> v98: add Home browser chrome visibility settings.
+      // v98 -> v99: move legacy Noodle image dimensions to package settings.
       version: 99,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {

--- a/packages/server/src/services/image/image-generation-settings.ts
+++ b/packages/server/src/services/image/image-generation-settings.ts
@@ -14,7 +14,6 @@ export interface ImageGenerationSize {
 export interface ImageGenerationUserSettings {
   background: ImageGenerationSize;
   illustration: ImageGenerationSize;
-  noodle: ImageGenerationSize;
   game: ImageGenerationSize;
   portrait: ImageGenerationSize;
   selfie: ImageGenerationSize;
@@ -27,7 +26,6 @@ const IMAGE_DIMENSION_MAX = 4096;
 const DEFAULT_IMAGE_GENERATION_SETTINGS: ImageGenerationUserSettings = {
   background: { width: 1280, height: 720 },
   illustration: { width: 896, height: 1280 },
-  noodle: { width: 1024, height: 1536 },
   game: { width: 1280, height: 720 },
   portrait: { width: 1024, height: 1024 },
   selfie: { width: 896, height: 1152 },
@@ -88,7 +86,6 @@ export function parseImageGenerationUserSettings(raw: string | null): ImageGener
         "imageIllustrationHeight",
         DEFAULT_IMAGE_GENERATION_SETTINGS.illustration,
       ),
-      noodle: readSize(parsed, "imageNoodleWidth", "imageNoodleHeight", DEFAULT_IMAGE_GENERATION_SETTINGS.noodle),
       game: readSize(parsed, "imageGameWidth", "imageGameHeight", DEFAULT_IMAGE_GENERATION_SETTINGS.game),
       portrait: readSize(
         parsed,

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -1322,11 +1322,6 @@ assert.deepEqual(resolveIllustratorImageSize({ width: 960, height: 540 }, "portr
   width: 540,
   height: 960,
 });
-assert.deepEqual(parseImageGenerationUserSettings(null).noodle, { width: 1024, height: 1536 });
-assert.deepEqual(parseImageGenerationUserSettings('{"imageNoodleWidth":1536,"imageNoodleHeight":1024}').noodle, {
-  width: 1536,
-  height: 1024,
-});
 
 const minimalProfessorMariPersona = buildPersonaCreateRow(
   { name: "Minimal helper persona" },

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -466,7 +466,7 @@ assert.match(
   "active Roleplay tracker agents should expose their saved prompt templates",
 );
 assert.match(reducedAmbientEffectsHookSource, /manualPreference \|\| systemPreference/u);
-  assert.match(uiStoreSource, /version: 98/u);
+  assert.match(uiStoreSource, /version: 99/u);
 assert.match(globalStylesSource, /data-marinara-reduced-effects/u);
 const accentTransitionStyles =
   globalStylesSource.match(


### PR DESCRIPTION
## Linked issue

Closes #5831

## Why this change

Noodle and Slurp are downloadable feature packages. Their image canvas controls belong in their own settings screens, not in generic Engine image-generation settings.

## What changed

- Removed the Noodle image-size row from Engine Settings.
- Removed the Noodle canvas fields and setter from the Engine UI store.
- Removed Noodle from the generic Engine image-settings parser.
- Added a one-time legacy browser-storage handoff for existing Noodle dimensions.
- Updated the Engine changelog and regression expectations.

## Package and security impact

- Affected package IDs: Engine host integration for noodle and slurp.
- Engine compatibility impact: None.
- New or changed permissions/entrypoints: None.
- Restart, storage, update, or uninstall impact: Existing browser settings use a one-time handoff to package settings.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm regression:prompt` passes locally
- [ ] `pnpm regression:ui` passes locally
- [ ] Manually verify the affected settings in a browser

### Manual verification notes

- Manual browser verification remains required for package settings, image generation, light/dark mode, and mobile layout.

## Documentation impact

- [x] No documentation changes needed

## UI evidence (if applicable)

- Screenshots or recordings must be added after manual browser verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Image canvas size settings for Noodle and Slurp are now managed in their respective package settings instead of Engine Settings.
  * Noodle image dimensions no longer appear among the general engine image settings.
  * Existing Noodle image-size preferences are migrated automatically to preserve user configuration.
  * Package-specific settings remain available through the relevant package configuration areas for continued control of image dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->