### PR TITLE
fix(mari): read-only package stores and group-scoped sandbox teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Professor Mari's shell sandbox closes its two remaining supply-chain gaps (#5892). Installed-package folders (`node_modules` and the pnpm stores, nested ones included) are now read-only inside the sandbox - a command can no longer plant ready-made package code there - while build-tool cache folders inside them stay writable so builds keep working. And stopping a sandboxed command now takes its whole process tree with it, so a background process it left behind can no longer keep writing after the safety scan has run.
+
 - Professor Mari's self-check now audits every step of a longer job, not just the last thing she says (#5819). In a batch - "I created the first character, now doing the second" - each claim is checked against the work done since her previous checked claim, so skipping a step gets caught immediately instead of riding an earlier success. When a step is missing she is told to look first and only redo work a check shows is truly absent, never blindly.
 - Mari can answer "did you finish?" truthfully again (#5830). A run that only reported on earlier work could never satisfy the old check - her honest recap was challenged twice and then replaced with an error. A recap backed by a fresh look at the actual state now passes, a wrap-up right after checked work needs nothing extra, and "I've verified..." (describing a check, not a change) no longer trips the detector at all. A claim with nothing behind it whatsoever is still challenged, and a change the store observed failing still blocks every later claim until a retry proves it saved.
 

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -3879,10 +3879,16 @@ ${sections.join("\n\n")}
           signal.removeEventListener("abort", abortHandler);
           void sandboxed.cleanup().finally(callback);
         };
