### PR TITLE
fix(avatars): drop the prose lead sentence for tag-grammar style profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- Avatar "Generate with AI" no longer prepends the prose sentence "Create a polished character avatar portrait for ..." when the active style profile uses Danbooru or tag grammar; the profile's avatar subject tags carry the composition, and a tag-only fallback is used when a tag profile has none. Prose and hybrid profiles are unchanged.
 - Moved Noodle and Slurp image canvas settings out of Engine Settings and into their respective package settings.
 
 - Fixed PNG metadata decompression, Nano Banana full-body image requests, GPT Image 2 OpenRouter routing, capability swipe timestamps, and bounded import uploads.

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -19,6 +19,7 @@ import {
   PROFESSOR_MARI_ID,
   CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS,
   findImageStyleProfile,
+  type ImageStyleProfile,
   MAX_FILE_SIZES,
 } from "@marinara-engine/shared";
 import type { CharacterData, ConversationCallCharacterVideoClipKind, ExportEnvelope } from "@marinara-engine/shared";

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -43,6 +43,7 @@ import { loadImageGenerationUserSettings } from "../services/image/image-generat
 import { compileImagePrompt } from "../services/image/image-prompt-compiler.js";
 import { resolveImagePromptReviewSize } from "../services/image/image-prompt-review.js";
 import { resolveImageConnectionFallback } from "../services/generation/media-connection-fallback.js";
