### PR TITLE
fix: unify Roleplay picker and group agent activity outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Mobile Roleplay Connections/Personas now uses the same themed surface as the character response picker. The Agents menu groups each agent's reports with its outputs, preserving dismissal, saved custom-output editing, and the separate Echo Chamber window (#5883).
 - Mobile image previews now bound both dimensions, including tall illustrations, and large PNG metadata no longer bypasses previews. This reduces image-arrival decoding pressure without changing appearance settings or saved originals (#5870).
 
 - Mobile chat illustrations and gallery tiles use smaller cached display copies to reduce image decoding pressure; opening and downloading still uses the original. Saved automatic Roleplay illustrations also appear as soon as they arrive, without waiting for remaining agent work (#5870).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -12370,6 +12370,194 @@ test("custom generation parameters become reusable chat controls", async ({ page
   }
 });
 
+test("Mobile Roleplay quick picker matches the character selector surface", async ({ page, isMobile }, testInfo) => {
+  test.skip(!isMobile, "The combined quick picker is mobile-only.");
+  const characterIds: string[] = [];
+  let chatId: string | undefined;
+  try {
+    for (const name of ["Picker botanist", "Picker librarian"]) {
+      const response = await page.request.post("/api/characters", { data: { data: { name } } });
+      expect(response.ok()).toBeTruthy();
+      characterIds.push(((await response.json()) as { id: string }).id);
+    }
+    const response = await page.request.post("/api/chats", {
+      data: { name: "Roleplay picker surface fixture", mode: "roleplay", characterIds },
+    });
+    expect(response.ok()).toBeTruthy();
+    chatId = ((await response.json()) as { id: string }).id;
+    await page.request.patch(`/api/chats/${chatId}/metadata`, {
+      data: { groupChatMode: "individual", groupResponseOrder: "sequential" },
+    });
+    await page.request.post(`/api/chats/${chatId}/messages`, {
+      data: { role: "assistant", content: "The garden is ready for inspection." },
+    });
+    await page.addInitScript((id) => localStorage.setItem("marinara-active-chat-id", id), chatId);
+    await page.goto("/");
+    await expect(page.getByText("The garden is ready for inspection.", { exact: true })).toBeVisible();
+    for (const theme of ["dark", "light", "custom"] as const) {
+      await page.evaluate(async (theme) => {
+        const { useUIStore } = await import("/src/stores/ui.store.ts" as string);
+        const ui = useUIStore.getState();
+        ui.setTheme(theme === "light" ? "light" : "dark");
+        ui.setAppBackgroundColor(theme === "custom" ? "#0b1920" : "");
+        ui.setChatChromeTextColor(theme === "custom" ? "#22d3ee" : "");
+      }, theme);
+      await page.getByTitle("Trigger character response", { exact: true }).click();
+      const characterPicker = page.getByText("Trigger Response", { exact: true }).locator("..");
+      await expect(characterPicker).toBeVisible();
+      const surface = await characterPicker.evaluate((element) => getComputedStyle(element).backgroundColor);
+      await page.getByTitle("Trigger character response", { exact: true }).click();
+      await page.getByTitle("Quick Switcher", { exact: true }).click();
+      const picker = page.locator(".fixed[data-chat-floating-panel]");
+      await expect(picker).toBeVisible();
+      for (const tab of ["Connections", "Personas"]) {
+        await picker.getByRole("button", { name: tab, exact: true }).click();
+        await testInfo.attach(`roleplay-picker-${theme}-${tab}`, {
+          body: await page.screenshot(),
+          contentType: "image/png",
+        });
+        await expect(picker).toHaveCSS("background-color", surface);
+        const bounds = await picker.boundingBox();
+        expect(bounds!.x).toBeGreaterThanOrEqual(0);
+        expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(page.viewportSize()!.width);
+      }
+      await page.getByTitle("Quick Switcher", { exact: true }).click();
+    }
+  } finally {
+    if (chatId) await page.request.delete(`/api/chats/${chatId}`);
+    for (const id of characterIds) await page.request.delete(`/api/characters/${id}`);
+  }
+});
+
+test("Agents menu groups outputs under their own reports and preserves output controls", async ({ page }, testInfo) => {
+  const response = await page.request.post("/api/chats", {
+    data: { name: "Grouped agent activity fixture", mode: "roleplay", characterIds: [] },
+  });
+  expect(response.ok()).toBeTruthy();
+  const chat = (await response.json()) as { id: string };
+  let customText = "Saved garden notes.";
+  await page.route(`**/api/agents/runs/${chat.id}/custom`, (route) =>
+    route.fulfill({
+      json: [
+        {
+          id: "activity-custom-run",
+          agentConfigId: "custom-config",
+          agentType: "custom-notes",
+          agentName: "Garden notes",
+          chatId: chat.id,
+          messageId: "fixture-message",
+          resultType: "custom",
+          resultData: { text: customText },
+          tokensUsed: 12,
+          durationMs: 100,
+          success: true,
+          error: null,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    }),
+  );
+  await page.route("**/api/agents/runs/activity-custom-run", async (route) => {
+    customText = route.request().postDataJSON().resultData.text;
+    await route.fulfill({ json: { success: true } });
+  });
+  try {
+    await page.request.post(`/api/chats/${chat.id}/messages`, {
+      data: { role: "assistant", content: "A quiet day in the garden." },
+    });
+    await page.addInitScript((id) => localStorage.setItem("marinara-active-chat-id", id), chat.id);
+    await page.goto("/");
+    await expect(page.getByText("A quiet day in the garden.", { exact: true })).toBeVisible();
+    await page.getByRole("button", { name: "Agents & Actions", exact: true }).click();
+    await page.evaluate(async (chatId) => {
+      const { useAgentStore } = await import("/src/stores/agent.store.ts" as string);
+      const store = useAgentStore.getState();
+      store.setProcessingRun("activity-run", true, chatId);
+      for (const [type, name] of [
+        ["echo-chamber", "Echo Chamber"],
+        ["world-state", "World State"],
+        ["custom-notes", "Garden notes"],
+      ]) {
+        store.updateTaskProgress(chatId, "activity-run", {
+          callId: type,
+          agents: [{ id: `${type}-config`, type, name, phase: "post_processing" }],
+          stage: "received",
+          receivedChunks: 10,
+          receivedCharacters: 50,
+          elapsedMs: 2000,
+        });
+      }
+      // Two concurrent calls for an agent must retain separate metrics, but not duplicate its outputs.
+      store.setProcessingRun("overlapping-run", true, chatId);
+      store.updateTaskProgress(chatId, "overlapping-run", {
+        callId: "echo-overlap",
+        agents: [{ id: "echo-chamber-config", type: "echo-chamber", name: "Echo Chamber", phase: "parallel" }],
+        stage: "received",
+        receivedChunks: 2,
+        receivedCharacters: 15,
+        elapsedMs: 1000,
+      });
+      store.addThoughtBubble("echo-chamber", "Echo Chamber", "The readers loved the garden.");
+      store.addThoughtBubble("world-state", "World State", "Location: Garden. Weather: Sunny.");
+      store.addThoughtBubble("legacy-agent", "Legacy agent", "Output without progress remains available.");
+      store.setProcessingRun("activity-run", false, chatId);
+      store.setProcessingRun("overlapping-run", false, chatId);
+    }, chat.id);
+    const status = page.getByRole("region", { name: "Agent task status" });
+    const echo = status.locator('[data-agent-activity="echo-chamber"]');
+    const world = status.locator('[data-agent-activity="world-state"]');
+    await expect(echo.getByText("The readers loved the garden.", { exact: true })).toBeVisible();
+    await expect(echo.getByText("Output received", { exact: true })).toHaveCount(2);
+    await expect(echo.getByText("Location: Garden. Weather: Sunny.", { exact: true })).toHaveCount(0);
+    await expect(world.getByText("Location: Garden. Weather: Sunny.", { exact: true })).toBeVisible();
+    await expect(page.getByText("The readers loved the garden.", { exact: true })).toHaveCount(1);
+    await expect(page.getByText("Output without progress remains available.", { exact: true })).toBeVisible();
+    await echo.locator("[data-agent-output]").scrollIntoViewIfNeeded();
+    await testInfo.attach("agent-activity-grouping", { body: await page.screenshot(), contentType: "image/png" });
+    expect(
+      await echo
+        .locator("dl")
+        .last()
+        .evaluate(
+          (element) =>
+            !!(
+              element.compareDocumentPosition(
+                element.parentElement!.parentElement!.querySelector("[data-agent-output]")!,
+              ) & Node.DOCUMENT_POSITION_FOLLOWING
+            ),
+        ),
+    ).toBe(true);
+    await echo.getByRole("button", { name: "Dismiss output from Echo Chamber" }).click();
+    await expect(echo.getByText("The readers loved the garden.", { exact: true })).toHaveCount(0);
+    await expect(echo.getByText("Output received", { exact: true })).toHaveCount(2);
+    await expect(world.getByText("Location: Garden. Weather: Sunny.", { exact: true })).toBeVisible();
+    await page.getByRole("button", { name: "Clear all", exact: true }).click();
+    await expect(page.getByText("Output without progress remains available.", { exact: true })).toHaveCount(0);
+    const custom = status.locator('[data-agent-activity="custom-notes"]');
+    await expect(custom.getByText("Saved garden notes.", { exact: true })).toBeVisible();
+    await custom.getByTitle("Edit output", { exact: true }).click();
+    await custom.getByRole("textbox").fill("Edited garden notes.");
+    await custom.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(custom.getByText("Edited garden notes.", { exact: true })).toBeVisible();
+    await page.evaluate(async () => {
+      const { useUIStore } = await import("/src/stores/ui.store.ts" as string);
+      useUIStore.getState().setTheme("light");
+    });
+    await custom.scrollIntoViewIfNeeded();
+    await testInfo.attach("agent-activity-saved-output-light", {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    });
+    // A reload has no live telemetry; the saved custom-output fallback must remain usable.
+    await page.reload();
+    await page.getByRole("button", { name: "Agents & Actions", exact: true }).click();
+    await page.getByRole("button", { name: /Custom outputs/ }).click();
+    await expect(page.getByText("Edited garden notes.", { exact: true })).toBeVisible();
+  } finally {
+    await page.request.delete(`/api/chats/${chat.id}`);
+  }
+});
+
 test("Agents menu shows private-content-free progress, timings and reported usage", async ({ page }, testInfo) => {
   const response = await page.request.post("/api/chats", {
     data: { name: "Agent progress fixture", mode: "roleplay", characterIds: [] },

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -12385,12 +12385,14 @@ test("Mobile Roleplay quick picker matches the character selector surface", asyn
     });
     expect(response.ok()).toBeTruthy();
     chatId = ((await response.json()) as { id: string }).id;
-    await page.request.patch(`/api/chats/${chatId}/metadata`, {
+    const metadataResponse = await page.request.patch(`/api/chats/${chatId}/metadata`, {
       data: { groupChatMode: "individual", groupResponseOrder: "sequential" },
     });
-    await page.request.post(`/api/chats/${chatId}/messages`, {
+    expect(metadataResponse.ok(), await metadataResponse.text()).toBeTruthy();
+    const messageResponse = await page.request.post(`/api/chats/${chatId}/messages`, {
       data: { role: "assistant", content: "The garden is ready for inspection." },
     });
+    expect(messageResponse.ok(), await messageResponse.text()).toBeTruthy();
     await page.addInitScript((id) => localStorage.setItem("marinara-active-chat-id", id), chatId);
     await page.goto("/");
     await expect(page.getByText("The garden is ready for inspection.", { exact: true })).toBeVisible();
@@ -12406,6 +12408,7 @@ test("Mobile Roleplay quick picker matches the character selector surface", asyn
       const characterPicker = page.getByText("Trigger Response", { exact: true }).locator("..");
       await expect(characterPicker).toBeVisible();
       const surface = await characterPicker.evaluate((element) => getComputedStyle(element).backgroundColor);
+      expect(surface).not.toMatch(/^(?:transparent|rgba\([^)]*,\s*0\))$/u);
       await page.getByTitle("Trigger character response", { exact: true }).click();
       await page.getByTitle("Quick Switcher", { exact: true }).click();
       const picker = page.locator(".fixed[data-chat-floating-panel]");
@@ -12424,8 +12427,8 @@ test("Mobile Roleplay quick picker matches the character selector surface", asyn
       await page.getByTitle("Quick Switcher", { exact: true }).click();
     }
   } finally {
-    if (chatId) await page.request.delete(`/api/chats/${chatId}`);
-    for (const id of characterIds) await page.request.delete(`/api/characters/${id}`);
+    if (chatId) await bestEffortDelete(page.request, `/api/chats/${chatId}`);
+    await Promise.all(characterIds.map((id) => bestEffortDelete(page.request, `/api/characters/${id}`)));
   }
 });
 
@@ -12458,13 +12461,17 @@ test("Agents menu groups outputs under their own reports and preserves output co
     }),
   );
   await page.route("**/api/agents/runs/activity-custom-run", async (route) => {
-    customText = route.request().postDataJSON().resultData.text;
+    if (route.request().method() !== "PATCH") return route.continue();
+    const body = route.request().postDataJSON() as { resultData?: { text?: string } } | null;
+    expect(body?.resultData?.text).toEqual(expect.any(String));
+    customText = body!.resultData!.text!;
     await route.fulfill({ json: { success: true } });
   });
   try {
-    await page.request.post(`/api/chats/${chat.id}/messages`, {
+    const messageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
       data: { role: "assistant", content: "A quiet day in the garden." },
     });
+    expect(messageResponse.ok(), await messageResponse.text()).toBeTruthy();
     await page.addInitScript((id) => localStorage.setItem("marinara-active-chat-id", id), chat.id);
     await page.goto("/");
     await expect(page.getByText("A quiet day in the garden.", { exact: true })).toBeVisible();
@@ -12515,17 +12522,16 @@ test("Agents menu groups outputs under their own reports and preserves output co
     await echo.locator("[data-agent-output]").scrollIntoViewIfNeeded();
     await testInfo.attach("agent-activity-grouping", { body: await page.screenshot(), contentType: "image/png" });
     expect(
-      await echo
-        .locator("dl")
-        .last()
-        .evaluate(
-          (element) =>
-            !!(
-              element.compareDocumentPosition(
-                element.parentElement!.parentElement!.querySelector("[data-agent-output]")!,
-              ) & Node.DOCUMENT_POSITION_FOLLOWING
-            ),
-        ),
+      await echo.evaluate((block) => {
+        const metrics = block.querySelectorAll("dl");
+        const output = block.querySelector("[data-agent-output]");
+        const lastMetrics = metrics[metrics.length - 1];
+        return (
+          !!lastMetrics &&
+          !!output &&
+          !!(lastMetrics.compareDocumentPosition(output) & Node.DOCUMENT_POSITION_FOLLOWING)
+        );
+      }),
     ).toBe(true);
     await echo.getByRole("button", { name: "Dismiss output from Echo Chamber" }).click();
     await expect(echo.getByText("The readers loved the garden.", { exact: true })).toHaveCount(0);
@@ -12554,7 +12560,7 @@ test("Agents menu groups outputs under their own reports and preserves output co
     await page.getByRole("button", { name: /Custom outputs/ }).click();
     await expect(page.getByText("Edited garden notes.", { exact: true })).toBeVisible();
   } finally {
-    await page.request.delete(`/api/chats/${chat.id}`);
+    await bestEffortDelete(page.request, `/api/chats/${chat.id}`);
   }
 });
 

--- a/packages/client/src/components/agents/AgentTaskStatus.tsx
+++ b/packages/client/src/components/agents/AgentTaskStatus.tsx
@@ -1,8 +1,14 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useAgentStore, type AgentProgressEntry } from "../../stores/agent.store";
 
-export function AgentTaskStatus({ chatId }: { chatId: string }) {
+export function AgentTaskStatus({
+  chatId,
+  renderOutput,
+}: {
+  chatId: string;
+  renderOutput?: (agentType: string) => ReactNode;
+}) {
   const { t } = useTranslation();
   const progress = useAgentStore((state) => state.taskProgress);
   const [now, setNow] = useState(Date.now);
@@ -36,76 +42,86 @@ export function AgentTaskStatus({ chatId }: { chatId: string }) {
       className="space-y-2 border-b border-[var(--border)] px-3 py-2 text-[0.625rem]"
     >
       <h3 className="font-semibold">{t("agents.progress.title")}</h3>
-      {groups.map(([key, { agent, calls }]) => {
-        const latest = calls[calls.length - 1]!;
-        const startedAt = Math.min(...calls.map((call) => call.startedAt));
-        const end = Math.max(
-          ...calls.map(
-            (call) =>
-              call.startedAt +
-              call.elapsedMs +
-              (!call.stopped && (call.stage === "waiting" || call.stage === "streaming")
-                ? Math.max(0, now - call.receivedAt)
-                : 0),
-          ),
-        );
-        const firstChunks = calls
-          .filter((call) => call.ttftMs !== undefined)
-          .map((call) => call.startedAt + call.ttftMs!);
-        const phase = agent.phase === "pre_generation" ? "pre" : agent.phase === "parallel" ? "parallel" : "post";
-        const activeCalls = calls.filter(
-          (call) => !call.stopped && (call.stage === "waiting" || call.stage === "streaming"),
-        );
-        const state = activeCalls.length
-          ? activeCalls.some((call) => call.stage === "streaming")
-            ? "streaming"
-            : "waiting"
-          : latest.stopped
-            ? "stopped"
-            : latest.stage;
-        const tokens = (field: "promptTokens" | "completionTokens") =>
-          calls.every((call) => call[field] !== undefined)
-            ? calls.reduce((total, call) => total + call[field]!, 0).toLocaleString()
-            : t("agents.progress.unreported");
-        return (
-          <div key={key} className="space-y-1 border-t border-[var(--border)] pt-2">
-            <div className="flex flex-wrap justify-between gap-x-2 gap-y-1">
-              <span className="font-medium break-words">{agent.name}</span>
-              <span>{t(`agents.progress.phase.${phase}`)}</span>
-            </div>
-            <p className="text-[var(--muted-foreground)]">{t(`agents.progress.state.${state}`)}</p>
-            <p>
-              {t("agents.progress.received", {
-                chunks: calls.reduce((sum, call) => sum + call.receivedChunks, 0),
-                characters: calls.reduce((sum, call) => sum + call.receivedCharacters, 0),
-              })}
-            </p>
-            <dl className="grid grid-cols-2 gap-x-3 gap-y-1 text-[var(--muted-foreground)]">
-              <div>
-                <dt>{t("agents.progress.input")}</dt>
-                <dd>{tokens("promptTokens")}</dd>
-              </div>
-              <div>
-                <dt>{t("agents.progress.output")}</dt>
-                <dd>{tokens("completionTokens")}</dd>
-              </div>
-              <div title={t("agents.progress.ttftHelp")}>
-                <dt>{t("agents.progress.ttft")}</dt>
-                <dd>
-                  {firstChunks.length ? seconds(Math.min(...firstChunks) - startedAt) : t("agents.progress.unreported")}
-                </dd>
-              </div>
-              <div>
-                <dt>{t("agents.progress.elapsed")}</dt>
-                <dd>{seconds(end - startedAt)}</dd>
-              </div>
-            </dl>
-            {calls.some((call) => call.agents.length > 1) && (
-              <p className="text-[var(--muted-foreground)]">{t("agents.progress.sharedBatch")}</p>
-            )}
-          </div>
-        );
-      })}
+      {[...new Set(groups.map(([, { agent }]) => agent.type))].map((agentType) => (
+        <div key={agentType} data-agent-activity={agentType} className="space-y-2">
+          {/* Keep concurrent run reports separate, with their agent's outputs shown only once. */}
+          {groups
+            .filter(([, { agent }]) => agent.type === agentType)
+            .map(([key, { agent, calls }]) => {
+              const latest = calls[calls.length - 1]!;
+              const startedAt = Math.min(...calls.map((call) => call.startedAt));
+              const end = Math.max(
+                ...calls.map(
+                  (call) =>
+                    call.startedAt +
+                    call.elapsedMs +
+                    (!call.stopped && (call.stage === "waiting" || call.stage === "streaming")
+                      ? Math.max(0, now - call.receivedAt)
+                      : 0),
+                ),
+              );
+              const firstChunks = calls
+                .filter((call) => call.ttftMs !== undefined)
+                .map((call) => call.startedAt + call.ttftMs!);
+              const phase = agent.phase === "pre_generation" ? "pre" : agent.phase === "parallel" ? "parallel" : "post";
+              const activeCalls = calls.filter(
+                (call) => !call.stopped && (call.stage === "waiting" || call.stage === "streaming"),
+              );
+              const state = activeCalls.length
+                ? activeCalls.some((call) => call.stage === "streaming")
+                  ? "streaming"
+                  : "waiting"
+                : latest.stopped
+                  ? "stopped"
+                  : latest.stage;
+              const tokens = (field: "promptTokens" | "completionTokens") =>
+                calls.every((call) => call[field] !== undefined)
+                  ? calls.reduce((total, call) => total + call[field]!, 0).toLocaleString()
+                  : t("agents.progress.unreported");
+              return (
+                <div key={key} className="space-y-1 border-t border-[var(--border)] pt-2">
+                  <div className="flex flex-wrap justify-between gap-x-2 gap-y-1">
+                    <span className="font-medium break-words">{agent.name}</span>
+                    <span>{t(`agents.progress.phase.${phase}`)}</span>
+                  </div>
+                  <p className="text-[var(--muted-foreground)]">{t(`agents.progress.state.${state}`)}</p>
+                  <p>
+                    {t("agents.progress.received", {
+                      chunks: calls.reduce((sum, call) => sum + call.receivedChunks, 0),
+                      characters: calls.reduce((sum, call) => sum + call.receivedCharacters, 0),
+                    })}
+                  </p>
+                  <dl className="grid grid-cols-2 gap-x-3 gap-y-1 text-[var(--muted-foreground)]">
+                    <div>
+                      <dt>{t("agents.progress.input")}</dt>
+                      <dd>{tokens("promptTokens")}</dd>
+                    </div>
+                    <div>
+                      <dt>{t("agents.progress.output")}</dt>
+                      <dd>{tokens("completionTokens")}</dd>
+                    </div>
+                    <div title={t("agents.progress.ttftHelp")}>
+                      <dt>{t("agents.progress.ttft")}</dt>
+                      <dd>
+                        {firstChunks.length
+                          ? seconds(Math.min(...firstChunks) - startedAt)
+                          : t("agents.progress.unreported")}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>{t("agents.progress.elapsed")}</dt>
+                      <dd>{seconds(end - startedAt)}</dd>
+                    </div>
+                  </dl>
+                  {calls.some((call) => call.agents.length > 1) && (
+                    <p className="text-[var(--muted-foreground)]">{t("agents.progress.sharedBatch")}</p>
+                  )}
+                </div>
+              );
+            })}
+          {renderOutput?.(agentType)}
+        </div>
+      ))}
       <p className="text-[var(--muted-foreground)]">{t("agents.progress.tokenNote")}</p>
     </section>
   );

--- a/packages/client/src/components/chat/QuickSwitcherMobile.tsx
+++ b/packages/client/src/components/chat/QuickSwitcherMobile.tsx
@@ -358,7 +358,10 @@ export function QuickSwitcherMobile({ contextBudget }: { contextBudget?: Profess
           <div
             ref={menuRef}
             data-chat-floating-panel
-            className="fixed z-[9999] flex min-w-0 flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--background)] shadow-2xl"
+            className={cn(
+              "fixed z-[9999] flex min-w-0 flex-col overflow-hidden rounded-xl border border-foreground/10 shadow-2xl",
+              chatMode === "roleplay" ? "bg-[var(--card)]" : "bg-[var(--background)]",
+            )}
             style={
               pos
                 ? {

--- a/packages/client/src/components/chat/RoleplayHUDActionsMenu.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDActionsMenu.tsx
@@ -68,7 +68,17 @@ export function RoleplayHUDActionsMenu({
   showInjectionsTab,
 }: RoleplayHUDActionsMenuProps) {
   const { t: localizeUi } = useUiTranslation();
-  const hasTaskProgress = useAgentStore((state) => state.taskProgress.some((entry) => entry.chatId === chatId));
+  const taskProgress = useAgentStore((state) => state.taskProgress);
+  const reportedAgentTypes = useMemo(
+    () =>
+      new Set(
+        taskProgress
+          .filter((entry) => entry.chatId === chatId)
+          .flatMap((entry) => entry.agents.map((agent) => agent.type)),
+      ),
+    [chatId, taskProgress],
+  );
+  const hasTaskProgress = reportedAgentTypes.size > 0;
   const [tab, setTab] = useState<AgentsMenuTab>("activity");
   const [stoppingAgents, setStoppingAgents] = useState(false);
   const uniqueAgentCount = new Set(thoughtBubbles.map((bubble) => bubble.agentId)).size;
@@ -86,6 +96,7 @@ export function RoleplayHUDActionsMenu({
         ? latestHistoricalCustomRuns
         : [];
   const hasCustomRuns = customActivityRuns.length > 0;
+  const unreportedCustomRuns = customActivityRuns.filter((run) => !reportedAgentTypes.has(run.agentType));
   const injectableCustomRuns = useMemo(
     () => getLatestInjectableCustomRuns(customAgentRuns, agentConfigs ?? [], enabledAgentTypes),
     [customAgentRuns, agentConfigs, enabledAgentTypes],
@@ -132,6 +143,32 @@ export function RoleplayHUDActionsMenu({
     if (!isAgentProcessing) setStoppingAgents(false);
   }, [isAgentProcessing]);
 
+  const renderThoughtBubble = (bubble: ThoughtBubble, index: number) => (
+    <div
+      key={`${bubble.agentId}-${bubble.timestamp}`}
+      data-agent-output
+      className="relative rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 p-2 text-[0.625rem]"
+    >
+      <button
+        onClick={() => dismissThoughtBubble(index)}
+        aria-label={localizeUi("agents.activity.dismissOutput", { agent: bubble.agentName })}
+        className="absolute right-1.5 top-1.5 text-[var(--muted-foreground)]/50 transition-colors hover:text-[var(--foreground)]"
+      >
+        <X size="0.625rem" />
+      </button>
+      <div className="pr-4">
+        <span className="font-semibold text-foreground/75">{bubble.agentName}</span>
+        {bubble.agentId === "continuity" ? (
+          <ContinuityIssueChecklist content={bubble.content} compact />
+        ) : (
+          <p className="mt-0.5 whitespace-pre-wrap break-words text-[var(--muted-foreground)] leading-relaxed">
+            {bubble.content}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+
   return (
     <>
       {tabs.length > 1 && (
@@ -161,7 +198,41 @@ export function RoleplayHUDActionsMenu({
 
       {activeTab === "activity" && (
         <>
-          <AgentTaskStatus chatId={chatId} />
+          {thoughtBubbles.length > 0 && (
+            <div className="flex items-center justify-between border-b border-[var(--border)] px-3 py-1.5">
+              <span className="text-[0.625rem] text-[var(--muted-foreground)]">
+                {uniqueAgentCount} {localizeUi("ui.agents.agentcatalogview.agent")}
+                {uniqueAgentCount !== 1 ? localizeUi("ui.noodle.stageprofileview.s") : ""}{" "}
+                {localizeUi("ui.chat.roleplayhudactionsmenu.triggered")}
+              </span>
+              <button
+                onClick={clearThoughtBubbles}
+                className="text-[0.625rem] text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)]"
+              >
+                {localizeUi("ui.chat.roleplayhudactionsmenu.clearAll")}
+              </button>
+            </div>
+          )}
+          <AgentTaskStatus
+            chatId={chatId}
+            renderOutput={(agentType) => (
+              <>
+                {thoughtBubbles.map((bubble, index) =>
+                  bubble.agentId === agentType ? renderThoughtBubble(bubble, index) : null,
+                )}
+                {customActivityRuns
+                  .filter((run) => run.agentType === agentType)
+                  .map((run) => (
+                    <div key={run.id} className="space-y-1">
+                      <p className="text-[var(--muted-foreground)]">
+                        {localizeUi("agents.activity.latestSavedOutput")}
+                      </p>
+                      <CustomAgentRunItem run={run} />
+                    </div>
+                  ))}
+              </>
+            )}
+          />
           {isAgentProcessing && (
             <div className="flex items-center gap-2 border-b border-[var(--border)] px-3 py-2">
               <Sparkles size="0.75rem" className="animate-pulse text-[var(--muted-foreground)]" />
@@ -175,52 +246,17 @@ export function RoleplayHUDActionsMenu({
               {localizeUi("ui.chat.roleplayhudactionsmenu.noAgentActivityYet")}
             </div>
           )}
-          {thoughtBubbles.length > 0 && (
-            <>
-              <div className="flex items-center justify-between border-b border-[var(--border)] px-3 py-1.5">
-                <span className="text-[0.625rem] text-[var(--muted-foreground)]">
-                  {uniqueAgentCount} {localizeUi("ui.agents.agentcatalogview.agent")}
-                  {uniqueAgentCount !== 1 ? localizeUi("ui.noodle.stageprofileview.s") : ""}{" "}
-                  {localizeUi("ui.chat.roleplayhudactionsmenu.triggered")}
-                </span>
-                <button
-                  onClick={clearThoughtBubbles}
-                  className="text-[0.625rem] text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)]"
-                >
-                  {localizeUi("ui.chat.roleplayhudactionsmenu.clearAll")}
-                </button>
-              </div>
-              <div className="flex flex-col gap-1 p-2">
-                {thoughtBubbles.map((bubble, index) => (
-                  <div
-                    key={`${bubble.agentId}-${bubble.timestamp}`}
-                    className="relative rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 p-2 text-[0.625rem]"
-                  >
-                    <button
-                      onClick={() => dismissThoughtBubble(index)}
-                      className="absolute right-1.5 top-1.5 text-[var(--muted-foreground)]/50 transition-colors hover:text-[var(--foreground)]"
-                    >
-                      <X size="0.625rem" />
-                    </button>
-                    <div className="pr-4">
-                      <span className="font-semibold text-foreground/75">{bubble.agentName}</span>
-                      {bubble.agentId === "continuity" ? (
-                        <ContinuityIssueChecklist content={bubble.content} compact />
-                      ) : (
-                        <p className="mt-0.5 whitespace-pre-wrap text-[var(--muted-foreground)] leading-relaxed">
-                          {bubble.content}
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </>
+          {thoughtBubbles.some((bubble) => !reportedAgentTypes.has(bubble.agentId)) && (
+            <div className="flex flex-col gap-1 p-2">
+              {thoughtBubbles.map((bubble, index) =>
+                !reportedAgentTypes.has(bubble.agentId) ? renderThoughtBubble(bubble, index) : null,
+              )}
+            </div>
           )}
 
-          {(hasCustomRuns || customAgentRunsLoading) && (
+          {(unreportedCustomRuns.length > 0 || customAgentRunsLoading) && (
             <CustomAgentRunsSection
-              runs={customActivityRuns}
+              runs={unreportedCustomRuns}
               loading={customAgentRunsLoading}
               title={localizeUi("ui.chat.roleplayhudactionsmenu.customOutputs")}
               countMode="latest"

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -33,6 +33,8 @@
   "achievements.definitions.whoNeedsIrlFriends.description_one": "Created {{target}} Conversation chat.",
   "achievements.definitions.whoNeedsIrlFriends.description_other": "Created {{target}} Conversation chats.",
   "achievements.definitions.whoNeedsIrlFriends.title": "Who Needs IRL Friends",
+  "agents.activity.dismissOutput": "Dismiss output from {{agent}}",
+  "agents.activity.latestSavedOutput": "Latest saved output",
   "agents.illustrator.manualOnlyIntervalHelp": "Set to 0 for manual-only generation. Automatic Illustrator runs stop; Gallery actions remain available.",
   "agents.progress.elapsed": "Elapsed",
   "agents.progress.input": "Input tokens",


### PR DESCRIPTION
## Linked issue

Closes #5883. Owner: @SpicyMarinara; implementation by Codex. Target: **staging only**.

## Why this change

The mobile Roleplay Connections/Personas picker used the navy page background, unlike the character response selector. The agent menu separated every status report from every output, making it hard to follow an agent's result.

## What changed

- Reuse the character selector's existing card color for the mobile Roleplay picker; Conversation/Game styling is untouched.
- Group reports by agent type, then render that agent's existing output cards directly below. Concurrent run metrics remain separate; output cards appear once.
- Keep dismissal, Clear all, continuity rendering, saved custom-output editing, outputs without telemetry, and the reload fallback. Saved custom results are labelled "Latest saved output".
- Keep the separate Echo Chamber window unchanged. No server/provider/package, data model, new setting, dependency, graphics or recovery changes.
- Add English localization for the accessible dismissal label and saved-output label, plus an Unreleased changelog entry.

## Validation

Automated results (not human checklist claims):

- `pnpm install` and `pnpm check` pass, including localization, formatting, lint, TypeScript and production build.
- Focused Playwright suite: **8 passed, 1 deliberately skipped** (mobile-only picker on desktop), across desktop Chromium, mobile Chromium and mobile WebKit. Covers both picker tabs in dark/light/custom colors, viewport fit, agent/output matching, overlapping calls, dismissal, Clear all, saved custom editing/reload, and existing progress/usage/stopped-timer behavior.
- Red proofs: picker background assertion failed with `rgb(5,3,18)` instead of the character selector's `rgba(20,20,20,0.85)`; output-grouping assertion failed before the layout change.
- Production Docker Linux/arm64 image built and ran successfully at integrated head `dc4e4b56abb7ce901d72c85d44256a1ac69b7135`. Mobile WebKit verified health/build, both picker tabs, and a synthetic SSE result arriving under its status before the stream closes, followed by dismissal; no page errors. Normal production API rate limits stayed enabled.
- After incorporating the unrelated staging update (#5882), `pnpm check` and all 8 focused browser checks passed again. The existing agent-progress Node regression also passed.
- CodeRabbit's follow-up review covers `c9ca7176bc831fec6c763bfef5008f51413e61b4` with no new actionable comments; all five initial test-fixture comments are addressed. The follow-up is test-only; `pnpm check` and all 8 focused browser checks pass at this head. All required CI checks and the full Release Regression Matrix passed before merge.
- Merged into staging as `4666e71ce4344f6526e53ce7fa22c686c6dac8d1`; main is unchanged.

Human verification to-do list (intentionally unchecked):

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually compare both mobile Roleplay picker tabs with the character response selector using your theme.
- Manually verify live agent results appear beneath their own reports, and dismiss/edit controls still work.
- Manually verify the separate Echo Chamber window is unchanged on iPhone Home Screen.

Browser proof uses synthetic fixtures; no private screenshots or paid providers. Physical iPhone Home Screen/live provider generations were not exercised. This focused UI PR makes no claim about the separate black-screen investigation (#5870).

## Docs and release impact

CHANGELOG updated. No user-guide or version/release changes; no docs-i18n follow-up needed.

## UI evidence

[Before/after browser screenshots and proof details](https://gist.github.com/SpicyMarinara/6aa19cf0b1a6a5dabe52a2725083d02c). Download and open `proof.html` to view the embedded synthetic screenshots.