+        let killIssued = false;
         const killChild = () => {
           // #5892: group kill - the detached spawn makes the child a group
           // leader, so backgrounded grandchildren die with it (the macOS
           // teardown-survivor residual). Escalates for TERM-trapping trees.
+          // Idempotent: abort and timeout can BOTH fire, and a second call
+          // would overwrite hardKillTimer, orphaning the first escalation to
+          // SIGKILL a possibly recycled process group after close.
+          if (killIssued) return;
+          killIssued = true;
           killSandboxedProcessTree(child, "SIGTERM");
           hardKillTimer = setTimeout(() => killSandboxedProcessTree(child, "SIGKILL"), KILL_ESCALATION_MS);
           hardKillTimer.unref?.();

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -89,6 +89,7 @@ import { sidecarModelService } from "../sidecar/sidecar-model.service.js";
 import {
   detectUnreviewedSensitiveChanges,
   getWorkspaceShellSandboxStatus,
+  killSandboxedProcessTree,
   snapshotSensitiveWorkspaceFiles,
   spawnWorkspaceSandboxedShell,
   type SensitiveScanResult,
@@ -3866,20 +3867,25 @@ ${sections.join("\n\n")}
         let settled = false;
         let timedOut = false;
         let graceTimer: NodeJS.Timeout | null = null;
+        let hardKillTimer: NodeJS.Timeout | null = null;
         const finish = (callback: () => void) => {
           if (settled) return;
           settled = true;
           clearTimeout(timer);
           if (graceTimer) clearTimeout(graceTimer);
+          // A stale escalation must never fire a raw group SIGKILL at a pid
+          // the OS may have recycled after the tree already died.
+          if (hardKillTimer) clearTimeout(hardKillTimer);
           signal.removeEventListener("abort", abortHandler);
           void sandboxed.cleanup().finally(callback);
         };
         const killChild = () => {
-          child.kill();
-          // A TERM-trapping child (reachable on macOS, where seatbelt has no
-          // PID-namespace teardown) must not outlive the net: escalate.
-          const hardKill = setTimeout(() => child.kill("SIGKILL"), KILL_ESCALATION_MS);
-          hardKill.unref?.();
+          // #5892: group kill - the detached spawn makes the child a group
+          // leader, so backgrounded grandchildren die with it (the macOS
+          // teardown-survivor residual). Escalates for TERM-trapping trees.
+          killSandboxedProcessTree(child, "SIGTERM");
+          hardKillTimer = setTimeout(() => killSandboxedProcessTree(child, "SIGKILL"), KILL_ESCALATION_MS);
+          hardKillTimer.unref?.();
         };
         const abortHandler = () => {
           aborted = true;

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -88,6 +88,7 @@ import { getProfessorMariWorkspaceSkillsService } from "./workspace-skills.servi
 import { sidecarModelService } from "../sidecar/sidecar-model.service.js";
 import {
   detectUnreviewedSensitiveChanges,
+  restoreReplacedStoreLinks,
   getWorkspaceShellSandboxStatus,
   killSandboxedProcessTree,
   snapshotSensitiveWorkspaceFiles,
@@ -3967,6 +3968,13 @@ ${sections.join("\n\n")}
    */
   private async revertAndStageSensitiveAftermath(snapshot: SensitiveWorkspaceSnapshot): Promise<string[]> {
     const MAX_POSTEXEC_STAGED = 5;
+    let linkLines: string[] = [];
+    try {
+      linkLines = await restoreReplacedStoreLinks(snapshot);
+    } catch (err) {
+      logger.error(err, "[mari] Store-link integrity pass failed");
+      linkLines = ["Store-link integrity check failed; treat package-store paths as unreviewed."];
+    }
     let scan: SensitiveScanResult;
     try {
       scan = await detectUnreviewedSensitiveChanges(this.workspaceRoot, snapshot);
@@ -3974,7 +3982,7 @@ ${sections.join("\n\n")}
       logger.error(err, "[mari] Post-execution sensitive-file scan failed");
       return ["Post-execution sensitive-file scan failed; treat this run's file changes as unreviewed."];
     }
-    const lines: string[] = [];
+    const lines: string[] = [...linkLines];
     if (snapshot.entryCapExceeded || scan.entryCapExceeded) {
       lines.push(
         "Post-execution scan stopped at its entry cap; part of the workspace went uninspected - treat this run's file changes as unreviewed.",

--- a/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
+++ b/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, realpathSync } from "node:fs";
-import { lstat, mkdtemp, readdir, readlink, rm } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readdir, readlink, rm } from "node:fs/promises";
 import type { Stats } from "node:fs";
 import { delimiter, dirname, join, relative, resolve, sep } from "node:path";
 import { tmpdir } from "node:os";
@@ -120,9 +120,41 @@ function uniqueExistingMountPaths(paths: Array<string | undefined>) {
 // The walk runs fresh on every spawn on purpose: caching would let a newly
 // created secret file slip past the deny list. It is async so a large
 // workspace scan yields to the event loop instead of blocking other requests.
+// #5892: package-store trees become READ-ONLY in the sandbox. Sandboxed bash
+// has no legitimate install path (isPackageManagerMutationCommand refuses
+// package-manager mutations before execution, and approved dependency
+// installs run OUTSIDE the sandbox), so the #5786 residual - planting
+// ready-made node_modules/<pkg> code that executes on the server's next
+// require - closes structurally. Build-tool caches that legitimately live
+// inside the store get writable carve-outs, pre-created when absent so a
+// first build is not broken by its own missing cache directory.
+const PACKAGE_STORE_DIR_NAMES = new Set(["node_modules", ".pnpm", ".pnpm-store"]);
+// .vite-temp: modern Vite bundles a TS/ESM config into node_modules/.vite-temp
+// before anything else runs (probed against this repo's vite@7.x), so without
+// the carve-out every default-scaffold build fails on a read-only store.
+const PACKAGE_STORE_WRITABLE_CACHES = [".cache", ".vite", ".vite-temp"];
+
+async function packageStoreCacheCarveouts(packageStores: string[]): Promise<string[]> {
+  const carveouts: string[] = [];
+  for (const store of packageStores) {
+    if (!store.endsWith(`${sep}node_modules`)) continue;
+    for (const cache of PACKAGE_STORE_WRITABLE_CACHES) {
+      const cachePath = join(store, cache);
+      try {
+        await mkdir(cachePath, { recursive: true });
+        carveouts.push(cachePath);
+      } catch {
+        /* an unreadable store keeps its cache unwritable - fail closed */
+      }
+    }
+  }
+  return carveouts;
+}
+
 async function workspacePolicyPaths(workspaceRoot: string) {
   const forbidden: string[] = [];
   const sensitive: string[] = [];
+  const packageStores: string[] = [];
   const visit = async (path: string) => {
     const policy = workspacePathAccessPolicy(workspaceRoot, path);
     if (policy === "forbidden") {
@@ -136,6 +168,12 @@ async function workspacePolicyPaths(workspaceRoot: string) {
     }
     if (!stats.isDirectory() || stats.isSymbolicLink()) return;
     for (const entry of await readdir(path, { withFileTypes: true })) {
+      if (entry.isDirectory() && PACKAGE_STORE_DIR_NAMES.has(entry.name)) {
+        // Seen while being skipped: recorded for the read-only bind at zero
+        // extra walk cost, nested stores included.
+        packageStores.push(join(path, entry.name));
+        continue;
+      }
       if (entry.isDirectory() && POLICY_SCAN_SKIPPED_DIRS.has(entry.name)) continue;
       await visit(join(path, entry.name));
     }
@@ -144,6 +182,7 @@ async function workspacePolicyPaths(workspaceRoot: string) {
   return {
     forbidden: uniqueExistingPaths(forbidden),
     sensitive: uniqueExistingPaths(sensitive),
+    packageStores: uniqueExistingPaths(packageStores),
   };
 }
 
@@ -178,10 +217,9 @@ const SCAN_RETAINED_CONTENT_BUDGET_BYTES = 8 * 1024 * 1024;
 // The scan's own skip set is NARROWER than the spawn walk's: dist/, build/,
 // coverage/, .cache/ are walked (a manifest planted there is exactly the
 // #5786 class - verified bypass otherwise), while the package-store trees
-// stay skipped for cost. Their contents are a documented residual: writing
-// inside node_modules was always sandbox-permitted, and the review floor
-// defends the manifests that would INSTALL such content, not the store
-// itself.
+// stay skipped for cost. That skip is safe since #5892: the stores are
+// READ-ONLY in the sandbox (see PACKAGE_STORE_DIR_NAMES), and a store
+// directory the run itself creates is walked in full by the scan.
 const SCAN_SKIPPED_DIRS = new Set(["node_modules", ".pnpm", ".pnpm-store", ".git"]);
 // A hostile command can mkdir-storm the workspace; the scan must stay
 // bounded. Past the cap the walk stops and says so - the caller treats the
@@ -298,7 +336,14 @@ async function walkSensitiveEntries(
     }
     if (!stats.isDirectory() || stats.isSymbolicLink()) return;
     const name = path === workspaceRoot ? "" : path.slice(path.lastIndexOf(sep) + 1);
-    if (SCAN_SKIPPED_DIRS.has(name)) return;
+    if (SCAN_SKIPPED_DIRS.has(name)) {
+      // A PRE-EXISTING store is skipped for cost (and is read-only in the
+      // sandbox anyway); one the run itself CREATED has no bind covering it
+      // and must be walked in full - the marker below is what lets detect's
+      // descend predicate tell the two apart.
+      onEntry(path, { kind: "dir" });
+      if (!descendIntoCoveredDir(path)) return;
+    }
     let entries;
     try {
       entries = await readdir(path, { withFileTypes: true });
@@ -408,6 +453,7 @@ export async function buildMacosWorkspaceShellProfile(
   allowChildProcesses = true,
 ) {
   const policyPaths = await workspacePolicyPaths(workspaceRoot);
+  const storeCaches = writableWorkspace ? await packageStoreCacheCarveouts(policyPaths.packageStores) : [];
   const readable = macosReadRoots(workspaceRoot, env, sandboxTemp)
     .map((path) => `    (subpath ${sandboxLiteral(path)})`)
     .join("\n");
@@ -415,6 +461,12 @@ export async function buildMacosWorkspaceShellProfile(
   const sensitiveWrites = policyPaths.sensitive.map((path) => `    (subpath ${sandboxLiteral(path)})`).join("\n");
   const forbiddenReadRule = forbiddenReads ? `(deny file-read*\n${forbiddenReads})` : "";
   const sensitiveWriteRule = writableWorkspace && sensitiveWrites ? `(deny file-write*\n${sensitiveWrites})` : "";
+  const storeWrites = policyPaths.packageStores.map((path) => `    (subpath ${sandboxLiteral(path)})`).join("\n");
+  const storeWriteRule = writableWorkspace && storeWrites ? `(deny file-write*\n${storeWrites})` : "";
+  const storeCacheAllows = storeCaches.map((path) => `    (subpath ${sandboxLiteral(path)})`).join("\n");
+  // Placed AFTER the store deny: seatbelt's last matching rule wins, so the
+  // cache subpaths stay writable inside the otherwise read-only store.
+  const storeCacheRule = writableWorkspace && storeCacheAllows ? `(allow file-write*\n${storeCacheAllows})` : "";
   const workspaceWriteRule = writableWorkspace ? `    (subpath ${sandboxLiteral(workspaceRoot)})\n` : "";
   const processRules = allowChildProcesses
     ? `(allow process*)\n(allow signal)`
@@ -436,6 +488,8 @@ ${workspaceWriteRule}
     (literal "/dev/tty"))
 ${forbiddenReadRule}
 ${sensitiveWriteRule}
+${storeWriteRule}
+${storeCacheRule}
 (deny network*)
 `;
 }
@@ -460,7 +514,7 @@ function linuxReadRoots(workspaceRoot: string, env: NodeJS.ProcessEnv) {
   ]);
 }
 
-async function linuxBubblewrapArgs(
+export async function linuxBubblewrapArgs(
   workspaceRoot: string,
   env: NodeJS.ProcessEnv,
   sandboxTemp: string,
@@ -489,6 +543,16 @@ async function linuxBubblewrapArgs(
   for (const path of policyPaths.sensitive) {
     args.push("--ro-bind", path, path);
   }
+  if (writableWorkspace) {
+    for (const store of policyPaths.packageStores) {
+      args.push("--ro-bind", store, store);
+    }
+    // Later mounts stack over earlier ones: the cache dirs come back
+    // writable inside the read-only store.
+    for (const cache of await packageStoreCacheCarveouts(policyPaths.packageStores)) {
+      args.push("--bind", cache, cache);
+    }
+  }
   for (const path of policyPaths.forbidden) {
     if ((await lstat(path)).isDirectory()) args.push("--tmpfs", path);
     else args.push("--ro-bind", "/dev/null", path);
@@ -506,7 +570,13 @@ export async function spawnWorkspaceSandboxedProcess(
     throw new Error(`${status.reason}`);
   }
 
-  const workspaceRoot = resolve(input.workspaceRoot);
+  // #5892: canonicalize BEFORE any rules are derived. The store/sensitive
+  // ro-binds go through realpath (uniqueExistingPaths), so a symlink
+  // component in the workspace path would otherwise put the writable
+  // workspace bind and the read-only binds on two different mount points -
+  // and every deny would silently fail open on Linux.
+  const resolvedRoot = resolve(input.workspaceRoot);
+  const workspaceRoot = existsSync(resolvedRoot) ? realpathSync(resolvedRoot) : resolvedRoot;
   const writableWorkspace = input.writableWorkspace !== false;
   const allowChildProcesses = input.allowChildProcesses !== false;
   const sandboxTemp = await mkdtemp(join(tmpdir(), "marinara-mari-shell-"));
@@ -539,13 +609,13 @@ export async function spawnWorkspaceSandboxedProcess(
           input.executable,
           ...input.args,
         ],
-        { cwd: workspaceRoot, env, windowsHide: true, stdio: ["pipe", "pipe", "pipe"] },
+        { cwd: workspaceRoot, env, windowsHide: true, detached: true, stdio: ["pipe", "pipe", "pipe"] },
       );
     } else {
       child = spawn(
         findBubblewrap()!,
         await linuxBubblewrapArgs(workspaceRoot, env, sandboxTemp, input.executable, input.args, writableWorkspace),
-        { cwd: workspaceRoot, env, windowsHide: true, stdio: ["pipe", "pipe", "pipe"] },
+        { cwd: workspaceRoot, env, windowsHide: true, detached: true, stdio: ["pipe", "pipe", "pipe"] },
       );
     }
   } catch (error) {
@@ -563,6 +633,30 @@ export async function spawnWorkspaceSandboxedProcess(
       await rm(sandboxTemp, { recursive: true, force: true });
     },
   };
+}
+
+/**
+ * #5892: signal the sandboxed process GROUP (the spawn is detached, so the
+ * child leads its own group), taking backgrounded grandchildren with it - the
+ * macOS teardown-survivor residual, since seatbelt has no PID-namespace
+ * equivalent of bubblewrap's --die-with-parent. Residuals: a process that
+ * setsid()s itself out of the group, and - macOS only - a tree orphaned by a
+ * hard SERVER crash (teardown never runs; Linux is covered by
+ * --die-with-parent regardless of grouping). A store exposed as a SYMLINK is
+ * also not enumerated for the read-only binds (dirent.isDirectory() is false
+ * for links); writes through the link land at its target, which the normal
+ * policy covers when the target is itself sensitive or store-named.
+ */
+export function killSandboxedProcessTree(child: Pick<ChildProcess, "pid" | "kill">, signal: NodeJS.Signals): void {
+  if (typeof child.pid === "number" && process.platform !== "win32") {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      /* group gone or not a leader - fall through to the direct child */
+    }
+  }
+  child.kill(signal);
 }
 
 export async function spawnWorkspaceSandboxedShell(input: SpawnWorkspaceShellInput): Promise<WorkspaceSandboxedShell> {

--- a/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
+++ b/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
@@ -134,10 +134,16 @@ const PACKAGE_STORE_DIR_NAMES = new Set(["node_modules", ".pnpm", ".pnpm-store"]
 // the carve-out every default-scaffold build fails on a read-only store.
 const PACKAGE_STORE_WRITABLE_CACHES = [".cache", ".vite", ".vite-temp"];
 
-async function packageStoreCacheCarveouts(packageStores: string[]): Promise<string[]> {
+/**
+ * Takes the LOGICAL node_modules stores (see workspacePolicyPaths) - a store
+ * exposed through a symlink has a canonical target with some other basename,
+ * so a physical-name check here would leave linked stores without their
+ * cache carve-outs and every build writing node_modules/.cache would fail.
+ * Exported for the regression lane.
+ */
+export async function packageStoreCacheCarveouts(nodeModulesStores: string[]): Promise<string[]> {
   const carveouts: string[] = [];
-  for (const store of packageStores) {
-    if (!store.endsWith(`${sep}node_modules`)) continue;
+  for (const store of nodeModulesStores) {
     for (const cache of PACKAGE_STORE_WRITABLE_CACHES) {
       const cachePath = join(store, cache);
       try {
@@ -156,6 +162,10 @@ export async function workspacePolicyPaths(workspaceRoot: string) {
   const forbidden: string[] = [];
   const sensitive: string[] = [];
   const packageStores: string[] = [];
+  // Canonical paths whose LOGICAL name is node_modules - the only store kind
+  // whose caches must stay writable - tracked separately because a symlinked
+  // store's canonical target carries a different basename.
+  const nodeModulesStores: string[] = [];
   const visit = async (path: string) => {
     const policy = workspacePathAccessPolicy(workspaceRoot, path);
     if (policy === "forbidden") {
@@ -175,6 +185,7 @@ export async function workspacePolicyPaths(workspaceRoot: string) {
           // Seen while being skipped: recorded for the read-only bind at
           // zero extra walk cost, nested stores included.
           packageStores.push(storePath);
+          if (entry.name === "node_modules") nodeModulesStores.push(storePath);
         } else if (entry.isSymbolicLink()) {
           // CWE-59: a store exposed AS a symlink must protect its TARGET -
           // writes travel through the link. Only in-workspace targets need a
@@ -187,6 +198,7 @@ export async function workspacePolicyPaths(workspaceRoot: string) {
               statSync(target).isDirectory()
             ) {
               packageStores.push(target);
+              if (entry.name === "node_modules") nodeModulesStores.push(target);
             }
           } catch {
             /* dangling or unreadable link */
@@ -203,6 +215,7 @@ export async function workspacePolicyPaths(workspaceRoot: string) {
     forbidden: uniqueExistingPaths(forbidden),
     sensitive: uniqueExistingPaths(sensitive),
     packageStores: uniqueExistingPaths(packageStores),
+    nodeModulesStores: uniqueExistingPaths(nodeModulesStores),
   };
 }
 
@@ -473,7 +486,7 @@ export async function buildMacosWorkspaceShellProfile(
   allowChildProcesses = true,
 ) {
   const policyPaths = await workspacePolicyPaths(workspaceRoot);
-  const storeCaches = writableWorkspace ? await packageStoreCacheCarveouts(policyPaths.packageStores) : [];
+  const storeCaches = writableWorkspace ? await packageStoreCacheCarveouts(policyPaths.nodeModulesStores) : [];
   const readable = macosReadRoots(workspaceRoot, env, sandboxTemp)
     .map((path) => `    (subpath ${sandboxLiteral(path)})`)
     .join("\n");
@@ -569,7 +582,7 @@ export async function linuxBubblewrapArgs(
     }
     // Later mounts stack over earlier ones: the cache dirs come back
     // writable inside the read-only store.
-    for (const cache of await packageStoreCacheCarveouts(policyPaths.packageStores)) {
+    for (const cache of await packageStoreCacheCarveouts(policyPaths.nodeModulesStores)) {
       args.push("--bind", cache, cache);
     }
   }

--- a/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
+++ b/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
@@ -8,6 +8,7 @@ import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { MAX_REVIEW_FILE_BYTES, workspacePathAccessPolicy } from "./workspace-change-review.service.js";
 import { getBubblewrapRuntimeStatus } from "../sandbox/bubblewrap-runtime.js";
+import { logger } from "../../lib/logger.js";
 
 export type WorkspaceShellSandboxBackend = "macos-seatbelt" | "linux-bubblewrap";
 export type WorkspaceProcessIsolationBackend = WorkspaceShellSandboxBackend | "node-permission-opt-in";
@@ -346,7 +347,18 @@ async function fingerprintSensitiveFile(path: string, stats: Stats): Promise<Sen
 }
 
 async function canonicalStorePaths(workspaceRoot: string): Promise<string[]> {
-  const policy = await workspacePolicyPaths(workspaceRoot);
+  // The policy walk deliberately THROWS on unreadable entries - for the
+  // spawn path that is fail-closed (a rule it cannot mint is a command that
+  // does not run). The scan must not inherit that hard failure: no store
+  // exemptions is the fail-safe direction here (the scan then walks and
+  // REPORTS more, never less), so contain the walk error to an empty set.
+  let policy;
+  try {
+    policy = await workspacePolicyPaths(workspaceRoot);
+  } catch (err) {
+    logger.warn(err, "[mari] Store discovery for the post-run scan failed; scanning without store exemptions");
+    return [];
+  }
   const canonical: string[] = [];
   for (const store of policy.packageStores) {
     try {

--- a/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
+++ b/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { existsSync, realpathSync, statSync } from "node:fs";
 import { lstat, mkdir, mkdtemp, readdir, readlink, rename, rm, symlink } from "node:fs/promises";
 import type { Stats } from "node:fs";
@@ -166,6 +167,17 @@ export async function packageStoreCacheCarveouts(nodeModulesStores: string[]): P
 
 /** Exported for the regression lane; production goes through the profile builders. */
 export async function workspacePolicyPaths(workspaceRoot: string) {
+  // CWE-59 (#5894 review): the containment checks below compare CANONICAL
+  // store targets against this root - a symlinked root (macOS tmpdirs live
+  // under /var -> /private/var) would reject every in-workspace linked store
+  // as "outside" and silently drop its bind rule AND its storeLinks entry,
+  // leaving nothing to restore post-run. Resolve the root to its physical
+  // path before anything is measured against it.
+  try {
+    workspaceRoot = realpathSync(workspaceRoot);
+  } catch {
+    /* an unreadable root fails loudly in the walk below */
+  }
   const forbidden: string[] = [];
   const sensitive: string[] = [];
   const packageStores: string[] = [];
@@ -507,8 +519,22 @@ export async function restoreReplacedStoreLinks(snapshot: SensitiveWorkspaceSnap
         }
         await rm(link, { force: true });
       } else if (current) {
-        const quarantine = `${link}.unreviewed-${Date.now()}`;
-        await rename(link, quarantine);
+        // #5894 review: the destination must be unguessable and collisions
+        // retried - rename onto a NON-EMPTY directory fails, so a command
+        // that pre-planted content at a predictable timestamp name would
+        // keep its impostor live at the store path.
+        let quarantine: string | null = null;
+        let renameFailure: unknown = null;
+        for (let attempt = 0; attempt < 3 && quarantine === null; attempt += 1) {
+          const candidate = `${link}.unreviewed-${randomBytes(6).toString("hex")}`;
+          try {
+            await rename(link, candidate);
+            quarantine = candidate;
+          } catch (renameErr) {
+            renameFailure = renameErr;
+          }
+        }
+        if (quarantine === null) throw renameFailure;
         lines.push(
           `A package-store symlink was replaced during the run; the replacement was quarantined to ${quarantine
             .slice(link.length - basename(link).length)

--- a/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
+++ b/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import { lstat, mkdir, mkdtemp, readdir, readlink, rm } from "node:fs/promises";
 import type { Stats } from "node:fs";
 import { delimiter, dirname, join, relative, resolve, sep } from "node:path";
@@ -151,7 +151,8 @@ async function packageStoreCacheCarveouts(packageStores: string[]): Promise<stri
   return carveouts;
 }
 
-async function workspacePolicyPaths(workspaceRoot: string) {
+/** Exported for the regression lane; production goes through the profile builders. */
+export async function workspacePolicyPaths(workspaceRoot: string) {
   const forbidden: string[] = [];
   const sensitive: string[] = [];
   const packageStores: string[] = [];
@@ -168,10 +169,29 @@ async function workspacePolicyPaths(workspaceRoot: string) {
     }
     if (!stats.isDirectory() || stats.isSymbolicLink()) return;
     for (const entry of await readdir(path, { withFileTypes: true })) {
-      if (entry.isDirectory() && PACKAGE_STORE_DIR_NAMES.has(entry.name)) {
-        // Seen while being skipped: recorded for the read-only bind at zero
-        // extra walk cost, nested stores included.
-        packageStores.push(join(path, entry.name));
+      if (PACKAGE_STORE_DIR_NAMES.has(entry.name)) {
+        const storePath = join(path, entry.name);
+        if (entry.isDirectory()) {
+          // Seen while being skipped: recorded for the read-only bind at
+          // zero extra walk cost, nested stores included.
+          packageStores.push(storePath);
+        } else if (entry.isSymbolicLink()) {
+          // CWE-59: a store exposed AS a symlink must protect its TARGET -
+          // writes travel through the link. Only in-workspace targets need a
+          // rule (outside targets are never sandbox-writable to begin with);
+          // a dangling link protects nothing.
+          try {
+            const target = realpathSync(storePath);
+            if (
+              (target === workspaceRoot || target.startsWith(workspaceRoot + sep)) &&
+              statSync(target).isDirectory()
+            ) {
+              packageStores.push(target);
+            }
+          } catch {
+            /* dangling or unreadable link */
+          }
+        }
         continue;
       }
       if (entry.isDirectory() && POLICY_SCAN_SKIPPED_DIRS.has(entry.name)) continue;
@@ -642,10 +662,7 @@ export async function spawnWorkspaceSandboxedProcess(
  * equivalent of bubblewrap's --die-with-parent. Residuals: a process that
  * setsid()s itself out of the group, and - macOS only - a tree orphaned by a
  * hard SERVER crash (teardown never runs; Linux is covered by
- * --die-with-parent regardless of grouping). A store exposed as a SYMLINK is
- * also not enumerated for the read-only binds (dirent.isDirectory() is false
- * for links); writes through the link land at its target, which the normal
- * policy covers when the target is itself sensitive or store-named.
+ * --die-with-parent regardless of grouping).
  */
 export function killSandboxedProcessTree(child: Pick<ChildProcess, "pid" | "kill">, signal: NodeJS.Signals): void {
   if (typeof child.pid === "number" && process.platform !== "win32") {

--- a/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
+++ b/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
@@ -148,6 +148,12 @@ export async function packageStoreCacheCarveouts(nodeModulesStores: string[]): P
       const cachePath = join(store, cache);
       try {
         await mkdir(cachePath, { recursive: true });
+        // CWE-59: mkdir succeeds through an existing directory SYMLINK, and
+        // the write grant would then aim at the link's target. Only a real
+        // directory sitting canonically at store/<cache> qualifies.
+        const stats = await lstat(cachePath);
+        if (stats.isSymbolicLink() || !stats.isDirectory()) continue;
+        if (realpathSync(cachePath) !== join(realpathSync(store), cache)) continue;
         carveouts.push(cachePath);
       } catch {
         /* an unreadable store keeps its cache unwritable - fail closed */
@@ -265,6 +271,13 @@ type SensitiveFingerprint = { kind: "file"; hash: string; content: Buffer | null
 export type SensitiveWorkspaceSnapshot = {
   files: Map<string, SensitiveFingerprint>;
   /**
+   * Canonical package-store paths at snapshot time. Store contents are the
+   * scan's documented residual; tracking them canonically keeps a store
+   * exposed through a symlink exempt even if the link is created or deleted
+   * during the run.
+   */
+  storePaths: string[];
+  /**
    * Subtrees the PRE-run walk could not inspect. Anything detected under
    * them later cannot be attributed to the command - a pre-existing file
    * would look "created" - so the revert must never delete there.
@@ -332,11 +345,25 @@ async function fingerprintSensitiveFile(path: string, stats: Stats): Promise<Sen
   }
 }
 
+async function canonicalStorePaths(workspaceRoot: string): Promise<string[]> {
+  const policy = await workspacePolicyPaths(workspaceRoot);
+  const canonical: string[] = [];
+  for (const store of policy.packageStores) {
+    try {
+      canonical.push(realpathSync(store));
+    } catch {
+      /* vanished between walks */
+    }
+  }
+  return canonical;
+}
+
 async function walkSensitiveEntries(
   workspaceRoot: string,
   onEntry: (path: string, fingerprint: SensitiveFingerprint) => void,
   descendIntoCoveredDir: (path: string) => boolean,
   unscannable: string[],
+  storePaths: readonly string[] = [],
 ): Promise<{ entryCapExceeded: boolean }> {
   let remainingEntries = MAX_SCAN_ENTRIES;
   let entryCapExceeded = false;
@@ -368,6 +395,17 @@ async function walkSensitiveEntries(
       if (!descendIntoCoveredDir(path)) return;
     }
     if (!stats.isDirectory() || stats.isSymbolicLink()) return;
+    // Canonical store identity beats physical naming: a store exposed (or
+    // once exposed) through a symlink is exempt by its TARGET path, so the
+    // scan neither reverts legitimate carve-out writes inside it nor - if
+    // the link vanished mid-run - misreads the target as "created" files.
+    if (storePaths.length > 0) {
+      try {
+        if (storePaths.includes(realpathSync(path))) return;
+      } catch {
+        /* keep walking; per-entry containment reports deeper failures */
+      }
+    }
     const name = path === workspaceRoot ? "" : path.slice(path.lastIndexOf(sep) + 1);
     if (SCAN_SKIPPED_DIRS.has(name)) {
       // A PRE-EXISTING store is skipped for cost (and is read-only in the
@@ -395,13 +433,15 @@ async function walkSensitiveEntries(
 export async function snapshotSensitiveWorkspaceFiles(workspaceRoot: string): Promise<SensitiveWorkspaceSnapshot> {
   const files = new Map<string, SensitiveFingerprint>();
   const unscannable: string[] = [];
+  const storePaths = await canonicalStorePaths(workspaceRoot);
   const { entryCapExceeded } = await walkSensitiveEntries(
     workspaceRoot,
     (path, fingerprint) => files.set(resolve(path), fingerprint),
     () => false,
     unscannable,
+    storePaths,
   );
-  return { files, unscannable, entryCapExceeded };
+  return { files, unscannable, entryCapExceeded, storePaths };
 }
 
 function stageableText(content: Buffer | null): string | null {
@@ -451,6 +491,11 @@ export async function detectUnreviewedSensitiveChanges(
     // rule covering them: walk them in full.
     (path) => !before.files.has(resolve(path)),
     unscannable,
+    // SNAPSHOT-time stores only: those were read-only-bound for the whole
+    // run (so nothing unreviewed can sit in them, and a link deleted
+    // mid-run cannot expose its already-exempt target), while a store the
+    // run itself CREATED was never bound and must be walked in full.
+    before.storePaths,
   );
   return { hits, unscannable, entryCapExceeded: capState.entryCapExceeded };
 }

--- a/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
+++ b/packages/server/src/services/professor-mari/workspace-shell-sandbox.ts
@@ -1,8 +1,8 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, realpathSync, statSync } from "node:fs";
-import { lstat, mkdir, mkdtemp, readdir, readlink, rm } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readdir, readlink, rename, rm, symlink } from "node:fs/promises";
 import type { Stats } from "node:fs";
-import { delimiter, dirname, join, relative, resolve, sep } from "node:path";
+import { basename, delimiter, dirname, join, relative, resolve, sep } from "node:path";
 import { tmpdir } from "node:os";
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
@@ -169,6 +169,7 @@ export async function workspacePolicyPaths(workspaceRoot: string) {
   const forbidden: string[] = [];
   const sensitive: string[] = [];
   const packageStores: string[] = [];
+  const storeLinks: Array<{ link: string; target: string }> = [];
   // Canonical paths whose LOGICAL name is node_modules - the only store kind
   // whose caches must stay writable - tracked separately because a symlinked
   // store's canonical target carries a different basename.
@@ -205,6 +206,7 @@ export async function workspacePolicyPaths(workspaceRoot: string) {
               statSync(target).isDirectory()
             ) {
               packageStores.push(target);
+              storeLinks.push({ link: storePath, target });
               if (entry.name === "node_modules") nodeModulesStores.push(target);
             }
           } catch {
@@ -223,6 +225,7 @@ export async function workspacePolicyPaths(workspaceRoot: string) {
     sensitive: uniqueExistingPaths(sensitive),
     packageStores: uniqueExistingPaths(packageStores),
     nodeModulesStores: uniqueExistingPaths(nodeModulesStores),
+    storeLinks,
   };
 }
 
@@ -278,6 +281,14 @@ export type SensitiveWorkspaceSnapshot = {
    * during the run.
    */
   storePaths: string[];
+  /**
+   * Store symlinks (link -> canonical target) at snapshot time. The mount
+   * layer can only protect the TARGET - the link entry itself lives in the
+   * writable workspace - so post-run integrity is checked here: a link
+   * unlinked and recreated as a real directory is an escape from the
+   * read-only store, quarantined and restored by restoreReplacedStoreLinks.
+   */
+  storeLinks: StoreLink[];
   /**
    * Subtrees the PRE-run walk could not inspect. Anything detected under
    * them later cannot be attributed to the command - a pre-existing file
@@ -346,7 +357,9 @@ async function fingerprintSensitiveFile(path: string, stats: Stats): Promise<Sen
   }
 }
 
-async function canonicalStorePaths(workspaceRoot: string): Promise<string[]> {
+type StoreLink = { link: string; target: string };
+
+async function canonicalStorePaths(workspaceRoot: string): Promise<{ paths: string[]; links: StoreLink[] }> {
   // The policy walk deliberately THROWS on unreadable entries - for the
   // spawn path that is fail-closed (a rule it cannot mint is a command that
   // does not run). The scan must not inherit that hard failure: no store
@@ -357,7 +370,7 @@ async function canonicalStorePaths(workspaceRoot: string): Promise<string[]> {
     policy = await workspacePolicyPaths(workspaceRoot);
   } catch (err) {
     logger.warn(err, "[mari] Store discovery for the post-run scan failed; scanning without store exemptions");
-    return [];
+    return { paths: [], links: [] };
   }
   const canonical: string[] = [];
   for (const store of policy.packageStores) {
@@ -367,7 +380,7 @@ async function canonicalStorePaths(workspaceRoot: string): Promise<string[]> {
       /* vanished between walks */
     }
   }
-  return canonical;
+  return { paths: canonical, links: policy.storeLinks };
 }
 
 async function walkSensitiveEntries(
@@ -445,7 +458,7 @@ async function walkSensitiveEntries(
 export async function snapshotSensitiveWorkspaceFiles(workspaceRoot: string): Promise<SensitiveWorkspaceSnapshot> {
   const files = new Map<string, SensitiveFingerprint>();
   const unscannable: string[] = [];
-  const storePaths = await canonicalStorePaths(workspaceRoot);
+  const { paths: storePaths, links: storeLinks } = await canonicalStorePaths(workspaceRoot);
   const { entryCapExceeded } = await walkSensitiveEntries(
     workspaceRoot,
     (path, fingerprint) => files.set(resolve(path), fingerprint),
@@ -453,7 +466,7 @@ export async function snapshotSensitiveWorkspaceFiles(workspaceRoot: string): Pr
     unscannable,
     storePaths,
   );
-  return { files, unscannable, entryCapExceeded, storePaths };
+  return { files, unscannable, entryCapExceeded, storePaths, storeLinks };
 }
 
 function stageableText(content: Buffer | null): string | null {
@@ -462,6 +475,55 @@ function stageableText(content: Buffer | null): string | null {
   // Binary content does not survive a utf8 round-trip; such files can be
   // reverted (bytes retained) but never staged as a text diff.
   return Buffer.compare(Buffer.from(text, "utf8"), content) === 0 ? text : null;
+}
+
+/**
+ * #5894 review (CWE-59, third edition): the mount layer protects a linked
+ * store's TARGET, but the link entry itself sits in the writable workspace -
+ * a command can unlink it and recreate it as a real directory, writing into
+ * an unprotected impostor that shadows the read-only store (require() would
+ * resolve planted code from it with no sensitive-named file involved).
+ * Post-run, every snapshot-time store link is verified: an impostor is
+ * QUARANTINED BY RENAME (never deleted - a concurrent legitimate writer is
+ * conceivable, and the quarantine name is not skip-named, so the normal scan
+ * still stages any sensitive-by-name files inside it) and the link restored.
+ * Returns engine lines describing what happened.
+ */
+export async function restoreReplacedStoreLinks(snapshot: SensitiveWorkspaceSnapshot): Promise<string[]> {
+  const lines: string[] = [];
+  for (const { link, target } of snapshot.storeLinks) {
+    try {
+      let current: Stats | null = null;
+      try {
+        current = await lstat(link);
+      } catch {
+        current = null;
+      }
+      if (current?.isSymbolicLink()) {
+        try {
+          if (realpathSync(link) === target) continue;
+        } catch {
+          /* dangling now - fall through to restore */
+        }
+        await rm(link, { force: true });
+      } else if (current) {
+        const quarantine = `${link}.unreviewed-${Date.now()}`;
+        await rename(link, quarantine);
+        lines.push(
+          `A package-store symlink was replaced during the run; the replacement was quarantined to ${quarantine
+            .slice(link.length - basename(link).length)
+            .replace(/[\r\n]+/gu, " ")} and the link restored - ask the user to inspect the quarantined directory.`,
+        );
+      }
+      await symlink(target, link, "junction");
+    } catch (err) {
+      logger.error(err, "[mari] Could not restore a replaced package-store symlink");
+      lines.push(
+        `A package-store symlink changed during the run and could not be restored; ask the user to inspect it.`,
+      );
+    }
+  }
+  return lines;
 }
 
 export async function detectUnreviewedSensitiveChanges(

--- a/scripts/regressions/mari-guard-sibling-paths.regression.ts
+++ b/scripts/regressions/mari-guard-sibling-paths.regression.ts
@@ -15,6 +15,7 @@ import assert from "node:assert/strict";
 import {
   chmodSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -23,7 +24,9 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
+import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
+import { setTimeout as delay } from "node:timers/promises";
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
 import {
@@ -41,6 +44,7 @@ import {
   killSandboxedProcessTree,
   linuxBubblewrapArgs,
   packageStoreCacheCarveouts,
+  restoreReplacedStoreLinks,
   snapshotSensitiveWorkspaceFiles,
   workspacePolicyPaths,
 } from "../../packages/server/src/services/professor-mari/workspace-shell-sandbox.js";
@@ -795,6 +799,66 @@ assert.match(sandboxFlat, /process\.kill\(-child\.pid, signal\);/u);
         false,
         "a store link deleted mid-run cannot expose its target as created files",
       );
+
+      // CWE-59, third edition (#5894 review): the mount layer protects the
+      // TARGET, but the link ENTRY sits in the writable workspace - unlink it,
+      // recreate it as a real directory, and writes land in an unprotected
+      // impostor that shadows the read-only store. Post-run link integrity
+      // quarantines the impostor by rename (never deletes - the scan still
+      // walks it for sensitive files) and restores the symlink.
+      symlinkSync(join(workspace, "real-store"), join(workspace, "node_modules"), "junction");
+      const linkSnapshot = await snapshotSensitiveWorkspaceFiles(workspace);
+      assert.ok(
+        linkSnapshot.storeLinks.some(
+          (pair) => pair.link === join(workspace, "node_modules") && pair.target === realStore,
+        ),
+        "the snapshot records the store link and its canonical target",
+      );
+      // An intact link is left alone.
+      assert.deepEqual(await restoreReplacedStoreLinks(linkSnapshot), []);
+      assert.ok(lstatSync(join(workspace, "node_modules")).isSymbolicLink(), "an intact link is untouched");
+
+      // The attack: unlink, recreate as a directory, plant require-resolvable
+      // code (no sensitive-named file needed) plus a sensitive-named file.
+      rmSync(join(workspace, "node_modules"), { recursive: true, force: true });
+      mkdirSync(join(workspace, "node_modules", "evil"), { recursive: true });
+      writeFileSync(join(workspace, "node_modules", "evil", "index.js"), "module.exports = 666;");
+      writeFileSync(join(workspace, "node_modules", "package.json"), '{"name":"impostor"}');
+      const restoreLines = await restoreReplacedStoreLinks(linkSnapshot);
+      assert.equal(restoreLines.length, 1, "the replacement is reported to the engine region");
+      assert.match(restoreLines[0] ?? "", /quarantined/u);
+      assert.ok(
+        lstatSync(join(workspace, "node_modules")).isSymbolicLink() &&
+          realpathSync(join(workspace, "node_modules")) === realStore,
+        "the store link is restored to its canonical target",
+      );
+      const quarantine = readdirSync(workspace).find((name) => name.startsWith("node_modules.unreviewed-"));
+      assert.ok(quarantine, "the impostor is quarantined by rename, not deleted");
+      assert.ok(
+        existsSync(join(workspace, quarantine ?? "", "evil", "index.js")),
+        "planted code survives inside the quarantine for the user to inspect",
+      );
+      // The quarantine is NOT store-exempt and NOT skip-named: the normal scan
+      // stages its sensitive-by-name files.
+      const afterRestore = await detectUnreviewedSensitiveChanges(workspace, linkSnapshot);
+      assert.ok(
+        afterRestore.hits.some(
+          (hit) => hit.relativePath.includes("unreviewed-") && hit.relativePath.endsWith("package.json"),
+        ),
+        "sensitive files inside the quarantined impostor still reach the review gate",
+      );
+      rmSync(join(workspace, quarantine ?? "node_modules.unreviewed-none"), { recursive: true, force: true });
+
+      // A link DELETED outright (not replaced) is restored silently - the
+      // target is a protected store, so the link's absence is never an
+      // intended workspace state.
+      rmSync(join(workspace, "node_modules"), { recursive: true, force: true });
+      assert.deepEqual(await restoreReplacedStoreLinks(linkSnapshot), []);
+      assert.ok(
+        lstatSync(join(workspace, "node_modules")).isSymbolicLink() &&
+          realpathSync(join(workspace, "node_modules")) === realStore,
+        "a deleted store link is restored",
+      );
     }
   } finally {
     rmSync(workspace, { recursive: true, force: true });
@@ -808,11 +872,70 @@ assert.match(sandboxFlat, /process\.kill\(-child\.pid, signal\);/u);
 // the orphaned timer could SIGKILL a recycled process group after close. A
 // sequence-level simulation needs a live sandbox spawn, so the guard whose
 // absence recreates the bug is pinned instead.
+assert.match(
+  flatAgentSource,
+  /linkLines = await restoreReplacedStoreLinks\(snapshot\);.*scan = await detectUnreviewedSensitiveChanges\(this\.workspaceRoot, snapshot\);/u,
+  "the aftermath pass restores store links before the sensitive-change scan",
+);
+
 assert.match(flatAgentSource, /let killIssued = false;/u);
 assert.match(
   flatAgentSource,
   /if \(killIssued\) return; killIssued = true; killSandboxedProcessTree\(child, "SIGTERM"\);/u,
   "only the first killChild call ever schedules the escalation timer",
 );
+
+// ── #5894 review: group teardown RUNTIME case (POSIX) ───────────────────────
+// The Trivial finding asks for a live Bubblewrap teardown regression. Neither
+// CI nor the dev boxes install bwrap, so a bwrap-gated test would skip
+// everywhere it could ever run - the bwrap layer stays pinned via
+// linuxBubblewrapArgs (--die-with-parent, --new-session) above. What CAN run
+// for real is the semantics the finding is about: a TERM-trapping grandchild
+// that never setsid()s must die with the PROCESS GROUP when the production
+// TERM -> hard-kill escalation fires. The spawn shape mirrors production:
+// detached, so the child leads its own group.
+if (process.platform === "win32") {
+  console.log("POSIX process groups unavailable on Windows; the runtime teardown case runs in CI.");
+} else {
+  const child = spawn("bash", ["-c", "trap '' TERM; (trap '' TERM; sleep 300) & echo GRANDCHILD:$!; wait"], {
+    detached: true,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  const grandchildPid = await new Promise<number>((resolvePid, rejectPid) => {
+    let buffered = "";
+    const bail = setTimeout(() => rejectPid(new Error("grandchild never announced itself")), 5000);
+    child.stdout.on("data", (chunk: Buffer) => {
+      buffered += chunk.toString();
+      const match = /GRANDCHILD:(\d+)/u.exec(buffered);
+      if (match?.[1]) {
+        clearTimeout(bail);
+        resolvePid(Number(match[1]));
+      }
+    });
+    child.on("error", rejectPid);
+  });
+  const alive = (pid: number): boolean => {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  // Validity check first: the trap really absorbs the graceful signal, so
+  // this case cannot silently degrade into "TERM killed it anyway".
+  killSandboxedProcessTree(child, "SIGTERM");
+  await delay(300);
+  assert.ok(alive(grandchildPid), "the TERM-trapping grandchild survives the graceful signal (trap works)");
+  // The production hard-kill escalation: SIGKILL the group.
+  killSandboxedProcessTree(child, "SIGKILL");
+  const deadline = Date.now() + 5000;
+  while (alive(grandchildPid) && Date.now() < deadline) await delay(100);
+  assert.equal(
+    alive(grandchildPid),
+    false,
+    "the escalated group kill takes the non-setsid grandchild before any post-run scan could race it",
+  );
+}
 
 console.log("Mari guard sibling-paths regression passed.");

--- a/scripts/regressions/mari-guard-sibling-paths.regression.ts
+++ b/scripts/regressions/mari-guard-sibling-paths.regression.ts
@@ -754,6 +754,47 @@ assert.match(sandboxFlat, /process\.kill\(-child\.pid, signal\);/u);
         false,
         "a dangling store link protects nothing and never throws",
       );
+      rmSync(join(workspace, "node_modules"), { recursive: true, force: true });
+
+      // A symlinked CACHE inside the store must never receive a write grant -
+      // mkdir({recursive}) succeeds through a directory link, and the grant
+      // would aim at the link's target (CWE-59, second edition).
+      symlinkSync(join(workspace, "real-store"), join(workspace, "node_modules"), "junction");
+      mkdirSync(join(workspace, "cache-target"));
+      // The earlier carve-out assertion created a REAL .cache here; replace
+      // it with the hostile link shape this case exists to reject.
+      rmSync(join(workspace, "real-store", ".cache"), { recursive: true, force: true });
+      symlinkSync(join(workspace, "cache-target"), join(workspace, "real-store", ".cache"), "junction");
+      const guarded = await packageStoreCacheCarveouts((await workspacePolicyPaths(workspace)).nodeModulesStores);
+      assert.equal(
+        guarded.some((path) => path.endsWith(".cache")),
+        false,
+        "a symlinked cache is rejected; only a real directory canonically inside the store qualifies",
+      );
+      assert.ok(
+        guarded.some((path) => path.endsWith(".vite")),
+        "the sibling real caches still carve out",
+      );
+      rmSync(join(workspace, "real-store", ".cache"), { recursive: true, force: true });
+
+      // The scan exempts the linked store by CANONICAL identity: writes into
+      // the target (legitimate carve-out traffic) are never reverted, and a
+      // link DELETED mid-run cannot expose the target as "created" files.
+      const storeSnapshot = await snapshotSensitiveWorkspaceFiles(workspace);
+      writeFileSync(join(workspace, "real-store", "package.json"), '{"name":"cache-metadata"}');
+      const throughLink = await detectUnreviewedSensitiveChanges(workspace, storeSnapshot);
+      assert.equal(
+        throughLink.hits.some((hit) => hit.relativePath.includes("real-store")),
+        false,
+        "the linked store's target is exempt from the scan while the link stands",
+      );
+      rmSync(join(workspace, "node_modules"), { recursive: true, force: true });
+      const afterUnlink = await detectUnreviewedSensitiveChanges(workspace, storeSnapshot);
+      assert.equal(
+        afterUnlink.hits.some((hit) => hit.relativePath.includes("real-store")),
+        false,
+        "a store link deleted mid-run cannot expose its target as created files",
+      );
     }
   } finally {
     rmSync(workspace, { recursive: true, force: true });

--- a/scripts/regressions/mari-guard-sibling-paths.regression.ts
+++ b/scripts/regressions/mari-guard-sibling-paths.regression.ts
@@ -36,7 +36,10 @@ import {
   bashCommandTargetsSensitivePath,
 } from "../../packages/server/src/services/professor-mari/workspace-change-review.service.js";
 import {
+  buildMacosWorkspaceShellProfile,
   detectUnreviewedSensitiveChanges,
+  killSandboxedProcessTree,
+  linuxBubblewrapArgs,
   snapshotSensitiveWorkspaceFiles,
 } from "../../packages/server/src/services/professor-mari/workspace-shell-sandbox.js";
 
@@ -345,11 +348,16 @@ assert.match(
     // A manifest planted in a PRE-EXISTING build-output dir is the same
     // #5786 class - the scan's skip set is narrower than the spawn walk's.
     writeFileSync(join(workspace, "dist", "package.json"), '{"name":"planted"}');
-    // node_modules stays skipped for cost - the documented residual; its
-    // contents were always sandbox-writable, and the review floor defends
-    // the manifests that would INSTALL such content.
+    // A PRE-EXISTING node_modules stays scan-skipped for cost - safe since
+    // #5892, because the sandbox binds it read-only. (The workspace seeded
+    // one before the snapshot above.)
     mkdirSync(join(workspace, "node_modules", "evil"), { recursive: true });
     writeFileSync(join(workspace, "node_modules", "evil", "package.json"), '{"name":"evil"}');
+    // A store the run itself CREATES has no bind covering it, so the scan
+    // must walk it in full - losing this descent was a review-caught
+    // regression (#5892 verification round).
+    mkdirSync(join(workspace, "fresh-tool", "node_modules", "planted"), { recursive: true });
+    writeFileSync(join(workspace, "fresh-tool", "node_modules", "planted", "package.json"), '{"name":"planted"}');
     // Normal files never report.
     writeFileSync(join(workspace, "notes.txt"), "edited");
 
@@ -358,7 +366,13 @@ assert.match(
     const byPath = new Map(scan.hits.map((hit) => [hit.relativePath, hit]));
     assert.deepEqual(
       [...byPath.keys()].sort(),
-      ["dist/package.json", "fresh/package.json", "package.json", "win/installer/installer.nsi"],
+      [
+        "dist/package.json",
+        "fresh-tool/node_modules/planted/package.json",
+        "fresh/package.json",
+        "package.json",
+        "win/installer/installer.nsi",
+      ],
       "exactly the uncovered sensitive changes report - covered dirs and normal files stay silent",
     );
     assert.equal(byPath.get("fresh/package.json")?.change, "created");
@@ -371,7 +385,12 @@ assert.match(
     );
     assert.equal(byPath.get("win/installer/installer.nsi")?.change, "created");
     assert.equal(byPath.get("dist/package.json")?.attributionUncertain, false);
-    assert.ok(!byPath.has("node_modules/evil/package.json"), "the package-store residual is skipped by design");
+    assert.ok(!byPath.has("node_modules/evil/package.json"), "a pre-existing store stays skipped (it is ro-bound)");
+    assert.equal(
+      byPath.get("fresh-tool/node_modules/planted/package.json")?.change,
+      "created",
+      "a store the run created is walked in full - no bind covers it",
+    );
 
     // Binary content is revertable (bytes retained) but never staged as text.
     const binary = Buffer.from([0x00, 0xff, 0xfe, 0x00, 0x81]);
@@ -567,7 +586,10 @@ assert.match(
 );
 // Timeout gets the same bounded settle as abort, and the kill escalates.
 assert.match(flatAgentSource, /const KILL_ESCALATION_MS = 2_000;/u);
-assert.match(flatAgentSource, /child\.kill\("SIGKILL"\)/u);
+// #5892: teardown signals the whole detached process GROUP, with SIGKILL
+// escalation - a TERM-trapping tree or backgrounded grandchild dies too.
+assert.match(flatAgentSource, /killSandboxedProcessTree\(child, "SIGTERM"\);/u);
+assert.match(flatAgentSource, /killSandboxedProcessTree\(child, "SIGKILL"\), KILL_ESCALATION_MS\)/u);
 // The revert writes BYTES, never a utf8 round-trip that would corrupt
 // binary lockfiles.
 assert.match(flatAgentSource, /await writeFile\(hit\.absolutePath, hit\.beforeContent\);/u);
@@ -579,5 +601,100 @@ assert.doesNotMatch(
   /abortHandler = \(\) => \{ killChild\(\); finish\(/u,
   "the abort handler no longer settles immediately",
 );
+
+// ── #5892: package stores are read-only in the sandbox, caches carved out ──
+// Both backends' generated rules are asserted functionally - the store deny
+// must cover nested stores, and the cache carve-out must come AFTER the deny
+// (bubblewrap: later mounts stack; seatbelt: last matching rule wins).
+{
+  // realpathSync: macOS tmpdir() is a /var/folders symlink, and the emitted
+  // binds are realpath'd - un-canonicalized expectations would false-fail.
+  const workspace = realpathSync(mkdtempSync(join(tmpdir(), "store-robind-")));
+  try {
+    mkdirSync(join(workspace, "node_modules", "some-pkg"), { recursive: true });
+    mkdirSync(join(workspace, "packages", "a", "node_modules"), { recursive: true });
+    mkdirSync(join(workspace, ".pnpm-store"), { recursive: true });
+
+    const bwrapArgs = await linuxBubblewrapArgs(workspace, {}, tmpdir(), "/bin/bash", ["-c", "true"], true);
+    const flatArgs = bwrapArgs.join("\u0000");
+    const rootStore = join(workspace, "node_modules");
+    const nestedStore = join(workspace, "packages", "a", "node_modules");
+    const pnpmStore = join(workspace, ".pnpm-store");
+    for (const store of [rootStore, nestedStore, pnpmStore]) {
+      assert.ok(flatArgs.includes(`--ro-bind\u0000${store}\u0000${store}`), `store is read-only: ${store}`);
+    }
+    const cachePath = join(rootStore, ".cache");
+    assert.ok(existsSync(cachePath), "the cache carve-out is pre-created so first builds work");
+    const roIndex = bwrapArgs.findIndex((arg, i) => arg === "--ro-bind" && bwrapArgs[i + 1] === rootStore);
+    const cacheIndex = bwrapArgs.findIndex((arg, i) => arg === "--bind" && bwrapArgs[i + 1] === cachePath);
+    assert.ok(roIndex >= 0 && cacheIndex > roIndex, "the writable cache mount stacks OVER the read-only store");
+
+    // Profile literals are JSON-stringified realpaths - build the expected
+    // fragments the same way the profile does.
+    const literal = (path: string) => JSON.stringify(realpathSync(path));
+    const profile = await buildMacosWorkspaceShellProfile(workspace, {}, tmpdir(), true, "/bin/bash", true);
+    const rootStoreRule = profile.indexOf(`(subpath ${literal(rootStore)})`);
+    const cacheRule = profile.indexOf(`(subpath ${literal(cachePath)})`);
+    assert.ok(rootStoreRule >= 0, "seatbelt denies store writes");
+    assert.ok(profile.includes(`(subpath ${literal(nestedStore)})`), "seatbelt denies the nested store too");
+    assert.ok(
+      profile.lastIndexOf("(deny file-write*", rootStoreRule) >= 0,
+      "the store subpath sits inside a deny block",
+    );
+    assert.ok(
+      cacheRule > rootStoreRule &&
+        profile.lastIndexOf("(allow file-write*", cacheRule) > profile.lastIndexOf("(deny file-write*", cacheRule),
+      "the cache subpath sits in an ALLOW block after the deny - last matching rule wins",
+    );
+
+    // A read-only workspace emits no store rules at all (nothing is writable
+    // to begin with).
+    const roProfile = await buildMacosWorkspaceShellProfile(workspace, {}, tmpdir(), false, "/bin/bash", true);
+    assert.ok(!roProfile.includes(`(subpath ${literal(rootStore)})`));
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+}
+
+// killSandboxedProcessTree, honestly scoped: the fallback branch is proven
+// on POSIX (pid 2**30 exceeds every pid_max, so the group signal throws
+// ESRCH); on win32 the platform guard makes this the direct path, so the
+// assertion is gated. The group-signal SUCCESS path is proven by killing a
+// real detached leader below (grandchild efficacy stays a source pin - a
+// full tree test would be timing-flaky in a lane).
+{
+  let direct: string | null = null;
+  const fakeChild = {
+    pid: 2 ** 30,
+    kill(signal?: NodeJS.Signals | number) {
+      direct = String(signal);
+      return true;
+    },
+  };
+  killSandboxedProcessTree(fakeChild, "SIGTERM");
+  if (process.platform !== "win32") {
+    assert.equal(direct, "SIGTERM", "an unreachable group falls back to the direct child");
+  }
+}
+if (process.platform !== "win32") {
+  const { spawn } = await import("node:child_process");
+  const leader = spawn("sleep", ["30"], { detached: true, stdio: "ignore" });
+  const exited = new Promise<void>((resolveExit) => leader.once("close", () => resolveExit()));
+  killSandboxedProcessTree(leader, "SIGKILL");
+  const winner = await Promise.race([
+    exited.then(() => "killed" as const),
+    new Promise<"hung">((resolveHang) => setTimeout(() => resolveHang("hung"), 5_000)),
+  ]);
+  assert.equal(winner, "killed", "the group signal kills a real detached leader promptly");
+}
+
+// The spawns are detached so the child leads its own killable group.
+const sandboxFlat = sandboxSource;
+assert.equal(
+  (sandboxFlat.match(/detached: true/gu) ?? []).length,
+  2,
+  "both backend spawns are detached - group semantics for teardown",
+);
+assert.match(sandboxFlat, /process\.kill\(-child\.pid, signal\);/u);
 
 console.log("Mari guard sibling-paths regression passed.");

--- a/scripts/regressions/mari-guard-sibling-paths.regression.ts
+++ b/scripts/regressions/mari-guard-sibling-paths.regression.ts
@@ -41,6 +41,7 @@ import {
   killSandboxedProcessTree,
   linuxBubblewrapArgs,
   snapshotSensitiveWorkspaceFiles,
+  workspacePolicyPaths,
 } from "../../packages/server/src/services/professor-mari/workspace-shell-sandbox.js";
 
 const workspaceAgentSource = readFileSync(
@@ -696,5 +697,67 @@ assert.equal(
   "both backend spawns are detached - group semantics for teardown",
 );
 assert.match(sandboxFlat, /process\.kill\(-child\.pid, signal\);/u);
+
+// ── #5894 review: store-name SYMLINKS protect their canonical targets ───────
+// CWE-59: a pre-existing node_modules symlink is not a directory, so the old
+// walk skipped it entirely - a command could write THROUGH the link into its
+// in-workspace target with no read-only bind. The walk now resolves the
+// link: in-workspace directory targets get the rule, outside targets are
+// rejected (never sandbox-writable anyway), dangling links protect nothing.
+{
+  const workspace = mkdtempSync(join(tmpdir(), "store-symlink-"));
+  const outside = mkdtempSync(join(tmpdir(), "store-outside-"));
+  try {
+    mkdirSync(join(workspace, "real-store"));
+    writeFileSync(join(workspace, "real-store", "left-pad.js"), "module.exports = 1;");
+    let symlinksSupported = true;
+    try {
+      symlinkSync(join(workspace, "real-store"), join(workspace, "node_modules"), "junction");
+    } catch {
+      symlinksSupported = false;
+    }
+    if (symlinksSupported) {
+      const linked = await workspacePolicyPaths(workspace);
+      const realStore = realpathSync(join(workspace, "real-store"));
+      assert.ok(
+        linked.packageStores.some((path) => realpathSync(path) === realStore),
+        "a store-name symlink binds its canonical in-workspace target read-only",
+      );
+      rmSync(join(workspace, "node_modules"), { recursive: true, force: true });
+
+      symlinkSync(outside, join(workspace, "node_modules"), "junction");
+      const escaping = await workspacePolicyPaths(workspace);
+      assert.ok(
+        !escaping.packageStores.some((path) => realpathSync(path).startsWith(realpathSync(outside))),
+        "a link escaping the workspace never mints a rule for the outside target",
+      );
+      rmSync(join(workspace, "node_modules"), { recursive: true, force: true });
+
+      symlinkSync(join(workspace, "does-not-exist"), join(workspace, "node_modules"), "junction");
+      const dangling = await workspacePolicyPaths(workspace);
+      assert.equal(
+        dangling.packageStores.some((path) => path.includes("does-not-exist")),
+        false,
+        "a dangling store link protects nothing and never throws",
+      );
+    }
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+}
+
+// ── #5894 review: teardown is idempotent ────────────────────────────────────
+// Abort and timeout can BOTH invoke killChild; without the guard the second
+// call overwrote hardKillTimer, and finish() cleared only the newer one -
+// the orphaned timer could SIGKILL a recycled process group after close. A
+// sequence-level simulation needs a live sandbox spawn, so the guard whose
+// absence recreates the bug is pinned instead.
+assert.match(flatAgentSource, /let killIssued = false;/u);
+assert.match(
+  flatAgentSource,
+  /if \(killIssued\) return; killIssued = true; killSandboxedProcessTree\(child, "SIGTERM"\);/u,
+  "only the first killChild call ever schedules the escalation timer",
+);
 
 console.log("Mari guard sibling-paths regression passed.");

--- a/scripts/regressions/mari-guard-sibling-paths.regression.ts
+++ b/scripts/regressions/mari-guard-sibling-paths.regression.ts
@@ -824,6 +824,11 @@ assert.match(sandboxFlat, /process\.kill\(-child\.pid, signal\);/u);
       mkdirSync(join(workspace, "node_modules", "evil"), { recursive: true });
       writeFileSync(join(workspace, "node_modules", "evil", "index.js"), "module.exports = 666;");
       writeFileSync(join(workspace, "node_modules", "package.json"), '{"name":"impostor"}');
+      // A pre-planted NON-EMPTY decoy at a quarantine-shaped name must not
+      // block restoration (rename onto a non-empty directory fails, which a
+      // predictable destination would let the command force).
+      mkdirSync(join(workspace, "node_modules.unreviewed-deadbeef"));
+      writeFileSync(join(workspace, "node_modules.unreviewed-deadbeef", "occupied"), "x");
       const restoreLines = await restoreReplacedStoreLinks(linkSnapshot);
       assert.equal(restoreLines.length, 1, "the replacement is reported to the engine region");
       assert.match(restoreLines[0] ?? "", /quarantined/u);
@@ -832,8 +837,14 @@ assert.match(sandboxFlat, /process\.kill\(-child\.pid, signal\);/u);
           realpathSync(join(workspace, "node_modules")) === realStore,
         "the store link is restored to its canonical target",
       );
-      const quarantine = readdirSync(workspace).find((name) => name.startsWith("node_modules.unreviewed-"));
-      assert.ok(quarantine, "the impostor is quarantined by rename, not deleted");
+      const quarantine = readdirSync(workspace).find(
+        (name) => name.startsWith("node_modules.unreviewed-") && name !== "node_modules.unreviewed-deadbeef",
+      );
+      assert.ok(quarantine, "the impostor is quarantined by rename, not deleted, at an unpredictable name");
+      assert.ok(
+        existsSync(join(workspace, "node_modules.unreviewed-deadbeef", "occupied")),
+        "the decoy is left untouched",
+      );
       assert.ok(
         existsSync(join(workspace, quarantine ?? "", "evil", "index.js")),
         "planted code survives inside the quarantine for the user to inspect",
@@ -848,6 +859,7 @@ assert.match(sandboxFlat, /process\.kill\(-child\.pid, signal\);/u);
         "sensitive files inside the quarantined impostor still reach the review gate",
       );
       rmSync(join(workspace, quarantine ?? "node_modules.unreviewed-none"), { recursive: true, force: true });
+      rmSync(join(workspace, "node_modules.unreviewed-deadbeef"), { recursive: true, force: true });
 
       // A link DELETED outright (not replaced) is restored silently - the
       // target is a protected store, so the link's absence is never an
@@ -859,6 +871,24 @@ assert.match(sandboxFlat, /process\.kill\(-child\.pid, signal\);/u);
           realpathSync(join(workspace, "node_modules")) === realStore,
         "a deleted store link is restored",
       );
+
+      // A symlinked WORKSPACE ROOT (macOS tmpdirs: /var -> /private/var) must
+      // not defeat containment: the policy canonicalizes the root before the
+      // canonical store targets are measured against it, so the linked store
+      // keeps both its bind rule and the storeLinks pair restoration needs.
+      const rootLink = join(outside, "root-link");
+      symlinkSync(workspace, rootLink, "junction");
+      const throughRoot = await workspacePolicyPaths(rootLink);
+      assert.ok(
+        throughRoot.packageStores.some((path) => realpathSync(path) === realStore),
+        "a symlinked workspace root still mints the linked store's protection",
+      );
+      const rootSnapshot = await snapshotSensitiveWorkspaceFiles(rootLink);
+      assert.ok(
+        rootSnapshot.storeLinks.some((pair) => pair.target === realStore),
+        "storeLinks survive a symlinked root for post-run restoration",
+      );
+      rmSync(rootLink, { recursive: true, force: true });
     }
   } finally {
     rmSync(workspace, { recursive: true, force: true });

--- a/scripts/regressions/mari-guard-sibling-paths.regression.ts
+++ b/scripts/regressions/mari-guard-sibling-paths.regression.ts
@@ -40,6 +40,7 @@ import {
   detectUnreviewedSensitiveChanges,
   killSandboxedProcessTree,
   linuxBubblewrapArgs,
+  packageStoreCacheCarveouts,
   snapshotSensitiveWorkspaceFiles,
   workspacePolicyPaths,
 } from "../../packages/server/src/services/professor-mari/workspace-shell-sandbox.js";
@@ -723,6 +724,19 @@ assert.match(sandboxFlat, /process\.kill\(-child\.pid, signal\);/u);
         linked.packageStores.some((path) => realpathSync(path) === realStore),
         "a store-name symlink binds its canonical in-workspace target read-only",
       );
+      // The carve-outs follow the LOGICAL name: node_modules-through-a-link
+      // keeps its writable caches, so builds writing node_modules/.cache do
+      // not break on the read-only bind.
+      assert.ok(
+        linked.nodeModulesStores.some((path) => realpathSync(path) === realStore),
+        "the linked store is recognized as a logical node_modules",
+      );
+      const carveouts = await packageStoreCacheCarveouts(linked.nodeModulesStores);
+      assert.ok(
+        carveouts.some((path) => path.endsWith(".cache") && realpathSync(join(path, "..")) === realStore),
+        "cache carve-outs are created inside the canonical target",
+      );
+      assert.ok(existsSync(join(workspace, "real-store", ".vite")), "the carve-out directories exist on disk");
       rmSync(join(workspace, "node_modules"), { recursive: true, force: true });
 
       symlinkSync(outside, join(workspace, "node_modules"), "junction");


### PR DESCRIPTION
## Linked issue

Closes #5892

## Why this change

#5892 tracked the two residuals consciously left open by the #5786 post-execution scan (PR #5891): package-store trees stayed outside the scan for cost — so a command could plant ready-made `node_modules/<pkg>/` code that executes on the server's next `require` — and on macOS a process surviving seatbelt teardown could write *after* the scan walked.

## What changed

**Residual 1 closes at the mount layer, not the scan.** Package-store trees (`node_modules`, `.pnpm`, `.pnpm-store` — *nested included*, enumerated by the existing policy walk at zero extra I/O since it already sees each store while skipping into it) are now **read-only** inside the sandbox on both backends. The justification is structural: sandboxed bash has no legitimate install path (package-manager mutations are refused pre-execution; approved dependency installs run outside the sandbox). Build-tool caches stay writable via carve-outs (`.cache`, `.vite`, and `.vite-temp` — the review probed this repo's actual vite@7 and found TS-config builds bundle there before anything else runs), pre-created when absent so a first build isn't broken by its own missing cache dir. The workspace root is canonicalized before any rules derive — the review traced a Linux fail-open where a symlinked workspace path put the writable bind and the realpath'd read-only binds on different mount points.

**Residual 2 narrows to the theoretical.** Both backend spawns are `detached: true` and teardown signals the process **group** (SIGTERM, then SIGKILL escalation, timer cleared on settle so a stale group-kill can never hit a recycled pid). Backgrounded grandchildren die with the tree; what remains — `setsid` escapees, and trees orphaned by a hard *server* crash on macOS — is documented at the helper.

**Plus a regression the verification round caught in #5786's own revision**: the descent into *run-created* skip-named stores had been silently lost, leaving a fresh `node_modules` invisible to the scan *and* unbound. Restored, with a lane case pinning it.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- The `mari-guard-sibling-paths` lane asserts both backends' **generated rules** functionally: bwrap args ro-bind all stores (nested included) with the cache `--bind` stacking after its parent's ro-bind; the seatbelt profile places the cache allow after the store deny (last-match-wins), order-agnostically. A real detached leader is spawned and group-killed on POSIX; the ESRCH fallback is platform-gated honestly; the run-created-store descent and pre-existing-store skip are both pinned.
- The verification review (two agents, this repo's real Vite probed) produced 9 findings; all are folded in or documented: `.vite-temp` carve-out, workspace canonicalization, the lost-descent regression, the escalation-timer clear, macOS-crash-orphan and symlink-store residuals documented at the helper, lane realpath wrap and honest test gating.
- All Mari lanes pass; server lint clean; zero-error build. **Not exercised against live bwrap/seatbelt** — rule generation is covered functionally; the mount/precedence semantics are cited platform behavior.

## Docs and release impact

- [x] No docs changes needed (CHANGELOG entry included)
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable — sandbox policy and process teardown only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installed-package stores, including nested and pnpm directories, are now read-only in the sandbox.
  * Build-tool cache folders remain writable for supported workflows.
  * Stopping a sandboxed command now terminates background processes as well.
  * Improved protection for workspace paths and package-store symbolic links.
  * Newly created package stores are fully checked after sandboxed execution.
  * Sandbox teardown is more reliable across supported platforms, including process cleanup and link restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->