### PR TITLE
fix(agents): Beholder corrections 403 for anyone not on loopback

### DIFF
--- a/packages/server/src/routes/agents.routes.ts
+++ b/packages/server/src/routes/agents.routes.ts
@@ -291,9 +291,25 @@ export async function agentsRoutes(app: FastifyInstance) {
     "/beholder-state/:chatId",
     { config: { rateLimit: BEHOLDER_STATE_RATE_LIMIT } },
     async (req, reply) => {
-      // Guarded like the other write routes in this file: this rewrites the state the
-      // next prompt is built from, for any chat id the caller names.
-      if (!requirePrivilegedAccess(req, reply, { feature: "Beholder state correction" })) return;
+      // Deliberately NOT behind requirePrivilegedAccess.
+      //
+      // It was, and the effect was that correcting a slot returned 403 for everyone not
+      // on loopback. That gate admits a request only from loopback or with an
+      // X-Admin-Secret header, and a browser has no way to send that header — so behind
+      // a reverse proxy, on a LAN, or through a tunnel, every correction and the whole
+      // "start over" action failed, with no setting an operator could change to fix it.
+      // It failed quietly too: the gate does not log, so the server said nothing.
+      //
+      // The gate was the wrong tool for this route. This writes one chat's own tracked
+      // state, which is the same kind of act as editing a message in that chat, and
+      // chats.routes.ts guards none of its writes this way. Sitting next to the
+      // genuinely administrative routes in this file — import-policy, import — made it
+      // look like company it does not keep.
+      //
+      // What protects it instead: the app-wide Basic Auth hook registered in app.ts,
+      // which every route in the product sits behind; the rate limit configured above;
+      // and normalizeBeholderState below, which refuses a malformed body rather than
+      // letting it reach the state the next prompt is built from.
       const body = req.body as { state?: unknown } | undefined;
       const state = normalizeBeholderState(body?.state);
       if (!state) return reply.status(400).send({ error: "Invalid Beholder state" });

--- a/scripts/regressions/beholder-state-reachable.regression.ts
+++ b/scripts/regressions/beholder-state-reachable.regression.ts
@@ -4,105 +4,177 @@
 // requirePrivilegedAccess, which admits a request only from loopback or with an
 // X-Admin-Secret header. A browser cannot send that header — the shipped package
 // contains the string zero times — so behind a reverse proxy, on a LAN, or through a
-// tunnel, every slot edit and the entire "start over" action returned 403 and there was
-// no configuration that could change it. The gate does not log, and the panel's error
-// toast was invisible until 1.3.9, so it failed silently at both ends and read as the
-// whole feature being broken.
+// tunnel, every slot edit and the entire "start over" action returned 403, and no
+// setting could change that. The gate does not log and the panel's error toast was
+// invisible until 1.3.9, so it failed silently at both ends and read as the whole
+// feature being broken.
 //
-// This test states the property directly rather than trusting a comment: the gate that
-// caused it must still reject a proxied request (so nobody concludes it was harmless),
-// and the route must not be using it.
+// This drives the real route through the real app rather than reading the source. An
+// earlier version of this file matched source text, and it could have passed while the
+// route still returned 403 — one of its assertions was even satisfied by a comment
+// explaining the fix rather than by the code doing it.
+//
+// The app-wide Basic Auth hook is deliberately satisfied here, by allowing
+// unauthenticated private-network access, so that what is being measured is the ROUTE's
+// own authorization and not the product-wide lockdown that guards every endpoint.
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import type { FastifyReply, FastifyRequest } from "fastify";
-import { requirePrivilegedAccess } from "../../packages/server/src/middleware/privileged-gate.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-const root = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const dataDir = mkdtempSync(join(tmpdir(), "marinara-beholder-state-reachable-"));
+const previous = {
+  DATA_DIR: process.env.DATA_DIR,
+  FILE_STORAGE_DIR: process.env.FILE_STORAGE_DIR,
+  MARINARA_FILE_STORAGE_DIR: process.env.MARINARA_FILE_STORAGE_DIR,
+  NODE_ENV: process.env.NODE_ENV,
+  MARINARA_LITE: process.env.MARINARA_LITE,
+  ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK: process.env.ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK,
+  ADMIN_SECRET: process.env.ADMIN_SECRET,
+};
 
-/** A request as it arrives from behind a reverse proxy: authenticated, not loopback. */
-function proxiedRequest(): FastifyRequest {
-  return {
-    headers: { host: "127.0.0.1:7860", authorization: "Basic dXNlcjpwYXNz" },
-    ip: "192.168.1.50",
-    raw: { socket: { localAddress: "192.168.1.10" } },
-    url: "/api/agents/beholder-state/abc",
-  } as unknown as FastifyRequest;
-}
+/** A LAN address: what a reverse proxy or another machine looks like to the server. */
+const REMOTE = "192.168.1.50";
+const MESSAGE = "beholder-reachable-message";
 
-function captureReply() {
-  const sent: { status?: number; body?: unknown } = {};
-  const reply = {
-    status(code: number) {
-      sent.status = code;
-      return this;
-    },
-    send(body: unknown) {
-      sent.body = body;
-      return this;
-    },
-  } as unknown as FastifyReply;
-  return { reply, sent };
-}
+let app: {
+  close(): Promise<void>;
+  ready(): Promise<unknown>;
+  inject(options: Record<string, unknown>): Promise<{ statusCode: number; body: string }>;
+} | null = null;
 
-// ── The gate really does reject this request ────────────────────────────────
-// Without this, removing it from the route could be waved away as unnecessary.
-{
-  const previousSecret = process.env.ADMIN_SECRET;
-  const previousAllowRemote = process.env.ALLOW_UNAUTHENTICATED_REMOTE;
-  process.env.ALLOW_UNAUTHENTICATED_REMOTE = "true";
+try {
+  const fileStorageDir = join(dataDir, "file-storage");
+  process.env.DATA_DIR = dataDir;
+  process.env.FILE_STORAGE_DIR = fileStorageDir;
+  process.env.MARINARA_FILE_STORAGE_DIR = fileStorageDir;
+  process.env.NODE_ENV = "test";
+  process.env.MARINARA_LITE = "true";
+  // Satisfies the app-wide hook only. The route gate under test is separate.
+  process.env.ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK = "true";
   delete process.env.ADMIN_SECRET;
 
-  const { reply, sent } = captureReply();
-  const allowed = requirePrivilegedAccess(proxiedRequest(), reply, {
-    feature: "Beholder state correction",
+  const [{ buildApp }, { getDB }, { createAgentsStorage }] = await Promise.all([
+    import("../../packages/server/src/app.js"),
+    import("../../packages/server/src/db/connection.js"),
+    import("../../packages/server/src/services/storage/agents.storage.js"),
+  ]);
+
+  app = await buildApp();
+  await app.ready();
+
+  // A real chat, created through the API. agent_runs are stored per chat, so a run
+  // seeded against an id no chat owns is written somewhere the lookup never reads — and
+  // the route then answers 404, which looks exactly like the fix not working.
+  const created = await app.inject({
+    method: "POST",
+    url: "/api/chats",
+    remoteAddress: REMOTE,
+    headers: { host: "127.0.0.1:7860", "content-type": "application/json" },
+    payload: { name: "Beholder reachability", mode: "roleplay" },
   });
-  assert.equal(allowed, false, "the privileged gate should refuse a proxied browser request");
-  assert.equal(sent.status, 403, "and it refuses with the 403 the bug report described");
+  assert.equal(created.statusCode, 200, `could not create the chat to test against: ${created.body}`);
+  const CHAT = JSON.parse(created.body).id as string;
+  assert.ok(CHAT, "the created chat should have an id");
 
-  if (previousSecret === undefined) delete process.env.ADMIN_SECRET;
-  else process.env.ADMIN_SECRET = previousSecret;
-  if (previousAllowRemote === undefined) delete process.env.ALLOW_UNAUTHENTICATED_REMOTE;
-  else process.env.ALLOW_UNAUTHENTICATED_REMOTE = previousAllowRemote;
-}
+  const agents = createAgentsStorage(await getDB());
+  // Created directly rather than through ensureBuiltinConfig. BUILT_IN_AGENTS is filled
+  // from installed capability package manifests, and Beholder is a downloadable package
+  // now, so in a bare test app that list is empty and the built-in path yields nothing.
+  // The route's lookup joins on the config TYPE, which is all this needs to satisfy.
+  const config = await agents.create({
+    type: "beholder",
+    name: "Beholder",
+    description: "seeded for this regression",
+    phase: "post",
+    enabled: true,
+    connectionId: null,
+    imagePath: null,
+    promptTemplate: "",
+    settings: {},
+  } as never);
+  assert.ok(config?.id, "a Beholder agent config should exist to hang the run off");
+  assert.equal(config.type, "beholder", "and it must keep the type the route looks up");
+  await agents.saveRun({
+    agentConfigId: config!.id,
+    chatId: CHAT,
+    messageId: MESSAGE,
+    result: {
+      type: "beholder",
+      data: { characters: [{ name: "Maggie", body: { waist: { worn: [{ item: "belt" }] } } }] },
+      tokensUsed: 0,
+      durationMs: 1,
+      success: true,
+      error: null,
+    },
+  });
 
-// ── So the route must not be behind it ──────────────────────────────────────
-{
-  const source = readFileSync(join(root, "packages/server/src/routes/agents.routes.ts"), "utf8");
-  const marker = '"/beholder-state/:chatId",';
-  const start = source.indexOf(marker);
-  assert.ok(start > -1, "the beholder-state route should still exist");
+  // Confirm the seed is findable the same way the route finds it, so a seeding problem
+  // cannot masquerade as the route refusing the write.
+  const seeded = await agents.getLastSuccessfulRunByType("beholder", CHAT);
+  assert.ok(seeded, "the seeded Beholder run should be findable before the route is exercised");
 
-  // The PUT handler, up to the next route registration.
-  const after = source.slice(start);
-  const end = after.indexOf("app.get<", 1);
-  const handler = end > -1 ? after.slice(0, end) : after;
+  const put = (chatId: string, state: unknown) =>
+    app!.inject({
+      method: "PUT",
+      url: `/api/agents/beholder-state/${chatId}`,
+      remoteAddress: REMOTE,
+      headers: { host: "127.0.0.1:7860", "content-type": "application/json" },
+      payload: { state },
+    });
 
-  // The CALL, not the word: the handler explains at length why the gate is absent, and
-  // a bare substring check fails on that explanation. Matching the invocation lets the
-  // reasoning stay next to the code it explains.
-  assert.doesNotMatch(
-    handler,
-    /requirePrivilegedAccess\s*\(/u,
-    "the beholder-state write must not require loopback or an admin secret — a browser " +
-      "behind a proxy can satisfy neither, and this is ordinary chat data",
+  // ── The correction the bug report could not make ──────────────────────────
+  const corrected = {
+    characters: [{ name: "Maggie", body: { waist: { worn: [{ item: "black belt" }] } } }],
+  };
+  const write = await put(CHAT, corrected);
+  assert.notEqual(
+    write.statusCode,
+    403,
+    "a correction from a non-loopback address must not be refused — a browser behind a " +
+      "reverse proxy can offer neither loopback nor an X-Admin-Secret header",
   );
-  // The protections that replace it are not optional.
-  assert.ok(handler.includes("BEHOLDER_STATE_RATE_LIMIT"), "the write must stay rate limited");
-  assert.ok(handler.includes("normalizeBeholderState"), "and must still refuse a malformed body");
-}
+  assert.equal(write.statusCode, 200, `expected the correction to be accepted, got ${write.body}`);
 
-// ── The neighbouring administrative routes keep their gate ──────────────────
-// The point is that this route was miscategorised, not that the gate is wrong.
-{
-  const source = readFileSync(join(root, "packages/server/src/routes/agents.routes.ts"), "utf8");
-  for (const feature of ["Custom Agent imports", "Custom Agent import"]) {
-    assert.ok(
-      source.includes(`requirePrivilegedAccess(req, reply, { feature: "${feature}" })`),
-      `${feature} is genuinely administrative and must stay behind the privileged gate`,
-    );
+  // ── and it has to actually persist ────────────────────────────────────────
+  const read = await app.inject({
+    method: "GET",
+    url: `/api/agents/beholder-state/${CHAT}`,
+    remoteAddress: REMOTE,
+    headers: { host: "127.0.0.1:7860" },
+  });
+  assert.equal(read.statusCode, 200, "reading the state back must work from the same address");
+  assert.match(read.body, /black belt/u, "the correction must survive the round trip, not merely be accepted");
+
+  // ── the protections that replace the gate still work ──────────────────────
+  const malformed = await put(CHAT, { characters: "not a list" });
+  assert.equal(malformed.statusCode, 400, "a malformed body must still be refused");
+
+  const unknownChat = await put("chat-with-no-beholder-run", corrected);
+  assert.equal(unknownChat.statusCode, 404, "a chat with no run to correct must still say so");
+
+  // ── the neighbouring administrative routes keep their gate ────────────────
+  // The point is that this route was miscategorised, not that the gate is wrong. Driven
+  // rather than read, for the same reason as above.
+  const adminRoute = await app.inject({
+    method: "PATCH",
+    url: "/api/agents/import-policy",
+    remoteAddress: REMOTE,
+    headers: { host: "127.0.0.1:7860", "content-type": "application/json" },
+    payload: { enabled: true },
+  });
+  assert.equal(
+    adminRoute.statusCode,
+    403,
+    "changing the Custom Agent import policy is genuinely administrative and must stay " + "behind the privileged gate",
+  );
+
+  console.log("beholder state route reachable behind a proxy: OK");
+} finally {
+  await app?.close().catch(() => {});
+  for (const [key, value] of Object.entries(previous)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
   }
+  rmSync(dataDir, { recursive: true, force: true });
 }
-
-console.log("beholder state route reachable behind a proxy: OK");

--- a/scripts/regressions/beholder-state-reachable.regression.ts
+++ b/scripts/regressions/beholder-state-reachable.regression.ts
@@ -1,0 +1,108 @@
+// Correcting a Beholder slot has to work when the browser is not on loopback.
+//
+// It did not. `PUT /api/agents/beholder-state/:chatId` was wrapped in
+// requirePrivilegedAccess, which admits a request only from loopback or with an
+// X-Admin-Secret header. A browser cannot send that header — the shipped package
+// contains the string zero times — so behind a reverse proxy, on a LAN, or through a
+// tunnel, every slot edit and the entire "start over" action returned 403 and there was
+// no configuration that could change it. The gate does not log, and the panel's error
+// toast was invisible until 1.3.9, so it failed silently at both ends and read as the
+// whole feature being broken.
+//
+// This test states the property directly rather than trusting a comment: the gate that
+// caused it must still reject a proxied request (so nobody concludes it was harmless),
+// and the route must not be using it.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { requirePrivilegedAccess } from "../../packages/server/src/middleware/privileged-gate.js";
+
+const root = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+
+/** A request as it arrives from behind a reverse proxy: authenticated, not loopback. */
+function proxiedRequest(): FastifyRequest {
+  return {
+    headers: { host: "127.0.0.1:7860", authorization: "Basic dXNlcjpwYXNz" },
+    ip: "192.168.1.50",
+    raw: { socket: { localAddress: "192.168.1.10" } },
+    url: "/api/agents/beholder-state/abc",
+  } as unknown as FastifyRequest;
+}
+
+function captureReply() {
+  const sent: { status?: number; body?: unknown } = {};
+  const reply = {
+    status(code: number) {
+      sent.status = code;
+      return this;
+    },
+    send(body: unknown) {
+      sent.body = body;
+      return this;
+    },
+  } as unknown as FastifyReply;
+  return { reply, sent };
+}
+
+// ── The gate really does reject this request ────────────────────────────────
+// Without this, removing it from the route could be waved away as unnecessary.
+{
+  const previousSecret = process.env.ADMIN_SECRET;
+  const previousAllowRemote = process.env.ALLOW_UNAUTHENTICATED_REMOTE;
+  process.env.ALLOW_UNAUTHENTICATED_REMOTE = "true";
+  delete process.env.ADMIN_SECRET;
+
+  const { reply, sent } = captureReply();
+  const allowed = requirePrivilegedAccess(proxiedRequest(), reply, {
+    feature: "Beholder state correction",
+  });
+  assert.equal(allowed, false, "the privileged gate should refuse a proxied browser request");
+  assert.equal(sent.status, 403, "and it refuses with the 403 the bug report described");
+
+  if (previousSecret === undefined) delete process.env.ADMIN_SECRET;
+  else process.env.ADMIN_SECRET = previousSecret;
+  if (previousAllowRemote === undefined) delete process.env.ALLOW_UNAUTHENTICATED_REMOTE;
+  else process.env.ALLOW_UNAUTHENTICATED_REMOTE = previousAllowRemote;
+}
+
+// ── So the route must not be behind it ──────────────────────────────────────
+{
+  const source = readFileSync(join(root, "packages/server/src/routes/agents.routes.ts"), "utf8");
+  const marker = '"/beholder-state/:chatId",';
+  const start = source.indexOf(marker);
+  assert.ok(start > -1, "the beholder-state route should still exist");
+
+  // The PUT handler, up to the next route registration.
+  const after = source.slice(start);
+  const end = after.indexOf("app.get<", 1);
+  const handler = end > -1 ? after.slice(0, end) : after;
+
+  // The CALL, not the word: the handler explains at length why the gate is absent, and
+  // a bare substring check fails on that explanation. Matching the invocation lets the
+  // reasoning stay next to the code it explains.
+  assert.doesNotMatch(
+    handler,
+    /requirePrivilegedAccess\s*\(/u,
+    "the beholder-state write must not require loopback or an admin secret — a browser " +
+      "behind a proxy can satisfy neither, and this is ordinary chat data",
+  );
+  // The protections that replace it are not optional.
+  assert.ok(handler.includes("BEHOLDER_STATE_RATE_LIMIT"), "the write must stay rate limited");
+  assert.ok(handler.includes("normalizeBeholderState"), "and must still refuse a malformed body");
+}
+
+// ── The neighbouring administrative routes keep their gate ──────────────────
+// The point is that this route was miscategorised, not that the gate is wrong.
+{
+  const source = readFileSync(join(root, "packages/server/src/routes/agents.routes.ts"), "utf8");
+  for (const feature of ["Custom Agent imports", "Custom Agent import"]) {
+    assert.ok(
+      source.includes(`requirePrivilegedAccess(req, reply, { feature: "${feature}" })`),
+      `${feature} is genuinely administrative and must stay behind the privileged gate`,
+    );
+  }
+}
+
+console.log("beholder state route reachable behind a proxy: OK");


### PR DESCRIPTION
## Linked issue

Reported in Discord by a user running behind a reverse proxy:

> also any manual change just gives a 403, with no errors in the log
> I am running with a reverse proxy so i imagine that is the issue
> cant even clear all, as it 403s
> yeah its totally borked. even disabling the renabling the agent dosent clear the data

Their diagnosis was right on every point.

## Why this change

`PUT /api/agents/beholder-state/:chatId` was behind `requirePrivilegedAccess`, which admits a request only from **loopback** or with an **`X-Admin-Secret`** header. A browser cannot send that header — the shipped Beholder package contains the string zero times — so behind a reverse proxy, on a LAN, or through a tunnel, every slot correction and the entire "start over" action was impossible, with no setting an operator could change. Following the error's own advice and setting `ADMIN_SECRET` would not have helped.

It failed silently at both ends. The gate does not log, so the server said nothing; and the panel's error toast was invisible until beholder 1.3.9, so the UI said nothing either. That is why it was reported as the whole feature being broken rather than one blocked action — and why "disabling and re-enabling the agent doesn't clear the data" followed, since the tracked state lives in the last successful run and the only route that clears it was the one returning 403.

The gate was the wrong tool here. This route writes **one chat's own tracked state** — the same class of act as editing a message in that chat — and `chats.routes.ts` guards none of its writes this way (zero uses in the entire file). Sitting next to the genuinely administrative routes in `agents.routes.ts`, `import-policy` and `import`, gave it company it does not keep.

## What changed

- Removed `requirePrivilegedAccess` from that one route, with the reasoning recorded inline so it is not reintroduced by someone tidying up an inconsistency.
- Added `scripts/regressions/beholder-state-reachable.regression.ts`.

Unchanged, and what protects the route instead:

- the **app-wide Basic Auth hook** registered in `app.ts`, which every route in the product sits behind;
- the **rate limit** already configured on the route;
- **`normalizeBeholderState`**, which refuses a malformed body rather than letting it reach the state the next prompt is built from.

`import-policy` and `import` keep their gate, and the regression asserts that too — the point is that this route was miscategorised, not that the gate is wrong.

## Verification

Reproduced against a real server, authenticated, from a non-loopback address (`192.168.x.x`, which is what a reverse proxy looks like to the server):

| | request | result |
|---|---|---|
| **staging today** | `PUT /api/agents/beholder-state/:chatId` | **403** `ADMIN_SECRET is required for privileged APIs` |
| **this branch** | same request | **200**, correction persists |

Both builds were run from the same working tree with the same data and credentials; the only difference was this change, set aside and restored with `git stash` to produce the "before" row.

The new regression asserts both halves: that `requirePrivilegedAccess` **still rejects** such a request when called (so nobody concludes the gate was harmless and the change unnecessary), and that this route no longer calls it. `docker-proxy-auth.regression.ts` still passes, which is the check that the gate itself is unmodified. Server typecheck clean.

## Note for reviewers

This removes an authorization check, so it deserves a careful read rather than a rubber stamp. The argument is that the check was never reachable for the feature's actual users, protected nothing an authenticated caller could not already do through `chats.routes.ts`, and cost every non-loopback install the ability to correct its own data. If you would rather keep a check here, the consistent version would be `{ trustedNetwork: true }` plus the client sending credentials — but that still leaves reverse-proxy users out, and the neighbouring GET on the same path has never been guarded at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01992DGH2exasKGaJiqRnteC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Beholder state corrections can now be submitted from browsers behind reverse proxies, LANs, and tunnels.
  - Requests continue to use application authentication, rate limiting, and request validation.
  - Nearby administrative routes remain protected by privileged access controls.

- **Tests**
  - Added regression coverage confirming proxied access and preserving security controls for administrative routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->