### PR TITLE
fix(mobile): stabilize chat scrolling and compact controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Mobile Roleplay keeps composer boundary drags inside the input, avoids animated press transforms on message actions, opens older-message editors at their beginning, and returns the reopened Echo Chamber to its latest message (#5851).
+- Mobile galleries keep generation labels and image actions within their available width, use neutral Delete controls, and give the Local Speech Model selector consistent spacing. Desktop layouts are unchanged (#5851).
+
 - Updated transitive Browserslist, query-string, and URI parsing dependencies to address their current security advisories (#5847).
 
 - Context Circle rings now use the configured accent color while keeping a muted background ring for separation across light and dark themes (#5840).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2147,6 +2147,15 @@ test("mobile Roleplay Peek prompt keeps its tapped action visible and labels pro
       body: await page.screenshot({ fullPage: true }),
       contentType: "image/png",
     });
+    await page.getByRole("button", { name: "Close assembled prompt", exact: true }).tap();
+    await expect(page.getByRole("heading", { name: "Assembled Prompt" })).toHaveCount(0);
+    await expect(peekPrompt.locator("svg")).toBeVisible();
+    await expect(peekPrompt).toHaveCSS("color", actionColor);
+    // A touch action must not create an animated transform layer underneath
+    // the dialog: iOS can leave that SVG layer unpainted after dismissal.
+    await expect(peekPrompt).not.toHaveCSS("transition-property", "all");
+    await peekPrompt.tap();
+    await expect(page.getByRole("heading", { name: "Assembled Prompt" })).toBeVisible();
   } finally {
     if (chatId) await bestEffortDelete(page.request, `/api/chats/${chatId}?force=true`);
   }
@@ -7576,6 +7585,7 @@ test("Gallery Illustrate offers active custom image agents", async ({ page, requ
   const activeAgentName = `Gallery Image Agent ${suffix}`;
   const inactiveAgentName = `Inactive Gallery Agent ${suffix}`;
   const createdAgentIds: string[] = [];
+  const additionalChatIds: string[] = [];
   let chatId: string | null = null;
 
   try {
@@ -7614,6 +7624,17 @@ test("Gallery Illustrate offers active custom image agents", async ({ page, requ
       data: { enableAgents: true, activeAgentIds: ["illustrator", agents[0]!.type] },
     });
     expect(metadataResponse.ok()).toBeTruthy();
+    const imageResponse = await request.post(`/api/gallery/${chat.id}/upload`, {
+      multipart: {
+        file: {
+          name: "mobile-gallery.png",
+          mimeType: "image/png",
+          buffer: Buffer.from(TRANSPARENT_PNG_BASE64, "base64"),
+        },
+        prompt: "Synthetic gallery layout probe.",
+      },
+    });
+    expect(imageResponse.ok()).toBeTruthy();
 
     await page.route("**/api/capability-packages/installed", async (route) => {
       await route.fulfill({
@@ -7679,6 +7700,41 @@ test("Gallery Illustrate offers active custom image agents", async ({ page, requ
     const illustrateButton = drawer.getByRole("button", { name: "Illustrate", exact: true });
     await expect(illustrateButton).toBeVisible();
     await expect(illustrateButton).toHaveAttribute("aria-haspopup", "menu");
+    const expectMobileGalleryControls = async (mode: string) => {
+      if (!mobile) return;
+      const originalViewport = page.viewportSize()!;
+      for (const width of [320, originalViewport.width]) {
+        await page.setViewportSize({ width, height: originalViewport.height });
+        await testInfo.attach(`gallery-layout-${mode}-${width}-${testInfo.project.name}.png`, {
+          body: await drawer.screenshot(),
+          contentType: "image/png",
+        });
+        const labels = drawer.locator(
+          ".mari-gallery-generation-actions > button > span, .mari-gallery-generation-actions > div > button > span",
+        );
+        expect(await labels.count()).toBeGreaterThan(0);
+        for (const label of await labels.all()) {
+          await expect
+            .poll(() => label.evaluate((element) => element.scrollWidth - element.clientWidth))
+            .toBeLessThanOrEqual(1);
+        }
+        const tile = drawer.getByRole("button", { name: "Open gallery image", exact: true }).locator("..");
+        const tileBox = await tile.boundingBox();
+        expect(tileBox).not.toBeNull();
+        for (const button of await tile.locator("button[aria-label]").all()) {
+          const box = await button.boundingBox();
+          expect(box).not.toBeNull();
+          expect(box!.x).toBeGreaterThanOrEqual(tileBox!.x);
+          expect(box!.x + box!.width).toBeLessThanOrEqual(tileBox!.x + tileBox!.width + 1);
+        }
+        const pin = tile.getByRole("button", { name: "Pin image to chat", exact: true });
+        await expect(tile.getByRole("button", { name: "Delete gallery image", exact: true })).toHaveCSS(
+          "color",
+          await pin.evaluate((element) => getComputedStyle(element).color),
+        );
+      }
+    };
+    await expectMobileGalleryControls("roleplay");
     await illustrateButton.click();
 
     const menu = drawer.getByRole("menu", { name: "Choose an image agent" });
@@ -7687,8 +7743,54 @@ test("Gallery Illustrate offers active custom image agents", async ({ page, requ
     await expect(menu.getByRole("menuitem", { name: inactiveAgentName, exact: true })).toHaveCount(0);
     await drawer.getByRole("searchbox", { name: "Search gallery images", exact: true }).dispatchEvent("pointerdown");
     await expect(menu).toHaveCount(0);
+    if (mobile) {
+      for (const mode of ["conversation", "game"] as const) {
+        await drawer.getByRole("button", { name: "Close gallery", exact: true }).click();
+        const response = await request.post("/api/chats", {
+          data: { name: `Mobile ${mode} gallery`, mode, characterIds: [] },
+        });
+        expect(response.ok()).toBeTruthy();
+        const nextChat = (await response.json()) as { id: string };
+        additionalChatIds.push(nextChat.id);
+        const metadata = await request.patch(`/api/chats/${nextChat.id}/metadata`, {
+          data: {
+            enableAgents: true,
+            activeAgentIds: ["illustrator", agents[0]!.type],
+            conversationCommandToggles: { selfie: true },
+            gameId: "mobile-gallery-proof",
+            gameSessionStatus: "active",
+            gameSessionNumber: 1,
+            gameIntroPresented: true,
+            enableSpriteGeneration: true,
+          },
+        });
+        expect(metadata.ok()).toBeTruthy();
+        const upload = await request.post(`/api/gallery/${nextChat.id}/upload`, {
+          multipart: {
+            file: {
+              name: "mobile-gallery.png",
+              mimeType: "image/png",
+              buffer: Buffer.from(TRANSPARENT_PNG_BASE64, "base64"),
+            },
+            prompt: "Synthetic gallery layout probe.",
+          },
+        });
+        expect(upload.ok()).toBeTruthy();
+        await page.evaluate(async (chatId) => {
+          const { useChatStore } = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
+          useChatStore.getState().setActiveChatId(chatId);
+        }, nextChat.id);
+        await expect(page.locator(`[data-chat-mode="${mode}"]`).first()).toBeVisible();
+        const gallery = page.getByRole("button", { name: "Gallery", exact: true }).filter({ visible: true });
+        if (!(await gallery.isVisible())) await page.getByRole("button", { name: "More options", exact: true }).click();
+        await gallery.click();
+        await expect(drawer.getByRole("button", { name: "Open gallery image", exact: true })).toBeVisible();
+        await expectMobileGalleryControls(mode);
+      }
+    }
   } finally {
     if (chatId) await request.delete(`/api/chats/${chatId}`).catch(() => undefined);
+    await Promise.all(additionalChatIds.map((id) => bestEffortDelete(request, `/api/chats/${id}?force=true`)));
     await Promise.all(
       createdAgentIds.map((agentId) => request.delete(`/api/agents/${agentId}`).catch(() => undefined)),
     );
@@ -13059,8 +13161,6 @@ test("Music Player stays unavailable until Music DJ is installed", async ({ page
 });
 
 test("Connections exposes Local Whisper only while Conversation Calls is installed", async ({ page }, testInfo) => {
-  test.skip(!testInfo.project.name.includes("desktop"), "The capability ownership path is covered on desktop.");
-
   const errors = collectUnexpectedErrors(page);
   let callsInstalled = true;
   const callsPackage = {
@@ -13161,6 +13261,21 @@ test("Connections exposes Local Whisper only while Conversation Calls is install
   let rightPanel = await openExpandedLocalModel();
   await expect(rightPanel.getByText("Local Speech Model", { exact: true })).toBeVisible();
   await expect(rightPanel.getByRole("button", { name: "Download Whisper" })).toBeVisible();
+  if (testInfo.project.name.includes("mobile")) {
+    const speechSelect = rightPanel.locator("select").filter({ has: page.locator('option[value="whisper_tiny"]') });
+    await expect(speechSelect).toBeVisible();
+    const spacing = await speechSelect.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return { left: parseFloat(style.paddingLeft), right: parseFloat(style.paddingRight) };
+    });
+    expect(spacing.left).toBeGreaterThanOrEqual(8);
+    expect(spacing.right).toBeGreaterThanOrEqual(24);
+    await speechSelect.scrollIntoViewIfNeeded();
+    await testInfo.attach(`mobile-whisper-spacing-${testInfo.project.name}.png`, {
+      body: await rightPanel.screenshot(),
+      contentType: "image/png",
+    });
+  }
 
   callsInstalled = false;
   await page.reload();
@@ -19114,6 +19229,90 @@ test("memory recall modal accepts clicks from chat settings", async ({ page }, t
   await expect(drawer.getByRole("heading", { name: "Chat Settings" })).toBeVisible();
 });
 
+test("mobile reopening Echo Chamber and editing older Roleplay messages restore the intended position", async ({
+  page,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.includes("mobile"), "These scroll anchors are mobile-only.");
+  const response = await page.request.post("/api/chats", {
+    data: { name: "Mobile scroll anchors", mode: "roleplay", characterIds: [] },
+  });
+  expect(response.ok()).toBeTruthy();
+  const chat = (await response.json()) as { id: string };
+  try {
+    await page.request.patch(`/api/chats/${chat.id}/metadata`, {
+      data: { enableAgents: true, activeAgentIds: ["echo-chamber"] },
+    });
+    let olderMessageId = "";
+    for (let index = 0; index < 12; index++) {
+      const message = await page.request.post(`/api/chats/${chat.id}/messages`, {
+        data: {
+          role: "assistant",
+          content: Array.from(
+            { length: index === 1 ? 50 : 3 },
+            (_, line) => `History ${index + 1}, line ${line + 1}.`,
+          ).join("\n"),
+        },
+      });
+      expect(message.ok()).toBeTruthy();
+      if (index === 1) olderMessageId = ((await message.json()) as { id: string }).id;
+    }
+    await page.route(`**/api/agents/echo-messages/${chat.id}`, (route) =>
+      route.fulfill({
+        json: Array.from({ length: 40 }, (_, index) => ({
+          characterName: "Observer",
+          reaction: `Echo reaction ${index + 1}.`,
+          timestamp: index,
+        })),
+      }),
+    );
+    await prepareFreshClient(page);
+    await page.addInitScript((chatId) => {
+      const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui")!);
+      Object.assign(persisted.state, { messagesPerPage: 10, echoChamberOpen: true });
+      localStorage.setItem("marinara-engine-ui", JSON.stringify(persisted));
+      localStorage.setItem("marinara-active-chat-id", chatId);
+    }, chat.id);
+    await page.goto("/");
+    const echo = page.locator('[data-roleplay-agent-window="echo"]');
+    await expect(echo.getByText("Echo reaction 40.", { exact: true })).toBeInViewport();
+    await echo.getByTitle("Collapse Echo Chamber", { exact: true }).tap();
+    await page.getByTitle("Open Echo Chamber", { exact: true }).tap();
+    await expect.soft(echo.getByText("Echo reaction 40.", { exact: true })).toBeInViewport();
+    await echo.getByTitle("Collapse Echo Chamber", { exact: true }).tap();
+
+    const transcript = page.locator('[data-chat-mode="roleplay"] [data-chat-scroll]');
+    await transcript.evaluate((element) => {
+      element.scrollTop = 0;
+    });
+    await page.getByRole("button", { name: "Load More", exact: true }).tap();
+    const older = page.locator(`[data-message-id="${olderMessageId}"]`);
+    await expect(older).toBeAttached();
+    await older.dispatchEvent("click");
+    const edit = older.getByTitle("Edit", { exact: true });
+    await edit.scrollIntoViewIfNeeded();
+    await edit.tap();
+    const editor = older.locator("[data-chat-message-editor]");
+    await expect(editor).toBeFocused();
+    await expect
+      .poll(() =>
+        editor.evaluate((element: HTMLTextAreaElement) => ({
+          selection: element.selectionStart,
+          scroll: element.scrollTop,
+          visibleStart:
+            element.getBoundingClientRect().top >=
+            element.closest("[data-chat-scroll]")!.getBoundingClientRect().top - 1,
+        })),
+      )
+      .toEqual({ selection: 0, scroll: 0, visibleStart: true });
+    await testInfo.attach(`mobile-scroll-anchors-${testInfo.project.name}.png`, {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    });
+  } finally {
+    await bestEffortDelete(page.request, `/api/chats/${chat.id}?force=true`);
+  }
+});
+
 test("mobile Load More clears the collapsed Echo Chamber", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("mobile"), "Echo Chamber touch clearance is mobile-only.");
 
@@ -19403,6 +19602,34 @@ test("mobile chat composer follows the visual viewport above the software keyboa
       .poll(() => transcript.evaluate((element) => element.scrollHeight - element.scrollTop - element.clientHeight))
       .toBeLessThanOrEqual(2);
     await expect(textarea).toBeVisible();
+    await expect(textarea).toHaveCSS("overscroll-behavior-y", "contain");
+    await textarea.fill("Scrollable draft line.\n".repeat(30));
+    const boundaryGestures = await textarea.evaluate((element: HTMLTextAreaElement) => {
+      const drag = (delta: number, touches = 1) => {
+        const dispatch = (type: string, y: number) => {
+          const event = new Event(type, { bubbles: true, cancelable: true });
+          Object.defineProperty(event, "touches", { value: Array.from({ length: touches }, () => ({ clientY: y })) });
+          element.dispatchEvent(event);
+          return event.defaultPrevented;
+        };
+        dispatch("touchstart", 100);
+        return dispatch("touchmove", 100 + delta);
+      };
+      element.setSelectionRange(0, 0);
+      element.scrollTop = 20;
+      const inside = drag(-10);
+      element.scrollTop = element.scrollHeight;
+      const bottom = drag(-10);
+      element.scrollTop = 0;
+      const top = drag(10);
+      const multitouch = drag(10, 2);
+      element.setSelectionRange(0, 4);
+      const selection = drag(10);
+      return { inside, bottom, top, multitouch, selection };
+    });
+    expect(boundaryGestures).toEqual({ inside: false, bottom: true, top: true, multitouch: false, selection: false });
+    await textarea.fill("");
+    await textarea.blur();
     await expect.poll(() => composer.evaluate((element) => getComputedStyle(element).paddingBottom)).toBe("34px");
 
     const initialViewportHeight = await page.evaluate(() => window.innerHeight);

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -19281,7 +19281,18 @@ test("mobile reopening Echo Chamber and editing older Roleplay messages restore 
     await expect(echo.getByText("Echo reaction 40.", { exact: true })).toBeInViewport();
     await echo.getByTitle("Collapse Echo Chamber", { exact: true }).tap();
     await page.getByTitle("Open Echo Chamber", { exact: true }).tap();
-    await expect.soft(echo.getByText("Echo reaction 40.", { exact: true })).toBeInViewport();
+    await expect(echo.getByText("Echo reaction 40.", { exact: true })).toBeInViewport();
+    await echo.getByTitle("Collapse Echo Chamber", { exact: true }).tap();
+
+    const mobileViewport = page.viewportSize()!;
+    await page.setViewportSize({ width: 900, height: mobileViewport.height });
+    await page.getByTitle("Open Echo Chamber", { exact: true }).tap();
+    await expect(echo.getByRole("button", { name: "Resize Echo Chamber" })).toBeVisible();
+    await page.setViewportSize(mobileViewport);
+    await expect(echo.getByText("Echo reaction 40.", { exact: true })).toBeInViewport();
+    await echo.getByTitle("Collapse Echo Chamber", { exact: true }).tap();
+    await page.getByTitle("Open Echo Chamber", { exact: true }).tap();
+    await expect(echo.getByText("Echo reaction 40.", { exact: true })).toBeInViewport();
     await echo.getByTitle("Collapse Echo Chamber", { exact: true }).tap();
 
     const transcript = page.locator('[data-chat-mode="roleplay"] [data-chat-scroll]');
@@ -19304,7 +19315,8 @@ test("mobile reopening Echo Chamber and editing older Roleplay messages restore 
           scroll: element.scrollTop,
           visibleStart:
             element.getBoundingClientRect().top >=
-            element.closest("[data-chat-scroll]")!.getBoundingClientRect().top - 1,
+              element.closest("[data-chat-scroll]")!.getBoundingClientRect().top - 1 &&
+            element.getBoundingClientRect().top < element.closest("[data-chat-scroll]")!.getBoundingClientRect().bottom,
         })),
       )
       .toEqual({ selection: 0, scroll: 0, visibleStart: true });

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -7782,7 +7782,11 @@ test("Gallery Illustrate offers active custom image agents", async ({ page, requ
         }, nextChat.id);
         await expect(page.locator(`[data-chat-mode="${mode}"]`).first()).toBeVisible();
         const gallery = page.getByRole("button", { name: "Gallery", exact: true }).filter({ visible: true });
-        if (!(await gallery.isVisible())) await page.getByRole("button", { name: "More options", exact: true }).click();
+        if (!(await gallery.isVisible())) {
+          await page
+            .getByRole("button", { name: mode === "game" ? "Game actions" : "More options", exact: true })
+            .click();
+        }
         await gallery.click();
         await expect(drawer.getByRole("button", { name: "Open gallery image", exact: true })).toBeVisible();
         await expectMobileGalleryControls(mode);

--- a/packages/client/src/components/chat/ChatGallery.tsx
+++ b/packages/client/src/components/chat/ChatGallery.tsx
@@ -590,13 +590,13 @@ export function ChatGallery({
 
   return (
     <>
-      <div className="flex flex-col gap-3 p-4">
+      <div className="flex flex-col gap-3 p-4 max-md:p-3">
         {(canIllustrate ||
           onGenerateSelfie ||
           onGenerateStoryboard ||
           (sceneVideosEnabled && onGenerateVideo) ||
           onGenerateBackground) && (
-          <div className={actionGridClass}>
+          <div className={cn("mari-gallery-generation-actions", actionGridClass)}>
             {canIllustrate && (
               <div ref={illustrateMenuRef} className="relative min-w-0">
                 <button
@@ -622,7 +622,7 @@ export function ChatGallery({
                       : localizeUi("ui.chat.chatgallery.illustrate")}
                   </span>
                   {illustrateAgents.length > 0 && !isIllustrating ? (
-                    <ChevronDown size="0.875rem" className="shrink-0" />
+                    <ChevronDown size="0.875rem" className="shrink-0 max-md:absolute max-md:right-1 max-md:top-1" />
                   ) : null}
                 </button>
                 {illustrateMenuOpen && (
@@ -1094,8 +1094,8 @@ export function ChatGallery({
                     {/* Overlay */}
                     {!selectingImages && (
                       <div className="pointer-events-none absolute inset-0 flex items-end bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 max-md:opacity-100">
-                        <div className="flex w-full items-center justify-between p-2">
-                          <div className="flex gap-1">
+                        <div className="mari-gallery-image-actions flex w-full items-center justify-between p-2">
+                          <div className="flex gap-1 max-md:contents">
                             <button
                               type="button"
                               onClick={() => handlePinImage(img)}

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -388,6 +388,34 @@ export const ChatInput = memo(function ChatInput({
     setAttachments(next);
   }, []);
 
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea || !isMobileComposerViewport || mode !== "roleplay") return;
+    // iOS can chain a textarea's boundary drag into the keyboard's root
+    // scroll area even when html/body disallow overscroll. Keep inner text
+    // scrolling, selection, and multi-touch gestures native.
+    let previousY = 0;
+    const start = (event: TouchEvent) => {
+      previousY = event.touches[0]?.clientY ?? 0;
+    };
+    const move = (event: TouchEvent) => {
+      if (event.touches.length !== 1) return;
+      const y = event.touches[0]!.clientY;
+      const delta = y - previousY;
+      previousY = y;
+      if (textarea.selectionStart !== textarea.selectionEnd) return;
+      const atTop = textarea.scrollTop <= 0;
+      const atBottom = textarea.scrollTop + textarea.clientHeight >= textarea.scrollHeight - 1;
+      if ((delta > 0 && atTop) || (delta < 0 && atBottom)) event.preventDefault();
+    };
+    textarea.addEventListener("touchstart", start, { passive: true });
+    textarea.addEventListener("touchmove", move, { passive: false });
+    return () => {
+      textarea.removeEventListener("touchstart", start);
+      textarea.removeEventListener("touchmove", move);
+    };
+  }, [isMobileComposerViewport, mode]);
+
   const insertTextAtCursor = useCallback(
     (text: string) => {
       const el = textareaRef.current;

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -819,6 +819,7 @@ const EditTextarea = memo(function EditTextarea({
   useLayoutEffect(() => {
     if (ref.current) {
       autoResize();
+      if (window.matchMedia("(max-width: 767px)").matches) ref.current.setSelectionRange(0, 0);
       ref.current.focus({ preventScroll: true });
     }
   }, [autoResize]);
@@ -2308,7 +2309,17 @@ export const ChatMessage = memo(function ChatMessage({
   useLayoutEffect(() => {
     // Restore scroll position saved before the state change
     if (scrollRestoreRef.current) {
-      scrollRestoreRef.current.el.scrollTop = scrollRestoreRef.current.top;
+      const { el, top } = scrollRestoreRef.current;
+      el.scrollTop = top;
+      if (editing && window.matchMedia("(max-width: 767px)").matches) {
+        const editor = msgRef.current?.querySelector<HTMLTextAreaElement>("[data-chat-message-editor]");
+        if (editor) {
+          editor.scrollTop = 0;
+          // The action row can be far below a long message's first line.
+          // Align only the transcript, never scroll the mobile app shell.
+          el.scrollTop += editor.getBoundingClientRect().top - el.getBoundingClientRect().top - 8;
+        }
+      }
       scrollRestoreRef.current = null;
     }
   }, [editing]);

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -336,7 +336,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
 
   // ── Compute position style relative to the chat area container ──
   const [posStyle, setPosStyle] = useState<CSSProperties>({});
-  const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
+  const [isMobile, setIsMobile] = useState(() => typeof window !== "undefined" && window.innerWidth < 768);
   const mobileCollapsed = isMobile && !echoChamberOpen;
   const resizeFromLeft = !isMobile && echoChamberSide.endsWith("right");
   const resizeFromTop = !isMobile && echoChamberSide.startsWith("bottom");
@@ -454,7 +454,10 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
   );
 
   useEffect(() => {
-    const clampCurrentSize = () => setPanelSize((size) => (size ? clampPanelSize(size.width, size.height) : null));
+    const clampCurrentSize = () => {
+      setIsMobile(window.innerWidth < 768);
+      setPanelSize((size) => (size ? clampPanelSize(size.width, size.height) : null));
+    };
     window.addEventListener("resize", clampCurrentSize);
     return () => window.removeEventListener("resize", clampCurrentSize);
   }, [clampPanelSize]);
@@ -462,7 +465,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
   useEffect(() => {
     if (!echoEnabled) return;
     // On mobile, position below the HUD bar.
-    if (typeof window !== "undefined" && window.innerWidth < 768) {
+    if (isMobile) {
       const update = () => {
         const hudEl = findVisibleHud();
         // Position relative to container, so measure HUD bottom relative to rpg-chat-area
@@ -543,7 +546,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
       discoveryObserver?.disconnect();
       window.removeEventListener("resize", scheduleUpdate);
     };
-  }, [echoEnabled, echoChamberSide, trackerPanelEnabled, trackerPanelOpen, trackerPanelSide]);
+  }, [echoEnabled, echoChamberSide, isMobile, trackerPanelEnabled, trackerPanelOpen, trackerPanelSide]);
 
   useEffect(() => {
     if (!echoEnabled || (isMobile && hiddenOnMobile) || mobileCollapsed) return;

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -337,6 +337,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
   // ── Compute position style relative to the chat area container ──
   const [posStyle, setPosStyle] = useState<CSSProperties>({});
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
+  const mobileCollapsed = isMobile && !echoChamberOpen;
   const resizeFromLeft = !isMobile && echoChamberSide.endsWith("right");
   const resizeFromTop = !isMobile && echoChamberSide.startsWith("bottom");
 
@@ -545,7 +546,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
   }, [echoEnabled, echoChamberSide, trackerPanelEnabled, trackerPanelOpen, trackerPanelSide]);
 
   useEffect(() => {
-    if (!echoEnabled || (isMobile && hiddenOnMobile)) return;
+    if (!echoEnabled || (isMobile && hiddenOnMobile) || mobileCollapsed) return;
 
     let frame = window.requestAnimationFrame(() => {
       frame = window.requestAnimationFrame(() => {
@@ -556,7 +557,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     });
 
     return () => window.cancelAnimationFrame(frame);
-  }, [echoEnabled, hiddenOnMobile, isMobile]);
+  }, [echoEnabled, hiddenOnMobile, isMobile, mobileCollapsed]);
 
   if (!echoEnabled || (isMobile && hiddenOnMobile)) return null;
   const visibleMessages = echoMessages.slice(0, visibleCount);

--- a/packages/client/src/components/chat/MessageActionButton.tsx
+++ b/packages/client/src/components/chat/MessageActionButton.tsx
@@ -41,7 +41,7 @@ export function MessageActionButton({
       disabled={disabled}
       tabIndex={tabIndex}
       className={cn(
-        "inline-flex h-[1.7em] w-[1.7em] shrink-0 items-center justify-center rounded-md p-0 text-[0.8125rem] leading-none transition-all active:scale-90 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-30",
+        "inline-flex h-[1.7em] w-[1.7em] shrink-0 items-center justify-center rounded-md p-0 text-[0.8125rem] leading-none transition-colors md:transition-all md:active:scale-90 max-md:active:bg-[var(--marinara-chat-message-action-bg-hover)] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-30",
         "text-[var(--marinara-chat-message-action-text)] [@media(pointer:fine)]:hover:bg-[var(--marinara-chat-message-action-bg-hover)] [@media(pointer:fine)]:hover:text-[var(--marinara-chat-message-action-text-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]",
         className,
       )}

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -526,18 +526,26 @@ function SidecarCard() {
                   )}
                   {!speechModelDownloaded && speechAvailable && (
                     <div className="mt-2 flex flex-col gap-2">
-                      <select
-                        value={speechModelChoice}
-                        onChange={(event) => setSpeechModelChoice(event.target.value as SidecarSpeechModelId)}
-                        className="mari-chrome-field h-8 text-xs"
-                        disabled={speechDownloading || speechModels.length === 0}
-                      >
-                        {speechModels.map((model) => (
-                          <option key={model.id} value={model.id}>
-                            {model.label}
-                          </option>
-                        ))}
-                      </select>
+                      <div className="max-md:relative md:contents">
+                        <select
+                          value={speechModelChoice}
+                          onChange={(event) => setSpeechModelChoice(event.target.value as SidecarSpeechModelId)}
+                          className="mari-chrome-field h-8 text-xs max-md:w-full max-md:min-w-0 max-md:appearance-none max-md:pl-2.5 max-md:pr-8"
+                          aria-label={localizeUi("ui.panels.sidecarcard.localSpeechModel")}
+                          disabled={speechDownloading || speechModels.length === 0}
+                        >
+                          {speechModels.map((model) => (
+                            <option key={model.id} value={model.id}>
+                              {model.label}
+                            </option>
+                          ))}
+                        </select>
+                        <ChevronDown
+                          size="0.875rem"
+                          aria-hidden="true"
+                          className="mari-chrome-field-icon pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 md:hidden"
+                        />
+                      </div>
                       {activeSpeechModel && (
                         <p className="text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
                           {activeSpeechModel.description} {localizeUi("ui.noodle.stageprofileview.about")}{" "}

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -6072,6 +6072,37 @@ strong {
 }
 
 @media (max-width: 767px) {
+  [data-chat-mode="roleplay"] .mari-chat-input-textarea {
+    overscroll-behavior-y: contain;
+  }
+
+  .mari-gallery-generation-actions > button,
+  .mari-gallery-generation-actions > div > button {
+    @apply relative min-h-11 flex-col gap-1 px-1 py-2 text-[0.625rem];
+  }
+
+  .mari-gallery-generation-actions > button > svg,
+  .mari-gallery-generation-actions > div > button > svg {
+    @apply size-3;
+  }
+
+  .mari-gallery-generation-actions > button > span,
+  .mari-gallery-generation-actions > div > button > span {
+    @apply max-w-full whitespace-normal break-words;
+  }
+
+  .mari-gallery-image-actions {
+    @apply grid grid-cols-[repeat(auto-fit,minmax(24px,1fr))] gap-0.5 p-1;
+  }
+
+  .mari-gallery-image-actions button {
+    @apply flex min-h-8 min-w-0 items-center justify-center px-0;
+  }
+
+  .mari-gallery-image-actions .mari-chrome-accent-surface {
+    @apply border-transparent bg-white/20 text-white hover:bg-white/30;
+  }
+
   /*
    * WKWebView native backing color is set by the literal background-color in
    * index.html <style> (inline critical CSS — not cached by SW, always fresh).


### PR DESCRIPTION
## Linked issue

Closes #5851

## Why this change

Mobile users can lose their place while editing or reopening Echo Chamber, lose tapped message icons, pan the Roleplay composer into blank space, and find gallery or Whisper controls clipped. Fix these existing paths with small mobile-only changes, preserving desktop behavior.

## What changed

- Contain mobile Roleplay composer boundary drags with CSS plus a small native touch handler. Interior scrolling, selected text, and multi-touch remain native.
- Keep mobile message-button press feedback color-only so opening an overlay does not animate the tapped SVG's transform layer; preserve desktop press effects.
- Include the mobile Echo Chamber collapsed state in the existing scroll-to-latest effect.
- Align the beginning of a mobile message editor within its transcript instead of restoring the action row's old scroll offset.
- Compact mobile gallery generation buttons; fit image actions into the tile, wrapping only when needed; give Delete the same neutral mobile styling as its neighboring controls.
- Give the mobile Whisper selector explicit padding and an inset decorative arrow, retaining the native select interaction and the existing desktop appearance.
- Add regression proof to the existing browser suite. No new dependencies or abstractions, no main/release changes, no unrelated drafts.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated evidence (these are results, not checked human to-do boxes):

- `pnpm install --frozen-lockfile --offline`: passed.
- `pnpm check`: passed, including localization, formatting, workspace checks, E2E types, and production build.
- Final focused browser suite: 27 passed, 15 intentional project-specific skips across desktop Chromium, mobile Chromium, and mobile WebKit.
- Additional gallery checks pass in both mobile engines for Conversation, Roleplay, and Game at 320px and normal phone widths.
- Before-fix WebKit checks demonstrated Echo reopening above the latest reaction, an older message editor starting above the visible transcript, gallery label clipping, zero explicit Whisper padding, and missing composer scroll containment.
- Touch-handler regression checks boundary cancellation while preserving interior scrolling, selected text, and multi-touch. The message-action check now closes and reopens Peek Prompt, rather than ending while the first dialog remains open.

The connected browser is unavailable. These are automated browser checks against the real local app, not physical-device/manual verification. Manually verify the original iPhone long-press/keyboard drag and SVG repaint path on hardware; desktop WebKit emulation cannot establish native keyboard/compositor behavior. Also manually verify the selector with the native iOS choice sheet. No claims of physical iPhone or Android testing.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

Unreleased changelog entries cover all six issues. No version bump or release changes. Existing localized copy is reused; the speech selector receives the existing localized Local Speech Model accessible name.

## UI evidence (if applicable)

[Synthetic mobile before/after screenshots](https://gist.github.com/SpicyMarinara/79141bfd7bf30553c581dfd217c7ed25): gallery controls in all three modes at 320px, plus the older-message editor scroll regression. Private user screenshots are not republished.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile Roleplay composer scrolling and boundary touch behavior.
  * Older-message editing now positions the editor and cursor more reliably.
  * Echo Chamber reopening preserves the expected position on mobile.
  * Improved mobile message-action button behavior.

* **Style**
  * Refined mobile gallery controls, image actions, and layout.
  * Improved mobile speech model selector spacing and presentation.

* **Tests**
  * Expanded mobile coverage for gallery layouts, editing, scrolling, speech selection, and dialog reopening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->