### PR TITLE
fix(mobile): recover generation results and compact message controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Released temporary rendering hints after message entrance animations, reducing unnecessary compositor layers around long, growing Roleplay replies without changing their animation or layout (#5870).
 - Agent connection warnings and other notifications now use the selected accent for their border in light and dark themes (#5870).
+- Illustrator-only manual and retried image requests now finish saving after a browser disconnect; explicit Stop still cancels them. Reopened chats refresh saved messages and gallery images when server-side generation finishes (#5870).
+- Mobile Conversation and Roleplay message actions use compact icons and share one row across the available width, while keeping the larger desktop controls and saved swipe-menu preferences (#5873).
 
 - Restored Professor Mari preset creation after adding preset-level regex defaults, and preserved those defaults during unrelated preset edits.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Released temporary rendering hints after message entrance animations, reducing unnecessary compositor layers around long, growing Roleplay replies without changing their animation or layout (#5870).
+- Agent connection warnings and other notifications now use the selected accent for their border in light and dark themes (#5870).
+
 - Restored Professor Mari preset creation after adding preset-level regex defaults, and preserved those defaults during unrelated preset edits.
 
 - OpenAI-compatible image connections preserve non-GPT models' requested dimensions; FLUX.2 requests retry once after an explicit dimension-limit rejection using the reported bound (#5861).

--- a/docs/installation/ios-pwa.md
+++ b/docs/installation/ios-pwa.md
@@ -78,6 +78,8 @@ Your chats, characters, and settings are stored on the server, not on your iPhon
 
 **Safari keeps showing an old build.** Reload the page first. If it still looks old, follow the Clearing and reinstalling the PWA steps above.
 
+**The Home Screen app closes or turns blank during generation.** Reopen it and return to the chat. You do not need to restart a healthy server. Automatic chat replies and Illustrator-only manual or retried image requests keep running on the server after a lost browser connection. The reopened chat checks for unfinished work and refreshes saved messages and gallery images when it finishes. **Stop** still cancels the selected chat's generation. If the blank screen keeps returning, report your Support Diagnostics and whether reopening restores the chat; this recovery does not diagnose or prevent every iOS browser failure.
+
 **A red banner says saves will silently fail.** This is a network trust warning from the server, not an iPhone or iPad problem. The server owner needs to trust your address. See the [Remote Access guide](../REMOTE_ACCESS.md) and [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md).
 
 **Privileged actions are blocked.** Some maintenance actions need an admin secret from the server owner. On your iPhone or iPad, you save that value in **Settings**, then **Advanced**, then **Admin Access**. The [Remote Access guide](../REMOTE_ACCESS.md) explains what the admin secret is and how to get one.

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -5708,7 +5708,7 @@ test("stopped and refused generations keep sent text cleared and accept the firs
 });
 
 for (const mode of ["conversation", "roleplay"] as const) {
-  test(`${mode} message actions are roomy and first-swipe preferences persist independently`, async ({
+  test(`${mode} message actions fit mobile rows and first-swipe preferences persist independently`, async ({
     page,
     request,
   }, testInfo) => {
@@ -5784,12 +5784,19 @@ for (const mode of ["conversation", "roleplay"] as const) {
         for (const button of buttons) {
           const box = await button.boundingBox();
           expect(box).not.toBeNull();
-          expect(box!.width).toBeGreaterThanOrEqual(mobile ? 44 : 32);
-          expect(box!.height).toBeGreaterThanOrEqual(mobile ? 44 : 32);
+          expect(box!.width).toBeGreaterThanOrEqual(mobile ? 24 : 32);
+          expect(box!.height).toBeGreaterThanOrEqual(32);
           expect(box!.x).toBeGreaterThanOrEqual(bar!.x);
           expect(box!.x + box!.width).toBeLessThanOrEqual(bar!.x + bar!.width + 1);
           if (previous && Math.abs(previous.y - box!.y) < 1) {
-            expect(box!.x - previous.x - previous.width).toBeGreaterThanOrEqual(mobile ? 3 : 6);
+            expect(box!.x - previous.x - previous.width).toBeGreaterThanOrEqual(mobile ? -1 : 6);
+          }
+          if (mobile && previous) expect(Math.abs(previous.y - box!.y)).toBeLessThan(1);
+          const icon = button.locator("svg").first();
+          if (mobile && (await icon.count())) {
+            const iconBox = await icon.boundingBox();
+            expect(iconBox!.width).toBeGreaterThanOrEqual(14);
+            expect(iconBox!.width).toBeLessThanOrEqual(16);
           }
           previous = box;
         }

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -5171,6 +5171,65 @@ test("character schedules export the live draft and import safely", async ({ pag
   }
 });
 
+test("agent connection warning borders follow the configured accent", async ({ page, request }, testInfo) => {
+  const created = await request.post("/api/chats", {
+    data: {
+      name: "Agent connection warning",
+      mode: "roleplay",
+      characterIds: [],
+      connectionId: "synthetic-agent-warning-connection",
+    },
+  });
+  expect(created.ok()).toBeTruthy();
+  const chat = (await created.json()) as { id: string };
+  const message =
+    'Echo Chamber and Illustrator agents are using the default agent connection "Fixture model" (local-fixture). If this is a paid API model, agent calls may bill that provider.';
+  try {
+    await page.route("**/api/generate", (route) =>
+      route.fulfill({
+        contentType: "text/event-stream",
+        body: [
+          { type: "agent_warning", data: { code: "default_agent_connection_active", message } },
+          { type: "done", data: {} },
+        ]
+          .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+          .join(""),
+      }),
+    );
+    await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
+    await page.goto("/");
+    await setAppAccentColor(page, "#14b8a6");
+    await page.locator("textarea.mari-chat-input-textarea").fill("Show the model warning");
+    await page.locator("button.mari-chat-send-btn").click();
+    const warning = page.locator('[data-sonner-toast][data-type="warning"]').filter({ hasText: message });
+    await expect(warning).toBeVisible();
+    await testInfo.attach(`agent-warning-initial-${testInfo.project.name}.png`, {
+      body: await page.screenshot({ animations: "disabled" }),
+      contentType: "image/png",
+    });
+    for (const theme of ["dark", "light"] as const) {
+      await page.evaluate(async (nextTheme) => {
+        const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as PageUiStoreModule;
+        useUIStore.getState().setTheme(nextTheme);
+      }, theme);
+      for (const accent of ["#14b8a6", "#1256aa"]) {
+        await setAppAccentColor(page, accent);
+        const border = await readCssVariableColor(page, "--marinara-chat-chrome-panel-border");
+        expect(border).not.toBe(await readCssVariableColor(page, "--border"));
+        await expect(warning).toHaveCSS("border-top-color", border);
+      }
+      await testInfo.attach(`agent-warning-${theme}-${testInfo.project.name}.png`, {
+        body: await page.screenshot({ animations: "disabled" }),
+        contentType: "image/png",
+      });
+    }
+    await warning.getByRole("button", { name: "Close toast", exact: true }).click();
+    await expect(warning).toBeHidden();
+  } finally {
+    await request.delete(`/api/chats/${chat.id}`);
+  }
+});
+
 test("provider concurrency errors appear in generation toasts", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Generation error toast regression is covered on desktop.");
 

--- a/e2e/generation-recovery.e2e.ts
+++ b/e2e/generation-recovery.e2e.ts
@@ -1,0 +1,180 @@
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import { readFileSync } from "node:fs";
+
+const version = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version;
+
+async function createChat(request: APIRequestContext, name: string) {
+  const created = await request.post("/api/chats", {
+    data: { name, mode: "roleplay", characterIds: [], connectionId: "synthetic-recovery-connection" },
+  });
+  expect(created.ok()).toBeTruthy();
+  const chat = (await created.json()) as { id: string };
+  const saved = await request.post(`/api/chats/${chat.id}/messages`, {
+    data: { role: "assistant", content: `Saved narration for ${name}.` },
+  });
+  expect(saved.ok()).toBeTruthy();
+  return { chatId: chat.id, messageId: ((await saved.json()) as { id: string }).id };
+}
+
+async function openFreshChat(page: Page, chatId: string) {
+  await page.route("**/api/app-settings/ui", (route) => route.fulfill({ json: { value: "" } }));
+  await page.addInitScript(
+    ({ id, appVersion }) => {
+      localStorage.setItem("marinara-active-chat-id", id);
+      localStorage.setItem("marinara:whats-new:seen-version", appVersion);
+      localStorage.setItem(
+        "marinara-engine-ui",
+        JSON.stringify({
+          state: {
+            hasCompletedOnboarding: true,
+            rightPanelOpen: false,
+            sidebarOpen: false,
+            chatHelpSeenModes: ["conversation", "roleplay", "game"],
+          },
+          version: 65,
+        }),
+      );
+    },
+    { id: chatId, appVersion: version },
+  );
+  await page.goto("/");
+}
+
+test("a reopened chat receives a saved illustration after orphaned server work finishes", async ({
+  page,
+  request,
+}, testInfo) => {
+  const { chatId, messageId } = await createChat(request, "Reopened image generation");
+  let serverActive = true;
+  let statusReads = 0;
+  await page.route(`**/api/generate/status/${chatId}`, (route) => {
+    statusReads += 1;
+    return route.fulfill({ json: { active: serverActive } });
+  });
+  try {
+    await openFreshChat(page, chatId);
+    const message = page.locator(`[data-message-id="${messageId}"]`);
+    await expect(message).toBeVisible();
+    if (testInfo.project.name.includes("mobile")) {
+      await page.getByRole("button", { name: "More options", exact: true }).click();
+    }
+    await page.getByRole("button", { name: "Gallery", exact: true }).filter({ visible: true }).click();
+    const gallery = page.locator(".mari-chat-gallery-drawer");
+    await expect(gallery.getByText("No images yet", { exact: true })).toBeVisible();
+    const png = await page.evaluate(() => {
+      const canvas = document.createElement("canvas");
+      canvas.width = 320;
+      canvas.height = 200;
+      const context = canvas.getContext("2d")!;
+      context.fillStyle = "#164e63";
+      context.fillRect(0, 0, canvas.width, canvas.height);
+      context.fillStyle = "#e0f2fe";
+      context.font = "20px sans-serif";
+      context.fillText("Saved illustration fixture", 32, 100);
+      return canvas.toDataURL("image/png").split(",")[1]!;
+    });
+    const upload = await request.post(`/api/gallery/${chatId}/upload`, {
+      multipart: {
+        prompt: "Recovered illustration fixture",
+        file: { name: "recovered-illustration.png", mimeType: "image/png", buffer: Buffer.from(png, "base64") },
+      },
+    });
+    expect(upload.ok()).toBeTruthy();
+    const image = (await upload.json()) as { url: string };
+    const patched = await request.patch(`/api/chats/${chatId}/messages/${messageId}/extra`, {
+      data: { attachments: [{ type: "image", url: image.url, filename: "Recovered illustration fixture" }] },
+    });
+    expect(patched.ok()).toBeTruthy();
+    // The previous browser process is gone: no illustration or done SSE is delivered.
+    serverActive = false;
+    await expect(gallery.getByRole("img", { name: "Recovered illustration fixture", exact: true })).toBeVisible();
+    await gallery.getByRole("button", { name: "Close gallery", exact: true }).click();
+    const recovered = message.getByRole("img", { name: "Recovered illustration fixture", exact: true });
+    await expect(recovered).toBeVisible();
+    await expect.poll(() => recovered.evaluate((element: HTMLImageElement) => element.naturalWidth)).toBe(320);
+    expect(statusReads).toBeGreaterThanOrEqual(2);
+    await testInfo.attach("recovered-illustration", {
+      body: await page.screenshot({ animations: "disabled" }),
+      contentType: "image/png",
+    });
+  } finally {
+    await request.delete(`/api/chats/${chatId}`);
+  }
+});
+
+test("idle chats do not poll and navigating away stops orphan recovery", async ({ page, request }) => {
+  const first = await createChat(request, "Active orphan");
+  const second = await createChat(request, "Idle chat");
+  const reads = { active: 0, idle: 0 };
+  await page.route(`**/api/generate/status/${first.chatId}`, (route) => {
+    reads.active += 1;
+    return route.fulfill({ json: { active: true } });
+  });
+  await page.route(`**/api/generate/status/${second.chatId}`, (route) => {
+    reads.idle += 1;
+    return route.fulfill({ json: { active: false } });
+  });
+  try {
+    await openFreshChat(page, first.chatId);
+    await expect.poll(() => reads.active).toBeGreaterThanOrEqual(2);
+    await page.evaluate(async (chatId) => {
+      const { useChatStore } = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
+      useChatStore.getState().setActiveChatId(chatId);
+    }, second.chatId);
+    await expect(page.locator(`[data-message-id="${second.messageId}"]`)).toBeVisible();
+    await expect.poll(() => reads.idle).toBe(1);
+    const afterNavigation = { ...reads };
+    await page.waitForTimeout(2_200);
+    expect(reads).toEqual(afterNavigation);
+  } finally {
+    await request.delete(`/api/chats/${first.chatId}`);
+    await request.delete(`/api/chats/${second.chatId}`);
+  }
+});
+
+test("orphan recovery yields to a resumed local stream and its typewriter", async ({ page, request }) => {
+  const { chatId, messageId } = await createChat(request, "Local stream ownership");
+  let serverActive = true;
+  let statusReads = 0;
+  let messageReads = 0;
+  await page.route(`**/api/generate/status/${chatId}`, (route) => {
+    statusReads += 1;
+    return route.fulfill({ json: { active: serverActive } });
+  });
+  page.on("request", (req) => {
+    if (new URL(req.url()).pathname === `/api/chats/${chatId}/messages`) messageReads += 1;
+  });
+  try {
+    await openFreshChat(page, chatId);
+    await expect(page.locator(`[data-message-id="${messageId}"]`)).toBeVisible();
+    await expect.poll(() => statusReads).toBeGreaterThanOrEqual(2);
+    await page.evaluate(async (id) => {
+      const { useChatStore } = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
+      const state = useChatStore.getState();
+      state.setAbortController(id, new AbortController());
+      state.setStreaming(true, id);
+      state.setStreamBuffer("The local typewriter still owns this reply.", id);
+    }, chatId);
+    serverActive = false;
+    const readsWithLocalOwner = { statusReads, messageReads };
+    await page.waitForTimeout(1_200);
+    expect({ statusReads, messageReads }).toEqual(readsWithLocalOwner);
+    // Cleanup releases the network controller before the visible typewriter settles.
+    await page.evaluate(async (id) => {
+      const { useChatStore } = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
+      useChatStore.getState().setAbortController(id, null);
+    }, chatId);
+    await page.waitForTimeout(1_200);
+    expect({ statusReads, messageReads }).toEqual(readsWithLocalOwner);
+    await page.evaluate(async (id) => {
+      const { useChatStore } = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
+      useChatStore.getState().setStreaming(false, id);
+      useChatStore.getState().clearStreamBuffer(id);
+    }, chatId);
+    await expect.poll(() => statusReads).toBeGreaterThan(readsWithLocalOwner.statusReads);
+    await page.waitForTimeout(1_200);
+    expect(messageReads).toBe(readsWithLocalOwner.messageReads);
+  } finally {
+    await request.delete(`/api/chats/${chatId}`);
+  }
+});

--- a/e2e/generation-recovery.e2e.ts
+++ b/e2e/generation-recovery.e2e.ts
@@ -29,6 +29,7 @@ async function openFreshChat(page: Page, chatId: string) {
             hasCompletedOnboarding: true,
             rightPanelOpen: false,
             sidebarOpen: false,
+            messagesPerPage: 20,
             chatHelpSeenModes: ["conversation", "roleplay", "game"],
           },
           version: 65,
@@ -168,8 +169,17 @@ test("orphan recovery yields to a resumed local stream and its typewriter", asyn
     expect({ statusReads, messageReads }).toEqual(readsWithLocalOwner);
     await page.evaluate(async (id) => {
       const { useChatStore } = (await import("/src/stores/chat.store.ts" as string)) as PageChatStoreModule;
+      const { useAgentStore } = (await import("/src/stores/agent.store.ts" as string)) as PageAgentStoreModule;
+      useAgentStore.getState().setProcessingRun("local-illustrator-tail", true, id);
       useChatStore.getState().setStreaming(false, id);
       useChatStore.getState().clearStreamBuffer(id);
+    }, chatId);
+    // The durable reply may release the composer while its local agent SSE lives on.
+    await page.waitForTimeout(1_200);
+    expect({ statusReads, messageReads }).toEqual(readsWithLocalOwner);
+    await page.evaluate(async (id) => {
+      const { useAgentStore } = (await import("/src/stores/agent.store.ts" as string)) as PageAgentStoreModule;
+      useAgentStore.getState().setProcessingRun("local-illustrator-tail", false, id);
     }, chatId);
     await expect.poll(() => statusReads).toBeGreaterThan(readsWithLocalOwner.statusReads);
     await page.waitForTimeout(1_200);

--- a/e2e/message-animation-lifecycle.e2e.ts
+++ b/e2e/message-animation-lifecycle.e2e.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+
+test("message entrance releases rendering hints while long replies keep growing", async ({ page }) => {
+  const css = readFileSync(new URL("../packages/client/src/styles/globals.css", import.meta.url), "utf8");
+  const entranceCss = css.slice(css.indexOf("@keyframes message-in {"), css.indexOf("@keyframes slide-in-left {"));
+  expect(entranceCss).toContain(".animate-message-in");
+  await page.setContent(`
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      ${entranceCss}
+      body { margin: 0; }
+      main { height: 80vh; overflow: auto; }
+      article { padding: 12px; font: 16px/1.5 sans-serif; }
+      p { margin: 0 0 12px; }
+    </style>
+    <main>${"<article>Saved Roleplay message.</article>".repeat(20)}<article id="reply"></article></main>
+  `);
+  const reply = page.locator("#reply");
+  const longParagraph = "Synthetic Roleplay reply with ordinary words and punctuation. ".repeat(24);
+  await reply.evaluate(async (element, paragraph) => {
+    element.textContent = paragraph;
+    element.classList.add("animate-message-in");
+    const animations = element.getAnimations();
+    if (animations.length !== 1) throw new Error("The existing message entrance must still animate");
+    await animations[0].finished;
+  }, longParagraph);
+
+  await expect(reply).toHaveCSS("will-change", "auto");
+  await expect(reply).toHaveCSS("transform", "none");
+  await expect(reply).toHaveCSS("opacity", "1");
+  await reply.evaluate((element, paragraph) => {
+    for (let index = 0; index < 12; index++) {
+      const line = document.createElement("p");
+      line.textContent = paragraph;
+      element.append(line);
+    }
+  }, longParagraph);
+  const settledGeometry = await reply.boundingBox();
+  expect(settledGeometry!.height).toBeGreaterThan(2_000);
+  await expect(reply).toHaveCSS("will-change", "auto");
+  expect(await reply.evaluate((element) => element.getAnimations().length)).toBe(0);
+
+  // The retained class must have no visual or layout effect after its entrance.
+  await reply.evaluate((element) => element.classList.remove("animate-message-in"));
+  expect(await reply.boundingBox()).toEqual(settledGeometry);
+});

--- a/e2e/message-animation-lifecycle.e2e.ts
+++ b/e2e/message-animation-lifecycle.e2e.ts
@@ -23,7 +23,7 @@ test("message entrance releases rendering hints while long replies keep growing"
     element.classList.add("animate-message-in");
     const animations = element.getAnimations();
     if (animations.length !== 1) throw new Error("The existing message entrance must still animate");
-    await animations[0].finished;
+    await animations[0]!.finished;
   }, longParagraph);
 
   await expect(reply).toHaveCSS("will-change", "auto");

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1129,7 +1129,7 @@ export function App() {
           toastOptions={{
             style: {
               background: "var(--card)",
-              border: "1px solid var(--border)",
+              border: "1px solid var(--marinara-chat-chrome-panel-border)",
               color: "var(--foreground)",
               userSelect: "text",
               WebkitUserSelect: "text",

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -146,6 +146,7 @@ import {
   useChatNotes,
   useDeleteChatNote,
   useClearChatNotes,
+  useGenerationStatus,
   chatKeys,
 } from "../../hooks/use-chats";
 import { useUpdateGameWidgets } from "../../hooks/use-game";
@@ -911,13 +912,10 @@ export function ChatSettingsDrawer({
   const isConversation = chatMode === "conversation";
   const isGame = chatMode === "game";
   const isRoleplayMode = chatMode === "roleplay";
-  const { data: generationStatus, refetch: refetchGenerationStatus } = useQuery({
-    queryKey: ["generation-status", chat.id],
-    queryFn: () => api.get<{ active: boolean }>(`/generate/status/${encodeURIComponent(chat.id)}`),
-    enabled: open && isRoleplayMode,
-    staleTime: 0,
-    refetchInterval: (query) => (query.state.data?.active ? 1_000 : false),
-  });
+  const { data: generationStatus, refetch: refetchGenerationStatus } = useGenerationStatus(
+    chat.id,
+    open && isRoleplayMode,
+  );
   const activeGeneration = hasLocalGeneration || generationStatus?.active === true;
   const handleStopActiveGeneration = useCallback(async () => {
     setStoppingGeneration(true);

--- a/packages/client/src/components/chat/MessageActionButton.tsx
+++ b/packages/client/src/components/chat/MessageActionButton.tsx
@@ -41,7 +41,7 @@ export function MessageActionButton({
       disabled={disabled}
       tabIndex={tabIndex}
       className={cn(
-        "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md p-0 text-base leading-none transition-colors md:transition-all md:active:scale-90 max-md:min-h-[44px] max-md:min-w-[44px] max-md:active:bg-[var(--marinara-chat-message-action-bg-hover)] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-30",
+        "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md p-0 text-base leading-none transition-colors md:transition-all md:active:scale-90 max-md:h-8 max-md:w-7 max-md:max-w-full max-md:text-sm max-md:active:bg-[var(--marinara-chat-message-action-bg-hover)] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-30",
         "text-[var(--marinara-chat-message-action-text)] [@media(pointer:fine)]:hover:bg-[var(--marinara-chat-message-action-bg-hover)] [@media(pointer:fine)]:hover:text-[var(--marinara-chat-message-action-text-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]",
         className,
       )}

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -271,9 +271,57 @@ export function useChat(id: string | null) {
   });
 }
 
+export function useGenerationStatus(chatId: string | null, enabled = true) {
+  return useQuery({
+    queryKey: ["generation-status", chatId ?? ""],
+    queryFn: ({ signal }) =>
+      api.get<{ active: boolean }>(`/generate/status/${encodeURIComponent(chatId ?? "")}`, { signal }),
+    enabled: !!chatId && enabled,
+    staleTime: 0,
+    refetchInterval: (query) => (query.state.data?.active ? 1_000 : false),
+  });
+}
+
+function hasLocalGeneration(state: ReturnType<typeof useChatStore.getState>, chatId: string) {
+  return (
+    state.abortControllers.has(chatId) ||
+    (state.isStreaming && state.streamingChatId === chatId) ||
+    state.backgroundIllustrationChatIds.has(chatId)
+  );
+}
+
 export function useChatMessages(chatId: string | null, pageSize: number = 0, enabled = true) {
   const queryClient = useQueryClient();
   const previousWindow = useRef({ chatId, pageSize });
+  const orphanedGeneration = useRef<string | null>(null);
+  const canRecover = useChatStore(
+    (state) => !!chatId && state.activeChatId === chatId && !hasLocalGeneration(state, chatId),
+  );
+  const { data: generationStatus } = useGenerationStatus(chatId, enabled && canRecover);
+  useEffect(() => {
+    const state = useChatStore.getState();
+    if (!chatId || !enabled || state.activeChatId !== chatId || hasLocalGeneration(state, chatId)) {
+      orphanedGeneration.current = null;
+      return;
+    }
+    if (orphanedGeneration.current !== chatId) orphanedGeneration.current = null;
+    if (generationStatus?.active) {
+      orphanedGeneration.current = chatId;
+    } else if (generationStatus?.active === false && orphanedGeneration.current === chatId) {
+      orphanedGeneration.current = null;
+      // A fresh browser has no surviving SSE callback. Refresh saved rows once
+      // that server work finishes, but leave live local streams/typewriters alone.
+      for (const queryKey of [
+        chatKeys.messages(chatId),
+        chatKeys.messageCount(chatId),
+        chatKeys.messagePeek(chatId),
+        chatKeys.detail(chatId),
+        ["gallery", chatId],
+      ]) {
+        void queryClient.invalidateQueries({ queryKey });
+      }
+    }
+  }, [chatId, enabled, canRecover, generationStatus?.active, queryClient]);
   const query = useInfiniteQuery({
     queryKey: chatKeys.messages(chatId ?? ""),
     queryFn: ({ pageParam, signal }) => {

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -294,17 +294,30 @@ export function useChatMessages(chatId: string | null, pageSize: number = 0, ena
   const queryClient = useQueryClient();
   const previousWindow = useRef({ chatId, pageSize });
   const orphanedGeneration = useRef<string | null>(null);
+  const localAgentsProcessing = useAgentStore((state) => !!chatId && state.processingChatIds.includes(chatId));
   const canRecover = useChatStore(
     (state) => !!chatId && state.activeChatId === chatId && !hasLocalGeneration(state, chatId),
   );
-  const { data: generationStatus } = useGenerationStatus(chatId, enabled && canRecover);
+  const { data: generationStatus, isFetching: checkingGeneration } = useGenerationStatus(
+    chatId,
+    enabled && canRecover && !localAgentsProcessing,
+  );
   useEffect(() => {
     const state = useChatStore.getState();
-    if (!chatId || !enabled || state.activeChatId !== chatId || hasLocalGeneration(state, chatId)) {
+    if (
+      !chatId ||
+      !enabled ||
+      state.activeChatId !== chatId ||
+      hasLocalGeneration(state, chatId) ||
+      useAgentStore.getState().processingChatIds.includes(chatId)
+    ) {
       orphanedGeneration.current = null;
       return;
     }
     if (orphanedGeneration.current !== chatId) orphanedGeneration.current = null;
+    // Re-enabling the query must not adopt a cached active status from before
+    // a local stream took ownership. Wait for the fresh server response.
+    if (checkingGeneration) return;
     if (generationStatus?.active) {
       orphanedGeneration.current = chatId;
     } else if (generationStatus?.active === false && orphanedGeneration.current === chatId) {
@@ -321,7 +334,7 @@ export function useChatMessages(chatId: string | null, pageSize: number = 0, ena
         void queryClient.invalidateQueries({ queryKey });
       }
     }
-  }, [chatId, enabled, canRecover, generationStatus?.active, queryClient]);
+  }, [chatId, enabled, canRecover, localAgentsProcessing, checkingGeneration, generationStatus?.active, queryClient]);
   const query = useInfiniteQuery({
     queryKey: chatKeys.messages(chatId ?? ""),
     queryFn: ({ pageParam, signal }) => {

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -5102,7 +5102,6 @@ strong {
 
 .animate-message-in {
   animation: message-in 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-  will-change: transform, opacity;
 }
 
 @keyframes slide-in-left {

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -6071,6 +6071,22 @@ strong {
 }
 
 @media (max-width: 767px) {
+  .mari-message-actions {
+    flex-wrap: nowrap;
+    column-gap: 0;
+    padding-inline: 0;
+  }
+
+  .mari-message-actions > button,
+  .mari-message-actions > div {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .mari-message-actions > div > button {
+    width: 100%;
+  }
+
   [data-chat-mode="roleplay"] .mari-chat-input-textarea {
     overscroll-behavior-y: contain;
   }

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -4199,9 +4199,10 @@ export async function registerRetryAgentsRoute(
 
     startSseReply(reply, { "X-Accel-Buffering": "no" });
 
-    // Abort in-flight agent LLM calls when the client disconnects, and stop
-    // writing to a closed socket. Mirrors the main /generate handler so a dropped
-    // retry tab does not leak upstream provider requests to completion.
+    // Illustrator saves its output to the chat even if the mobile tab disappears.
+    // Explicit Stop still cancels through activeAgentRuns; other retries retain
+    // their existing disconnect cancellation.
+    const preserveIllustratorOnDisconnect = agentTypes.every((agentType) => agentType === "illustrator");
     const abortController = new AbortController();
     const assertRetrySetupActive = () => abortController.signal.throwIfAborted();
     const notifyFallback = createReplyFallbackNotifier(reply);
@@ -4223,7 +4224,7 @@ export async function registerRetryAgentsRoute(
     const stopSseKeepalive = startSseKeepalive(reply);
     const onClientClose = () => {
       clientDisconnected = true;
-      abortController.abort();
+      if (!preserveIllustratorOnDisconnect) abortController.abort();
     };
     reply.raw.on("close", onClientClose);
 

--- a/scripts/regressions/illustrator-disconnect.regression.ts
+++ b/scripts/regressions/illustrator-disconnect.regression.ts
@@ -1,0 +1,230 @@
+// Real HTTP disconnects must not cancel a reviewed Illustrator image, but the
+// existing Stop/Stop Agents endpoint must still cancel it before persistence.
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createServer, request as httpRequest, type ServerResponse } from "node:http";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const fixtureDir = mkdtempSync(join(tmpdir(), "marinara-illustrator-disconnect-data-"));
+process.env.DATA_DIR = fixtureDir;
+process.env.FILE_STORAGE_DIR = join(fixtureDir, "storage");
+process.env.NODE_ENV = "test";
+process.env.MARINARA_LITE = "true";
+process.env.IMAGE_LOCAL_URLS_ENABLED = "true";
+process.env.LOG_LEVEL = "silent";
+
+const requireServer = createRequire(new URL("../../packages/server/package.json", import.meta.url));
+const Fastify = requireServer("fastify") as typeof import("fastify").default;
+const { getDB, closeDB } = await import("../../packages/server/src/db/connection.js");
+const { generateRoutes } = await import("../../packages/server/src/routes/generate.routes.js");
+const { createChatsStorage } = await import("../../packages/server/src/services/storage/chats.storage.js");
+const { createAgentsStorage } = await import("../../packages/server/src/services/storage/agents.storage.js");
+const { createConnectionsStorage } = await import("../../packages/server/src/services/storage/connections.storage.js");
+const { createGalleryStorage } = await import("../../packages/server/src/services/storage/gallery.storage.js");
+const { replaceBuiltInAgentDefinitions } = await import("../../packages/shared/dist/index.js");
+replaceBuiltInAgentDefinitions([
+  {
+    id: "illustrator",
+    name: "Illustrator",
+    description: "Isolated disconnect fixture",
+    phase: "post_processing",
+    enabledByDefault: true,
+    category: "utility",
+    defaultTools: [],
+    defaultSettings: { runInterval: 5 },
+    defaultPromptTemplate: "Fixture",
+  },
+  {
+    id: "echo-chamber",
+    name: "Echo Chamber",
+    description: "Unrelated retry cancellation control",
+    phase: "post_processing",
+    enabledByDefault: true,
+    category: "utility",
+    defaultTools: [],
+    defaultSettings: {},
+    defaultPromptTemplate: "Fixture",
+  },
+]);
+
+const png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+let imageStarted = Promise.withResolvers<ServerResponse>();
+const providerRequests: string[] = [];
+const provider = createServer(async (request, response) => {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  providerRequests.push(request.url ?? "");
+  if (!request.url?.endsWith("/images/generations") && !request.url?.endsWith("/chat/completions")) {
+    response.writeHead(500).end("Unexpected provider call: fixture must not call an LLM");
+    return;
+  }
+  const body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>;
+  if (request.url.endsWith("/images/generations")) assert.equal(body.prompt, "A small synthetic laboratory");
+  imageStarted.resolve(response);
+});
+
+const db = await getDB();
+const chats = createChatsStorage(db);
+const connections = createConnectionsStorage(db);
+const agents = createAgentsStorage(db);
+const gallery = createGalleryStorage(db);
+const app = Fastify();
+const streamClosed = new Map<string, ReturnType<typeof Promise.withResolvers<void>>>();
+app.addHook("preHandler", (request, reply, done) => {
+  if (request.url === "/api/generate/retry-agents") {
+    const chatId = (request.body as { chatId: string }).chatId;
+    reply.raw.once("close", () => streamClosed.get(chatId)?.resolve());
+  }
+  done();
+});
+app.decorate("db", db);
+await app.register(generateRoutes, { prefix: "/api/generate" });
+
+async function waitUntil(check: () => Promise<boolean>, description: string) {
+  const deadline = Date.now() + 10_000;
+  while (!(await check())) {
+    assert.ok(Date.now() < deadline, description);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+try {
+  await new Promise<void>((resolve) => provider.listen(0, "127.0.0.1", resolve));
+  const providerAddress = provider.address();
+  assert.ok(providerAddress && typeof providerAddress === "object");
+  const providerUrl = `http://127.0.0.1:${providerAddress.port}/v1`;
+  const textConnection = await connections.create({
+    name: "Unused mock text provider",
+    provider: "custom",
+    baseUrl: providerUrl,
+    model: "fixture",
+    apiKey: "fixture",
+  });
+  const imageConnection = await connections.create({
+    name: "Held mock image provider",
+    provider: "image_generation",
+    baseUrl: providerUrl,
+    model: "dall-e-3",
+    imageService: "openai",
+    imageGenerationSource: "openai",
+    apiKey: "fixture",
+  });
+  await agents.create({
+    type: "illustrator",
+    name: "Illustrator",
+    phase: "post_processing",
+    connectionId: textConnection.id,
+    settings: { imageConnectionId: imageConnection.id, enabledTools: [] },
+  });
+  await agents.create({
+    type: "echo-chamber",
+    name: "Echo Chamber",
+    phase: "post_processing",
+    connectionId: textConnection.id,
+    settings: { enabledTools: [] },
+  });
+  await app.listen({ host: "127.0.0.1", port: 0 });
+  const appAddress = app.server.address();
+  assert.ok(appAddress && typeof appAddress === "object");
+  const appUrl = `http://127.0.0.1:${appAddress.port}`;
+
+  for (const stop of [null, "agents", "generation", "other-agent-disconnect"] as const) {
+    const otherAgent = stop === "other-agent-disconnect";
+    const chat = await chats.create({
+      name: `Illustrator disconnect ${stop ?? "passive"}`,
+      mode: "roleplay",
+      characterIds: [],
+      connectionId: textConnection.id,
+      promptPresetId: null,
+    });
+    assert.ok(chat);
+    await chats.patchMetadata(chat.id, {
+      enableAgents: true,
+      activeAgentIds: [otherAgent ? "echo-chamber" : "illustrator"],
+      illustratorUseAvatarReferences: false,
+      illustratorIncludeCharacterAppearance: false,
+    });
+    const message = await chats.createMessage({ chatId: chat.id, role: "assistant", content: "Saved reply." });
+    assert.ok(message);
+    imageStarted = Promise.withResolvers<ServerResponse>();
+    streamClosed.set(chat.id, Promise.withResolvers<void>());
+    const body = JSON.stringify({
+      chatId: chat.id,
+      agentTypes: [otherAgent ? "echo-chamber" : "illustrator"],
+      ...(!otherAgent && {
+        illustratorRetryTargets: ["illustration"],
+        illustratorPromptReviewOverride: {
+          prompt: "A small synthetic laboratory",
+          resultData: { shouldGenerate: true, prompt: "A small synthetic laboratory" },
+        },
+      }),
+    });
+    let sseOutput = "";
+    const sseResponse = Promise.withResolvers<import("node:http").IncomingMessage>();
+    const clientRequest = httpRequest(
+      `${appUrl}/api/generate/retry-agents`,
+      { method: "POST", headers: { "content-type": "application/json", "content-length": Buffer.byteLength(body) } },
+      (response) => {
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          sseOutput += chunk;
+        });
+        response.on("error", () => {});
+        sseResponse.resolve(response);
+      },
+    );
+    clientRequest.on("error", (error) => sseResponse.reject(error));
+    clientRequest.end(body);
+    const imageResponse = await Promise.race([
+      imageStarted.promise,
+      new Promise<never>((_, reject) => {
+        const timer = setTimeout(() => reject(new Error(`Image request did not start: ${sseOutput}`)), 10_000);
+        timer.unref();
+      }),
+    ]);
+    const stream = await sseResponse.promise;
+    const active = async () =>
+      (await app.inject({ method: "GET", url: `/api/generate/status/${chat.id}` })).json().active === true;
+    assert.equal(await active(), true);
+    if (stop && !otherAgent) {
+      const aborted = await app.inject({
+        method: "POST",
+        url: "/api/generate/abort",
+        payload: { chatId: chat.id, ...(stop === "agents" ? { agentsOnly: true } : {}) },
+      });
+      assert.equal(aborted.json().aborted, true, aborted.body);
+    }
+    stream.destroy();
+    // Wait for the actual peer close before resolving the provider. This is not
+    // an injected AbortError or a synthetic event dispatched into the handler.
+    await streamClosed.get(chat.id)!.promise;
+    if (!stop) assert.equal(await active(), true, "Passive disconnect must retain the image run");
+    if (otherAgent) await waitUntil(async () => !(await active()), "Other agent retries must cancel on disconnect");
+    imageResponse.setHeader("content-type", "application/json");
+    imageResponse.end(JSON.stringify({ data: [{ b64_json: png }] }));
+    await waitUntil(async () => !(await active()), "Image run did not settle");
+    const savedImages = await gallery.listByChatId(chat.id);
+    assert.equal(savedImages.length, stop ? 0 : 1, `Image persistence after ${stop ?? "passive disconnect"}`);
+    const expectedAttachments = stop ? 0 : 1;
+    const savedMessage = await chats.getMessage(message.id);
+    const savedSwipes = await chats.getSwipes(message.id);
+    assert.equal((JSON.parse(savedMessage!.extra).attachments ?? []).length, expectedAttachments);
+    assert.equal((JSON.parse(savedSwipes[0]!.extra).attachments ?? []).length, expectedAttachments);
+    if (!stop)
+      assert.deepEqual(readFileSync(join(fixtureDir, "gallery", savedImages[0]!.filePath)), Buffer.from(png, "base64"));
+  }
+  assert.equal(providerRequests.filter((url) => url.endsWith("/images/generations")).length, 3);
+  assert.equal(providerRequests.filter((url) => url.endsWith("/chat/completions")).length, 1);
+  console.info("Illustrator HTTP disconnect and explicit Stop regressions passed.");
+} finally {
+  // Release outstanding provider sockets first so a failed assertion cannot
+  // leave a preserved retry hanging while Fastify drains active requests.
+  provider.closeAllConnections();
+  app.server.closeAllConnections();
+  await app.close();
+  await new Promise<void>((resolve) => provider.close(() => resolve()));
+  await closeDB();
+  rmSync(fixtureDir, { recursive: true, force: true });
+}

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -10210,7 +10210,9 @@ assert.equal(({} as { tags?: string[] }).tags, undefined, "Background metadata m
   );
   assert.match(conversationSurfaceSource, /onIllustrateWithAgent=\{onIllustrateWithAgent\}/u);
 
-  assert.match(settingsDrawerSource, /\/generate\/status\/\$\{encodeURIComponent\(chat\.id\)\}/u);
+  assert.match(settingsDrawerSource, /useGenerationStatus\(\s*chat\.id,\s*open && isRoleplayMode/u);
+  const generationStatusHookSource = readFileSync(join(REPOSITORY_ROOT, "packages/client/src/hooks/use-chats.ts"), "utf8");
+  assert.match(generationStatusHookSource, /\/generate\/status\/\$\{encodeURIComponent\(chatId \?\? ""\)\}/u);
   assert.match(settingsDrawerSource, /isRoleplayMode && \(activeGeneration \|\| stoppingGeneration\)/u);
   assert.match(settingsDrawerSource, /await abortGenerationForChat\(chat\.id, controller\)/u);
   const stopGenerationActionStart = settingsDrawerSource.indexOf(


### PR DESCRIPTION
## Linked issue

Closes #5873.
Refs #5870. Keep #5870 open for physical iPhone confirmation of the reported persistent black screen.

## Why this change

Mari's installed iPhone Home Screen app can become blank after long Roleplay replies/agent work, and reopening does not reliably reveal Illustrator results. Docker stays healthy and Messages per page is 20. Separately, #5873 reports that the recent fixed 44 px mobile action widths force wrapping; the maintainer requests near-old mobile sizing while preserving larger desktop controls.

## What changed

- Remove one permanent `will-change` declaration after message entrance animations. The animation and layout remain intact.
- Reuse the existing accent-derived panel border for notifications, including agent/model warnings.
- Preserve Illustrator-only manual/retried work on passive socket disconnect. Existing explicit Stop/Stop Agents cancellation and unrelated retry cancellation remain unchanged.
- Reuse the existing generation-status query when opening a chat without a local generation. Poll only while the server is active, then refresh saved messages and gallery results once. Navigation, local streams, typewriters and agent tails retain ownership.
- Compact the existing Conversation/Roleplay mobile icons to 0.875rem (about 1 px larger than the old 0.8125rem icons at the default app scale), and share one row's width without changing desktop sizes, action order, or saved swipe preferences.
- Add focused regression proof, Unreleased notes and iOS recovery guidance. No new dependencies, schema, reload workaround or job system.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated evidence (checkboxes intentionally remain unchecked for human verification):
- `pnpm check` passed, including localization, formatting, lint, E2E types and production/PWA build.
- Real Fastify + loopback HTTP image provider regression passed: passive disconnect saves exact image bytes, gallery row, message and swipe attachments; Stop Agents and ordinary Stop prevent persistence; an unrelated Echo Chamber retry still aborts on disconnect. Baseline failed on lost image persistence.
- Final 21 focused browser checks passed across desktop Chromium, mobile Chromium and mobile WebKit: compact one-row actions at 320 px and normal mobile width, action order, persisted swipe preferences, warning accents in light/dark themes, completed animation lifetime, reopened image visible in gallery/transcript without SSE, idle/no polling, navigation, and local stream/typewriter/agent-tail guards.
- Baseline WebKit failed on lingering compositor hint; warning baseline failed on orchid border; mobile action baseline failed on oversized icons and visibly wrapped rows.
- Linux/amd64 Docker build and runtime smoke passed: health endpoint, production desktop Chromium and iPhone-sized WebKit shell/action controls, no page errors. The image uses e2fcb821c production sources; the later 0b230a3e7 commit changes only an existing source-location regression assertion. The temporary container and synthetic data were removed after testing.
- Existing open-issues regression now verifies both the drawer hook call and the extracted status endpoint; focused rerun passed after CI identified the obsolete inline-source assertion. Attached-agent Stop, message-page cache, Roleplay streaming and gallery recovery regressions also passed in isolated test data.

### Manual verification notes

Manually verify on an actual iPhone Home Screen PWA connected to Docker: long Roleplay replies with agents/Illustrator, app interruption and reopening before the image finishes, and the chosen warning-border accent. Also manually verify Samsung Internet and Firefox Android at 100% browser zoom, with optional message tools enabled.

**Claim boundary:** removal of an unnecessary long-reply compositor hint is proven, but the physical iPhone WebKit/GPU failure has not been reproduced. This PR mitigates a concrete rendering-pressure source and fixes proven image cancellation/recovery paths; it does not establish guaranteed elimination of all iOS blank screens. Automatic /generate already survives passive disconnects; the server cancellation change specifically concerns Illustrator-only /retry-agents. No private chat screenshots or paid model calls were used.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

Unreleased changelog and iOS PWA troubleshooting updated. Translation follow-up: #5874. Staging only; no main promotion, release/version bump, or unrelated draft changes.

## UI evidence (if applicable)

[Synthetic before/after browser proof](https://gist.github.com/SpicyMarinara/a8b8247cd1a1dc9620c9b6627bb2172c). Includes warning before/after, compact Conversation/Roleplay actions and reopened image delivery. All screenshots use synthetic content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Long Roleplay messages now release temporary animation resources after entering view.
  - Notifications and connection warnings use the selected accent color for borders in both themes.
  - Illustrator image requests can finish saving after a browser disconnect; explicit stopping still cancels them.
  - Reopened chats now refresh saved messages and gallery images after server-side generation completes.
  - Mobile message actions now fit in a compact shared row while desktop controls remain unchanged.

- **Documentation**
  - Added iOS/iPadOS troubleshooting guidance for generation interruptions, recovery, cancellation, and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
