### PR TITLE
fix(mobile): reduce Illustrator image-arrival pressure and refresh saved images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Mobile chat illustrations and gallery tiles use smaller cached display copies to reduce image decoding pressure; opening and downloading still uses the original. Saved automatic Roleplay illustrations also appear as soon as they arrive, without waiting for remaining agent work (#5870).
+
 - Conversation swipe menus now reuse Roleplay's compact, unboxed controls on desktop and mobile, with arrows and counters following the configured chat-chrome text color instead of pink/orchid styling (#5875).
 - Released temporary rendering hints after message entrance animations, reducing unnecessary compositor layers around long, growing Roleplay replies without changing their animation or layout (#5870).
 - Agent connection warnings and other notifications now use the selected accent for their border in light and dark themes (#5870).

--- a/e2e/illustration-arrival.e2e.ts
+++ b/e2e/illustration-arrival.e2e.ts
@@ -1,0 +1,194 @@
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+
+const version = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version;
+const requireServer = createRequire(new URL("../packages/server/package.json", import.meta.url));
+const sharp = requireServer("sharp");
+
+async function openChat(page: Page, chatId: string) {
+  await page.route("**/api/app-settings/ui", (route) => route.fulfill({ json: { value: "" } }));
+  await page.addInitScript(
+    ({ id, appVersion }) => {
+      localStorage.setItem("marinara-active-chat-id", id);
+      localStorage.setItem("marinara:whats-new:seen-version", appVersion);
+      localStorage.setItem(
+        "marinara-engine-ui",
+        JSON.stringify({
+          state: {
+            hasCompletedOnboarding: true,
+            rightPanelOpen: false,
+            sidebarOpen: false,
+            messagesPerPage: 20,
+            enableStreaming: true,
+            streamingSpeed: 100,
+            chatHelpSeenModes: ["conversation", "roleplay", "game"],
+          },
+          version: 65,
+        }),
+      );
+    },
+    { id: chatId, appVersion: version },
+  );
+  await page.goto("/");
+}
+
+async function saveIllustration(request: APIRequestContext, chatId: string, messageId: string) {
+  const original = await sharp({
+    create: { width: 2048, height: 3072, channels: 3, background: "#164e63" },
+  })
+    .png()
+    .toBuffer();
+  const upload = await request.post(`/api/gallery/${chatId}/upload`, {
+    multipart: {
+      prompt: "Synthetic arrival illustration",
+      file: { name: "arrival.png", mimeType: "image/png", buffer: original },
+    },
+  });
+  expect(upload.ok()).toBeTruthy();
+  const image = (await upload.json()) as { id: string; url: string };
+  const attached = await request.patch(`/api/chats/${chatId}/messages/${messageId}/extra`, {
+    data: {
+      attachments: [{ type: "image", url: image.url, filename: "Arrival illustration", galleryId: image.id }],
+    },
+  });
+  expect(attached.ok()).toBeTruthy();
+  return { ...image, original };
+}
+
+for (const mode of ["roleplay", "conversation"] as const) {
+  test(`${mode} mobile image previews avoid decoding the original; opening still uses it`, async ({
+    page,
+    request,
+  }, testInfo) => {
+    const created = await request.post("/api/chats", {
+      data: { name: "Illustration preview proof", mode, characterIds: [], connectionId: "synthetic" },
+    });
+    expect(created.ok()).toBeTruthy();
+    const chat = (await created.json()) as { id: string };
+    try {
+      for (let index = 0; index < 19; index++) {
+        const prior = await request.post(`/api/chats/${chat.id}/messages`, {
+          data: { role: index % 2 ? "assistant" : "user", content: `Prior message ${index + 1}.` },
+        });
+        expect(prior.ok()).toBeTruthy();
+      }
+      const saved = await request.post(`/api/chats/${chat.id}/messages`, {
+        data: { role: "assistant", content: "The illustration accompanies this reply." },
+      });
+      expect(saved.ok()).toBeTruthy();
+      const message = (await saved.json()) as { id: string };
+      const image = await saveIllustration(request, chat.id, message.id);
+      const errors: string[] = [];
+      page.on("pageerror", (error) => errors.push(error.message));
+      const originalRequests: string[] = [];
+      page.on("request", (req) => {
+        if (req.url().endsWith(image.url)) originalRequests.push(req.url());
+      });
+      await openChat(page, chat.id);
+      const attachment = page.getByRole("img", { name: "Arrival illustration", exact: true });
+      await expect(attachment).toBeVisible();
+      const mobile = testInfo.project.name.includes("mobile");
+      await expect
+        .poll(() => attachment.evaluate((img: HTMLImageElement) => img.naturalWidth))
+        .toBe(mobile ? 1024 : 2048);
+      if (mobile) expect(originalRequests).toEqual([]);
+      await testInfo.attach("chat-preview", {
+        body: await page.screenshot({ path: testInfo.outputPath("chat-preview.png") }),
+        contentType: "image/png",
+      });
+
+      if (mobile) await page.getByRole("button", { name: "More options", exact: true }).click();
+      await page.getByRole("button", { name: "Gallery", exact: true }).filter({ visible: true }).click();
+      const drawer = page.locator(".mari-chat-gallery-drawer");
+      const tile = drawer.getByRole("img", { name: "Synthetic arrival illustration", exact: true });
+      await expect(tile).toBeVisible();
+      await expect.poll(() => tile.evaluate((img: HTMLImageElement) => img.naturalWidth)).toBe(mobile ? 320 : 2048);
+      if (mobile) expect(originalRequests).toEqual([]);
+      await testInfo.attach("gallery-preview", {
+        body: await page.screenshot({ path: testInfo.outputPath("gallery-preview.png") }),
+        contentType: "image/png",
+      });
+
+      await drawer.getByRole("button", { name: "Open gallery image", exact: true }).click();
+      const fullImage = page.getByRole("dialog").getByRole("img", { name: "Synthetic arrival illustration" });
+      await expect(fullImage).toBeVisible();
+      await expect.poll(() => fullImage.evaluate((img: HTMLImageElement) => img.naturalWidth)).toBe(2048);
+      const downloaded = await request.get(image.url);
+      expect(await downloaded.body()).toEqual(image.original);
+      expect(errors).toEqual([]);
+    } finally {
+      await request.delete(`/api/chats/${chat.id}`);
+    }
+  });
+}
+
+test("a saved automatic illustration appears before the remaining agent stream closes", async ({
+  page,
+  request,
+}, testInfo) => {
+  // Control only the provider SSE timing; persistence and image serving use the real server.
+  await page.addInitScript(() => {
+    const nativeFetch = window.fetch.bind(window);
+    window.fetch = async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (new URL(url, location.origin).pathname !== "/api/generate") return nativeFetch(input, init);
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            Object.assign(window, { illustrationStream: controller });
+          },
+        }),
+        { headers: { "Content-Type": "text/event-stream" } },
+      );
+    };
+  });
+  const created = await request.post("/api/chats", {
+    data: { name: "Automatic illustration tail", mode: "roleplay", characterIds: [], connectionId: "synthetic" },
+  });
+  expect(created.ok()).toBeTruthy();
+  const chat = (await created.json()) as { id: string };
+  const emit = (type: string, data: unknown) =>
+    page.evaluate(
+      (event) => {
+        const controller = (window as unknown as { illustrationStream: ReadableStreamDefaultController })
+          .illustrationStream;
+        controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`));
+      },
+      { type, data },
+    );
+  try {
+    await openChat(page, chat.id);
+    await page.locator("textarea.mari-chat-input-textarea").fill("Illustrate this reply.");
+    await page.locator("button.mari-chat-send-btn").click();
+    await expect.poll(() => page.evaluate(() => "illustrationStream" in window)).toBe(true);
+    const saved = await request.post(`/api/chats/${chat.id}/messages`, {
+      data: { role: "assistant", content: "A finished reply with an image on the way." },
+    });
+    expect(saved.ok()).toBeTruthy();
+    const message = (await saved.json()) as { id: string; content: string };
+    await emit("token", message.content);
+    await emit("message_saved", message);
+    await emit("assistant_message_ready", message);
+    await emit("agent_start", { phase: "post_generation" });
+    await emit("illustration_queued", { messageId: message.id });
+    await emit("done", "");
+    await expect(page.locator(`[data-message-id="${message.id}"]`)).toBeVisible();
+    await expect(page.locator('[data-message-id="__streaming__"]')).toHaveCount(0);
+    const image = await saveIllustration(request, chat.id, message.id);
+    await emit("illustration", { messageId: message.id, imageUrl: image.url, galleryId: image.id });
+
+    // A slow background/agent tail still owns the SSE, but this image is durable.
+    await expect(page.getByRole("img", { name: "Arrival illustration", exact: true })).toBeVisible();
+    await testInfo.attach("automatic-arrival", {
+      body: await page.screenshot({ path: testInfo.outputPath("automatic-arrival.png") }),
+      contentType: "image/png",
+    });
+    await page.evaluate(() => {
+      (window as unknown as { illustrationStream: ReadableStreamDefaultController }).illustrationStream.close();
+    });
+    await expect(page.getByRole("img", { name: "Arrival illustration", exact: true })).toBeVisible();
+  } finally {
+    await request.delete(`/api/chats/${chat.id}`);
+  }
+});

--- a/packages/client/src/components/chat/ChatGallery.tsx
+++ b/packages/client/src/components/chat/ChatGallery.tsx
@@ -33,7 +33,8 @@ import {
   type ChatAssetBrowserItem,
   type ChatImage,
 } from "../../hooks/use-gallery";
-import type { GeneratedSceneVideo } from "@marinara-engine/shared";
+import { BACKGROUND_THUMBNAIL_WIDTH, type GeneratedSceneVideo } from "@marinara-engine/shared";
+import { ChatImagePreview } from "./ChatImagePreview";
 import { useGalleryStore } from "../../stores/gallery.store";
 import { toast } from "sonner";
 import { ImageUploadDropzone } from "../ui/ImageUploadDropzone";
@@ -940,8 +941,9 @@ export function ChatGallery({
                           <Check size="0.9rem" />
                         </span>
                       ) : null}
-                      <img
+                      <ChatImagePreview
                         src={asset.url}
+                        mobileWidth={BACKGROUND_THUMBNAIL_WIDTH}
                         alt={asset.prompt || asset.name}
                         loading="lazy"
                         decoding="async"
@@ -1083,8 +1085,9 @@ export function ChatGallery({
                           : localizeUi("ui.chat.chatgallery.openGalleryImage")
                       }
                     >
-                      <img
+                      <ChatImagePreview
                         src={img.url}
+                        mobileWidth={BACKGROUND_THUMBNAIL_WIDTH}
                         alt={img.prompt || "Gallery image"}
                         loading="lazy"
                         decoding="async"

--- a/packages/client/src/components/chat/ChatImagePreview.tsx
+++ b/packages/client/src/components/chat/ChatImagePreview.tsx
@@ -1,0 +1,17 @@
+import type { ImgHTMLAttributes } from "react";
+import { CHAT_IMAGE_PREVIEW_WIDTH } from "@marinara-engine/shared";
+
+/** Only local gallery images have cached previews. External/data URLs keep their existing behavior. */
+export function ChatImagePreview({
+  src,
+  mobileWidth = CHAT_IMAGE_PREVIEW_WIDTH,
+  ...props
+}: ImgHTMLAttributes<HTMLImageElement> & { mobileWidth?: number }) {
+  const preview = src && /^\/api\/gallery\/file\/[^/?#]+\/[^/?#]+$/.test(src) ? `${src}?w=${mobileWidth}` : null;
+  return (
+    <picture className="contents">
+      {preview && <source media="(max-width: 767px)" srcSet={preview} />}
+      <img loading="lazy" decoding="async" {...props} src={src} />
+    </picture>
+  );
+}

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -13,6 +13,7 @@ import {
 import { useChatGalleryFilenameIndex } from "../../hooks/use-characters";
 import { useReducedAmbientEffects } from "../../hooks/use-reduced-ambient-effects";
 import { PendingTypingDots } from "./PendingTypingDots";
+import { ChatImagePreview } from "./ChatImagePreview";
 import { isDiceRollResult } from "../dice/AnimatedDiceRoll";
 import { DiceMessageContent } from "./ConversationMessageShared";
 import {
@@ -3487,7 +3488,7 @@ export const ChatMessage = memo(function ChatMessage({
                           value1: att.filename || att.name || localizeUi("ui.ui.spritegenerationmodal.image"),
                         })}
                       >
-                        <img
+                        <ChatImagePreview
                           src={att.url || att.data}
                           alt={att.filename || att.name || "image"}
                           className="max-h-[70vh] max-w-full rounded-lg object-contain sm:max-h-[32rem]"
@@ -3951,7 +3952,7 @@ export const ChatMessage = memo(function ChatMessage({
                         value1: att.filename || att.name || localizeUi("ui.ui.spritegenerationmodal.image"),
                       })}
                     >
-                      <img
+                      <ChatImagePreview
                         src={att.url || att.data}
                         alt={att.filename || att.name || "image"}
                         className="max-h-[70vh] max-w-full rounded-lg object-contain sm:max-h-[32rem]"

--- a/packages/client/src/components/chat/ConversationMessageShared.tsx
+++ b/packages/client/src/components/chat/ConversationMessageShared.tsx
@@ -18,6 +18,7 @@ import { renderInlineWithCustomEmojis } from "../../lib/custom-emoji-render";
 import { renderWithStickerBlocks } from "../../lib/sticker-render";
 import { applyTextareaQuoteFormat } from "../../lib/textarea-quotes";
 import { ImagePromptPanel } from "./ImagePromptPanel";
+import { ChatImagePreview } from "./ChatImagePreview";
 import { MessageActionButton } from "./MessageActionButton";
 import { SwipeJumpControl } from "./SwipeJumpControl";
 import { useUIStore } from "../../stores/ui.store";
@@ -563,7 +564,7 @@ export function ConversationMessageAttachments({
               className="block cursor-zoom-in rounded-lg text-left"
               title={localizeUi("ui.noodle.noodlepostcard.openImage")}
             >
-              <img
+              <ChatImagePreview
                 src={att.url || att.data}
                 alt={att.filename || att.name || "image"}
                 className="max-h-[70vh] max-w-full rounded-lg object-contain sm:max-h-[32rem]"

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -2666,11 +2666,10 @@ export function useGenerate() {
                 reason?: string;
               };
               toast(illData.reason ? `🎨 ${illData.reason}` : "🎨 Scene illustration generated");
-              // During streaming the real message is deferred — refreshing now
-              // would insert it into the cache alongside the StreamingIndicator,
-              // causing a duplicate flash. The finally block's authoritative
-              // refresh will pick up the illustration attachment from DB.
-              if (!streamingEnabled && !isGameGeneration) {
+              // Roleplay can already have handed off to the durable row while other
+              // agents still own this stream. Show its saved image immediately;
+              // only defer when the live message presentation still owns the row.
+              if (!isGameGeneration && canRefreshCurrentMessagesNow()) {
                 await refreshMessagesAuthoritatively(qc, params.chatId, persistedMessages.values());
               }
               void qc.invalidateQueries({ queryKey: ["gallery", params.chatId] });

--- a/packages/server/src/routes/gallery.routes.ts
+++ b/packages/server/src/routes/gallery.routes.ts
@@ -35,6 +35,7 @@ import {
 import { resolveGameVideoRuntime } from "../services/video/game-video-runtime.js";
 import { generateImage, removeSavedImageFromDisk, saveImageToDisk } from "../services/image/image-generation.js";
 import { resolveGalleryImagePath } from "../services/image/gallery-image-path.js";
+import { parseThumbnailWidth, resolveThumbPath } from "../services/image/image-thumbnail.js";
 import {
   resolveConnectionImageDefaults,
   resolveConnectionImageQuality,
@@ -1787,6 +1788,14 @@ export async function galleryRoutes(app: FastifyInstance) {
 
     const validatedImage = await validateImageAssetFile(storedFile.absolutePath, storedFile.filename);
     if (!validatedImage) return reply.status(404).send({ error: "Not found" });
+
+    const width = parseThumbnailWidth((req.query as { w?: string }).w);
+    const thumbPath = width ? await resolveThumbPath(storedFile.absolutePath, width) : null;
+    const preview = thumbPath ? await validateImageAssetFile(thumbPath, basename(thumbPath)) : null;
+    if (preview) {
+      await validatedImage.handle.close();
+      return sendValidatedMediaFile(reply, preview, { method: req.method, rangeHeader: req.headers.range });
+    }
 
     return sendValidatedMediaFile(reply, validatedImage, { method: req.method, rangeHeader: req.headers.range });
   });

--- a/packages/server/src/routes/gallery.routes.ts
+++ b/packages/server/src/routes/gallery.routes.ts
@@ -1793,7 +1793,7 @@ export async function galleryRoutes(app: FastifyInstance) {
     const thumbPath = width ? await resolveThumbPath(storedFile.absolutePath, width) : null;
     const preview = thumbPath ? await validateImageAssetFile(thumbPath, basename(thumbPath)) : null;
     if (preview) {
-      await validatedImage.handle.close();
+      await validatedImage.handle.close().catch(() => undefined);
       return sendValidatedMediaFile(reply, preview, { method: req.method, rangeHeader: req.headers.range });
     }
 

--- a/packages/server/src/services/image/image-thumbnail.ts
+++ b/packages/server/src/services/image/image-thumbnail.ts
@@ -48,7 +48,10 @@ export async function resolveThumbPath(filePath: string, width: number): Promise
   try {
     // Inside the try: the source can vanish between the caller's existsSync and this stat.
     const key = createHash("sha1").update(filePath).digest("hex").slice(0, 16);
-    const thumbPath = join(THUMB_DIR, `${width}-${statSync(filePath).mtimeMs}-${key}.webp`);
+    // v2 invalidates older copies that could flatten animation or lose EXIF orientation.
+    const thumbPath = join(THUMB_DIR, `v2-${width}-${statSync(filePath).mtimeMs}-${key}.webp`);
+    if (existsSync(thumbPath)) return thumbPath;
+
     const sharp = await getSharp();
     const image = sharp(filePath);
     const metadata = await image.metadata();
@@ -74,8 +77,6 @@ export async function resolveThumbPath(filePath: string, width: number): Promise
       }
       if (!staticPng) return null;
     }
-    if (existsSync(thumbPath)) return thumbPath;
-
     const buffer = await image.rotate().resize({ width, withoutEnlargement: true }).webp({ quality: 72 }).toBuffer();
     if (!existsSync(THUMB_DIR)) mkdirSync(THUMB_DIR, { recursive: true });
     const temporaryPath = `${thumbPath}.${process.pid}.${randomUUID()}.tmp`;

--- a/packages/server/src/services/image/image-thumbnail.ts
+++ b/packages/server/src/services/image/image-thumbnail.ts
@@ -1,24 +1,23 @@
 // ──────────────────────────────────────────────
-// Shared on-disk image thumbnailer (chat backgrounds + game asset images)
+// Shared on-disk image thumbnailer (backgrounds, gallery + game asset images)
 // ──────────────────────────────────────────────
 import { existsSync, mkdirSync, renameSync, statSync, unlinkSync } from "fs";
-import { writeFile } from "fs/promises";
+import { open, writeFile } from "fs/promises";
 import { createHash, randomUUID } from "crypto";
 import { extname, join } from "path";
 import { DATA_DIR } from "../../utils/data-dir.js";
 import { logger } from "../../lib/logger.js";
 import { getSharp } from "./sharp-runtime.js";
-import { BACKGROUND_THUMBNAIL_WIDTH } from "@marinara-engine/shared";
+import { BACKGROUND_THUMBNAIL_WIDTH, CHAT_IMAGE_PREVIEW_WIDTH } from "@marinara-engine/shared";
 
 // Sibling of the image directories, never inside them: the background library listing walks its own dir.
 const THUMB_DIR = join(DATA_DIR, "backgrounds-thumbs");
 
 /**
- * Widths the thumbnailer will honour, so `?w=` can't be used to fill the disk. One entry on
- * purpose: the sidebar row banner and the settings picker tile both fit inside 320px even at
- * 3x, so they share a single cached file. Add a width here when something needs a bigger one.
+ * Fixed widths only, so `?w=` cannot create arbitrarily many copies of each image.
+ * Compact tiles share 320px; mobile inline illustrations use 1024px.
  */
-const THUMB_WIDTHS = new Set([BACKGROUND_THUMBNAIL_WIDTH]);
+const THUMB_WIDTHS = new Set([BACKGROUND_THUMBNAIL_WIDTH, CHAT_IMAGE_PREVIEW_WIDTH]);
 
 /**
  * Extensions worth handing to sharp. Anything else (animated GIF, SVG, audio, video — the game
@@ -40,8 +39,8 @@ export function parseThumbnailWidth(value: unknown): number | null {
  *
  * Cache key includes the source path and mtime so replacing a file serves the new image
  * immediately and two sources with the same basename never collide.
- * ponytail: superseded thumbs are never swept; they are a few KB each and bounded by
- * how often someone re-uploads over a filename. Add a sweep if that stops being true.
+ * ponytail: unused previews are not swept. There are two fixed sizes per source/version;
+ * add a cache sweep if accumulated gallery previews become a storage burden.
  */
 export async function resolveThumbPath(filePath: string, width: number): Promise<string | null> {
   if (!THUMB_WIDTHS.has(width) || !THUMBABLE_EXTS.has(extname(filePath).toLowerCase())) return null;
@@ -50,10 +49,34 @@ export async function resolveThumbPath(filePath: string, width: number): Promise
     // Inside the try: the source can vanish between the caller's existsSync and this stat.
     const key = createHash("sha1").update(filePath).digest("hex").slice(0, 16);
     const thumbPath = join(THUMB_DIR, `${width}-${statSync(filePath).mtimeMs}-${key}.webp`);
+    const sharp = await getSharp();
+    const image = sharp(filePath);
+    const metadata = await image.metadata();
+    if ((metadata.pages ?? 1) > 1) return null;
+    if (metadata.format === "png") {
+      // Sharp does not expose APNG frame counts. acTL must precede the first IDAT.
+      // ponytail: inspect only 64 KiB of headers; unusually large metadata keeps the
+      // original. Increase this ceiling if those images need previews too.
+      const handle = await open(filePath, "r");
+      let staticPng = false;
+      try {
+        const { buffer, bytesRead } = await handle.read(Buffer.alloc(64 * 1024), 0, 64 * 1024, 0);
+        for (let offset = 8; offset + 8 <= bytesRead; offset += 12 + buffer.readUInt32BE(offset)) {
+          const chunk = buffer.toString("ascii", offset + 4, offset + 8);
+          if (chunk === "acTL") return null;
+          if (chunk === "IDAT") {
+            staticPng = true;
+            break;
+          }
+        }
+      } finally {
+        await handle.close();
+      }
+      if (!staticPng) return null;
+    }
     if (existsSync(thumbPath)) return thumbPath;
 
-    const sharp = await getSharp();
-    const buffer = await sharp(filePath).resize({ width, withoutEnlargement: true }).webp({ quality: 72 }).toBuffer();
+    const buffer = await image.resize({ width, withoutEnlargement: true }).webp({ quality: 72 }).toBuffer();
     if (!existsSync(THUMB_DIR)) mkdirSync(THUMB_DIR, { recursive: true });
     const temporaryPath = `${thumbPath}.${process.pid}.${randomUUID()}.tmp`;
     try {

--- a/packages/server/src/services/image/image-thumbnail.ts
+++ b/packages/server/src/services/image/image-thumbnail.ts
@@ -76,7 +76,7 @@ export async function resolveThumbPath(filePath: string, width: number): Promise
     }
     if (existsSync(thumbPath)) return thumbPath;
 
-    const buffer = await image.resize({ width, withoutEnlargement: true }).webp({ quality: 72 }).toBuffer();
+    const buffer = await image.rotate().resize({ width, withoutEnlargement: true }).webp({ quality: 72 }).toBuffer();
     if (!existsSync(THUMB_DIR)) mkdirSync(THUMB_DIR, { recursive: true });
     const temporaryPath = `${thumbPath}.${process.pid}.${randomUUID()}.tmp`;
     try {

--- a/packages/shared/src/constants/defaults.ts
+++ b/packages/shared/src/constants/defaults.ts
@@ -26,6 +26,9 @@ export const DEFAULT_CONNECTION_ID = "__default_openrouter__";
 /** Shared width for cached background thumbnails used by compact client surfaces. */
 export const BACKGROUND_THUMBNAIL_WIDTH = 320;
 
+/** Mobile inline illustrations; full-size originals remain available in the lightbox/download. */
+export const CHAT_IMAGE_PREVIEW_WIDTH = 1024;
+
 /** Maximum length for image-backend instructions stored on an image connection. */
 export const MAX_IMAGE_PROMPT_INSTRUCTIONS_LENGTH = 20_000;
 

--- a/scripts/regressions/gallery-previews.regression.ts
+++ b/scripts/regressions/gallery-previews.regression.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -48,6 +49,13 @@ try {
   for (const source of ["shared", "legacy"]) {
     const file = await seed(source, `${source}/image.png`, original);
     const url = `/api/gallery/file/${source}/image.png`;
+    const thumbDir = join(fixtureDir, "backgrounds-thumbs");
+    mkdirSync(thumbDir, { recursive: true });
+    const key = createHash("sha1").update(file).digest("hex").slice(0, 16);
+    writeFileSync(
+      join(thumbDir, `320-${statSync(file).mtimeMs}-${key}.webp`),
+      await sharp(original).resize(10).webp().toBuffer(),
+    );
     for (const width of [320, 1024]) {
       const response = await app.inject(`${url}?w=${width}`);
       assert.equal(response.statusCode, 200);
@@ -59,6 +67,15 @@ try {
       const cached = await resolveThumbPath(file, width);
       assert.ok(cached);
       assert.deepEqual(response.rawPayload, readFileSync(cached));
+      const metadata = sharp.prototype.metadata;
+      sharp.prototype.metadata = () => {
+        throw new Error("Cache hits must not reopen image metadata");
+      };
+      try {
+        assert.equal(await resolveThumbPath(file, width), cached);
+      } finally {
+        sharp.prototype.metadata = metadata;
+      }
       const head = await app.inject({ method: "HEAD", url: `${url}?w=${width}` });
       assert.equal(head.headers["content-length"], String(response.rawPayload.length));
       assert.equal(head.rawPayload.length, 0);

--- a/scripts/regressions/gallery-previews.regression.ts
+++ b/scripts/regressions/gallery-previews.regression.ts
@@ -90,6 +90,14 @@ try {
   const smallPreview = await app.inject("/api/gallery/file/small/image.png?w=1024");
   assert.equal((await sharp(smallPreview.rawPayload).metadata()).width, 40, "Small images are not enlarged");
 
+  const rotated = await sharp(small).withMetadata({ orientation: 6 }).jpeg().toBuffer();
+  await seed("rotated", "rotated/image.jpg", rotated);
+  const rotatedPreview = await sharp(
+    (await app.inject("/api/gallery/file/rotated/image.jpg?w=320")).rawPayload,
+  ).metadata();
+  assert.equal(rotatedPreview.width, 60);
+  assert.equal(rotatedPreview.height, 40, "Previews retain the original's displayed EXIF orientation");
+
   // One-frame APNG with valid animation chunks: even this must remain an original,
   // not be silently flattened by Sharp's static PNG decoder.
   const animation = Buffer.alloc(8);

--- a/scripts/regressions/gallery-previews.regression.ts
+++ b/scripts/regressions/gallery-previews.regression.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { crc32 } from "node:zlib";
+
+const fixtureDir = mkdtempSync(join(tmpdir(), "marinara-gallery-previews-"));
+process.env.DATA_DIR = fixtureDir;
+process.env.FILE_STORAGE_DIR = join(fixtureDir, "storage");
+process.env.NODE_ENV = "test";
+process.env.LOG_LEVEL = "silent";
+const requireServer = createRequire(new URL("../../packages/server/package.json", import.meta.url));
+const sharp = requireServer("sharp");
+const Fastify = requireServer("fastify");
+const { getDB, closeDB } = await import("../../packages/server/src/db/connection.js");
+const { galleryRoutes } = await import("../../packages/server/src/routes/gallery.routes.js");
+const { createGalleryStorage } = await import("../../packages/server/src/services/storage/gallery.storage.js");
+const { parseThumbnailWidth, resolveThumbPath } =
+  await import("../../packages/server/src/services/image/image-thumbnail.js");
+const db = await getDB();
+const storage = createGalleryStorage(db);
+const app = Fastify();
+app.decorate("db", db);
+await app.register(galleryRoutes, { prefix: "/api/gallery" });
+
+async function seed(chatId: string, filePath: string, bytes: Buffer) {
+  const absolute = join(fixtureDir, "gallery", filePath);
+  mkdirSync(dirname(absolute), { recursive: true });
+  writeFileSync(absolute, bytes);
+  await storage.create({ chatId, filePath, prompt: "Synthetic image", provider: "fixture", model: "fixture" });
+  return absolute;
+}
+
+function pngChunk(type: string, data: Buffer) {
+  const chunk = Buffer.alloc(data.length + 12);
+  chunk.writeUInt32BE(data.length);
+  chunk.write(type, 4, "ascii");
+  data.copy(chunk, 8);
+  chunk.writeUInt32BE(crc32(chunk.subarray(4, -4)), chunk.length - 4);
+  return chunk;
+}
+
+try {
+  const original = await sharp({ create: { width: 2048, height: 3072, channels: 3, background: "#164e63" } })
+    .png()
+    .toBuffer();
+  for (const source of ["shared", "legacy"]) {
+    const file = await seed(source, `${source}/image.png`, original);
+    const url = `/api/gallery/file/${source}/image.png`;
+    for (const width of [320, 1024]) {
+      const response = await app.inject(`${url}?w=${width}`);
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.headers["content-type"], "image/webp");
+      const meta = await sharp(response.rawPayload).metadata();
+      assert.equal(meta.width, width);
+      assert.equal(meta.height, width * 1.5);
+      assert.equal(response.headers["cache-control"], "public, max-age=0");
+      const cached = await resolveThumbPath(file, width);
+      assert.ok(cached);
+      assert.deepEqual(response.rawPayload, readFileSync(cached));
+      const head = await app.inject({ method: "HEAD", url: `${url}?w=${width}` });
+      assert.equal(head.headers["content-length"], String(response.rawPayload.length));
+      assert.equal(head.rawPayload.length, 0);
+      const range = await app.inject({ url: `${url}?w=${width}`, headers: { range: "bytes=0-15" } });
+      assert.equal(range.statusCode, 206);
+      assert.deepEqual(range.rawPayload, response.rawPayload.subarray(0, 16));
+    }
+    for (const suffix of ["", "?w=0", "?w=-1", "?w=4096", "?w=nope", "?w=Infinity"]) {
+      const response = await app.inject(url + suffix);
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(response.rawPayload, original, "Original download and unsupported widths remain unchanged");
+    }
+    assert.deepEqual(readFileSync(file), original, "Preview creation must not overwrite the original");
+    assert.equal((await app.inject(`/api/gallery/file/unrelated/image.png?w=320`)).statusCode, 404);
+  }
+
+  // The URL is scoped to the owning chat even when the actual generated file lives in shared/.
+  await seed("owner", "shared/generated.png", original);
+  assert.equal((await app.inject("/api/gallery/file/owner/generated.png?w=1024")).statusCode, 200);
+  assert.equal((await app.inject("/api/gallery/file/shared/generated.png?w=1024")).statusCode, 404);
+  await seed("bad", "bad/fake.png", Buffer.from("not an image"));
+  assert.equal((await app.inject("/api/gallery/file/bad/fake.png?w=320")).statusCode, 404);
+  assert.equal((await app.inject("/api/gallery/file/owner/%2e%2e%2fgenerated.png?w=320")).statusCode, 400);
+
+  const small = await sharp({ create: { width: 40, height: 60, channels: 3, background: "#164e63" } })
+    .png()
+    .toBuffer();
+  await seed("small", "small/image.png", small);
+  const smallPreview = await app.inject("/api/gallery/file/small/image.png?w=1024");
+  assert.equal((await sharp(smallPreview.rawPayload).metadata()).width, 40, "Small images are not enlarged");
+
+  // One-frame APNG with valid animation chunks: even this must remain an original,
+  // not be silently flattened by Sharp's static PNG decoder.
+  const animation = Buffer.alloc(8);
+  animation.writeUInt32BE(1);
+  const frame = Buffer.alloc(26);
+  frame.writeUInt32BE(40, 4);
+  frame.writeUInt32BE(60, 8);
+  frame.writeUInt16BE(1, 20);
+  frame.writeUInt16BE(10, 22);
+  const apng = Buffer.concat([
+    small.subarray(0, 33),
+    pngChunk("acTL", animation),
+    pngChunk("fcTL", frame),
+    small.subarray(33),
+  ]);
+  const frames = Buffer.alloc(16 * 32 * 3, 120);
+  frames.fill(200, 16 * 16 * 3);
+  const animatedWebp = await sharp(frames, { raw: { width: 16, height: 32, channels: 3, pageHeight: 16 } })
+    .webp({ loop: 0, delay: [100, 200] })
+    .toBuffer();
+  assert.equal((await sharp(animatedWebp).metadata()).pages, 2);
+  const gif = await sharp(animatedWebp, { animated: true }).gif().toBuffer();
+  for (const [filename, bytes] of [
+    ["animated.png", apng],
+    ["animated.webp", animatedWebp],
+    ["animated.gif", gif],
+  ] as const) {
+    await seed("animated", `animated/${filename}`, bytes);
+    const response = await app.inject(`/api/gallery/file/animated/${filename}?w=320`);
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.rawPayload, bytes, "Animations retain their original bytes");
+  }
+  // Large PNG metadata uses the documented conservative fallback, not a partial decode.
+  const largeMetadata = Buffer.concat([
+    small.subarray(0, 33),
+    pngChunk("tEXt", Buffer.from(`Comment\0${"x".repeat(70_000)}`)),
+    small.subarray(33),
+  ]);
+  await seed("large-metadata", "large-metadata/image.png", largeMetadata);
+  assert.deepEqual((await app.inject("/api/gallery/file/large-metadata/image.png?w=320")).rawPayload, largeMetadata);
+  for (const width of ["123", "NaN", undefined]) assert.equal(parseThumbnailWidth(width), null);
+  console.info(
+    "Gallery preview sizes, original downloads, animation fallbacks, ownership and media validation passed.",
+  );
+} finally {
+  await app.close();
+  await closeDB();
+  rmSync(fixtureDir, { recursive: true, force: true });
+}

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -1479,8 +1479,8 @@ const illustrationHandlerSource =
   useGenerateSource.match(/case "illustration": \{[\s\S]*?case "illustration_queued":/u)?.[0] ?? "";
 assert.match(
   illustrationHandlerSource,
-  /if \(!streamingEnabled && !isGameGeneration\) \{[\s\S]*?refreshMessagesAuthoritatively/u,
-  "illustrations should not refresh the visible cache during Game generation",
+  /if \(!isGameGeneration && canRefreshCurrentMessagesNow\(\)\) \{[\s\S]*?refreshMessagesAuthoritatively/u,
+  "illustrations refresh after the live presentation hands off, but never during Game generation",
 );
 assert.match(
   useGenerateSource,


### PR DESCRIPTION
## Linked issue

Refs #5870. Leave the physical iPhone crash report open until the maintainer can retest; this is a bounded rendering mitigation plus a reproduced automatic-image refresh fix.

## Why this change

On current staging, Mari's iPhone Home Screen app goes black when an Illustrator image arrives. Restarting only the app restores it. A manual illustration subsequently appeared in both Gallery and the message after refresh, confirming it survived and was saved; the automatic illustration was still missing. Docker logs and physical-device profiling are unavailable, so GPU exhaustion is a hypothesis, not a confirmed diagnosis.

Two concrete paths were checked: mobile chat/gallery images decode the full original despite their small display size, and a saved automatic Roleplay image stays hidden while another agent keeps the generation stream open.

## What changed

- Reuse the existing on-disk thumbnailer for mobile inline chat images (1024px wide) and gallery tiles (320px). Native `picture` selection avoids fetching the original in the phone transcript/grid. Desktop, external/data URLs, lightbox, and downloads retain originals.
- Keep gallery ownership/path validation before thumbnailing; reuse validated media serving, including HEAD/range requests. Unsupported widths, animated sources, and unavailable decoding fall back to the original. Keep EXIF display orientation and do not upscale small images.
- Reuse the existing live-presentation guard to refresh an automatic illustration as soon as its message is durable, without waiting for the remaining agent tail. Game's deferred reveal is unchanged.
- No dependency, schema, agent package, provider request, or new setting changes. Added focused browser/API regressions and an Unreleased changelog entry.

## Validation

Recorded execution, separate from the unchecked human checklist:

- `pnpm check` passed (local TypeScript, ESLint, localization, formatting, E2E types, production build).
- `pnpm version:check` passed.
- Focused Playwright: 9/9 passed in development across desktop Chromium, mobile Chromium, and mobile WebKit, with 20-message fixture chats. Final production-Docker browser run: 15/15 passed across the same browsers (new arrival checks, reopened-image recovery, entrance-animation lifecycle). Phone chat/grid requests did not fetch the original; opening did, and downloads matched original bytes.
- Before the change: mobile `naturalWidth` was 2048 instead of 1024; a controlled provider SSE with an open remaining-agent tail failed to reveal a newly persisted illustration. After: both claims pass. SSE timing is synthetic; storage and media routes are real. This is not a reproduction of the physical black screen.
- `node scripts/run-regressions.mjs --filter gallery-previews` passed: current shared and legacy files, fixed widths, no upscaling, EXIF orientation, GIF/WebP/APNG preservation, large-PNG-metadata fallback, originals unchanged, cache reuse, HEAD/ranges, wrong ownership, traversal and invalid media.
- `node scripts/run-regressions.mjs --filter illustrator-disconnect` passed: actual HTTP disconnect preserves saving; explicit Stop cancels. This behavior was already fixed in #5871.
- Production Docker built and ran successfully after freeing local disk space: health, SPA, upload, both preview sizes and byte-identical original downloads passed. The isolated browser-fixture container used the existing E2E rate-limit bypass for rapid seeding; the initial isolated API smoke ran with normal limits. No host data was mounted.
- Initial broader local browser run and Docker build were interrupted by host ENOSPC / Docker connection loss, not treated as passes. Only reinstallable dependency caches from this task's three completed temporary worktrees were removed. A stale-server retry and dev-store-import tests aimed at a production server were not counted as passes; final production-compatible checks passed above.
- Updated the existing Roleplay streaming source assertion to match the new live-presentation guard while still requiring the Game-mode exclusion; that regression now passes. Required CI and CodeRabbit must pass before merge.
- Final head `e5463428e` includes the latest staging integration and both CodeRabbit fixes (versioned, early cache hits; guarded descriptor close). It passes `pnpm check`, the production Docker/API smoke, and all 15 selected production-browser checks.
- The complete Linux CI Node suite passes: 207/207. The isolated macOS run passed 206/207; the unchanged writer-lease fixture at `storage-writer-lock.regression.ts:314` forces a v4 record using a missing macOS boot ID, which the validator rejects. Its standalone rerun fails the same way. No storage-runtime or unrelated fixture change was added to this PR.
- The complete desktop Chromium, mobile Chromium, and mobile WebKit CI matrix passed. Initial CI mobile-Chromium shard 3 failed in the unchanged Home widget test: the random Chibi Professor Mari toast intercepted its bookmark-button click (confirmed in the log and failure screenshot). The new illustration tests passed even in that attempt; the shard and its required aggregate gate passed on rerun without code changes or skipped assertions. CodeRabbit completed its follow-up review of `e5463428e` with no outstanding findings.

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify manual and automatic Illustrator on the physical iPhone Home Screen app, using the existing Docker install and 20 messages per page.
- Manually verify no black screen on image arrival, with both gallery-open and gallery-closed cases; the screenshot alone does not establish a GPU cause.
- Manually verify the full-quality image still opens/downloads and animated uploads still animate.
- Real GPT Image / GPT-5.6-Sol calls were not made; tests used synthetic images and no paid provider requests.

## Docs and release impact

Changelog only; no version bump, translated user guide change, or main release.

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence

[Before/after screenshots and proof notes](https://gist.github.com/SpicyMarinara/774a3d7fb5fa58e993a9ae3d749aeb15). Download/open the self-contained `proof.html` to view the embedded screenshots. These prove the described rendering/refresh path, not an iPhone process crash diagnosis.
