### PR TITLE
fix(chat): match Conversation swipes to Roleplay controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Conversation swipe menus now reuse Roleplay's compact, unboxed controls on desktop and mobile, with arrows and counters following the configured chat-chrome text color instead of pink/orchid styling (#5875).
 - Released temporary rendering hints after message entrance animations, reducing unnecessary compositor layers around long, growing Roleplay replies without changing their animation or layout (#5870).
 - Agent connection warnings and other notifications now use the selected accent for their border in light and dark themes (#5870).
 - Illustrator-only manual and retried image requests now finish saving after a browser disconnect; explicit Stop still cancels them. Reopened chats refresh saved messages and gallery images when server-side generation finishes (#5870).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -5707,6 +5707,133 @@ test("stopped and refused generations keep sent text cleared and accept the firs
   }
 });
 
+test("Conversation swipe controls match Roleplay sizing and chat-chrome colors", async ({
+  page,
+  request,
+}, testInfo) => {
+  const fixtures: Array<{ chatId: string; messageId: string; layout: "roleplay" | "classic" | "bubble" | "grouped" }> =
+    [];
+  try {
+    for (const layout of ["roleplay", "classic", "bubble", "grouped"] as const) {
+      const created = await request.post("/api/chats", {
+        data: {
+          name: `${layout} swipe parity`,
+          mode: layout === "roleplay" ? "roleplay" : "conversation",
+          characterIds: [],
+        },
+      });
+      expect(created.ok()).toBeTruthy();
+      const { id: chatId } = (await created.json()) as { id: string };
+      const content =
+        layout === "grouped"
+          ? '<speaker="Alice">A synthetic grouped response.</speaker><speaker="Bob">Another synthetic turn.</speaker>'
+          : "A synthetic response for comparing the same swipe controls in each layout.";
+      const saved = await request.post(`/api/chats/${chatId}/messages`, { data: { role: "assistant", content } });
+      expect(saved.ok()).toBeTruthy();
+      const { id: messageId } = (await saved.json()) as { id: string };
+      fixtures.push({ chatId, messageId, layout });
+      const alternate = await request.post(`/api/chats/${chatId}/messages/${messageId}/swipes`, {
+        data: { content, silent: true },
+      });
+      expect(alternate.ok()).toBeTruthy();
+    }
+    await page.goto("/");
+    await setAppAccentColor(page, "#38bdf8");
+    const viewport = page.viewportSize()!;
+    for (const width of testInfo.project.name.includes("mobile") ? [320, viewport.width] : [viewport.width]) {
+      await page.setViewportSize({ width, height: viewport.height });
+      for (const theme of ["dark", "light"] as const) {
+        let roleplayMetrics: unknown;
+        for (const { chatId, messageId, layout } of fixtures) {
+          await page.evaluate(
+            async ({ id, style, nextTheme }) => {
+              const { useChatStore } = (await import("/src/stores/chat.store.ts" as string)) as {
+                useChatStore: { getState: () => { setActiveChatId: (id: string) => void } };
+              };
+              const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
+                useUIStore: {
+                  getState: () => {
+                    setConversationMessageStyle: (style: "classic" | "bubble") => void;
+                    setTheme: (theme: "dark" | "light") => void;
+                    setChatChromeTextColor: (color: string) => void;
+                  };
+                };
+              };
+              const ui = useUIStore.getState();
+              ui.setConversationMessageStyle(style === "bubble" ? "bubble" : "classic");
+              ui.setTheme(nextTheme);
+              ui.setChatChromeTextColor(nextTheme === "dark" ? "#c2dce5" : "#263a47");
+              useChatStore.getState().setActiveChatId(id);
+            },
+            { id: chatId, style: layout, nextTheme: theme },
+          );
+          const row = page.locator(`[data-message-id="${messageId}"]`);
+          const control = row.locator(".mari-message-swipes");
+          await expect(control).toBeVisible();
+          const input = control.getByRole("textbox");
+          await expect(input).toHaveValue("1");
+          const metrics = await control.evaluate((element) => {
+            const button = element.querySelector("button")!;
+            const field = element.querySelector("input")!;
+            const icon = button.querySelector("svg")!;
+            const styles = getComputedStyle(element);
+            return {
+              height: element.getBoundingClientRect().height,
+              gap: styles.gap,
+              padding: styles.padding,
+              fontSize: styles.fontSize,
+              buttonWidth: button.getBoundingClientRect().width,
+              buttonHeight: button.getBoundingClientRect().height,
+              iconWidth: icon.getBoundingClientRect().width,
+              inputWidth: field.getBoundingClientRect().width,
+              inputHeight: field.getBoundingClientRect().height,
+              inputFontSize: getComputedStyle(field).fontSize,
+              inputRadius: getComputedStyle(field).borderRadius,
+            };
+          });
+          if (layout === "roleplay") roleplayMetrics = metrics;
+          else expect.soft(metrics, `${layout} ${theme} ${width}px matches Roleplay`).toEqual(roleplayMetrics);
+          const actionColor = await readCssVariableColor(page, "--marinara-chat-message-action-text");
+          await expect.soft(control).toHaveCSS("color", actionColor, { timeout: 500 });
+          await expect.soft(control).toHaveCSS("border-top-width", "0px", { timeout: 500 });
+          await expect.soft(control).toHaveCSS("background-color", "rgba(0, 0, 0, 0)", { timeout: 500 });
+          await expect
+            .soft(input)
+            .toHaveCSS("color", await readCssVariableColor(page, "--marinara-chat-message-action-text-hover"), {
+              timeout: 500,
+            });
+          await testInfo.attach(`${layout}-swipes-${theme}-${width}.png`, {
+            body: await row.screenshot({ animations: "disabled" }),
+            contentType: "image/png",
+          });
+          // Wait for persistence, not just the optimistic counter, before the next interaction.
+          const selectSwipe = async (index: number, action: () => Promise<void>) => {
+            const saved = page.waitForResponse(
+              (response) =>
+                response.url().endsWith(`/messages/${messageId}/active-swipe`) &&
+                response.request().method() === "PUT" &&
+                response.request().postDataJSON().index === index,
+            );
+            await action();
+            expect(((await (await saved).json()) as { activeSwipeIndex: number }).activeSwipeIndex).toBe(index);
+            await expect(input).toHaveValue(String(index + 1));
+          };
+          await selectSwipe(1, () => control.getByRole("button", { name: "Next swipe", exact: true }).click());
+          await selectSwipe(0, () => control.getByRole("button", { name: "Previous swipe", exact: true }).click());
+          await selectSwipe(1, () => input.fill("2"));
+          await input.press("Enter");
+          await expect(control.getByRole("button", { name: "Previous swipe", exact: true })).toBeEnabled();
+          await selectSwipe(0, () => input.fill("1"));
+          await input.press("Enter");
+          await expect(control.getByRole("button", { name: "Previous swipe", exact: true })).toBeDisabled();
+        }
+      }
+    }
+  } finally {
+    for (const { chatId } of fixtures) await bestEffortDelete(request, `/api/chats/${chatId}?force=true`);
+  }
+});
+
 for (const mode of ["conversation", "roleplay"] as const) {
   test(`${mode} message actions fit mobile rows and first-swipe preferences persist independently`, async ({
     page,

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -98,7 +98,6 @@ import { MessageThinkingModal } from "./MessageThinkingModal";
 import { MESSAGE_ACTION_ICON_SIZE, MessageActionButton } from "./MessageActionButton";
 import { RoleplayStoryboardMessageMedia } from "./RoleplayStoryboardMessageMedia";
 
-const MESSAGE_SWIPE_ICON_SIZE = "1.15em";
 const MESSAGE_DOUBLE_TAP_MS = 320;
 const MESSAGE_DOUBLE_TAP_DISTANCE_PX = 26;
 const MESSAGE_CHROME_ACTIVE_ICON_CLASS =
@@ -3545,10 +3544,6 @@ export const ChatMessage = memo(function ChatMessage({
                 swipeCount={swipeCount}
                 onSetActiveSwipe={handleSetActiveSwipe}
                 onCreateNextSwipe={canCreateNextSwipe ? () => onRegenerate?.(message.id) : undefined}
-                className="px-1 text-[0.75rem] text-white/40"
-                buttonClassName="rounded-md p-[0.25em] transition-colors hover:bg-white/10 disabled:opacity-30"
-                inputClassName="border-white/10 bg-white/5 text-white/70 [color-scheme:dark]"
-                iconSize={MESSAGE_SWIPE_ICON_SIZE}
               />
             )}
 
@@ -4022,9 +4017,6 @@ export const ChatMessage = memo(function ChatMessage({
               swipeCount={swipeCount}
               onSetActiveSwipe={handleSetActiveSwipe}
               onCreateNextSwipe={canCreateNextSwipe ? () => onRegenerate?.(message.id) : undefined}
-              className="px-2 text-[0.75rem] text-[var(--muted-foreground)]"
-              buttonClassName="rounded p-[0.25em] transition-colors hover:bg-[var(--accent)] disabled:opacity-30"
-              iconSize={MESSAGE_SWIPE_ICON_SIZE}
             />
           )}
 

--- a/packages/client/src/components/chat/ConversationMessageShared.tsx
+++ b/packages/client/src/components/chat/ConversationMessageShared.tsx
@@ -657,12 +657,7 @@ export function ConversationMessageSwipes({
       swipeCount={swipeCount}
       onSetActiveSwipe={onSetActiveSwipe}
       onCreateNextSwipe={onCreateNextSwipe}
-      className={cn(
-        "inline-flex items-center gap-0.5 rounded-md border border-[var(--border)] bg-[var(--secondary)] px-1.5 py-0.5 text-[0.625rem] text-[var(--muted-foreground)]",
-        className,
-      )}
-      buttonClassName="rounded-sm p-0.5 transition-colors hover:bg-[var(--accent)] disabled:opacity-30"
-      inputClassName="h-[1.25rem] w-[2rem] border-none bg-transparent text-center text-[0.625rem] outline-none"
+      className={className}
     />
   );
 }

--- a/packages/client/src/components/chat/SwipeJumpControl.tsx
+++ b/packages/client/src/components/chat/SwipeJumpControl.tsx
@@ -3,6 +3,9 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { useTranslation as useUiTranslation } from "react-i18next";
 
+const SWIPE_BUTTON_CLASS =
+  "inline-flex min-h-8 min-w-8 items-center justify-center rounded-md p-[0.25em] transition-colors hover:bg-[var(--marinara-chat-message-action-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)] disabled:opacity-30 max-md:min-h-[44px] max-md:min-w-[44px]";
+
 interface SwipeJumpControlProps {
   messageId: string;
   activeSwipeIndex: number;
@@ -11,9 +14,6 @@ interface SwipeJumpControlProps {
   onSetActiveSwipe: (index: number) => void;
   onCreateNextSwipe?: () => void;
   className?: string;
-  buttonClassName?: string;
-  inputClassName?: string;
-  iconSize?: string;
 }
 
 export function SwipeJumpControl({
@@ -24,9 +24,6 @@ export function SwipeJumpControl({
   onSetActiveSwipe,
   onCreateNextSwipe,
   className,
-  buttonClassName,
-  inputClassName,
-  iconSize = "0.75rem",
 }: SwipeJumpControlProps) {
   const { t: localizeUi } = useUiTranslation();
   const [inputValue, setInputValue] = useState(() => String(activeSwipeIndex + 1));
@@ -60,13 +57,15 @@ export function SwipeJumpControl({
   };
 
   return (
-    <div className={cn("mari-message-swipes flex items-center gap-1.5", className)}>
+    <div
+      className={cn(
+        "mari-message-swipes flex items-center gap-1.5 px-1 text-[0.75rem] text-[var(--marinara-chat-message-action-text)]",
+        className,
+      )}
+    >
       <button
         type="button"
-        className={cn(
-          "inline-flex min-h-8 min-w-8 items-center justify-center max-md:min-h-[44px] max-md:min-w-[44px]",
-          buttonClassName,
-        )}
+        className={SWIPE_BUTTON_CLASS}
         onClick={(event) => {
           event.stopPropagation();
           setSwipeByDisplayIndex(activeSwipeIndex);
@@ -75,7 +74,7 @@ export function SwipeJumpControl({
         aria-label={localizeUi("ui.chat.swipejumpcontrol.previousSwipe")}
         title={localizeUi("ui.chat.swipejumpcontrol.previousSwipe")}
       >
-        <ChevronLeft size={iconSize} />
+        <ChevronLeft size="1.15em" />
       </button>
       <label className="sr-only" htmlFor={inputId}>
         {localizeUi("ui.chat.swipejumpcontrol.jumpToSwipe")}
@@ -97,20 +96,14 @@ export function SwipeJumpControl({
           event.stopPropagation();
           if (event.key === "Enter") event.currentTarget.blur();
         }}
-        className={cn(
-          "h-[1.375rem] w-9 rounded-full border border-transparent bg-[var(--marinara-chat-chrome-highlight-bg)] px-1.5 py-0.5 text-center tabular-nums text-[0.625rem] font-medium text-[var(--marinara-chat-chrome-panel-muted)] outline-none transition-[background-color,border-color,box-shadow,color] focus:border-[var(--marinara-chat-chrome-button-border-active)] focus:bg-[var(--marinara-chat-chrome-button-bg-active)]",
-          inputClassName,
-        )}
+        className="h-[1.375rem] w-9 rounded-full border border-[var(--marinara-chat-message-action-bg-hover)] bg-[color-mix(in_srgb,var(--marinara-chat-chrome-text)_5%,transparent)] px-1.5 py-0.5 text-center tabular-nums text-[0.625rem] font-medium text-[var(--marinara-chat-message-action-text-hover)] outline-none transition-[background-color,border-color,box-shadow,color] focus:border-[var(--marinara-chat-chrome-button-border-active)] focus:bg-[var(--marinara-chat-chrome-button-bg-active)]"
         aria-label={localizeUi("ui.chat.swipejumpcontrol.jumpToSwipe1ThroughValue1", { value1: displaySwipeCount })}
         title={localizeUi("ui.chat.swipejumpcontrol.jumpToSwipe1Value1", { value1: displaySwipeCount })}
       />
       <span className="tabular-nums">/{displaySwipeCount}</span>
       <button
         type="button"
-        className={cn(
-          "inline-flex min-h-8 min-w-8 items-center justify-center max-md:min-h-[44px] max-md:min-w-[44px]",
-          buttonClassName,
-        )}
+        className={SWIPE_BUTTON_CLASS}
         onClick={(event) => {
           event.stopPropagation();
           if (hasNextSwipe) {
@@ -131,7 +124,7 @@ export function SwipeJumpControl({
             : localizeUi("ui.chat.swipejumpcontrol.generateNextSwipe")
         }
       >
-        <ChevronRight size={iconSize} />
+        <ChevronRight size="1.15em" />
       </button>
     </div>
   );


### PR DESCRIPTION
## Linked issue

Closes #5875.

## Why this change

Conversation's swipe menu kept a separate, larger pink/orchid box after the mobile action-row fix. Mari requests the same compact Roleplay swipe controls on desktop and mobile, using the chosen chat-chrome text color.

## What changed

- Move Roleplay's existing swipe dimensions, spacing, arrow size and small counter pill into the already-shared `SwipeJumpControl`.
- Delete per-mode styling overrides, including Conversation's extra border/background/padding. Classic, bubble and grouped Conversation layouts use the same control.
- Reuse message-action chat-chrome text/hover tokens and the existing focus-ring token instead of fixed white or orchid colors.
- Add an Unreleased entry and browser regression. No navigation, regeneration, saved preference, localization copy, dependency, or release changes.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated evidence (checkboxes intentionally left for human verification):

- `pnpm install`, `pnpm localization:check` and full `pnpm check` passed.
- 9 focused Playwright checks passed across desktop Chromium, mobile Chromium and mobile WebKit. The new visual regression compares all three Conversation layouts against Roleplay at 320 px, normal phone widths and 1440 px desktop, in light/dark themes with custom chat-chrome colors. It verifies dimensions, unboxed styling, arrows and numeric jumps.
- Existing regeneration, action-order, and independently persisted first-swipe display-toggle checks passed unchanged.
- Before-fix WebKit reproduced the boxed orchid menu, extra height and differing arrow/counter sizing. Test navigation now waits for actual swipe persistence rather than racing optimistic counter updates.
- Linux/amd64 production Docker build and browser smoke passed at commit `521c22224088`: desktop Chromium and iPhone-sized WebKit rendered matching Conversation/Roleplay controls with no page errors.

### Manual verification notes

Manually verify Conversation and Roleplay swipe appearance on an actual desktop and phone, including a custom Chroma text color, light/dark theme, first-swipe regeneration, numeric jumps and the saved display toggle. Browser automation and synthetic screenshots do not claim physical-device testing.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

Changelog only. No documentation or version changes. Staging only; no main promotion or unrelated draft edits.

## UI evidence (if applicable)

[Synthetic before/after screenshots](https://gist.github.com/SpicyMarinara/ef4093e6850328820ce25f5faa5540a9): original Conversation menu, shared Conversation/Roleplay controls, bubble layout, light theme and desktop. No private user screenshots, chat assets or paid model calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Conversation swipe controls now use compact, unboxed styling consistently across desktop and mobile layouts.
  - Swipe arrows, counters, and jump-to-swipe fields now follow the configured chat-chrome colors instead of pink/orchid styling.
  - Swipe control sizing, spacing, borders, backgrounds, and input appearance are now consistent across chat layouts and themes.
  - Swipe navigation and index entry now preserve the active swipe correctly, with Previous controls enabling and disabling at the appropriate positions.
  - Roleplay text-to-speech controls now display microphone icons, while conversation controls retain speaker-volume icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->