### PR TITLE
feat(server): let capability packages register their own file tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- Added a storage API that lets a downloaded capability package register and persist its own file tables, with strict table-name validation. No caller is wired to it yet.
 - Removed the unfinished Slurp creator-feed material from the Noodle guides.
 - Updated the timeout reference in `.env.example` to use Slurp consistently.
 - Added a reusable Character Schedule Manager for Conversation schedules. It groups characters with and without schedules, supports bulk generation and removal, and provides per-character weekly renewal controls.

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -215,6 +215,33 @@ export type FileNativeStoreController = {
    * safe, a missed one is not. 0 = never written in this process.
    */
   getTableWriteGeneration: (table: string) => number;
+  /**
+   * Adds capability-package-owned file tables to the live store: host
+   * integration for downloaded packages that declare their own storage.
+   * Packages activate after initialize(), so this integrates
+   * a table into an already-running store rather than at boot. Names that fail
+   * validation, or that a table already claims, are skipped and logged — one bad
+   * package table must never abort host startup.
+   *
+   * Registered tables persist exactly like the Engine's own — they flush, they
+   * appear in the snapshot manifest, and a full data-directory backup captures
+   * them. They are deliberately NOT part of profile export/import; see the note
+   * beside profileTableObjects in backup.routes.ts for why.
+   *
+   * KNOWN CONSTRAINT — the registries are PROCESS-GLOBAL, not per store. A name
+   * registered here stays in tableMetasByName/FILE_BACKED_TABLES for the life of
+   * the process, so a store constructed later against a DIFFERENT storage
+   * directory already knows the name and boot-loads it from its own directory,
+   * where it finds nothing. That degrades to an empty table, never to corruption
+   * or a cross-directory read. It is accepted because production runs one store
+   * per process, and because the alternative — instance registries — means
+   * threading them through getMeta() and the whole module-level lookup surface.
+   * Per-instance registration is the correct fix if the Engine ever runs more
+   * than one store at a time. Until then: a test that constructs several stores
+   * MUST give each scenario a distinct table name, or its second store will
+   * silently exercise the boot loader instead of this method.
+   */
+  registerTables: (tables: readonly unknown[]) => void;
 };
 
 export type FileNativeDB = {
@@ -299,7 +326,7 @@ export const STORAGE_WRITER_LIVENESS_FILENAME = "live.sock";
 const SAVE_DEBOUNCE_MS = 750;
 const SAFETY_SAVE_MS = 10_000;
 
-export const FILE_BACKED_TABLES = [
+const BUILT_IN_FILE_BACKED_TABLES = [
   "chats",
   "messages",
   "message_swipes",
@@ -383,12 +410,28 @@ export const FILE_BACKED_TABLES = [
   "mari_workspace_context",
 ] as const;
 
-type FileBackedTable = (typeof FILE_BACKED_TABLES)[number];
+/**
+ * The Engine's own tables keep their literal-union type so CASCADES and other
+ * table-name constants stay compile-checked. The runtime list is a widened copy
+ * because capability packages register their own tables into a live store
+ * (registerTables): every consumer that walks "all file-backed tables" — the
+ * flush loop, the manifest, the Mari db tooling — must see them, and an
+ * `as const` tuple could never grow.
+ */
+type FileBackedTable = (typeof BUILT_IN_FILE_BACKED_TABLES)[number];
+/**
+ * The registry itself. Module-private because the ONLY sanctioned way to grow
+ * it is registerTables, which validates the name and updates every companion
+ * registry in the same breath; an outside push would land a name in the flush
+ * loop with no metadata and no shard classification.
+ */
+const fileBackedTables: string[] = [...BUILT_IN_FILE_BACKED_TABLES];
+export const FILE_BACKED_TABLES: readonly string[] = fileBackedTables;
 
 // #5302: every file-backed table uses the existing crash-safe shard pipeline.
 // Order remains significant for messages/swipes because swipe ownership is
 // resolved through the parent-message index.
-export const SHARDED_TABLES = FILE_BACKED_TABLES;
+export const SHARDED_TABLES: readonly string[] = FILE_BACKED_TABLES;
 
 /**
  * Child tables group by their stable owner. Every unlisted table uses its
@@ -436,7 +479,12 @@ const SHARD_KEY_COLUMNS: Record<string, string> = {
   memory_chunks: "chatId",
   mari_workspace_context: "chatId",
 };
-const SHARDED_TABLE_SET: ReadonlySet<string> = new Set(SHARDED_TABLES);
+// Deliberately mutable, unlike the arrays it mirrors: SHARDED_TABLES aliases
+// FILE_BACKED_TABLES, so a registered table becomes "sharded" by array identity
+// the instant it is pushed. If this set were the module-load snapshot it once
+// was, the load, flush and delete paths would each classify that same table
+// differently. Registration writes both, together, or neither.
+const SHARDED_TABLE_SET = new Set<string>(SHARDED_TABLES);
 
 /**
  * Chat-unit lazy tier (#5592 Phase 2). These tables no longer load at boot:
@@ -817,41 +865,66 @@ function tableNameOf(table: Table): string {
   return getFileTableConfig(table).name;
 }
 
+/**
+ * Table names become filesystem paths (`tables/<name>.json`, `tables/<name>/`)
+ * with no further escaping anywhere in this file, so this is the ONLY thing
+ * standing between a package-declared name and an arbitrary write outside the
+ * data directory. Allow exactly what the Engine's own names already look like:
+ * lowercase snake_case, no dots, no separators, no traversal, and short enough
+ * that `<name>.json` plus a shard filename stays inside path limits. Windows
+ * reserved basenames are excluded because Windows blocks them with any
+ * extension. Returns null when the name is acceptable.
+ */
+function fileBackedTableNameRejection(name: string): string | null {
+  if (typeof name !== "string" || name.length === 0) return "table name is empty";
+  if (name.length > 64) return "table name is longer than 64 characters";
+  if (!/^[a-z][a-z0-9_]*$/.test(name)) return "table name must match /^[a-z][a-z0-9_]*$/";
+  if (WINDOWS_RESERVED_BASENAMES.has(name.toUpperCase())) return "table name is reserved by Windows";
+  return null;
+}
+
+/** Shared shape work for schema-declared and package-registered tables alike;
+ *  the unique-constraint validation is the part neither may skip. */
+function buildFileTableMetadata(table: AnyFileTable, name: string): TableMeta {
+  const tableConfig = getFileTableConfig(table);
+  const columns: ColumnMeta[] = tableConfig.columns.map((column) => ({
+    key: column.key,
+    dbName: column.name,
+    column,
+    primary: column.primary,
+    hasDefault: column.hasDefault,
+    defaultValue: column.defaultValue,
+  }));
+  const meta: TableMeta = {
+    name,
+    table,
+    columns,
+    byKey: new Map(columns.map((column) => [column.key, column])),
+    byDbName: new Map(columns.map((column) => [column.dbName, column])),
+    primaryKey: columns.find((column) => column.primary)?.key ?? null,
+    uniqueConstraints: tableConfig.uniqueConstraints.map((constraint) => ({
+      keys: [...constraint.keys],
+      when: constraint.when,
+    })),
+  };
+  for (const constraint of meta.uniqueConstraints) {
+    if (constraint.keys.length === 0 || constraint.keys.some((key) => !meta.byKey.has(key))) {
+      throw new Error(`[file-storage] Invalid unique key metadata for ${name}: ${constraint.keys.join(", ")}`);
+    }
+  }
+  return meta;
+}
+
 function buildTableMetadata() {
   for (const candidate of Object.values(schema)) {
     if (!isFileTable(candidate)) continue;
     const table = candidate;
     const name = tableNameOf(table);
     if (!FILE_BACKED_TABLE_SET.has(name)) continue;
-    const tableConfig = getFileTableConfig(table);
-    const columns: ColumnMeta[] = tableConfig.columns.map((column) => ({
-      key: column.key,
-      dbName: column.name,
-      column,
-      primary: column.primary,
-      hasDefault: column.hasDefault,
-      defaultValue: column.defaultValue,
-    }));
-    const meta: TableMeta = {
-      name,
-      table,
-      columns,
-      byKey: new Map(columns.map((column) => [column.key, column])),
-      byDbName: new Map(columns.map((column) => [column.dbName, column])),
-      primaryKey: columns.find((column) => column.primary)?.key ?? null,
-      uniqueConstraints: tableConfig.uniqueConstraints.map((constraint) => ({
-        keys: [...constraint.keys],
-        when: constraint.when,
-      })),
-    };
-    for (const constraint of meta.uniqueConstraints) {
-      if (constraint.keys.length === 0 || constraint.keys.some((key) => !meta.byKey.has(key))) {
-        throw new Error(`[file-storage] Invalid unique key metadata for ${name}: ${constraint.keys.join(", ")}`);
-      }
-    }
+    const meta = buildFileTableMetadata(table, name);
     tableMetasByObject.set(table, meta);
     tableMetasByName.set(name, meta);
-    for (const column of columns) {
+    for (const column of meta.columns) {
       columnMetasByObject.set(column.column, column);
     }
   }
@@ -3382,6 +3455,198 @@ class FileTableStore {
     return this.tableWriteGenerations.get(table) ?? 0;
   }
 
+  /**
+   * Registers capability-package tables against the running store. Everything a
+   * boot-loaded table gets, a registered one must get too — metadata, a row
+   * container, its rows read off disk, membership in the flush loop and in the
+   * manifest — because the alternative is a table that accepts writes and
+   * silently loses them.
+   *
+   * Registered tables are SHARDED, like every Engine table (SHARDED_TABLES
+   * aliases FILE_BACKED_TABLES, so pushing a name makes it sharded whether we
+   * want it or not). Making them flat would mean opting a new table into the
+   * store's least-exercised path and would still leave the alias lying about
+   * them. One file per primary key, the default strategy for a table with no
+   * SHARD_KEY_COLUMNS entry.
+   *
+   * Failures are per-table and non-fatal: a package with one malformed table
+   * definition must not take the host down with it.
+   *
+   * Known constraint: the registries this writes (tableMetasByName,
+   * FILE_BACKED_TABLE_SET, SHARDED_TABLE_SET) are process-global, as the
+   * Engine's own table metadata already is. A registered name therefore
+   * outlives the store that registered it, so a later store built in the same
+   * process — a different storage directory, say — sees the name at boot and
+   * loads it from its own directory, finding nothing. That degrades to an
+   * empty table rather than to corruption or a cross-directory read, and
+   * production runs one store per process, so it is accepted here rather than
+   * threading instance-scoped registries through getMeta and every lookup that
+   * calls it. Tests that construct more than one store must use distinct table
+   * names, or a name registered by an earlier case makes a later one pass
+   * without exercising this method at all. Per-instance registries are the
+   * correct fix if the Engine ever runs several stores at once.
+   */
+  registerTables(tables: readonly unknown[]) {
+    for (const candidate of tables) {
+      if (!isFileTable(candidate)) {
+        logger.warn("[file-storage] Ignored a package table registration that is not a file table definition.");
+        continue;
+      }
+      const name = tableNameOf(candidate);
+      // The one non-negotiable check. tableFilePath/shardDirPath join this name
+      // straight into the storage tree with no sanitisation; that was safe only
+      // while every name came from the Engine's own hardcoded allowlist. A
+      // package-supplied "../../.ssh/authorized_keys" would otherwise be a write
+      // primitive outside the data directory.
+      const rejection = fileBackedTableNameRejection(name);
+      if (rejection) {
+        logger.error({ table: name }, "[file-storage] Rejected package table registration: %s", rejection);
+        continue;
+      }
+      if (tableMetasByName.has(name)) {
+        // Idempotent by design (re-registration on package reload) and a hard
+        // shadowing guard: the first definition of a name — always the Engine's
+        // own, since those are built at module load — keeps the name. Silently
+        // redefining it would repoint live queries at foreign column metadata.
+        const existing = tableMetasByName.get(name)!;
+        if (existing.table !== candidate) {
+          logger.warn(
+            { table: name },
+            "[file-storage] A table named %s is already registered; keeping the existing definition.",
+            name,
+          );
+        }
+        continue;
+      }
+      let meta: TableMeta;
+      try {
+        meta = buildFileTableMetadata(candidate, name);
+      } catch (err) {
+        logger.error(err, "[file-storage] Package table %s has invalid metadata and was not registered.", name);
+        continue;
+      }
+      if (!meta.primaryKey) {
+        // Registered tables shard by primary key (no SHARD_KEY_COLUMNS entry),
+        // so a keyless table would register cleanly and then throw "no stable
+        // shard key" on its first insert — long after the package author could
+        // connect the failure to the definition. Refuse it here, before the name
+        // enters any registry.
+        logger.error(
+          { table: name },
+          "[file-storage] Rejected package table registration: table has no primary key column",
+        );
+        continue;
+      }
+
+      tableMetasByObject.set(candidate, meta);
+      tableMetasByName.set(name, meta);
+      for (const column of meta.columns) columnMetasByObject.set(column.column, column);
+      fileBackedTables.push(name);
+      FILE_BACKED_TABLE_SET.add(name);
+      SHARDED_TABLE_SET.add(name);
+      // Never lazy: the lazy tier is keyed on chat units, which a package table
+      // has no part in. Fully resident is also what saveShardedTable's
+      // shard-deletion gate requires before it will unlink an emptied shard.
+      this.fullyResidentTables.add(name);
+      this.tables.set(name, this.loadRegisteredTableRows(meta));
+      logger.info(
+        { table: name, rows: this.tables.get(name)?.length ?? 0 },
+        "[file-storage] Registered package table.",
+      );
+    }
+  }
+
+  /**
+   * Reads a newly registered table's existing shards. Deliberately thinner than
+   * the boot loader: the self-heal machinery there (re-home detection, duplicate
+   * arbitration, malformed-row quarantine) exists to repair histories of format
+   * migrations and interrupted flushes that a table the Engine has never written
+   * cannot have. Corrupt-file recovery still applies, because that comes from
+   * parseJsonFile and applies to any file on disk.
+   */
+  private loadRegisteredTableRows(meta: TableMeta): Row[] {
+    const dir = shardDirPath(this.rootDir, meta.name);
+    let entries: string[] = [];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return []; // no shard dir yet — first run with this package installed
+    }
+    const known = new Set<string>();
+    const rows: Row[] = [];
+    const recoveredKeys = new Set<string>();
+    const staleFiles = new Set<string>();
+    for (const fileName of discoverShardPrimaries(entries)) {
+      const encoded = fileName.slice(0, -".json".length);
+      const path = join(dir, fileName);
+      const { value, recoveredFromBackup, recoveredFromFallback, unreadablePaths } = parseJsonFile<Row[]>(
+        path,
+        [],
+        Array.isArray,
+      );
+      const usable = (Array.isArray(value) ? value : []).filter(isRowRecord);
+      const skipped = (Array.isArray(value) ? value.length : 0) - usable.length;
+      const normalized = usable.map((row) => normalizeRow(meta, row));
+      // Neither primary nor backup could be read. The rows are gone either way,
+      // so the only remaining question is whether the bytes survive for someone
+      // to inspect — quarantine MOVES them aside, which also stops the next
+      // flush from overwriting the evidence. Must happen before the repair
+      // marks below: a file that has been moved away needs neither.
+      let quarantinedAway = false;
+      if (recoveredFromFallback && unreadablePaths.length > 0) {
+        const files = quarantineUnrecoverableFilesSync(unreadablePaths, `table ${meta.name} shard ${encoded}`);
+        if (files.length > 0) {
+          this.quarantinedTables.push({ table: meta.name, files });
+          quarantinedAway = files.some((file) => file.from === path);
+          logger.error(
+            { table: meta.name, shard: encoded, files },
+            "[file-storage] Shard was unrecoverable from primary and backup; quarantined corrupt files. Preserved files require manual recovery.",
+          );
+        }
+      }
+      if (recoveredFromBackup || recoveredFromFallback || skipped > 0) {
+        // Same self-heal contract the boot loader honours: the in-memory rows
+        // are now the good copy, so rewrite this shard from memory on the next
+        // flush, with .bak refresh suppressed for that write so a corrupt
+        // primary is never copied over the recovery source.
+        this.backupRecoveredPaths.add(path);
+        this.dirty = true;
+        this.dirtyTables.add(meta.name);
+        for (const row of normalized) recoveredKeys.add(this.shardKeyForRow(meta.name, row));
+        // A shard that recovered to NO usable rows yields no key to dirty, and a
+        // flush only visits shards by key — so the corrupt pair would survive
+        // every boot, be re-recovered, and re-log forever. Mark the physical
+        // FILE stale instead, exactly as the boot loader does for a primary
+        // recovered from a valid-but-empty backup: the flush then deletes it
+        // (zero-row shards are deleted by design) or rewrites it canonically.
+        if (normalized.length === 0 && !quarantinedAway) staleFiles.add(encoded);
+      }
+      if (skipped > 0) {
+        logger.warn(
+          { table: meta.name, shard: fileName, skipped },
+          "[file-storage] Skipped malformed rows in a package table shard.",
+        );
+      }
+      rows.push(...normalized);
+      // Known only when the primary actually sits on disk, same rule as the
+      // boot loader: counting a quarantined shard would report a phantom file.
+      if (!quarantinedAway && existsSync(path)) known.add(encoded);
+    }
+    this.knownShardFiles.set(meta.name, known);
+    if (entries.length > 0) this.shardDirsCreated.add(meta.name);
+    if (recoveredKeys.size > 0) {
+      const dirty = this.dirtyShards.get(meta.name) ?? new Set<string>();
+      for (const key of recoveredKeys) dirty.add(key);
+      this.dirtyShards.set(meta.name, dirty);
+    }
+    if (staleFiles.size > 0) {
+      const stale = this.staleShardFiles.get(meta.name) ?? new Set<string>();
+      for (const encoded of staleFiles) stale.add(encoded);
+      this.staleShardFiles.set(meta.name, stale);
+    }
+    return rows;
+  }
+
   contextForRow(meta: TableMeta, row: Row): RowContext {
     return {
       rows: { [meta.name]: row },
@@ -5059,6 +5324,7 @@ export async function createFileNativeDB(testHooks?: FileNativeStoreTestHooks): 
     close: () => store.close(),
     getQuarantinedTables: () => store.getQuarantinedTables(),
     getTableWriteGeneration: (table) => store.getTableWriteGeneration(table),
+    registerTables: (tables) => store.registerTables(tables),
     getResidentChatUnits: () => store.getResidentChatUnits(),
     getFullyResidentLazyTables: () => store.getFullyResidentLazyTables(),
     getResidentLazyRows: (table) => store.getResidentLazyRows(table),

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -3492,7 +3492,18 @@ class FileTableStore {
         logger.warn("[file-storage] Ignored a package table registration that is not a file table definition.");
         continue;
       }
-      const name = tableNameOf(candidate);
+      // isFileTable only proves the metadata symbol is present, not that it
+      // holds a usable object. A package-supplied value carrying a null or
+      // malformed metadata makes tableNameOf throw, so read the name inside the
+      // guard too: one bad definition must be skipped, not abort the loop and
+      // strand every later table in the same package.
+      let name: string;
+      try {
+        name = tableNameOf(candidate);
+      } catch (err) {
+        logger.error(err, "[file-storage] Ignored a package table registration with unreadable metadata.");
+        continue;
+      }
       // The one non-negotiable check. tableFilePath/shardDirPath join this name
       // straight into the storage tree with no sanitisation; that was safe only
       // while every name came from the Engine's own hardcoded allowlist. A
@@ -3622,9 +3633,16 @@ class FileTableStore {
         if (normalized.length === 0 && !quarantinedAway) staleFiles.add(encoded);
       }
       if (skipped > 0) {
+        // The next flush rewrites this shard from the normalized rows, so the
+        // malformed entries are about to be overwritten. Copy the source aside
+        // first, exactly as the boot loader does: without a readable .bak there
+        // is otherwise no copy of the dropped package data left anywhere.
+        const sourcePath = recoveredFromBackup && existsSync(`${path}.bak`) ? `${path}.bak` : path;
+        const files = preserveMalformedRowSourceSync(sourcePath, meta.name);
+        if (files.length > 0) this.quarantinedTables.push({ table: meta.name, files });
         logger.warn(
-          { table: meta.name, shard: fileName, skipped },
-          "[file-storage] Skipped malformed rows in a package table shard.",
+          { table: meta.name, shard: fileName, skipped, preservedFiles: files.map((file) => file.to) },
+          "[file-storage] Skipped malformed rows in a package table shard and preserved the source file.",
         );
       }
       rows.push(...normalized);

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -593,11 +593,24 @@ function schemaPrimaryKeyColumn(table: AnyFileTable) {
   return getFileTableConfig(table).columns.find((column) => column.primary) ?? null;
 }
 
+/**
+ * Profile export/import covers the ENGINE's tables only, and this map is how
+ * that boundary is enforced: it is built from the schema barrel, so a table a
+ * capability package registered at runtime (file-backed-store's registerTables)
+ * has no entry here and every loop below skips it.
+ *
+ * That exclusion is deliberate, not an oversight to "fix" by consulting the
+ * live registry. A profile snapshot is portable user data that may be restored
+ * into a different Engine install, where the package that owns those rows may
+ * not exist — importing them would be a restore-time failure or a silent orphan
+ * with no schema to validate against. Package data still persists normally and
+ * is captured by a full data-directory backup, which is scoped to one install.
+ */
 const profileTableObjects = new Map<string, AnyFileTable>();
 for (const candidate of Object.values(schema)) {
   if (!isFileTable(candidate)) continue;
   const tableName = schemaTableName(candidate);
-  if (tableName && FILE_BACKED_TABLES.includes(tableName as (typeof FILE_BACKED_TABLES)[number])) {
+  if (tableName && FILE_BACKED_TABLES.includes(tableName)) {
     profileTableObjects.set(tableName, candidate);
   }
 }

--- a/scripts/regressions/launcher/format-guard.regression.mjs
+++ b/scripts/regressions/launcher/format-guard.regression.mjs
@@ -211,7 +211,10 @@ const parseTableList = (source, constantName, label) => {
 const launcherShardedTables = parseTableList(launcherGuardSource, "SHARDED_TABLES", "protect-launcher-data.mjs");
 assert.deepEqual(
   launcherShardedTables,
-  parseTableList(storeSource, "FILE_BACKED_TABLES", "file-backed-store.ts"),
+  // BUILT_IN_FILE_BACKED_TABLES, not the widened FILE_BACKED_TABLES the store
+  // exports: capability packages register their own tables into that list at
+  // runtime, and an offline downgrade script can never know them.
+  parseTableList(storeSource, "BUILT_IN_FILE_BACKED_TABLES", "file-backed-store.ts"),
   "unshard's SHARDED_TABLES copy must match the store's — a new sharded table the script does not fold back " +
     "into a monolith would silently vanish for the downgraded build",
 );

--- a/scripts/regressions/package-table-registration.regression.ts
+++ b/scripts/regressions/package-table-registration.regression.ts
@@ -1,0 +1,305 @@
+// Capability packages ship their own fileTable() declarations, and the store
+// now accepts them at runtime through db._fileStore.registerTables(). That
+// removes the hardcoded allowlist which was the ONLY reason table names were
+// safe to join straight into the storage tree, so these regressions drive the
+// real store through:
+//   - a traversal name (and other hostile shapes) never reaching the disk,
+//   - a keyless table being refused before it can fail on first write,
+//   - a valid name becoming a real, queryable, sharded table,
+//   - re-registration being idempotent rather than redefining a live table,
+//   - a package never shadowing an Engine table of the same name,
+//   - registered rows surviving a flush and a full store reload,
+//   - a shard recovered from its .bak being rewritten instead of re-recovered
+//     on every boot,
+//   - a shard that recovers to no usable rows being cleared instead of
+//     surviving as a permanently corrupt pair,
+//   - an unreadable primary AND backup being quarantined for inspection rather
+//     than silently overwritten.
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Silence the shared logger before the store module is evaluated: these cases
+// deliberately provoke a dozen error-level rejections and quarantine reports,
+// and the pino-pretty transport worker that would pretty-print them can outlive
+// the finished test and hang the runner. Same env-then-dynamic-import shape as
+// illustrator-disconnect.regression.ts.
+process.env.LOG_LEVEL = "silent";
+const { fileTable, text } = await import("../../packages/server/src/db/file-schema.js");
+const { eq } = await import("../../packages/server/src/db/file-query.js");
+const { createFileNativeDB, FILE_BACKED_TABLES } = await import("../../packages/server/src/db/file-backed-store.js");
+const { chats } = await import("../../packages/server/src/db/schema/index.js");
+
+/** Every path under `root`, so a rejected name cannot create anything unnoticed. */
+function treeSnapshot(root: string): string[] {
+  return readdirSync(root, { recursive: true, withFileTypes: true })
+    .map((entry) => join(entry.parentPath, entry.name))
+    .sort();
+}
+
+/** The storage dir is nested one level inside the sandbox so a traversal that
+ *  escapes it still lands somewhere this test can inspect and clean up. */
+function tempStorageDir() {
+  const sandbox = mkdtempSync(join(tmpdir(), "marinara-pkg-tables-"));
+  const dir = join(sandbox, "storage");
+  mkdirSync(dir);
+  process.env.FILE_STORAGE_DIR = dir;
+  return { sandbox, dir };
+}
+
+const packageNotes = fileTable("package_demo_notes", {
+  id: text("id").primaryKey(),
+  body: text("body").notNull(),
+  createdAt: text("created_at").notNull(),
+});
+
+// Every name a package must not be able to persist under. The traversal cases
+// are the security point: tableFilePath/shardDirPath do no escaping.
+const hostileNames = [
+  "../../escaped",
+  "..",
+  "nested/table",
+  "back\\slash",
+  "Uppercase",
+  "trailing.",
+  "with space",
+  "_leading",
+  "9leading",
+  "con",
+  "a".repeat(65),
+];
+
+await rejectsHostileNames();
+await registersAndPersists();
+await refusesToShadowEngineTables();
+await healsRecoveredShardsOnRegistration();
+await clearsShardsThatRecoverToNoRows();
+await quarantinesUnreadableShardPairs();
+
+async function rejectsHostileNames() {
+  const { sandbox } = tempStorageDir();
+  const db = await createFileNativeDB();
+  try {
+    // Baseline AFTER a clean flush, so the comparison below sees only what the
+    // rejected registrations produced. The whole sandbox is walked, not just the
+    // storage dir: a traversal name that escaped would land beside it.
+    // Twice: the second flush is what creates the manifest's .bak, so a single
+    // one would leave normal store bookkeeping in the diff below.
+    await db._fileStore.flush();
+    await db._fileStore.flush();
+    const before = treeSnapshot(sandbox);
+
+    for (const name of hostileNames) {
+      db._fileStore.registerTables([fileTable(name, { id: text("id").primaryKey() })]);
+      assert.ok(!FILE_BACKED_TABLES.includes(name), `${name} must not join the file-backed table list`);
+    }
+    // A table with no primary key registers cleanly but can never resolve a
+    // shard key, so it must be refused up front rather than on first insert.
+    db._fileStore.registerTables([fileTable("package_demo_keyless", { body: text("body").notNull() })]);
+    assert.ok(!FILE_BACKED_TABLES.includes("package_demo_keyless"), "a table without a primary key is refused");
+
+    await db._fileStore.flush();
+    assert.deepEqual(
+      treeSnapshot(sandbox).filter((entry) => !before.includes(entry)),
+      [],
+      "a rejected table name must not create any file or directory, inside or outside the data directory",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+
+async function registersAndPersists() {
+  const { sandbox, dir } = tempStorageDir();
+  const db = await createFileNativeDB();
+  try {
+    db._fileStore.registerTables([packageNotes]);
+    assert.ok(FILE_BACKED_TABLES.includes("package_demo_notes"), "a valid package table joins the table list");
+
+    // Idempotent: a package reload registers the same table again and the
+    // already-live definition (and its rows) must survive untouched.
+    await db.insert(packageNotes).values({ id: "note-1", body: "hello", createdAt: "2026-09-05T10:00:00.000Z" });
+    db._fileStore.registerTables([packageNotes]);
+    const afterReregister = await db.select().from(packageNotes);
+    assert.equal(afterReregister.length, 1, "re-registration must not reset a live table");
+
+    await db._fileStore.flush();
+    const shardDir = join(dir, "tables", "package_demo_notes");
+    assert.ok(existsSync(shardDir), "a registered table flushes through the shard pipeline");
+    assert.ok(
+      !existsSync(join(dir, "tables", "package_demo_notes.json")),
+      "a registered table must not also grow a flat monolith",
+    );
+    assert.ok(
+      readdirSync(shardDir).some((entry) => entry.endsWith(".json")),
+      "the row is written to a shard file",
+    );
+  } finally {
+    await db._fileStore.close();
+  }
+
+  // Reload: registration happens after initialize(), so the rows on disk must
+  // be picked up by registerTables itself or they are silently lost.
+  const reopened = await createFileNativeDB();
+  try {
+    reopened._fileStore.registerTables([packageNotes]);
+    const rows = await reopened.select().from(packageNotes);
+    assert.equal(rows.length, 1, "registered rows survive a flush and a reload");
+    assert.equal(rows[0]!.body, "hello", "reloaded rows keep their values");
+
+    await reopened.delete(packageNotes).where(eq(packageNotes.id, "note-1"));
+    await reopened._fileStore.flush();
+    const remaining = readdirSync(join(dir, "tables", "package_demo_notes")).filter((e) => e.endsWith(".json"));
+    assert.equal(remaining.length, 0, "an emptied registered shard is deleted, not left as litter");
+  } finally {
+    await reopened._fileStore.close();
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+
+async function refusesToShadowEngineTables() {
+  const { sandbox } = tempStorageDir();
+  const db = await createFileNativeDB();
+  try {
+    await db.insert(chats).values({
+      id: "chat-1",
+      name: "Chat",
+      mode: "conversation",
+      createdAt: "2026-09-05T10:00:00.000Z",
+      updatedAt: "2026-09-05T10:00:00.000Z",
+    });
+    const impostor = fileTable("chats", { id: text("id").primaryKey(), hijacked: text("hijacked").notNull() });
+    db._fileStore.registerTables([impostor]);
+    const rows = await db.select().from(chats);
+    assert.equal(rows.length, 1, "the Engine's own chats table keeps its rows");
+    assert.equal(rows[0]!.name, "Chat", "the Engine's own column metadata is not replaced");
+    assert.equal(
+      FILE_BACKED_TABLES.filter((table) => table === "chats").length,
+      1,
+      "a shadowing attempt must not duplicate the name in the table list",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+
+console.info("Capability package table registration regressions passed.");
+
+async function healsRecoveredShardsOnRegistration() {
+  // A NAME THIS PROCESS HAS NEVER REGISTERED. The metadata registries are
+  // module-global, so a name registered by an earlier case is already in
+  // FILE_BACKED_TABLES and a later store would boot-load it through
+  // initialize() instead of through registerTables — which would quietly test
+  // the wrong code path.
+  const packageAudits = fileTable("package_demo_audits", {
+    id: text("id").primaryKey(),
+    body: text("body").notNull(),
+    createdAt: text("created_at").notNull(),
+  });
+  const { sandbox, dir } = tempStorageDir();
+  const shardDir = join(dir, "tables", "package_demo_audits");
+  mkdirSync(shardDir, { recursive: true });
+  const shardPath = join(shardDir, "audit-1.json");
+  // A corrupt primary with a good backup: registration must recover the rows
+  // AND mark the shard dirty, or the next boot recovers from .bak all over
+  // again, forever.
+  writeFileSync(shardPath, "{ this is not json", "utf8");
+  writeFileSync(
+    `${shardPath}.bak`,
+    JSON.stringify([{ id: "audit-1", body: "recovered", createdAt: "2026-09-05T10:00:00.000Z" }]),
+    "utf8",
+  );
+
+  const db = await createFileNativeDB();
+  try {
+    db._fileStore.registerTables([packageAudits]);
+    const rows = await db.select().from(packageAudits);
+    assert.equal(rows.length, 1, "registration loads rows already on disk for a table it has never seen");
+    assert.equal(rows[0]?.body, "recovered", "a registered table recovers its shard from the backup");
+    await db._fileStore.flush();
+    assert.deepEqual(
+      JSON.parse(readFileSync(shardPath, "utf8")),
+      rows,
+      "the recovered shard is rewritten canonically instead of being re-recovered on every boot",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+
+async function clearsShardsThatRecoverToNoRows() {
+  // Again a name this process has never registered, for the same reason.
+  const packageTraces = fileTable("package_demo_traces", {
+    id: text("id").primaryKey(),
+    body: text("body").notNull(),
+    createdAt: text("created_at").notNull(),
+  });
+  const { sandbox, dir } = tempStorageDir();
+  const shardDir = join(dir, "tables", "package_demo_traces");
+  mkdirSync(shardDir, { recursive: true });
+  const shardPath = join(shardDir, "trace-1.json");
+  // Corrupt primary, VALID BUT EMPTY backup: recovery succeeds and yields zero
+  // rows, so there is no shard key to dirty. Without a stale-file mark the
+  // flush never visits this shard and the corrupt pair is re-recovered and
+  // re-logged on every single boot.
+  writeFileSync(shardPath, "{ this is not json", "utf8");
+  writeFileSync(`${shardPath}.bak`, "[]", "utf8");
+
+  const db = await createFileNativeDB();
+  try {
+    db._fileStore.registerTables([packageTraces]);
+    assert.equal((await db.select().from(packageTraces)).length, 0, "an empty recovery contributes no rows");
+    await db._fileStore.flush();
+    assert.ok(!existsSync(shardPath), "the unusable shard primary is removed by the next flush");
+    assert.ok(!existsSync(`${shardPath}.bak`), "its backup is removed with it");
+  } finally {
+    await db._fileStore.close();
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+
+async function quarantinesUnreadableShardPairs() {
+  // Distinct name again: the registries are process-global, so reusing one
+  // would route this through the boot loader instead of registerTables.
+  const packageEvents = fileTable("package_demo_events", {
+    id: text("id").primaryKey(),
+    body: text("body").notNull(),
+    createdAt: text("created_at").notNull(),
+  });
+  const { sandbox, dir } = tempStorageDir();
+  const shardDir = join(dir, "tables", "package_demo_events");
+  mkdirSync(shardDir, { recursive: true });
+  const shardPath = join(shardDir, "event-1.json");
+  // NEITHER file parses: the rows are unrecoverable, so the bytes are the only
+  // thing left worth keeping. They must be moved aside for manual recovery, not
+  // left in place for the next flush to overwrite.
+  writeFileSync(shardPath, "{ this is not json", "utf8");
+  writeFileSync(`${shardPath}.bak`, "also not json", "utf8");
+
+  const db = await createFileNativeDB();
+  try {
+    db._fileStore.registerTables([packageEvents]);
+    assert.equal((await db.select().from(packageEvents)).length, 0, "an unreadable shard contributes no rows");
+    const quarantined = readdirSync(shardDir).filter((entry) => entry.includes(".corrupt-"));
+    assert.equal(quarantined.length, 2, "both the primary and its backup are quarantined");
+    assert.ok(!existsSync(shardPath), "the unreadable primary is moved aside, not left in place");
+    assert.deepEqual(
+      db._fileStore.getQuarantinedTables().map((entry) => entry.table),
+      ["package_demo_events"],
+      "the quarantine is reported against the registered table",
+    );
+    await db._fileStore.flush();
+    assert.deepEqual(
+      readdirSync(shardDir).filter((entry) => entry.includes(".corrupt-")).length,
+      2,
+      "a flush does not disturb the preserved files",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+}

--- a/scripts/regressions/package-table-registration.regression.ts
+++ b/scripts/regressions/package-table-registration.regression.ts
@@ -76,6 +76,7 @@ await refusesToShadowEngineTables();
 await healsRecoveredShardsOnRegistration();
 await clearsShardsThatRecoverToNoRows();
 await quarantinesUnreadableShardPairs();
+await preservesMalformedRowsOnRegistration();
 
 async function rejectsHostileNames() {
   const { sandbox } = tempStorageDir();
@@ -94,6 +95,12 @@ async function rejectsHostileNames() {
       db._fileStore.registerTables([fileTable(name, { id: text("id").primaryKey() })]);
       assert.ok(!FILE_BACKED_TABLES.includes(name), `${name} must not join the file-backed table list`);
     }
+    // isFileTable() only proves the metadata symbol is present. A package
+    // shipping a broken definition must be skipped, not throw out of the loop
+    // and strand the valid tables registered after it in the same call.
+    const brokenMetadata = { [Symbol.for("marinara:file-table")]: null } as unknown;
+    db._fileStore.registerTables([brokenMetadata, "not a table", null]);
+
     // A table with no primary key registers cleanly but can never resolve a
     // shard key, so it must be refused up front rather than on first insert.
     db._fileStore.registerTables([fileTable("package_demo_keyless", { body: text("body").notNull() })]);
@@ -140,8 +147,12 @@ async function registersAndPersists() {
     await db._fileStore.close();
   }
 
-  // Reload: registration happens after initialize(), so the rows on disk must
-  // be picked up by registerTables itself or they are silently lost.
+  // Reload. NOTE: the registries are process-global, so this second store
+  // already knows the name and boot-loads it through initialize(); the
+  // re-registration below therefore takes the idempotent path. That is the
+  // documented constraint, and this case asserts the rows survive either way.
+  // registerTables' own shard loading is covered by the cases below, which each
+  // use a name this process has never registered.
   const reopened = await createFileNativeDB();
   try {
     reopened._fileStore.registerTables([packageNotes]);
@@ -179,6 +190,49 @@ async function refusesToShadowEngineTables() {
       FILE_BACKED_TABLES.filter((table) => table === "chats").length,
       1,
       "a shadowing attempt must not duplicate the name in the table list",
+    );
+  } finally {
+    await db._fileStore.close();
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+
+async function preservesMalformedRowsOnRegistration() {
+  // Fresh name again, so this goes through registerTables and not the boot loader.
+  const packageMetrics = fileTable("package_demo_metrics", {
+    id: text("id").primaryKey(),
+    body: text("body").notNull(),
+    createdAt: text("created_at").notNull(),
+  });
+  const { sandbox, dir } = tempStorageDir();
+  const shardDir = join(dir, "tables", "package_demo_metrics");
+  mkdirSync(shardDir, { recursive: true });
+  const shardPath = join(shardDir, "metric-1.json");
+  // A readable shard holding one good row and one malformed entry. The next
+  // flush rewrites the file from the good row alone, so the malformed entry is
+  // about to be destroyed and there is no .bak holding a copy of it.
+  writeFileSync(
+    shardPath,
+    JSON.stringify([{ id: "metric-1", body: "kept", createdAt: "2026-09-05T10:00:00.000Z" }, "not a row"]),
+    "utf8",
+  );
+
+  const db = await createFileNativeDB();
+  try {
+    db._fileStore.registerTables([packageMetrics]);
+    const rows = await db.select().from(packageMetrics);
+    assert.equal(rows.length, 1, "the usable row is kept");
+    const preserved = readdirSync(shardDir).filter((entry) => entry.includes(".corrupt-"));
+    assert.equal(preserved.length, 1, "the source file is copied aside before the malformed row is dropped");
+    assert.ok(
+      readFileSync(join(shardDir, preserved[0]!), "utf8").includes("not a row"),
+      "the preserved copy still contains the dropped entry",
+    );
+    await db._fileStore.flush();
+    assert.deepEqual(
+      JSON.parse(readFileSync(shardPath, "utf8")),
+      rows,
+      "the shard is rewritten from the usable rows",
     );
   } finally {
     await db._fileStore.close();

--- a/scripts/regressions/package-table-registration.regression.ts
+++ b/scripts/regressions/package-table-registration.regression.ts
@@ -95,12 +95,6 @@ async function rejectsHostileNames() {
       db._fileStore.registerTables([fileTable(name, { id: text("id").primaryKey() })]);
       assert.ok(!FILE_BACKED_TABLES.includes(name), `${name} must not join the file-backed table list`);
     }
-    // isFileTable() only proves the metadata symbol is present. A package
-    // shipping a broken definition must be skipped, not throw out of the loop
-    // and strand the valid tables registered after it in the same call.
-    const brokenMetadata = { [Symbol.for("marinara:file-table")]: null } as unknown;
-    db._fileStore.registerTables([brokenMetadata, "not a table", null]);
-
     // A table with no primary key registers cleanly but can never resolve a
     // shard key, so it must be refused up front rather than on first insert.
     db._fileStore.registerTables([fileTable("package_demo_keyless", { body: text("body").notNull() })]);
@@ -111,6 +105,18 @@ async function rejectsHostileNames() {
       treeSnapshot(sandbox).filter((entry) => !before.includes(entry)),
       [],
       "a rejected table name must not create any file or directory, inside or outside the data directory",
+    );
+
+    // isFileTable() only proves the metadata symbol is present. A package
+    // shipping a broken definition must be skipped, not throw out of the loop
+    // and strand the valid tables that follow it in the same call. Registered
+    // after the tree comparison above, because this one is meant to succeed.
+    const validAfterBroken = fileTable("package_demo_after_broken", { id: text("id").primaryKey() });
+    const brokenMetadata = { [Symbol.for("marinara:file-table")]: null } as unknown;
+    db._fileStore.registerTables([brokenMetadata, "not a table", null, validAfterBroken]);
+    assert.ok(
+      FILE_BACKED_TABLES.includes("package_demo_after_broken"),
+      "a malformed definition is skipped and the valid table after it still registers",
     );
   } finally {
     await db._fileStore.close();


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`.

## Linked issue

Closes #5878

## Why this change

The Slurp capability package needs package-owned storage. Slurp declares its own file tables and cannot persist them.

The file-backed store builds every table's metadata once at module load, from a hardcoded allowlist of the Engine's own tables. Any name outside that list has no metadata, so `getMeta()` throws `[file-storage] Unsupported table: <name>`. A downloaded capability package therefore has no supported way to persist its own data; it can only borrow an Engine table that was designed for something else.

This PR closes the Engine-side gap: it adds the storage API that accepts package-declared tables into a live store.

## What changed

**`registerTables` on the store controller.** Packages activate after `initialize()`, so registration runs against an already-running store rather than at boot. A registered table gets everything a boot-loaded table gets, because the alternative is a table that accepts writes and silently loses them: validated metadata, a row container, its existing on-disk rows, membership in the flush loop, and an entry in the snapshot manifest. Registration is idempotent, so a package reload re-registering the same table does not reset it. It cannot shadow a table that already exists — the first definition of a name, always the Engine's own since those are built at module load, keeps the name. Failures are per table and logged rather than thrown, so one malformed package table definition cannot abort host startup.

**Table-name validation.** Table names become filesystem paths (`tables/<name>.json`, `tables/<name>/`) with no escaping anywhere in the store. That was safe only while every name came from the Engine's own hardcoded list; an unvalidated package-supplied name would be an arbitrary-write primitive outside the data directory. `fileBackedTableNameRejection` now gates every registered name and accepts only what the Engine's own names already look like: non-empty, at most 64 characters, matching `/^[a-z][a-z0-9_]*$/`, and not a Windows reserved basename (Windows blocks those with any extension). The length bound keeps `<name>.json` plus a shard filename inside path limits. A rejected name is refused before it reaches any path join or any registry.

The regression asserts this against the real store: it registers a set of hostile names — `../../escaped`, `..`, `nested/table`, `back\slash`, `Uppercase`, `trailing.`, `with space`, `_leading`, `9leading`, `con`, and a 65-character name — and then walks the entire sandbox tree, which is one level above the storage directory so an escape would land somewhere the test can see. It asserts that no rejected name joins the file-backed table list and that not one file or directory was created, inside or outside the data directory.

**Sharding.** Registered tables are sharded, like every Engine table. `SHARDED_TABLES` aliases `FILE_BACKED_TABLES`, so a name pushed onto the list becomes sharded by array identity whether or not that was intended; making registered tables flat would opt a brand-new table into the store's least-exercised path and would still leave the alias lying about them. That aliasing was also a trap worth closing: `SHARDED_TABLE_SET` used to be a module-load snapshot of the list, so after registration the array said "sharded" and the set said "not sharded", and the load, flush and delete paths would each have classified the same table differently. The set is now mutable and registration writes the list and the set together, or neither.

**No primary key is refused at registration.** Registered tables have no `SHARD_KEY_COLUMNS` entry, so they shard by primary key. A keyless table would register cleanly and then throw "no stable shard key" on its first insert, long after a package author could connect the failure to the definition. It is now refused up front, before the name enters any registry.

**Profile export/import.** Registered tables persist exactly like Engine tables and are captured by a full data-directory backup, but they are deliberately excluded from profile export. `profileTableObjects` in `backup.routes.ts` is built from the schema barrel, so a runtime-registered table has no entry and every loop skips it. That exclusion is intentional, not an oversight to fix by consulting the live registry: a profile snapshot is portable user data that may be restored into a different install where the owning package does not exist, so importing those rows would be a restore-time failure or a silent orphan with no schema to validate against. A comment at that site records the reasoning.

**Known constraint — the registries are process-global.** `tableMetasByName`, `FILE_BACKED_TABLE_SET` and `SHARDED_TABLE_SET` are module-level, as the Engine's own table metadata already is. A registered name therefore outlives the store that registered it: a store constructed later in the same process, against a different storage directory, already knows the name, boot-loads it from its own directory, and finds nothing. That degrades to an empty table, never to corruption or a cross-directory read. It is accepted because production runs one store per process, and because the alternative — instance-scoped registries — means threading a store through `getMeta()` and the entire module-level lookup surface. Per-instance registration is the correct fix if the Engine ever runs more than one store at a time. Until then there is a concrete consequence for tests: a test that constructs several stores **must** give each scenario a distinct table name, or its second store silently exercises the boot loader instead of `registerTables`. The regression follows that rule explicitly, with a comment at each case that needs a fresh name.

**No caller is wired yet.** Nothing in the Engine currently loads package-supplied table objects. This PR is the storage-side API only; connecting a package loader to it is separate work.

Also included:

- `FILE_BACKED_TABLES` is now a widened runtime list built from `BUILT_IN_FILE_BACKED_TABLES`, so every consumer that walks "all file-backed tables" sees registered names. The Engine's own tuple keeps its literal-union type so `CASCADES` and other table-name constants stay compile-checked. The list itself is module-private; the only sanctioned way to grow it is `registerTables`, which validates the name and updates every companion registry in the same breath.
- `scripts/regressions/launcher/format-guard.regression.mjs` now compares the launcher's `SHARDED_TABLES` copy against `BUILT_IN_FILE_BACKED_TABLES` rather than the widened list. An offline downgrade script can never know a runtime-registered name.
- `loadRegisteredTableRows` reads a newly registered table's existing shards. It is deliberately thinner than the boot loader: the re-home detection, duplicate arbitration and format-migration repair there exist for histories a table the Engine has never written cannot have. Corrupt-file recovery still applies, because that comes from `parseJsonFile` and applies to any file on disk.
- `buildFileTableMetadata` is extracted so schema-declared and package-registered tables share the same shape and unique-constraint validation.
- New regression `scripts/regressions/package-table-registration.regression.ts` (auto-discovered by the runner).

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

The checkboxes above are left unticked for a human to confirm. This change has no UI surface and no wired caller, so the meaningful verification is the new regression, which drives the real store end to end rather than a mock. It is written to be run as `node ./scripts/run-regressions.mjs --filter package-table-registration` after `pnpm build:shared`, and each case builds a real store over a fresh temporary storage directory:

1. **Hostile names.** Flush twice to a clean baseline (the second flush is what creates the manifest's `.bak`, so normal store bookkeeping stays out of the comparison), snapshot the whole sandbox, register each hostile name plus a keyless table, flush again, and assert the sandbox tree is byte-for-byte unchanged and no rejected name entered `FILE_BACKED_TABLES`.
2. **Register and persist.** Register a valid table, insert a row, re-register the same table and confirm the row survives, flush, and check on disk that a shard directory exists and that no flat `<name>.json` monolith was also created. Then close the store, open a new one over the same directory, register again, and confirm the row is read back with its values intact. Delete the row, flush, and confirm the emptied shard is removed rather than left as litter.
3. **Shadowing.** Insert a real `chats` row, register an impostor table also named `chats` with different columns, and confirm the Engine's rows and column metadata are untouched and the name is not duplicated in the table list.
4. **Recovery on registration.** Plant a corrupt shard primary with a good `.bak`. Registration must recover the rows *and* mark the shard dirty; the test then flushes and reads the file back to confirm it was rewritten canonically, so the next boot does not recover from backup all over again.
5. **Recovery to zero rows.** Plant a corrupt primary with a valid-but-empty `.bak`. There is no shard key to dirty, so the file is marked stale instead; the test confirms the flush removes the primary and its backup rather than leaving a corrupt pair that is re-recovered and re-logged on every boot.
6. **Unrecoverable pair.** Plant a primary and a `.bak` that both fail to parse, and confirm both are quarantined for manual inspection, reported through `getQuarantinedTables()` against the registered table, and left undisturbed by the following flush.

The regression sets `LOG_LEVEL=silent` before importing the store, because these cases deliberately provoke error-level rejections and quarantine reports, and the pretty-print transport worker can otherwise outlive the test and hang the runner.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

A `CHANGELOG.md` entry is added under `[Unreleased]`. No user-facing docs change, because there is no user-facing surface yet. No version bump.

## UI evidence (if applicable)

Not applicable; no UI surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capability packages can register persistent file tables at runtime.
  * Registered tables support sharding, querying, persistence across restarts, and safe backup recovery.
  * Table names are strictly validated to prevent unsafe or conflicting registrations.
  * Re-registering an existing table is handled safely and consistently.

* **Bug Fixes**
  * Improved recovery of damaged or unreadable table data, including quarantining unusable files and rewriting recovered shards canonically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->