### PR TITLE
fix(mobile): bound illustration previews through large PNG metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Mobile image previews now bound both dimensions, including tall illustrations, and large PNG metadata no longer bypasses previews. This reduces image-arrival decoding pressure without changing appearance settings or saved originals (#5870).
+
 - Mobile chat illustrations and gallery tiles use smaller cached display copies to reduce image decoding pressure; opening and downloading still uses the original. Saved automatic Roleplay illustrations also appear as soon as they arrive, without waiting for remaining agent work (#5870).
 
 - Conversation swipe menus now reuse Roleplay's compact, unboxed controls on desktop and mobile, with arrows and counters following the configured chat-chrome text color instead of pink/orchid styling (#5875).

--- a/e2e/illustration-arrival.e2e.ts
+++ b/e2e/illustration-arrival.e2e.ts
@@ -1,6 +1,7 @@
 import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
+import { crc32 } from "node:zlib";
 
 const version = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version;
 const requireServer = createRequire(new URL("../packages/server/package.json", import.meta.url));
@@ -33,12 +34,21 @@ async function openChat(page: Page, chatId: string) {
   await page.goto("/");
 }
 
-async function saveIllustration(request: APIRequestContext, chatId: string, messageId: string) {
-  const original = await sharp({
-    create: { width: 2048, height: 3072, channels: 3, background: "#164e63" },
+async function saveIllustration(request: APIRequestContext, chatId: string, messageId: string, height = 1536) {
+  // A normal GPT Image portrait is already 1024px wide; width-only resizing did
+  // not reduce it. Large ancillary metadata also used to bypass previews entirely.
+  const png = await sharp({
+    create: { width: 1024, height, channels: 3, background: "#164e63" },
   })
     .png()
     .toBuffer();
+  const metadata = Buffer.from(`Comment\0${"x".repeat(200_000)}`);
+  const chunk = Buffer.alloc(metadata.length + 12);
+  chunk.writeUInt32BE(metadata.length);
+  chunk.write("tEXt", 4, "ascii");
+  metadata.copy(chunk, 8);
+  chunk.writeUInt32BE(crc32(chunk.subarray(4, -4)), chunk.length - 4);
+  const original = Buffer.concat([png.subarray(0, 33), chunk, png.subarray(33)]);
   const upload = await request.post(`/api/gallery/${chatId}/upload`, {
     multipart: {
       prompt: "Synthetic arrival illustration",
@@ -57,70 +67,82 @@ async function saveIllustration(request: APIRequestContext, chatId: string, mess
 }
 
 for (const mode of ["roleplay", "conversation"] as const) {
-  test(`${mode} mobile image previews avoid decoding the original; opening still uses it`, async ({
-    page,
-    request,
-  }, testInfo) => {
-    const created = await request.post("/api/chats", {
-      data: { name: "Illustration preview proof", mode, characterIds: [], connectionId: "synthetic" },
-    });
-    expect(created.ok()).toBeTruthy();
-    const chat = (await created.json()) as { id: string };
-    try {
-      for (let index = 0; index < 19; index++) {
-        const prior = await request.post(`/api/chats/${chat.id}/messages`, {
-          data: { role: index % 2 ? "assistant" : "user", content: `Prior message ${index + 1}.` },
+  for (const height of [1536, 4096]) {
+    test(`${mode} mobile image previews bound 1024x${height} PNGs with large metadata; opening still uses the original`, async ({
+      page,
+      request,
+    }, testInfo) => {
+      const created = await request.post("/api/chats", {
+        data: { name: "Illustration preview proof", mode, characterIds: [], connectionId: "synthetic" },
+      });
+      expect(created.ok()).toBeTruthy();
+      const chat = (await created.json()) as { id: string };
+      try {
+        for (let index = 0; index < 19; index++) {
+          const prior = await request.post(`/api/chats/${chat.id}/messages`, {
+            data: { role: index % 2 ? "assistant" : "user", content: `Prior message ${index + 1}.` },
+          });
+          expect(prior.ok()).toBeTruthy();
+        }
+        const saved = await request.post(`/api/chats/${chat.id}/messages`, {
+          data: { role: "assistant", content: "The illustration accompanies this reply." },
         });
-        expect(prior.ok()).toBeTruthy();
+        expect(saved.ok()).toBeTruthy();
+        const message = (await saved.json()) as { id: string };
+        const image = await saveIllustration(request, chat.id, message.id, height);
+        const errors: string[] = [];
+        page.on("pageerror", (error) => errors.push(error.message));
+        const originalRequests: string[] = [];
+        page.on("request", (req) => {
+          if (req.url().endsWith(image.url)) originalRequests.push(req.url());
+        });
+        await openChat(page, chat.id);
+        await expect(page.locator(".mari-rp-reduced-paint")).toHaveCount(0);
+        const attachment = page.getByRole("img", { name: "Arrival illustration", exact: true });
+        await expect(attachment).toBeVisible();
+        const mobile = testInfo.project.name.includes("mobile");
+        await expect
+          .poll(() => attachment.evaluate((img: HTMLImageElement) => img.naturalWidth))
+          .toBe(mobile ? Math.round((1024 * 1024) / height) : 1024);
+        await expect
+          .poll(() => attachment.evaluate((img: HTMLImageElement) => img.naturalHeight))
+          .toBe(mobile ? 1024 : height);
+        if (mobile) expect(originalRequests).toEqual([]);
+        await testInfo.attach("chat-preview", {
+          body: await page.screenshot({ path: testInfo.outputPath("chat-preview.png") }),
+          contentType: "image/png",
+        });
+
+        if (mobile) await page.getByRole("button", { name: "More options", exact: true }).click();
+        await page.getByRole("button", { name: "Gallery", exact: true }).filter({ visible: true }).click();
+        const drawer = page.locator(".mari-chat-gallery-drawer");
+        const tile = drawer.getByRole("img", { name: "Synthetic arrival illustration", exact: true });
+        await expect(tile).toBeVisible();
+        await expect
+          .poll(() => tile.evaluate((img: HTMLImageElement) => img.naturalWidth))
+          .toBe(mobile ? Math.round((320 * 1024) / height) : 1024);
+        await expect
+          .poll(() => tile.evaluate((img: HTMLImageElement) => img.naturalHeight))
+          .toBe(mobile ? 320 : height);
+        if (mobile) expect(originalRequests).toEqual([]);
+        await testInfo.attach("gallery-preview", {
+          body: await page.screenshot({ path: testInfo.outputPath("gallery-preview.png") }),
+          contentType: "image/png",
+        });
+
+        await drawer.getByRole("button", { name: "Open gallery image", exact: true }).click();
+        const fullImage = page.getByRole("dialog").getByRole("img", { name: "Synthetic arrival illustration" });
+        await expect(fullImage).toBeVisible();
+        await expect.poll(() => fullImage.evaluate((img: HTMLImageElement) => img.naturalWidth)).toBe(1024);
+        await expect.poll(() => fullImage.evaluate((img: HTMLImageElement) => img.naturalHeight)).toBe(height);
+        const downloaded = await request.get(image.url);
+        expect(await downloaded.body()).toEqual(image.original);
+        expect(errors).toEqual([]);
+      } finally {
+        await request.delete(`/api/chats/${chat.id}`);
       }
-      const saved = await request.post(`/api/chats/${chat.id}/messages`, {
-        data: { role: "assistant", content: "The illustration accompanies this reply." },
-      });
-      expect(saved.ok()).toBeTruthy();
-      const message = (await saved.json()) as { id: string };
-      const image = await saveIllustration(request, chat.id, message.id);
-      const errors: string[] = [];
-      page.on("pageerror", (error) => errors.push(error.message));
-      const originalRequests: string[] = [];
-      page.on("request", (req) => {
-        if (req.url().endsWith(image.url)) originalRequests.push(req.url());
-      });
-      await openChat(page, chat.id);
-      const attachment = page.getByRole("img", { name: "Arrival illustration", exact: true });
-      await expect(attachment).toBeVisible();
-      const mobile = testInfo.project.name.includes("mobile");
-      await expect
-        .poll(() => attachment.evaluate((img: HTMLImageElement) => img.naturalWidth))
-        .toBe(mobile ? 1024 : 2048);
-      if (mobile) expect(originalRequests).toEqual([]);
-      await testInfo.attach("chat-preview", {
-        body: await page.screenshot({ path: testInfo.outputPath("chat-preview.png") }),
-        contentType: "image/png",
-      });
-
-      if (mobile) await page.getByRole("button", { name: "More options", exact: true }).click();
-      await page.getByRole("button", { name: "Gallery", exact: true }).filter({ visible: true }).click();
-      const drawer = page.locator(".mari-chat-gallery-drawer");
-      const tile = drawer.getByRole("img", { name: "Synthetic arrival illustration", exact: true });
-      await expect(tile).toBeVisible();
-      await expect.poll(() => tile.evaluate((img: HTMLImageElement) => img.naturalWidth)).toBe(mobile ? 320 : 2048);
-      if (mobile) expect(originalRequests).toEqual([]);
-      await testInfo.attach("gallery-preview", {
-        body: await page.screenshot({ path: testInfo.outputPath("gallery-preview.png") }),
-        contentType: "image/png",
-      });
-
-      await drawer.getByRole("button", { name: "Open gallery image", exact: true }).click();
-      const fullImage = page.getByRole("dialog").getByRole("img", { name: "Synthetic arrival illustration" });
-      await expect(fullImage).toBeVisible();
-      await expect.poll(() => fullImage.evaluate((img: HTMLImageElement) => img.naturalWidth)).toBe(2048);
-      const downloaded = await request.get(image.url);
-      expect(await downloaded.body()).toEqual(image.original);
-      expect(errors).toEqual([]);
-    } finally {
-      await request.delete(`/api/chats/${chat.id}`);
-    }
-  });
+    });
+  }
 }
 
 test("a saved automatic illustration appears before the remaining agent stream closes", async ({
@@ -180,6 +202,13 @@ test("a saved automatic illustration appears before the remaining agent stream c
 
     // A slow background/agent tail still owns the SSE, but this image is durable.
     await expect(page.getByRole("img", { name: "Arrival illustration", exact: true })).toBeVisible();
+    await expect
+      .poll(() =>
+        page
+          .getByRole("img", { name: "Arrival illustration", exact: true })
+          .evaluate((img: HTMLImageElement) => img.naturalHeight),
+      )
+      .toBe(testInfo.project.name.includes("mobile") ? 1024 : 1536);
     await testInfo.attach("automatic-arrival", {
       body: await page.screenshot({ path: testInfo.outputPath("automatic-arrival.png") }),
       contentType: "image/png",

--- a/packages/server/src/services/image/image-thumbnail.ts
+++ b/packages/server/src/services/image/image-thumbnail.ts
@@ -14,8 +14,8 @@ import { BACKGROUND_THUMBNAIL_WIDTH, CHAT_IMAGE_PREVIEW_WIDTH } from "@marinara-
 const THUMB_DIR = join(DATA_DIR, "backgrounds-thumbs");
 
 /**
- * Fixed widths only, so `?w=` cannot create arbitrarily many copies of each image.
- * Compact tiles share 320px; mobile inline illustrations use 1024px.
+ * Fixed bounds only, so `?w=` cannot create arbitrarily many copies of each image.
+ * Compact tiles fit inside 320px; mobile inline illustrations fit inside 1024px.
  */
 const THUMB_WIDTHS = new Set([BACKGROUND_THUMBNAIL_WIDTH, CHAT_IMAGE_PREVIEW_WIDTH]);
 
@@ -48,8 +48,9 @@ export async function resolveThumbPath(filePath: string, width: number): Promise
   try {
     // Inside the try: the source can vanish between the caller's existsSync and this stat.
     const key = createHash("sha1").update(filePath).digest("hex").slice(0, 16);
-    // v2 invalidates older copies that could flatten animation or lose EXIF orientation.
-    const thumbPath = join(THUMB_DIR, `v2-${width}-${statSync(filePath).mtimeMs}-${key}.webp`);
+    const source = statSync(filePath);
+    // v3 also invalidates width-only previews that left portrait/tall images too large.
+    const thumbPath = join(THUMB_DIR, `v3-${width}-${source.mtimeMs}-${key}.webp`);
     if (existsSync(thumbPath)) return thumbPath;
 
     const sharp = await getSharp();
@@ -58,26 +59,37 @@ export async function resolveThumbPath(filePath: string, width: number): Promise
     if ((metadata.pages ?? 1) > 1) return null;
     if (metadata.format === "png") {
       // Sharp does not expose APNG frame counts. acTL must precede the first IDAT.
-      // ponytail: inspect only 64 KiB of headers; unusually large metadata keeps the
-      // original. Increase this ceiling if those images need previews too.
+      // Read chunk headers, skipping metadata payloads rather than falling back to
+      // a full-size image when (for example) provenance data exceeds 64 KiB.
       const handle = await open(filePath, "r");
       let staticPng = false;
       try {
-        const { buffer, bytesRead } = await handle.read(Buffer.alloc(64 * 1024), 0, 64 * 1024, 0);
-        for (let offset = 8; offset + 8 <= bytesRead; offset += 12 + buffer.readUInt32BE(offset)) {
-          const chunk = buffer.toString("ascii", offset + 4, offset + 8);
+        const header = Buffer.alloc(8);
+        // Bound both I/O and offsets for malformed/pathological files. Unknown
+        // animation status still keeps the original instead of flattening it.
+        for (let offset = 8, chunks = 0; offset + 12 <= source.size && chunks < 1024; chunks++) {
+          const { bytesRead } = await handle.read(header, 0, header.length, offset);
+          if (bytesRead !== header.length) break;
+          const nextOffset = offset + 12 + header.readUInt32BE(0);
+          if (nextOffset > source.size) break;
+          const chunk = header.toString("ascii", 4, 8);
           if (chunk === "acTL") return null;
           if (chunk === "IDAT") {
             staticPng = true;
             break;
           }
+          offset = nextOffset;
         }
       } finally {
         await handle.close();
       }
       if (!staticPng) return null;
     }
-    const buffer = await image.rotate().resize({ width, withoutEnlargement: true }).webp({ quality: 72 }).toBuffer();
+    const buffer = await image
+      .rotate()
+      .resize({ width, height: width, fit: "inside", withoutEnlargement: true })
+      .webp({ quality: 72 })
+      .toBuffer();
     if (!existsSync(THUMB_DIR)) mkdirSync(THUMB_DIR, { recursive: true });
     const temporaryPath = `${thumbPath}.${process.pid}.${randomUUID()}.tmp`;
     try {

--- a/scripts/regressions/gallery-previews.regression.ts
+++ b/scripts/regressions/gallery-previews.regression.ts
@@ -52,17 +52,22 @@ try {
     const thumbDir = join(fixtureDir, "backgrounds-thumbs");
     mkdirSync(thumbDir, { recursive: true });
     const key = createHash("sha1").update(file).digest("hex").slice(0, 16);
-    writeFileSync(
-      join(thumbDir, `320-${statSync(file).mtimeMs}-${key}.webp`),
-      await sharp(original).resize(10).webp().toBuffer(),
-    );
+    for (const prefix of ["", "v2-"]) {
+      writeFileSync(
+        join(thumbDir, `${prefix}320-${statSync(file).mtimeMs}-${key}.webp`),
+        await sharp(original)
+          .resize(prefix ? 320 : 10)
+          .webp()
+          .toBuffer(),
+      );
+    }
     for (const width of [320, 1024]) {
       const response = await app.inject(`${url}?w=${width}`);
       assert.equal(response.statusCode, 200);
       assert.equal(response.headers["content-type"], "image/webp");
       const meta = await sharp(response.rawPayload).metadata();
-      assert.equal(meta.width, width);
-      assert.equal(meta.height, width * 1.5);
+      assert.equal(meta.width, Math.round(width / 1.5));
+      assert.equal(meta.height, width, "Both dimensions must fit the preview bound");
       assert.equal(response.headers["cache-control"], "public, max-age=0");
       const cached = await resolveThumbPath(file, width);
       assert.ok(cached);
@@ -100,6 +105,24 @@ try {
   assert.equal((await app.inject("/api/gallery/file/bad/fake.png?w=320")).statusCode, 404);
   assert.equal((await app.inject("/api/gallery/file/owner/%2e%2e%2fgenerated.png?w=320")).statusCode, 400);
 
+  // GPT Image's standard portrait size already fits the old width-only cap.
+  // Tall illustrations must not keep their full decoded height either.
+  for (const [width, height] of [
+    [1024, 1536],
+    [1024, 4096],
+    [4096, 1024],
+  ]) {
+    const bytes = await sharp({ create: { width, height, channels: 3, background: "#164e63" } })
+      .png()
+      .toBuffer();
+    await seed("dimensions", `dimensions/${width}x${height}.png`, bytes);
+    const response = await app.inject(`/api/gallery/file/dimensions/${width}x${height}.png?w=1024`);
+    const preview = await sharp(response.rawPayload).metadata();
+    assert.equal(Math.max(preview.width, preview.height), 1024);
+    assert.equal(preview.width, Math.round((width * 1024) / Math.max(width, height)));
+    assert.equal(preview.height, Math.round((height * 1024) / Math.max(width, height)));
+  }
+
   const small = await sharp({ create: { width: 40, height: 60, channels: 3, background: "#164e63" } })
     .png()
     .toBuffer();
@@ -130,6 +153,8 @@ try {
     pngChunk("fcTL", frame),
     small.subarray(33),
   ]);
+  const metadataChunk = pngChunk("tEXt", Buffer.from(`Comment\0${"x".repeat(200_000)}`));
+  const metadataApng = Buffer.concat([apng.subarray(0, 33), metadataChunk, apng.subarray(33)]);
   const frames = Buffer.alloc(16 * 32 * 3, 120);
   frames.fill(200, 16 * 16 * 3);
   const animatedWebp = await sharp(frames, { raw: { width: 16, height: 32, channels: 3, pageHeight: 16 } })
@@ -139,6 +164,7 @@ try {
   const gif = await sharp(animatedWebp, { animated: true }).gif().toBuffer();
   for (const [filename, bytes] of [
     ["animated.png", apng],
+    ["metadata-animated.png", metadataApng],
     ["animated.webp", animatedWebp],
     ["animated.gif", gif],
   ] as const) {
@@ -147,14 +173,17 @@ try {
     assert.equal(response.statusCode, 200);
     assert.deepEqual(response.rawPayload, bytes, "Animations retain their original bytes");
   }
-  // Large PNG metadata uses the documented conservative fallback, not a partial decode.
-  const largeMetadata = Buffer.concat([
-    small.subarray(0, 33),
-    pngChunk("tEXt", Buffer.from(`Comment\0${"x".repeat(70_000)}`)),
-    small.subarray(33),
-  ]);
+  // Metadata payloads must not make static generated PNGs bypass mobile previews.
+  const largeMetadata = Buffer.concat([original.subarray(0, 33), metadataChunk, original.subarray(33)]);
   await seed("large-metadata", "large-metadata/image.png", largeMetadata);
-  assert.deepEqual((await app.inject("/api/gallery/file/large-metadata/image.png?w=320")).rawPayload, largeMetadata);
+  for (const width of [320, 1024]) {
+    const response = await app.inject(`/api/gallery/file/large-metadata/image.png?w=${width}`);
+    assert.equal(response.headers["content-type"], "image/webp", "Large metadata must not fall back to the original");
+    const preview = await sharp(response.rawPayload).metadata();
+    assert.equal(preview.height, width);
+    assert.equal(preview.width, Math.round(width / 1.5));
+  }
+  assert.deepEqual((await app.inject("/api/gallery/file/large-metadata/image.png")).rawPayload, largeMetadata);
   for (const width of ["123", "NaN", undefined]) assert.equal(parseThumbnailWidth(width), null);
   console.info(
     "Gallery preview sizes, original downloads, animation fallbacks, ownership and media validation passed.",


### PR DESCRIPTION
## Linked issue

Refs #5870. Keep the issue open for physical-iPhone confirmation.

## Why

The maintainer confirmed that the installed iPhone Home Screen app still reloads or stays black around Illustrator image arrival on Docker build `36f5379b2e7d`. No appearance-setting workaround is acceptable. Inspection found two reproducible gaps in the previous mitigation: width-only previews leave portrait/tall images oversized, and static PNGs with more than 64 KiB of metadata before IDAT fall back to the full original.

## What changed

- Reuse the existing thumbnailer to fit both dimensions inside the existing 320/1024 preview bounds, preserving aspect ratio, EXIF orientation and small images.
- Read bounded PNG chunk headers and skip metadata payloads; keep APNG originals, including animation headers after large metadata.
- Invalidate old width-only disk previews with the v3 cache key.
- Extend existing regression and browser tests. No new dependencies, helpers, settings, recovery timers, provider changes, or original-image mutations.
- Include an Unreleased changelog entry.

## Automated evidence

- Red/green Node proof: the old dimensions fail; after fixing dimensions alone, large-metadata PNGs still fail by returning original PNG bytes instead of a preview. Both pass with the full patch.
- Old production Docker + new mobile WebKit test: fails (`naturalWidth` 1024 instead of 683). Patched production Docker: **21/21 selected browser checks pass** across desktop Chromium, mobile Chromium and mobile WebKit, including saved automatic arrival before the remaining agent stream closes and saved-result recovery after reopening.
- Portrait 1024×1536 → inline 683×1024; tall 1024×4096 → inline 256×1024. Gallery tiles fit inside 320×320. Fixtures include 200 KB ancillary PNG metadata and 20-message chats; Reduced paint effects remains off.
- Desktop/lightbox use originals; original downloads are byte-identical. Animation, ownership/traversal/media validation, range/HEAD, no enlargement, orientation and cache-hit/invalidation regressions pass.
- `pnpm check` passes. Local gallery regressions (6/6) and Roleplay swipe-media regression pass. Production Docker API smoke with normal rate limits passes health/SPA/upload/preview/original checks. Local Docker is Linux/arm64; CI additionally builds Linux/amd64.
- GitHub project validation, **207/207 Node regressions**, the complete desktop Chromium/mobile Chromium/mobile WebKit matrix, Docker build and CodeQL passed. CodeRabbit completed review of `c247211d7` with no actionable findings.

## Validation / manual test plan

- [ ] Manually verify manual and automatic Illustrator in the iPhone Home Screen app, using existing appearance settings and Messages per page = 20.
- [ ] Manually verify the app stays usable after image arrival and after reopening, with the result visible under the message and in Gallery.
- [ ] Manually verify desktop/mobile original image opening and downloads retain their quality.

## Proof boundaries and risk

The physical iPhone black-screen/GPU/process failure was **not reproduced or profiled** here. These tests prove reduced decoded dimensions and corrected delivery paths, not that every WebKit black screen is eliminated. The user's original GPT Image output was unavailable; large-metadata fixtures are synthetic. Paid provider calls were not made. Animated/unsupported images and deliberately opened originals retain the existing full-size behavior. Shared compact background/game-asset thumbnails also use the dimension bound; scene backgrounds and sprites are not changed.

## UI evidence

[Before/after mobile WebKit screenshots and detailed runtime evidence](https://gist.github.com/SpicyMarinara/511d44f4c8d0389ef9b99cdf0e94b5fc). Synthetic content only; download/open `proof.html` to view the embedded images. Screenshots retain the existing layout; assertions demonstrate the reduced decoded pixel sizes.

## Docs and release notes

- [ ] Review the Unreleased changelog entry.
- [ ] Confirm no release-version or translated-document changes are needed.