+import { buildAvatarPortraitLeadPrompt } from "../services/image/avatar-generation-prompt.js";
 import {
   ConversationCallVideoClipAvatarMismatchError,
   ConversationCallVideoClipNotFoundError,
@@ -503,15 +504,18 @@ const CHARACTER_SHEET_HARD_NEGATIVE_PROMPT =
 async function buildAvatarGenerationPrompt(
   promptOverridesStorage: ReturnType<typeof createPromptOverridesStorage>,
   body: AvatarGenerationBody,
-  profileSubjectTags: string,
+  profile: Pick<ImageStyleProfile, "promptMode" | "subjectTags">,
 ): Promise<string> {
   const name = body.name?.trim() || "Character";
   const appearance = body.appearance?.trim() || name;
   if (body.purpose === "character-sheet") {
     return loadPrompt(promptOverridesStorage, CHARACTERS_REFERENCE_SHEET, { name, appearance });
   }
-  if (profileSubjectTags.trim()) return `Create a polished character avatar portrait for ${name}.`;
-  return `Create a polished character avatar portrait for ${name}. Composition: centered face-and-shoulders portrait, readable expression, clear silhouette, suitable as a chat avatar.`;
+  return buildAvatarPortraitLeadPrompt({
+    name,
+    profileSubjectTags: profile.subjectTags.avatar ?? "",
+    promptMode: profile.promptMode,
+  });
 }
 
 async function resolveAvatarGenerationConnection(app: FastifyInstance, body: AvatarGenerationBody) {
@@ -1130,14 +1134,13 @@ export async function charactersRoutes(app: FastifyInstance) {
     if ("error" in dimensions) return reply.status(400).send({ error: dimensions.error });
     const { width, height } = dimensions;
     const imageDefaults = resolveConnectionImageDefaults(resolved.conn);
-    const profileSubjectTags =
-      findImageStyleProfile(
-        imageSettings.styleProfiles,
-        body.styleProfileId || imageDefaults?.styleProfileId || imageSettings.styleProfiles.defaultProfileId,
-      ).subjectTags[isCharacterSheet ? "illustration" : "avatar"] ?? "";
+    const avatarStyleProfile = findImageStyleProfile(
+      imageSettings.styleProfiles,
+      body.styleProfileId || imageDefaults?.styleProfileId || imageSettings.styleProfiles.defaultProfileId,
+    );
     const compiled = compileImagePrompt({
       kind: isCharacterSheet ? "illustration" : "avatar",
-      prompt: await buildAvatarGenerationPrompt(promptOverridesStorage, body, profileSubjectTags),
+      prompt: await buildAvatarGenerationPrompt(promptOverridesStorage, body, avatarStyleProfile),
       userPositive: isCharacterSheet ? undefined : body.appearance,
       styleProfiles: imageSettings.styleProfiles,
       styleProfileId: body.styleProfileId,
@@ -1211,11 +1214,10 @@ export async function charactersRoutes(app: FastifyInstance) {
     const imgSource = conn.imageGenerationSource || imgModel;
     const imgServiceHint = conn.imageService || imgSource;
     const imageDefaults = resolveConnectionImageDefaults(conn);
-    const profileSubjectTags =
-      findImageStyleProfile(
-        imageSettings.styleProfiles,
-        body.styleProfileId || imageDefaults?.styleProfileId || imageSettings.styleProfiles.defaultProfileId,
-      ).subjectTags[isCharacterSheet ? "illustration" : "avatar"] ?? "";
+    const avatarStyleProfile = findImageStyleProfile(
+      imageSettings.styleProfiles,
+      body.styleProfileId || imageDefaults?.styleProfileId || imageSettings.styleProfiles.defaultProfileId,
+    );
     const imageFallback = await resolveImageConnectionFallback(connections, conn.id);
     const compiled = promptOverride
       ? {
@@ -1224,7 +1226,7 @@ export async function charactersRoutes(app: FastifyInstance) {
         }
       : compileImagePrompt({
           kind: isCharacterSheet ? "illustration" : "avatar",
-          prompt: await buildAvatarGenerationPrompt(promptOverridesStorage, body, profileSubjectTags),
+          prompt: await buildAvatarGenerationPrompt(promptOverridesStorage, body, avatarStyleProfile),
           userPositive: isCharacterSheet ? undefined : body.appearance,
           styleProfiles: imageSettings.styleProfiles,
           styleProfileId: body.styleProfileId,

--- a/packages/server/src/services/image/avatar-generation-prompt.ts
+++ b/packages/server/src/services/image/avatar-generation-prompt.ts
@@ -1,0 +1,23 @@
+import type { ImagePromptMode } from "@marinara-engine/shared";
+
+const AVATAR_LEAD_TAG_FALLBACK = "solo, portrait, upper body, looking at viewer, centered composition";
+
+/**
+ * Lead prompt for the avatar "Generate with AI" path, which has no prompt-writing
+ * LLM: the compiler keeps this text verbatim. Prose grammars get the classic
+ * sentence. Tag grammars (Danbooru, tags) get nothing when the profile's avatar
+ * subject tags already carry the composition, and a tag-only fallback otherwise,
+ * so a prose clause never lands inside a tag prompt.
+ */
+export function buildAvatarPortraitLeadPrompt(args: {
+  name: string;
+  profileSubjectTags: string;
+  promptMode: ImagePromptMode;
+}): string {
+  const name = args.name.trim() || "Character";
+  const hasSubjectTags = args.profileSubjectTags.trim().length > 0;
+  const taggedGrammar = args.promptMode === "danbooru" || args.promptMode === "tagged";
+  if (taggedGrammar) return hasSubjectTags ? "" : AVATAR_LEAD_TAG_FALLBACK;
+  if (hasSubjectTags) return `Create a polished character avatar portrait for ${name}.`;
+  return `Create a polished character avatar portrait for ${name}. Composition: centered face-and-shoulders portrait, readable expression, clear silhouette, suitable as a chat avatar.`;
+}

--- a/scripts/regressions/avatar-lead-prompt.regression.ts
+++ b/scripts/regressions/avatar-lead-prompt.regression.ts
@@ -1,0 +1,49 @@
+// Guards the avatar "Generate with AI" lead prompt against tag-grammar profiles.
+//
+// The avatar path has no prompt-writing LLM: its lead sentence is a fixed template that the
+// compiler keeps verbatim (avatar prompts are never compacted). With a Danbooru or tags profile
+// that sentence became a prose clause inside a tag prompt, which NovelAI and Illustrious-style
+// checkpoints treat as noise. The profile's avatar subject tags already say what the image is.
+import assert from "node:assert/strict";
+import { buildAvatarPortraitLeadPrompt } from "../../packages/server/src/services/image/avatar-generation-prompt.js";
+
+const subjectTags = "solo, upper body, looking at viewer, centered composition";
+
+// Tag grammars: the subject tags carry the composition, so no sentence is emitted.
+assert.equal(
+  buildAvatarPortraitLeadPrompt({ name: "Delaney Rhodes", profileSubjectTags: subjectTags, promptMode: "danbooru" }),
+  "",
+  "Danbooru profiles with avatar subject tags get no prose lead",
+);
+assert.equal(
+  buildAvatarPortraitLeadPrompt({ name: "Delaney Rhodes", profileSubjectTags: subjectTags, promptMode: "tagged" }),
+  "",
+  "plain tag profiles behave the same way",
+);
+
+// Tag grammars without avatar subject tags still need a composition, expressed as tags.
+const taggedFallback = buildAvatarPortraitLeadPrompt({
+  name: "Delaney Rhodes",
+  profileSubjectTags: "",
+  promptMode: "danbooru",
+});
+assert.match(taggedFallback, /^solo, /, "fallback composition is written as tags");
+assert.doesNotMatch(taggedFallback, /Create a|portrait for/i, "no prose sneaks into the tag fallback");
+assert.doesNotMatch(taggedFallback, /Delaney/, "the character name is not a tag");
+
+// Prose grammars keep the existing sentences unchanged.
+assert.equal(
+  buildAvatarPortraitLeadPrompt({ name: "Delaney Rhodes", profileSubjectTags: subjectTags, promptMode: "natural" }),
+  "Create a polished character avatar portrait for Delaney Rhodes.",
+);
+assert.equal(
+  buildAvatarPortraitLeadPrompt({ name: "Delaney Rhodes", profileSubjectTags: "", promptMode: "hybrid" }),
+  "Create a polished character avatar portrait for Delaney Rhodes. Composition: centered face-and-shoulders portrait, readable expression, clear silhouette, suitable as a chat avatar.",
+);
+assert.equal(
+  buildAvatarPortraitLeadPrompt({ name: "   ", profileSubjectTags: subjectTags, promptMode: "natural" }),
+  "Create a polished character avatar portrait for Character.",
+  "blank names fall back to the generic label",
+);
+
+console.log("Avatar lead prompt regression passed.");


### PR DESCRIPTION
Closes #5836

## Why

The avatar "Generate with AI" path has no prompt-writing LLM: it builds a fixed lead sentence and the compiler keeps it verbatim, since avatar prompts are never compacted. With a Danbooru or tag-grammar profile (Illustrious, Pony, NovelAI) that sentence, "Create a polished character avatar portrait for <name>.", becomes a prose clause inside a comma-separated tag prompt. Tag models treat it as noise, and the profile's avatar subject tags already say what the image is.

## What changed

- New `services/image/avatar-generation-prompt.ts` with a pure `buildAvatarPortraitLeadPrompt` that picks the lead by prompt grammar: tag grammars get no sentence when the profile has avatar subject tags and a tag-only composition fallback when it has none; natural and hybrid grammars keep the existing sentences unchanged.
- `characters.routes.ts` resolves the style profile once per request and passes it to the avatar prompt builder instead of only its subject tags. Character sheets still use their own prompt template and are unaffected.
- CHANGELOG entry.

## Validation

- [ ] `pnpm check`
- [ ] `node scripts/run-regressions.mjs --filter avatar-lead` (new regression covering both tag grammars with and without subject tags, both prose grammars, and the blank-name fallback)
- [ ] Manually verify in the browser: with a Danbooru profile, open a character, choose Generate with AI for the avatar, and confirm the review or debug prompt starts with the profile's subject tags followed by the appearance text, with no "Create a polished character avatar portrait" sentence
- [ ] Manually verify the same with a natural-language profile still shows the sentence
- [ ] Manually verify a character sheet generation is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGCLPpohNDc1uPX8HcKJ9v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Avatar “Generate with AI” prompts for Danbooru and tag-based style profiles.
  - Avatar prompts now use the profile’s subject tags for composition instead of adding an introductory prose sentence.
  - Added a tag-formatted fallback when tag-based profiles have no subject tags.
  - Prose and hybrid style profiles retain their existing prompt behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->