### PR TITLE
fix(client): record reload and render recovery diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Support Diagnostics includes local client build and recovery events to investigate mobile reloads and black screens without collecting chat content or changing appearance settings (#5870).
 - Advanced Parameters can keep a chosen number of eligible past assistant reasoning blocks when exclusion is off (default 1; 0 keeps all), preserving provider-native reasoning and local custom-tag thinking. The allowance follows the target-character context; prompt previews, strict role formatting, reasoning-only turns, and encrypted tool-round continuation retain the correct reasoning. Plain-text and structured replay payloads count toward the context estimate; a provider session avoids resending rejected encrypted items without deleting saved thoughts (#5785).
 - Added example text to Assistant Reasoning Prefill without changing saved values (#5864).
 - Illustrator accepts Run Interval 0 for manual-only generation, including typed and stepped cadence in record-based editors, preserving Gallery actions while stopping automatic runs (Marinara-Agents #629).

--- a/e2e/client-runtime-diagnostics.e2e.ts
+++ b/e2e/client-runtime-diagnostics.e2e.ts
@@ -1,0 +1,181 @@
+import { expect, test, type Page } from "@playwright/test";
+import { readFileSync } from "node:fs";
+
+const appVersion = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version as string;
+type RuntimeReport = {
+  build: string;
+  page: string;
+  persistence: string;
+  navigation: string;
+  events: Array<{ page: string; kind: string; reason?: string; error?: string; reactCode?: number }>;
+};
+
+async function prepareClient(page: Page, chatId?: string) {
+  await page.route("**/api/app-settings/ui", (route) => route.fulfill({ json: { value: "" } }));
+  await page.addInitScript(
+    ({ version, id }) => {
+      localStorage.setItem("marinara:whats-new:seen-version", version);
+      if (id) localStorage.setItem("marinara-active-chat-id", id);
+      if (!localStorage.getItem("marinara-engine-ui")) {
+        localStorage.setItem(
+          "marinara-engine-ui",
+          JSON.stringify({
+            state: {
+              hasCompletedOnboarding: true,
+              rightPanelOpen: !id,
+              rightPanel: "settings",
+              settingsTab: "advanced",
+              sidebarOpen: false,
+              messagesPerPage: 20,
+              chatHelpSeenModes: ["conversation", "roleplay", "game"],
+            },
+            version: 65,
+          }),
+        );
+      }
+      let copied = "";
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: {
+          writeText: async (value: string) => {
+            copied = value;
+          },
+          readText: async () => copied,
+        },
+      });
+    },
+    { version: appVersion, id: chatId },
+  );
+}
+
+async function copyReport(page: Page) {
+  await page.getByRole("button", { name: "Copy Support Diagnostics", exact: true }).click();
+  await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toContain("Client runtime:");
+  const report = await page.evaluate(() => navigator.clipboard.readText());
+  const line = report.split("\n").find((line) => line.startsWith("Client runtime: "));
+  expect(line).toBeTruthy();
+  return { report, runtime: JSON.parse(line!.slice("Client runtime: ".length)) as RuntimeReport };
+}
+
+test("support diagnostics persists private-safe client errors and marks the existing Refresh App action", async ({
+  page,
+}, testInfo) => {
+  await prepareClient(page);
+  await page.goto("/");
+  const before = await copyReport(page);
+  expect(before.runtime.build).toContain(appVersion);
+  const sourcePage = before.runtime.page;
+  await page.evaluate(() => {
+    const error = new TypeError("PRIVATE_CHAT_TEXT: Minified React error #185");
+    error.stack = "TypeError: PRIVATE_CHAT_TEXT\n at https://private-host.test/assets/ChatArea-probe.js:1:42";
+    window.dispatchEvent(new ErrorEvent("error", { error }));
+  });
+  await page.getByRole("button", { name: "Refresh App", exact: true }).click();
+  await expect(page).toHaveURL(/spa_refresh=/);
+  const { report, runtime } = await copyReport(page);
+  expect(runtime.persistence).toBe("local");
+  expect(runtime.page).not.toBe(sourcePage);
+  expect(runtime.events).toContainEqual(
+    expect.objectContaining({ kind: "javascript-error", error: "TypeError", reactCode: 185, page: sourcePage }),
+  );
+  expect(runtime.events).toContainEqual(
+    expect.objectContaining({ kind: "reload-requested", reason: "settings-refresh", page: sourcePage }),
+  );
+  expect(report).not.toContain("PRIVATE_CHAT_TEXT");
+  expect(report).not.toContain("private-host");
+  await testInfo.attach("copied-client-diagnostics", { body: report, contentType: "text/plain" });
+  await testInfo.attach("support-diagnostics", { body: await page.screenshot(), contentType: "image/png" });
+});
+
+test("preload recovery is marked but an unrequested browser reload is not attributed to a crash or app recovery", async ({
+  page,
+}) => {
+  await prepareClient(page);
+  await page.goto("/");
+  const before = await copyReport(page);
+  await page.reload();
+  const ordinary = await copyReport(page);
+  expect(ordinary.runtime.navigation).toBe("reload");
+  expect(ordinary.runtime.page).not.toBe(before.runtime.page);
+  expect(ordinary.runtime.events.some((event) => event.kind === "reload-requested")).toBe(false);
+  await page.evaluate(() => {
+    const event = new Event("vite:preloadError", { cancelable: true });
+    Object.assign(event, { payload: new TypeError("PRIVATE_IMAGE_URL") });
+    window.dispatchEvent(event);
+  });
+  await expect(page).toHaveURL(/chunk_reload=/);
+  const recovered = await copyReport(page);
+  expect(recovered.runtime.events).toContainEqual(
+    expect.objectContaining({ kind: "reload-requested", reason: "chunk-recovery", page: ordinary.runtime.page }),
+  );
+  expect(recovered.report).not.toContain("PRIVATE_IMAGE_URL");
+  expect(recovered.runtime.page).not.toBe(ordinary.runtime.page);
+});
+
+test("Roleplay edit and older-message scrolling keeps the page alive and records only an edit milestone", async ({
+  page,
+  request,
+}, testInfo) => {
+  const created = await request.post("/api/chats", {
+    data: { name: "Disposable edit scroll proof", mode: "roleplay", characterIds: [] },
+  });
+  expect(created.ok()).toBeTruthy();
+  const chat = (await created.json()) as { id: string };
+  const ids: string[] = [];
+  let navigations = 0;
+  const errors: string[] = [];
+  page.on("framenavigated", (frame) => {
+    if (frame === page.mainFrame()) navigations++;
+  });
+  page.on("pageerror", (error) => errors.push(error.message));
+  try {
+    for (let index = 0; index < 60; index++) {
+      const saved = await request.post(`/api/chats/${chat.id}/messages`, {
+        data: {
+          role: index % 2 ? "assistant" : "user",
+          content: `Saved reply ${index + 1}. ${"An earlier paragraph remains readable while scrolling. ".repeat(12)}`,
+        },
+      });
+      expect(saved.ok()).toBeTruthy();
+      ids.push(((await saved.json()) as { id: string }).id);
+    }
+    await prepareClient(page, chat.id);
+    await page.goto("/");
+    const transcript = page.locator("[data-chat-scroll]");
+    const latest = page.locator(`[data-message-id="${ids.at(-1)}"]`);
+    await expect(latest).toBeVisible();
+    // Use the existing edit command so long-message action bars need not be
+    // scrolled into view before the reported edit/scroll sequence starts.
+    await page.evaluate((messageId) => {
+      window.dispatchEvent(new CustomEvent("marinara:start-edit-message", { detail: { messageId } }));
+    }, ids.at(-1));
+    await latest.locator("[data-chat-message-editor]").fill("PRIVATE_EDITED_MESSAGE");
+    await latest.getByRole("button", { name: "Save edit", exact: true }).click();
+    await expect(latest.locator("[data-chat-message-editor]")).toHaveCount(0);
+    await expect(latest).toContainText("PRIVATE_EDITED_MESSAGE");
+    await transcript.evaluate((element) => {
+      element.scrollTop = 0;
+    });
+    await page.getByRole("button", { name: "Load More", exact: true }).click();
+    await expect(page.locator(`[data-message-id="${ids[20]}"]`)).toBeAttached();
+    await transcript.evaluate((element) => {
+      element.scrollTop = 0;
+    });
+    await page.getByRole("button", { name: "Load More", exact: true }).click();
+    await expect(page.locator(`[data-message-id="${ids[0]}"]`)).toBeAttached();
+    await transcript.evaluate((element) => {
+      element.scrollTop = 200;
+    });
+    await expect(page.locator("textarea.mari-chat-input-textarea")).toBeVisible();
+    const recorded = await page.evaluate(() => localStorage.getItem("marinara-client-runtime-events") ?? "");
+    const events = JSON.parse(recorded) as RuntimeReport["events"];
+    expect(events.some((event) => event.kind === "message-edited")).toBe(true);
+    expect(events.some((event) => event.kind === "reload-requested")).toBe(false);
+    expect(recorded).not.toContain("PRIVATE_EDITED_MESSAGE");
+    expect(navigations).toBe(1);
+    expect(errors).toEqual([]);
+    await testInfo.attach("edit-and-scroll", { body: await page.screenshot(), contentType: "image/png" });
+  } finally {
+    await request.delete(`/api/chats/${chat.id}`);
+  }
+});

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -36,7 +36,8 @@ import {
 import { useSidecarStore } from "./stores/sidecar.store";
 import { useDialogStore } from "./stores/dialog.store";
 import { api, requestTimeoutSignal } from "./lib/api-client";
-import { forceRefreshSpa } from "./lib/browser-runtime";
+import { forceRefreshSpa, reloadBrowser } from "./lib/browser-runtime";
+import { recordClientError } from "./lib/client-runtime-diagnostics";
 import { showAppUpdatePrompt } from "./lib/app-update-prompt";
 import { formatRuntimeBuild, getServerRuntimeBuild, isRuntimeBuildCurrent } from "./lib/runtime-build";
 import {
@@ -150,6 +151,7 @@ export class AppRecoveryBoundary extends Component<{ children: ReactNode }, { er
   }
 
   componentDidCatch(error: unknown, info: ErrorInfo) {
+    recordClientError("render-error", error);
     console.error("[AppRecoveryBoundary] Unhandled render error", error, info.componentStack);
   }
 
@@ -162,7 +164,7 @@ export class AppRecoveryBoundary extends Component<{ children: ReactNode }, { er
     } catch {
       /* ignore storage reset errors */
     }
-    window.location.reload();
+    reloadBrowser("reset-ui");
   };
 
   render() {
@@ -190,7 +192,7 @@ export class AppRecoveryBoundary extends Component<{ children: ReactNode }, { er
               <div className="mt-4 flex flex-wrap gap-2">
                 <button
                   type="button"
-                  onClick={() => window.location.reload()}
+                  onClick={() => reloadBrowser("render-recovery")}
                   className="mari-chrome-control mari-chrome-control--selected px-3 py-2 text-sm"
                 >
                   {t("ui.app.recovery.reload")}
@@ -472,6 +474,7 @@ function isTextEntryFocused() {
 
 async function recoverFromVersionSkew(serverVersion: string) {
   await forceRefreshSpa({
+    reason: "version-update",
     queryParamKey: "v",
     queryParamValue: serverVersion,
   });

--- a/packages/client/src/components/capabilities/CapabilityElement.tsx
+++ b/packages/client/src/components/capabilities/CapabilityElement.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, RefreshCw, X } from "lucide-react";
 import type { CapabilityLocalizationContext } from "@marinara-engine/shared";
 import { retryCapabilityClientModule, useCapabilityClientModuleState } from "../../hooks/use-capability-packages";
 import { cn } from "../../lib/utils";
+import { reloadBrowser } from "../../lib/browser-runtime";
 
 type CapabilityElementNode = HTMLElement & {
   capabilityProps?: Record<string, unknown>;
@@ -308,7 +309,7 @@ function CapabilityRefreshState({
   const { t } = useTranslation();
   const displayName = capabilityName(packageId, name);
   const title = t("capabilities.refresh.title", { name: displayName });
-  const refresh = () => window.location.reload();
+  const refresh = () => reloadBrowser("capability-refresh");
   if (view === "toolbar") {
     return (
       <button

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -14,6 +14,7 @@ import { useChatGalleryFilenameIndex } from "../../hooks/use-characters";
 import { useReducedAmbientEffects } from "../../hooks/use-reduced-ambient-effects";
 import { PendingTypingDots } from "./PendingTypingDots";
 import { ChatImagePreview } from "./ChatImagePreview";
+import { recordClientRuntimeEvent } from "../../lib/client-runtime-diagnostics";
 import { isDiceRollResult } from "../dice/AnimatedDiceRoll";
 import { DiceMessageContent } from "./ConversationMessageShared";
 import {
@@ -2354,6 +2355,7 @@ export const ChatMessage = memo(function ChatMessage({
         setEditSavePending(true);
         try {
           await onEdit?.(message.id, content);
+          recordClientRuntimeEvent("message-edited");
         } catch {
           toast.error(localizeUi("ui.chat.chatmessage.couldNotSaveThatEdit"));
           return;

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -169,6 +169,7 @@ import { useAgentImportPolicy, useSetAgentImportsEnabled } from "../../hooks/use
 import { DraftNumberInput } from "../ui/DraftNumberInput";
 import { ExportFormatDialog, type ExportFormatChoice } from "../ui/ExportFormatDialog";
 import { inspectCharacterFilesForEmbeddedLorebooks } from "../../lib/character-import";
+import { getClientRuntimeDiagnostics } from "../../lib/client-runtime-diagnostics";
 import {
   detectBrowserGpu,
   formatSupportDiagnostics,
@@ -7778,6 +7779,7 @@ function AdvancedSettings() {
       .catch(() => undefined);
     const copied = await copyToClipboard(
       formatSupportDiagnostics({
+        clientRuntime: getClientRuntimeDiagnostics(),
         mariActingOn,
         // Distinguish "the server never answered" (frozen host) from ordinary
         // missing fields so support reports carry the signal (#5657): the

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -6,6 +6,7 @@ import { characterDataSchema, normalizeAvatarCrop, type AvatarCrop } from "@mari
 import { useQueryClient, type InfiniteData, type QueryClient } from "@tanstack/react-query";
 import { toast, type ExternalToast } from "sonner";
 import { api, ApiError, isPassiveStreamDisconnect } from "../lib/api-client";
+import { recordClientRuntimeEvent } from "../lib/client-runtime-diagnostics";
 import {
   formatAgentFailuresToast,
   illustratorRetryTargetsForFailures,
@@ -2659,6 +2660,7 @@ export function useGenerate() {
             }
 
             case "illustration": {
+              recordClientRuntimeEvent("image-arrived");
               illustrationSettled = true;
               const illData = event.data as {
                 messageId: string;
@@ -3760,6 +3762,7 @@ export function useGenerate() {
               break;
             }
             case "illustration": {
+              recordClientRuntimeEvent("image-arrived");
               const illData = event.data as { messageId: string; imageUrl: string; reason?: string };
               toast(illData.reason ? `🎨 ${illData.reason}` : "🎨 Scene illustration generated");
               // Refresh messages so the illustration attachment appears

--- a/packages/client/src/lib/app-update-prompt.ts
+++ b/packages/client/src/lib/app-update-prompt.ts
@@ -1,5 +1,6 @@
 import { toast } from "sonner";
 import { translate } from "../localization/i18n";
+import { reloadBrowser } from "./browser-runtime";
 
 const APP_UPDATE_TOAST_ID = "marinara-app-update";
 let latestRefresh: (() => void | Promise<void>) | null = null;
@@ -15,7 +16,7 @@ export function showAppUpdatePrompt(refresh: () => void | Promise<void>) {
       onClick: () => {
         void Promise.resolve()
           .then(() => latestRefresh?.())
-          .catch(() => window.location.reload());
+          .catch(() => reloadBrowser("update-fallback"));
       },
     },
   });

--- a/packages/client/src/lib/browser-runtime.ts
+++ b/packages/client/src/lib/browser-runtime.ts
@@ -1,7 +1,15 @@
+import { recordClientReload, type ClientReloadReason } from "./client-runtime-diagnostics";
+
 type ForceRefreshSpaOptions = {
   queryParamKey?: string;
   queryParamValue?: string;
+  reason?: ClientReloadReason;
 };
+
+export function reloadBrowser(reason: ClientReloadReason) {
+  recordClientReload(reason);
+  window.location.reload();
+}
 
 async function getServiceWorkerRegistrations() {
   if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
@@ -40,8 +48,10 @@ export async function clearBrowserRuntimeCaches() {
 export async function forceRefreshSpa({
   queryParamKey = "spa_refresh",
   queryParamValue = Date.now().toString(),
+  reason = "settings-refresh",
 }: ForceRefreshSpaOptions = {}) {
   await clearBrowserRuntimeCaches();
+  recordClientReload(reason);
   replaceCurrentUrl(queryParamKey, queryParamValue);
 }
 
@@ -75,9 +85,9 @@ export function registerPreloadErrorRecovery() {
       sessionStorage.setItem(PRELOAD_RECOVERY_AT_KEY, Date.now().toString());
       // We handle recovery via a full reload; stop Vite from also rethrowing.
       event.preventDefault();
-      void forceRefreshSpa({ queryParamKey: "chunk_reload" }).catch(() => {
+      void forceRefreshSpa({ queryParamKey: "chunk_reload", reason: "chunk-recovery" }).catch(() => {
         // Cache clearing failed; attempt a plain reload as a last resort.
-        window.location.reload();
+        reloadBrowser("chunk-recovery");
       });
     } catch {
       // sessionStorage unavailable or recovery failed → let Vite rethrow the error.

--- a/packages/client/src/lib/client-runtime-diagnostics.ts
+++ b/packages/client/src/lib/client-runtime-diagnostics.ts
@@ -1,0 +1,238 @@
+const STORAGE_KEY = "marinara-client-runtime-events";
+const MAX_EVENTS = 16;
+const EVENT_KINDS = [
+  "page-start",
+  "page-show",
+  "page-hide",
+  "visible",
+  "hidden",
+  "reload-requested",
+  "chunk-error",
+  "javascript-error",
+  "promise-error",
+  "render-error",
+  "message-edited",
+  "image-arrived",
+] as const;
+const RELOAD_REASONS = [
+  "chunk-recovery",
+  "version-update",
+  "service-worker-update",
+  "update-fallback",
+  "settings-refresh",
+  "render-recovery",
+  "reset-ui",
+  "capability-refresh",
+] as const;
+const ERROR_NAMES = [
+  "Error",
+  "TypeError",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "URIError",
+  "EvalError",
+  "Unknown",
+] as const;
+export type ClientReloadReason = (typeof RELOAD_REASONS)[number];
+type EventKind = (typeof EVENT_KINDS)[number];
+type RuntimeEvent = {
+  at: number;
+  page: string;
+  build: string;
+  kind: EventKind;
+  reason?: ClientReloadReason;
+  error?: (typeof ERROR_NAMES)[number];
+  reactCode?: number;
+  asset?: string;
+  view?: [number, number, number, number];
+};
+let events: RuntimeEvent[] = [];
+let page = "";
+let build = "unavailable";
+let storageAvailable = true;
+let stopListening: (() => void) | null = null;
+const seenErrors = new Set<string>();
+
+function isOneOf<T extends string>(value: unknown, choices: readonly T[]): value is T {
+  return typeof value === "string" && choices.includes(value as T);
+}
+
+function parseEvent(value: unknown): RuntimeEvent | null {
+  if (!value || typeof value !== "object") return null;
+  const entry = value as Record<string, unknown>;
+  if (
+    typeof entry.at !== "number" ||
+    !Number.isInteger(entry.at) ||
+    entry.at < 0 ||
+    entry.at > 8_640_000_000_000_000 ||
+    typeof entry.page !== "string" ||
+    !/^[a-z0-9-]{1,40}$/.test(entry.page) ||
+    typeof entry.build !== "string" ||
+    !/^[a-zA-Z0-9.+-]{1,80}$/.test(entry.build) ||
+    !isOneOf(entry.kind, EVENT_KINDS)
+  )
+    return null;
+  // Rebuild the object: never pass stored unknown fields through to the report.
+  const result: RuntimeEvent = { at: entry.at, page: entry.page, build: entry.build, kind: entry.kind };
+  if (isOneOf(entry.reason, RELOAD_REASONS)) result.reason = entry.reason;
+  if (isOneOf(entry.error, ERROR_NAMES)) result.error = entry.error;
+  if (
+    typeof entry.reactCode === "number" &&
+    Number.isInteger(entry.reactCode) &&
+    entry.reactCode >= 0 &&
+    entry.reactCode <= 100_000
+  )
+    result.reactCode = entry.reactCode;
+  // Asset basenames/positions only: no URLs, query strings, raw messages or stacks.
+  if (typeof entry.asset === "string" && /^[a-zA-Z0-9_-]{1,100}\.js:\d{1,8}:\d{1,8}$/.test(entry.asset))
+    result.asset = entry.asset;
+  if (
+    Array.isArray(entry.view) &&
+    entry.view.length === 4 &&
+    entry.view.every((n) => typeof n === "number" && Number.isFinite(n) && Math.abs(n) <= 1_000_000)
+  )
+    result.view = [...entry.view] as RuntimeEvent["view"];
+  return result;
+}
+
+function readEvents(): RuntimeEvent[] {
+  if (!storageAvailable) return events;
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(STORAGE_KEY);
+  } catch {
+    storageAvailable = false;
+    return events;
+  }
+  try {
+    // Ignore malformed/oversized records. Reconstruct through the allowlist so
+    // unknown fields in storage can never leak into a copied support report.
+    const parsed: unknown = raw && raw.length <= 16_384 ? JSON.parse(raw) : [];
+    if (!Array.isArray(parsed)) return [];
+    return parsed.slice(-MAX_EVENTS).flatMap((entry) => {
+      const result = parseEvent(entry);
+      return result ? [result] : [];
+    });
+  } catch {
+    return [];
+  }
+}
+
+function viewport(): RuntimeEvent["view"] {
+  // Sample only on diagnostic events, never on a scroll/animation timer.
+  const root = document.getElementById("root")?.getBoundingClientRect();
+  return [
+    Math.round(window.visualViewport?.height ?? window.innerHeight),
+    Math.round(window.visualViewport?.offsetTop ?? 0),
+    Math.round(root?.height ?? 0),
+    Math.round(root?.top ?? 0),
+  ];
+}
+
+function append(kind: EventKind, details: Partial<RuntimeEvent> = {}) {
+  if (!page) return;
+  try {
+    const result = parseEvent({ ...details, at: Date.now(), page, build, kind, view: viewport() });
+    if (!result) return;
+    events = [...readEvents(), result].slice(-MAX_EVENTS);
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(events));
+    } catch {
+      storageAvailable = false;
+    }
+  } catch {
+    // Diagnostics must never break rendering, editing or an intentional reload.
+  }
+}
+
+export function recordClientRuntimeEvent(kind: "message-edited" | "image-arrived") {
+  append(kind);
+}
+
+export function recordClientReload(reason: ClientReloadReason) {
+  append("reload-requested", { reason });
+}
+
+export function recordClientError(
+  kind: "javascript-error" | "promise-error" | "render-error" | "chunk-error",
+  error: unknown,
+) {
+  try {
+    const nativeError = error instanceof Error ? error : null;
+    const name = nativeError?.name;
+    const reactCode = nativeError?.message.match(/Minified React error #(\d+)/)?.[1];
+    const asset = nativeError?.stack?.match(/\/assets\/([a-zA-Z0-9_-]{1,100}\.js:\d{1,8}:\d{1,8})(?:\D|$)/)?.[1];
+    const details = {
+      error: isOneOf(name, ERROR_NAMES) ? name : ("Unknown" as const),
+      ...(reactCode ? { reactCode: Number(reactCode) } : {}),
+      ...(asset ? { asset } : {}),
+    };
+    const signature = JSON.stringify([kind, details]);
+    // A render/rejection loop must not become a synchronous storage-write loop.
+    if (seenErrors.has(signature) || seenErrors.size >= MAX_EVENTS) return;
+    seenErrors.add(signature);
+    append(kind, details);
+  } catch {
+    // Error objects can have throwing custom properties; ignore them safely.
+  }
+}
+
+/**
+ * Bounded, local-only observations, not crash detection. Page IDs keep different
+ * tabs distinguishable. A new page without a reload marker has an UNKNOWN cause.
+ * ponytail: event-only history cannot identify an OS/GPU process kill or record
+ * an already-dead renderer. Use a physical-device crash trace if events are silent.
+ */
+export function registerClientRuntimeDiagnostics(clientBuild: string) {
+  if (stopListening) return stopListening;
+  page = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  build = /^[a-zA-Z0-9.+-]{1,80}$/.test(clientBuild) ? clientBuild : "unavailable";
+  storageAvailable = true;
+  events = [];
+  seenErrors.clear();
+  const onError = (event: ErrorEvent) => recordClientError("javascript-error", event.error);
+  const onRejection = (event: PromiseRejectionEvent) => recordClientError("promise-error", event.reason);
+  const onPreloadError = (event: Event) =>
+    recordClientError("chunk-error", (event as Event & { payload?: unknown }).payload);
+  const onPageShow = () => append("page-show");
+  const onPageHide = () => append("page-hide");
+  const onVisibility = () => append(document.visibilityState === "visible" ? "visible" : "hidden");
+  window.addEventListener("error", onError);
+  window.addEventListener("unhandledrejection", onRejection);
+  window.addEventListener("vite:preloadError", onPreloadError);
+  window.addEventListener("pageshow", onPageShow);
+  window.addEventListener("pagehide", onPageHide);
+  document.addEventListener("visibilitychange", onVisibility);
+  append("page-start");
+  stopListening = () => {
+    window.removeEventListener("error", onError);
+    window.removeEventListener("unhandledrejection", onRejection);
+    window.removeEventListener("vite:preloadError", onPreloadError);
+    window.removeEventListener("pageshow", onPageShow);
+    window.removeEventListener("pagehide", onPageHide);
+    document.removeEventListener("visibilitychange", onVisibility);
+    stopListening = null;
+    page = "";
+  };
+  return stopListening;
+}
+
+export function getClientRuntimeDiagnostics() {
+  const history = readEvents();
+  const navigation = (performance.getEntriesByType("navigation")[0] as PerformanceNavigationTiming | undefined)?.type;
+  return {
+    build,
+    page,
+    persistence: storageAvailable ? "local" : "unavailable",
+    navigation: navigation ?? "unknown",
+    standalone:
+      window.matchMedia("(display-mode: standalone)").matches ||
+      (navigator as Navigator & { standalone?: boolean }).standalone === true,
+    // view = visual viewport height/offsetTop, root height/top, all in CSS px.
+    view: viewport(),
+    events: history,
+  };
+}
+
+export type ClientRuntimeDiagnostics = ReturnType<typeof getClientRuntimeDiagnostics>;

--- a/packages/client/src/lib/support-diagnostics.ts
+++ b/packages/client/src/lib/support-diagnostics.ts
@@ -1,4 +1,7 @@
+import type { ClientRuntimeDiagnostics } from "./client-runtime-diagnostics";
+
 export interface SupportDiagnostics {
+  clientRuntime?: ClientRuntimeDiagnostics;
   version: string;
   build: string;
   commit: string | null;
@@ -193,6 +196,9 @@ export function formatSupportDiagnostics(diagnostics: SupportDiagnostics): strin
     }`,
     `Client OS: ${available(diagnostics.clientOs)}`,
     `Browser / app shell: ${available(diagnostics.browser)}`,
+    // Like the existing server fields, this is an English technical support
+    // report, not UI copy. Event names are stable diagnostic protocol values.
+    `Client runtime: ${diagnostics.clientRuntime ? JSON.stringify(diagnostics.clientRuntime) : "Unavailable"}`,
     `GPU: ${available(diagnostics.gpu)}`,
     `Active connection: ${available(diagnostics.connectionName)}`,
     `Connection provider: ${available(diagnostics.connectionProvider)}`,

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -7535,7 +7535,7 @@
   "ui.panels.advancedsettings.supportDiagnostics": "Support Diagnostics",
   "ui.panels.advancedsettings.supportDiagnosticsCopied": "Support diagnostics copied.",
   "ui.panels.advancedsettings.supportDiagnosticsCopyFailed": "Could not copy support diagnostics.",
-  "ui.panels.advancedsettings.supportDiagnosticsDescription": "Copy version, build, system, GPU, active model and recent client recovery events for a support ticket. Recovery events stay on this device and exclude chat content. Includes the phrase Professor Mari last treated as a request, when recorded.",
+  "ui.panels.advancedsettings.supportDiagnosticsDescription": "Copy version, build, system, GPU, active model and recent client recovery events for a support ticket. Recovery events exclude chat content and are stored locally, not sent automatically. They are included when you copy this report. Includes the phrase Professor Mari last treated as a request, when recorded.",
   "ui.panels.advancedsettings.switching": "Switching…",
   "ui.panels.advancedsettings.switchToValue1": "Switch to {{value1}}",
   "ui.panels.advancedsettings.target": "target (",

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -7535,7 +7535,7 @@
   "ui.panels.advancedsettings.supportDiagnostics": "Support Diagnostics",
   "ui.panels.advancedsettings.supportDiagnosticsCopied": "Support diagnostics copied.",
   "ui.panels.advancedsettings.supportDiagnosticsCopyFailed": "Could not copy support diagnostics.",
-  "ui.panels.advancedsettings.supportDiagnosticsDescription": "Copy your version, build, system, GPU, and active model details for a support ticket. Includes the phrase Professor Mari last treated as a request, when one was recorded.",
+  "ui.panels.advancedsettings.supportDiagnosticsDescription": "Copy version, build, system, GPU, active model and recent client recovery events for a support ticket. Recovery events stay on this device and exclude chat content. Includes the phrase Professor Mari last treated as a request, when recorded.",
   "ui.panels.advancedsettings.switching": "Switching…",
   "ui.panels.advancedsettings.switchToValue1": "Switch to {{value1}}",
   "ui.panels.advancedsettings.target": "target (",

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -9,6 +9,9 @@ import { showAppUpdatePrompt } from "./lib/app-update-prompt";
 import { initializeLocalization } from "./localization/i18n";
 import { LocalizationProvider } from "./localization/LocalizationProvider";
 import { useUIStore } from "./stores/ui.store";
+import { APP_VERSION } from "@marinara-engine/shared";
+import { formatRuntimeBuild } from "./lib/runtime-build";
+import { recordClientReload, registerClientRuntimeDiagnostics } from "./lib/client-runtime-diagnostics";
 import "./styles/globals.css";
 
 // Installed capability clients can outlive the Engine build that produced
@@ -17,6 +20,7 @@ import "./styles/globals.css";
 // client is imported.
 Object.assign(globalThis, { React, ReactDOM });
 
+registerClientRuntimeDiagnostics(formatRuntimeBuild(APP_VERSION, __MARINARA_BUILD_COMMIT__));
 // Prevent Chrome/Edge from sleeping this tab
 startKeepAlive();
 installCsrfFetchShim();
@@ -61,7 +65,10 @@ function registerServiceWorker() {
         const updateSW = registerSW({
           immediate: true,
           onNeedRefresh() {
-            showAppUpdatePrompt(() => updateSW(true));
+            showAppUpdatePrompt(() => {
+              recordClientReload("service-worker-update");
+              return updateSW(true);
+            });
           },
           onRegisteredSW(_swUrl: string, registration?: ServiceWorkerRegistration) {
             if (!registration) {

--- a/scripts/regressions/client-runtime-diagnostics.regression.ts
+++ b/scripts/regressions/client-runtime-diagnostics.regression.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import {
+  getClientRuntimeDiagnostics,
+  recordClientError,
+  recordClientReload,
+  recordClientRuntimeEvent,
+  registerClientRuntimeDiagnostics,
+} from "../../packages/client/src/lib/client-runtime-diagnostics.js";
+import {
+  forceRefreshSpa,
+  registerPreloadErrorRecovery,
+  reloadBrowser,
+} from "../../packages/client/src/lib/browser-runtime.js";
+import { formatSupportDiagnostics } from "../../packages/client/src/lib/support-diagnostics.js";
+
+const key = "marinara-client-runtime-events";
+const privateText = "PRIVATE_PROMPT_AND_CHAT_TEXT";
+const data = new Map<string, string>();
+let writes = 0;
+let storageThrows = false;
+let writeThrows = false;
+let stop: (() => void) | undefined;
+const storage = {
+  getItem(name: string) {
+    if (storageThrows) throw new Error("storage blocked");
+    return data.get(name) ?? null;
+  },
+  setItem(name: string, value: string) {
+    writes++;
+    if (storageThrows || writeThrows) throw new Error("storage full");
+    data.set(name, value);
+  },
+};
+const documentStub = Object.assign(new EventTarget(), {
+  visibilityState: "visible",
+  getElementById: () => ({ getBoundingClientRect: () => ({ height: 800, top: 0 }) }),
+});
+const navigations: string[] = [];
+const windowStub = Object.assign(new EventTarget(), {
+  innerHeight: 800,
+  visualViewport: { height: 500, offsetTop: 12 },
+  matchMedia: () => ({ matches: true }),
+  location: {
+    href: "https://example.test/",
+    reload() {
+      assert.equal(getClientRuntimeDiagnostics().events.at(-1)?.kind, "reload-requested");
+      navigations.push("reload");
+    },
+    replace(url: string) {
+      assert.equal(getClientRuntimeDiagnostics().events.at(-1)?.kind, "reload-requested");
+      navigations.push(url);
+    },
+  },
+});
+const stubs = {
+  window: windowStub,
+  document: documentStub,
+  localStorage: storage,
+  sessionStorage: {
+    getItem: (name: string) => data.get(name) ?? null,
+    setItem: (name: string, value: string) => data.set(name, value),
+  },
+  navigator: { standalone: true },
+  performance: { getEntriesByType: () => [{ type: "reload" }] },
+};
+const previous = Object.fromEntries(
+  Object.keys(stubs).map((name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)]),
+);
+for (const [name, value] of Object.entries(stubs))
+  Object.defineProperty(globalThis, name, { configurable: true, value });
+const start = () => {
+  stop?.();
+  stop = registerClientRuntimeDiagnostics("2.4.5+abcd1234");
+};
+
+try {
+  // Old-page observations survive reopening. Unknown stored fields never do.
+  data.set(
+    key,
+    JSON.stringify([
+      {
+        at: 1,
+        page: "old-page",
+        build: "2.4.5+old",
+        kind: "reload-requested",
+        reason: "chunk-recovery",
+        secret: privateText,
+      },
+    ]),
+  );
+  start();
+  const first = getClientRuntimeDiagnostics();
+  assert.equal(first.events[0]?.reason, "chunk-recovery");
+  assert.equal(first.events[0]?.page, "old-page");
+  assert.equal(first.build, "2.4.5+abcd1234");
+  assert.deepEqual(first.view, [500, 12, 800, 0]);
+  assert.equal(first.standalone, true);
+  assert.equal(first.navigation, "reload");
+  assert.equal(first.persistence, "local");
+  assert.ok(!JSON.stringify(first).includes(privateText));
+  assert.equal(registerClientRuntimeDiagnostics("duplicate-registration"), stop, "registration is idempotent");
+
+  const error = new TypeError(`${privateText}: Minified React error #185`);
+  error.stack = `TypeError: ${privateText}\n at render (https://private-host.test/assets/ChatArea-abc123.js:1:42)\n at /private/${privateText}.js`;
+  recordClientError("render-error", error);
+  const captured = getClientRuntimeDiagnostics().events.at(-1);
+  assert.equal(captured?.error, "TypeError");
+  assert.equal(captured?.reactCode, 185);
+  assert.equal(captured?.asset, "ChatArea-abc123.js:1:42");
+  const beforeDuplicates = writes;
+  for (let index = 0; index < 1000; index++) recordClientError("render-error", error);
+  assert.equal(writes, beforeDuplicates, "duplicate error storms cannot write on every rejection");
+  windowStub.dispatchEvent(Object.assign(new Event("error"), { error }));
+  windowStub.dispatchEvent(Object.assign(new Event("unhandledrejection"), { reason: error }));
+  assert.ok(getClientRuntimeDiagnostics().events.some((event) => event.kind === "javascript-error"));
+  assert.ok(getClientRuntimeDiagnostics().events.some((event) => event.kind === "promise-error"));
+
+  const hostileError = new Error();
+  Object.defineProperty(hostileError, "name", {
+    get() {
+      throw new Error(privateText);
+    },
+  });
+  assert.doesNotThrow(() => recordClientError("render-error", hostileError));
+  recordClientRuntimeEvent("message-edited");
+  recordClientRuntimeEvent("image-arrived");
+  documentStub.visibilityState = "hidden";
+  documentStub.dispatchEvent(new Event("visibilitychange"));
+  windowStub.dispatchEvent(new Event("pagehide"));
+  const firstPage = getClientRuntimeDiagnostics().page;
+  start();
+  assert.notEqual(getClientRuntimeDiagnostics().page, firstPage);
+  assert.ok(
+    getClientRuntimeDiagnostics().events.some((event) => event.page === firstPage && event.kind === "page-hide"),
+  );
+  assert.ok(getClientRuntimeDiagnostics().events.some((event) => event.kind === "message-edited"));
+  assert.ok(!JSON.stringify(getClientRuntimeDiagnostics()).includes(privateText));
+  assert.ok(!JSON.stringify(getClientRuntimeDiagnostics()).includes("private-host"));
+
+  // Existing full reloads are marked before navigating, without new reloads.
+  const beforeReload = navigations.length;
+  reloadBrowser("render-recovery");
+  await forceRefreshSpa({ reason: "version-update", queryParamKey: "v", queryParamValue: "new" });
+  assert.equal(navigations.length, beforeReload + 2);
+  assert.equal(navigations.at(-1), "https://example.test/?v=new");
+  assert.equal(getClientRuntimeDiagnostics().events.at(-1)?.reason, "version-update");
+
+  registerPreloadErrorRecovery();
+  const preload = Object.assign(new Event("vite:preloadError", { cancelable: true }), { payload: error });
+  windowStub.dispatchEvent(preload);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(preload.defaultPrevented, true);
+  assert.equal(getClientRuntimeDiagnostics().events.at(-1)?.reason, "chunk-recovery");
+  const recovered = navigations.length;
+  const repeated = new Event("vite:preloadError", { cancelable: true });
+  windowStub.dispatchEvent(repeated);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(repeated.defaultPrevented, false, "the existing preload cooldown still exposes repeated failures");
+  assert.equal(navigations.length, recovered);
+
+  // Bounded history, malformed/oversized storage, and no inferred crash cause.
+  for (let index = 0; index < 30; index++) recordClientRuntimeEvent("message-edited");
+  assert.equal(getClientRuntimeDiagnostics().events.length, 16);
+  data.set(key, "malformed");
+  start();
+  assert.equal(getClientRuntimeDiagnostics().events.length, 1);
+  assert.equal(getClientRuntimeDiagnostics().persistence, "local");
+  data.set(key, "x".repeat(20_000));
+  start();
+  assert.equal(getClientRuntimeDiagnostics().events.length, 1);
+  assert.equal(getClientRuntimeDiagnostics().navigation, "reload");
+  assert.ok(!getClientRuntimeDiagnostics().events.some((event) => event.kind === "reload-requested"));
+
+  // Full/blocked storage retains current-page observations in memory and never
+  // prevents recovery; it explicitly cannot promise previous-page persistence.
+  writeThrows = true;
+  recordClientReload("settings-refresh");
+  assert.equal(getClientRuntimeDiagnostics().persistence, "unavailable");
+  assert.equal(getClientRuntimeDiagnostics().events.at(-1)?.reason, "settings-refresh");
+  assert.doesNotThrow(() => reloadBrowser("render-recovery"));
+  storageThrows = true;
+  start();
+  assert.equal(getClientRuntimeDiagnostics().persistence, "unavailable");
+  assert.equal(getClientRuntimeDiagnostics().events.at(-1)?.kind, "page-start");
+  const report = formatSupportDiagnostics({
+    version: "2.4.5",
+    build: "2.4.5+different-server",
+    commit: "different-server",
+    serverOs: "Linux",
+    clientOs: "iOS",
+    browser: "synthetic",
+    gpu: "synthetic",
+    connectionName: null,
+    connectionProvider: null,
+    model: null,
+    clientRuntime: getClientRuntimeDiagnostics(),
+  });
+  assert.ok(report.includes("2.4.5+different-server"));
+  assert.ok(report.includes('"build":"2.4.5+abcd1234"'));
+  assert.ok(report.includes('"persistence":"unavailable"'));
+  assert.ok(!report.includes(privateText));
+  console.info(
+    "Client diagnostics: bounded persistence, reload markers, error deduplication, privacy and unavailable-storage proofs passed.",
+  );
+} finally {
+  stop?.();
+  for (const name of Object.keys(stubs)) {
+    const descriptor = previous[name];
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+    else Reflect.deleteProperty(globalThis, name);
+  }
+}

--- a/scripts/regressions/tsconfig.client-lanes.json
+++ b/scripts/regressions/tsconfig.client-lanes.json
@@ -11,5 +11,5 @@
       "@marinara-engine/shared": ["../../packages/shared/src/index.ts"]
     }
   },
-  "include": ["tts-safari-play-guard.regression.ts"]
+  "include": ["tts-safari-play-guard.regression.ts", "client-runtime-diagnostics.regression.ts"]
 }


### PR DESCRIPTION
## Linked issue

Related to #5870. Keep that issue open: this diagnostic follow-up does not resolve or reproduce the physical-iPhone failure.

## Why this change

The maintainer still sees full-page refreshes and intermittent black screens in the installed iPhone app, including after editing and scrolling without image generation. Existing Support Diagnostics reports server health but cannot distinguish an app-requested client reload from an unknown browser interruption. The approved follow-up adds that missing evidence without another speculative rendering workaround.

## What changed

- Include the actual frontend build, viewport/root geometry and the last 16 local client events in Copy Support Diagnostics.
- Mark existing reload paths, observed JavaScript/React errors, and generic edit/image-arrival milestones. No new automatic reload, polling, scroll listener or network telemetry.
- Reconstruct stored records through a strict allowlist; exclude chat text, prompts, image URLs and raw exception messages/stacks. Deduplicate errors and tolerate unavailable/malformed storage.
- Preserve appearance settings, original image quality, existing preview bounds and generation recovery behavior. No new dependency or version bump.
- Update the canonical English diagnostics description and Unreleased changelog.

## Validation

Automated evidence: implementation `e5186c54a`, privacy wording clarification `4cd59e411`, final integrated head `89cadad2cf7bace2373e46704af3f6c3f7f64640` (staging update #5894; no additional client behavior change):

- `pnpm install` and `pnpm check` passed (including localization, TypeScript, lint and production build); `pnpm check` passed again at the final integrated head.
- Focused Node regression passed: cross-page persistence, privacy, malformed/oversized records, blocked/quota storage, error storms, reload attribution and the existing recovery cooldown.
- 24 focused browser checks passed across desktop Chromium, mobile Chromium and mobile WebKit: copying diagnostics, explicit/unmarked reloads, edit/save/load-older/scroll, bounded previews and saved illustration arrival.
- Production Docker image built and ran successfully. All 24 focused browser checks passed against the bundled Docker app, including a repeat at the final integrated head.
- Full GitHub Node/browser regression matrix, validation, Docker and CodeQL passed at the final integrated head. CodeRabbit completed through that head with no unresolved findings.

Human verification checklist (intentionally unchecked):

- [ ] Manually verify Copy Support Diagnostics after Refresh App on desktop and mobile.
- [ ] Manually verify generation, editing and older-message scrolling on the physical iPhone Home Screen app.
- [ ] Manually check dark/light appearance and unchanged settings.
- [ ] Review the local event record and its privacy boundaries.

## Risk and proof boundaries

- Entrypoints: existing update/reload actions, error boundary, browser lifecycle/errors, edit completion and illustration receipt.
- Positive controls: known reload reasons survive navigation; standard error class, minified React code and asset basename/position remain diagnosable.
- Negative controls: private text/hostnames/unknown stored fields are not copied; duplicate errors do not cause repeated storage writes; an unmarked browser reload is not labeled a crash or GPU failure.
- Browser tests use disposable synthetic fixtures and no paid provider calls. WebKit emulation is not physical iPhone/PWA verification.
- An OS-killed or already-dead renderer may leave no final event. Such a gap remains **unknown**, not proof of a GPU or memory failure. The black-screen cause remains unconfirmed.

## Docs and release impact

Unreleased changelog and existing localized Support Diagnostics description updated. No install/update behavior, user-facing docs files, release metadata or translated-doc changes.

## UI evidence

[Production Docker screenshots, copied synthetic diagnostics and proof notes](https://gist.github.com/SpicyMarinara/c4d70e31c7169eb86ebf0a8ab5a4bc5e). Screenshots inspected for the desktop/mobile control and readable Roleplay transcript. No visual redesign; only the existing diagnostics description changes. The report's React code 185 is an intentionally injected test input, not a reproduced app error.
