### PR TITLE
fix(mari): preserve edits and repair malformed command frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Professor Mari now executes a frame's edits before checking its completion claim, recovers common command formats, and repairs unrecognized commands instead of silently dropping them. Requested lorebook edits use the real save/review path; explicit previews remain read-only (#5966, #5967).
+
 - Restart Server now uses the launcher's console and waits for the old process to exit before replacing it, with bounded shutdown instead of detached or overlapping servers (#5934).
 - Malformed Game combat tags no longer trigger quadratic parsing delays in the browser (#5937).
 - Experience setup preserves explicit package configs without double nesting and accepts larger, bounded setup payloads (#5938).

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -516,7 +516,11 @@ const WORKSPACE_TOOL_DEFINITIONS: WorkspaceToolDefinition[] = [
         js: { type: "string" },
         serverJs: { type: "string" },
         activate: { type: "boolean" },
-        apply: { type: "boolean" },
+        apply: {
+          type: "boolean",
+          description:
+            "Set true for a requested change so it is saved or staged for review. False is an invisible preview: it saves nothing and creates no review card. Updates and deletes preview unless explicitly true.",
+        },
         reason: { type: "string" },
         data: {
           type: "object",
@@ -760,7 +764,7 @@ Revising a saved memory (read its full text, edit it, then write the whole new c
 {"say":"Found the memory. I'll read its full text before editing.","commands":[{"name":"app_data","arguments":{"action":"instruction.get","id":"memory-id"}}],"stop":false}
 {"say":"","commands":[{"name":"app_data","arguments":{"action":"instruction.update","id":"memory-id","data":{"content":"...the full memory text with the requested change applied..."},"reason":"User asked to reword this memory","apply":true}}],"stop":false}
 {"say":"","commands":[{"name":"app_data","arguments":{"action":"agent.create","data":{"name":"Image Marker","description":"Turns IMG_PROMPT markers into image prompts.","resultType":"image_prompt","activationKeywords":["IMG_PROMPT:"],"activationScanDepth":4,"settings":{"customCapabilities":{"trigger_image_generation":true}}},"reason":"User requested a marker-triggered image agent","apply":true}}],"stop":false}
-{"say":"","commands":[{"name":"app_data","arguments":{"action":"lorebook.updateEntry","entryId":"entry-id","patch":{"content":"new content"},"reason":"Update requested by user","apply":false}}],"stop":false}
+{"say":"","commands":[{"name":"app_data","arguments":{"action":"lorebook.updateEntry","entryId":"entry-id","patch":{"content":"new content"},"reason":"Update requested by user","apply":true}}],"stop":false}
 {"say":"","commands":[{"name":"app_data","arguments":{"action":"lorebook.deleteEntry","entryId":"entry-id","reason":"User asked to delete this entry","apply":true}}],"stop":false}
 
 Available command schemas:
@@ -1187,10 +1191,17 @@ export function isAppDataActionName(value: unknown): value is string {
 
 function rawJsonToolCalls(payload: Record<string, unknown>): unknown[] {
   const plural = payload.tool_calls ?? payload.toolCalls ?? payload.commands ?? payload.calls;
-  if (Array.isArray(plural)) return plural;
+  if (plural !== undefined) return Array.isArray(plural) ? plural : [plural];
   const single = payload.tool_call ?? payload.toolCall ?? payload.command;
   if (single !== undefined) return [single];
-  if (typeof payload.name === "string" || isAppDataActionName(payload.action)) return [payload];
+  if (
+    typeof payload.name === "string" ||
+    typeof payload.tool === "string" ||
+    typeof payload.tool_name === "string" ||
+    isRecord(payload.function) ||
+    isAppDataActionName(payload.action)
+  )
+    return [payload];
   return [];
 }
 
@@ -1206,9 +1217,17 @@ function parseJsonCommandCallsFromPayload(payload: Record<string, unknown>): Wor
       : directAction || nameAsAction
         ? "app_data"
         : null;
-    if (!workspaceName) return;
+    if (!workspaceName) {
+      // Reuse the provider parser for tool/parameters and native function wrappers.
+      calls.push(
+        ...parseTextualWorkspaceCommandCalls(
+          JSON.stringify({ ...raw, ...(typeof raw.tool_name === "string" ? { name: raw.tool_name } : {}) }),
+        ),
+      );
+      return;
+    }
 
-    const parsedArguments = parseToolArgumentsValue(raw.arguments ?? raw.args ?? raw.input ?? {});
+    const parsedArguments = parseToolArgumentsValue(raw.arguments ?? raw.args ?? raw.input ?? raw.parameters ?? {});
     const argumentsWithRecoveredAction =
       workspaceName === "app_data" && (directAction || nameAsAction)
         ? {
@@ -1366,6 +1385,8 @@ function stripWorkspaceCommands(content: string): string {
 export function parseAssistantWorkspaceAction(content: string): AssistantWorkspaceAction {
   const { content: contentWithoutJson, matches } = removeJsonActionFrames(content);
   const jsonCommands = matches.flatMap((match) => parseJsonCommandCallsFromPayload(match.payload));
+  const hasInvalidCommands =
+    jsonCommands.length !== matches.reduce((count, match) => count + rawJsonToolCalls(match.payload).length, 0);
   const textualCommands = parseTextualWorkspaceCommandCalls(contentWithoutJson);
   // If JSON frames are present, treat all prose outside them as protocol leakage.
   // Textual calls have no visible-text field, so retain their surrounding prose.
@@ -1390,16 +1411,18 @@ export function parseAssistantWorkspaceAction(content: string): AssistantWorkspa
       )
       .find((value) => value.length > 0)
       ?.slice(0, 2000) ?? null;
-  const commands = dedupeWorkspaceCommandCalls([
-    ...parseXmlCommandCalls(contentWithoutJson),
-    ...jsonCommands,
-    ...textualCommands,
-    ...parseBracketCommandCalls(contentWithoutJson),
-  ]);
-  const protocolValid = matches.length > 0;
+  const commands = hasInvalidCommands
+    ? []
+    : dedupeWorkspaceCommandCalls([
+        ...parseXmlCommandCalls(contentWithoutJson),
+        ...jsonCommands,
+        ...textualCommands,
+        ...parseBracketCommandCalls(contentWithoutJson),
+      ]);
+  const protocolValid = matches.length > 0 && !hasInvalidCommands;
   const explicitStop = [...matches].reverse().find((match) => jsonPayloadStopValue(match.payload) !== undefined);
   const explicitStopValue = explicitStop ? jsonPayloadStopValue(explicitStop.payload) : undefined;
-  const stop = explicitStopValue ?? (commands.length === 0 && protocolValid);
+  const stop = !hasInvalidCommands && (explicitStopValue ?? (commands.length === 0 && protocolValid));
   return {
     visibleText,
     commands,
@@ -1409,14 +1432,16 @@ export function parseAssistantWorkspaceAction(content: string): AssistantWorkspa
     understoodRequest,
     stop,
     protocolValid,
-    assistantHistoryContent: assistantHistoryContentForAction({
-      visibleText,
-      commands,
-      suggestions,
-      plan,
-      awaitingAuthorization,
-      stop,
-    }),
+    assistantHistoryContent: hasInvalidCommands
+      ? content
+      : assistantHistoryContentForAction({
+          visibleText,
+          commands,
+          suggestions,
+          plan,
+          awaitingAuthorization,
+          stop,
+        }),
   };
 }
 
@@ -1977,21 +2002,27 @@ export function resolveWorkspaceMutationVerification(
 }
 
 export function workspaceTextClaimsMutationCompletion(text: string): boolean {
-  const normalized = text.trim().replace(/\s+/gu, " ");
+  const normalized = text.trim().replace(/[’‘]/gu, "'").replace(/\s+/gu, " ");
   if (!normalized) return false;
+  if (/^(?:have|has|did|is|are|was|were)\b[^.!]*\?$/iu.test(normalized)) return false;
   const completedMutation =
     // #5830: "verified" is deliberately absent - it describes a READ, and it
     // is the exact word the guard's own coaching asks the model to produce.
-    "created|updated|changed|deleted|removed|renamed|wrote|written|fixed|implemented|built|installed|imported|exported|saved|enabled|disabled|assigned|linked|unlinked|generated|moved|copied|replaced";
+    "created|updated|changed|deleted|removed|renamed|wrote|written|fixed|implemented|built|installed|imported|exported|saved|enabled|disabled|assigned|linked|unlinked|generated|moved|copied|replaced|added|applied|edited|modified|set|inserted|completed";
+  const adverbs = "(?:(?:successfully|now|just|already)\\s+)*";
   return (
     new RegExp(
-      `\\b(?:i(?:'ve| have)?|we(?:'ve| have)?|it(?:'s| is)?|that(?:'s| is)?)\\s+(?:successfully\\s+)?(?:${completedMutation})\\b`,
+      `\\b(?:i(?:'ve| have)?|we(?:'ve| have)?|it(?:'s| is)?|that(?:'s| is)?)\\s+${adverbs}(?:${completedMutation})\\b`,
       "iu",
     ).test(normalized) ||
+    new RegExp(`\\b(?:is|are|was|were|has been|have been)\\s+${adverbs}(?:${completedMutation})\\b`, "iu").test(
+      normalized,
+    ) ||
     new RegExp(
-      `\\b(?:is|are|was|were|has been|have been)\\s+(?:successfully\\s+)?(?:${completedMutation})\\b`,
+      `^(?:(?:the )?(?:edit|change|update)s?\\s+)?${adverbs}(?:${completedMutation})\\b[^?]*[.!]?$`,
       "iu",
-    ).test(normalized)
+    ).test(normalized) ||
+    /^done[.!]*$/iu.test(normalized)
   );
 }
 
@@ -2070,9 +2101,8 @@ export type WorkspaceClaimAudit = {
  *
  * ACCEPTED RESIDUALS (this is a tripwire, not proof): a state read cannot be
  * semantically matched to the claim it backs, so a read of one thing can
- * pass an unrelated recap-shaped claim; and the claim DETECTOR only sees
- * subject-ful English ("I created..." - a bare participle "Created X." is
- * not detected, see #5830's open detector-design question).
+ * pass an unrelated recap-shaped claim; and the claim detector is an
+ * English-language tripwire, not a semantic proof of what the user asked.
  *
  * "unverified" and "staged" are tolerated mid-run without advancing the
  * watermark, so their debt stays visible to the terminal audit: a later
@@ -2683,6 +2713,7 @@ export class ProfessorMariWorkspaceService {
         };
 
         const rawContent = result.content ?? "";
+        debugLog?.("[debug/professor-mari] Raw response:\n%s", rawContent);
         const parsedAction = parseAssistantWorkspaceAction(rawContent);
         // #5725: Manual defers EVERY described mutation (empty-say command
         // frames - the post-approval pattern - still execute); Bypass never
@@ -2788,10 +2819,66 @@ export class ProfessorMariWorkspaceService {
           for (const chunk of chunkText(content)) args.onEvent({ type: "token", data: chunk });
           break;
         }
-        const claimAudit = auditWorkspaceCompletionClaim(action, commandResultsForContinuity, {
-          auditFrom: claimAuditWatermark,
-          hadPassedClaimAudit,
-        });
+        // Execute this frame before judging its claim; never execute a truncated frame.
+        let commandResults: WorkspaceCommandResult[] = [];
+        if (action.commands.length > 0 && !isLengthFinishReason(result.finishReason)) {
+          // #5725 Manual mode floor: a mutating command in a SILENT frame (no
+          // visible text, so the deferral above cannot describe anything) is
+          // only allowed in a run the user just approved. The flag is
+          // round-scoped; visible frames defer through shouldDeferMutations.
+          // Same superseded-run guard for the round-scoped shared write.
+          controller.signal.throwIfAborted();
+          this.activeRoundManualSilentMutationBlocked =
+            permissionsMode === "manual" && !action.visibleText && !manualApprovalArmed;
+          // #5748 ask-latch mirror: after this run has asked for approval, a
+          // SILENT mutating frame cannot be the user's answer either. Manual is
+          // carved out (its own floor plus manualApprovalArmed govern the
+          // post-Accept silent re-send) and Bypass never holds.
+          this.activeRoundAskLatchSilentMutationBlocked =
+            runAskedForApproval && !action.visibleText && permissionsMode !== "manual" && permissionsMode !== "bypass";
+          commandResults = await this.executeWorkspaceCommandBatch(
+            action.commands,
+            controller.signal,
+            workspaceTrace,
+            args.onEvent,
+          );
+          commandResultsForContinuity.push(...commandResults);
+          // #5740: upgrade the record's outcome to what the batch actually
+          // reported (results align 1:1 with the commands). Gated on this round
+          // carrying mutating commands so a later read-only round can never
+          // relabel an earlier round's failure as applied.
+          if (
+            runUnderstoodRequest !== null &&
+            this.latestUnderstoodRequest === runUnderstoodRequest &&
+            action.commands.some(isMutatingWorkspaceCommand)
+          ) {
+            // A store read-back mismatch is a persistence failure: the record
+            // must never say "applied" while the same result tells Mari not to
+            // claim success (the diagnostics line is the surface users paste).
+            const anyMutatingFailed = commandResults.some(
+              (commandResult, index) =>
+                isMutatingWorkspaceCommand(action.commands[index]!) &&
+                (!commandResult.success || appliedMutationReadBackMismatched(commandResult)),
+            );
+            // #5756: a round that staged a sensitive change applied nothing for
+            // it - report "held" so diagnostics never corroborate a completion
+            // claim the verification guard would refuse.
+            const anyStaged = commandResults.some(isStagedSensitiveMutation);
+            runUnderstoodRequest = {
+              ...runUnderstoodRequest,
+              outcome: anyMutatingFailed ? "failed" : anyStaged ? "held" : "applied",
+            };
+            this.latestUnderstoodRequest = runUnderstoodRequest;
+          }
+        }
+        const claimAudit =
+          (!action.protocolValid && action.commands.length === 0) ||
+          (action.commands.length > 0 && isLengthFinishReason(result.finishReason))
+            ? { issue: null, advanceWatermark: false }
+            : auditWorkspaceCompletionClaim(action, commandResultsForContinuity, {
+                auditFrom: claimAuditWatermark,
+                hadPassedClaimAudit,
+              });
         if (claimAudit.advanceWatermark) {
           claimAuditWatermark = commandResultsForContinuity.length;
           hadPassedClaimAudit = true;
@@ -2809,6 +2896,13 @@ export class ProfessorMariWorkspaceService {
             : midRunClaimRepairRounds <= MAX_MIDRUN_CLAIM_REPAIR_ROUNDS;
           if (withinRepairBudget) {
             messages.push({ role: "assistant", content: action.assistantHistoryContent });
+            if (commandResults.length > 0) {
+              messages.push({
+                role: "user",
+                content: formatCommandResultForPrompt(commandResults),
+                contextKind: "history",
+              });
+            }
             messages.push({
               role: "user",
               content:
@@ -2835,10 +2929,11 @@ export class ProfessorMariWorkspaceService {
         }
         if (action.commands.length === 0 && !action.stop) {
           if (!action.protocolValid) {
+            logger.warn("Professor Mari returned an invalid workspace command frame; requesting protocol repair");
             protocolRepairRounds += 1;
             if (protocolRepairRounds > maxProtocolRepairRounds) {
               const content =
-                "Professor Mari kept returning plain text instead of the required JSON command object, so I stopped before burning more requests. Ask her to continue and she can pick up from the saved trace.";
+                "Professor Mari kept returning invalid workspace command frames, so I stopped before burning more requests. Ask her to continue and she can pick up from the saved trace.";
               assistantText = appendVisibleText(assistantText, content);
               appendTraceStatus(workspaceTrace, content);
               args.onEvent({ type: "status", data: { content, kind: "info", level: "warning" } });
@@ -2859,7 +2954,7 @@ export class ProfessorMariWorkspaceService {
             role: "user",
             content: action.protocolValid
               ? "Continue the same workspace task. Return exactly one JSON object with commands to run now, or set stop to true if the task is complete."
-              : "Your previous assistant message violated the workspace protocol because it was not a JSON object. Do not repeat the prose outside JSON. Return exactly one JSON object now. If work remains, include the next commands and set stop to false. If the task is complete, put the final user-facing text in say and set stop to true.",
+              : "Your previous assistant message violated the workspace protocol: it was not a JSON object or contained an unrecognized command. Use only the listed command names and put each command in the commands array with name and arguments. Do not repeat the prose outside JSON. Return exactly one JSON object now. If work remains, include the next commands and set stop to false. If the task is complete, put the final user-facing text in say and set stop to true.",
             contextKind: "history",
           });
           continue;
@@ -2911,55 +3006,6 @@ export class ProfessorMariWorkspaceService {
 
         if (action.commands.length === 0) {
           break;
-        }
-
-        // #5725 Manual mode floor: a mutating command in a SILENT frame (no
-        // visible text, so the deferral above cannot describe anything) is
-        // only allowed in a run the user just approved. The flag is
-        // round-scoped; visible frames defer through shouldDeferMutations.
-        // Same superseded-run guard for the round-scoped shared write.
-        controller.signal.throwIfAborted();
-        this.activeRoundManualSilentMutationBlocked =
-          permissionsMode === "manual" && !action.visibleText && !manualApprovalArmed;
-        // #5748 ask-latch mirror: after this run has asked for approval, a
-        // SILENT mutating frame cannot be the user's answer either. Manual is
-        // carved out (its own floor plus manualApprovalArmed govern the
-        // post-Accept silent re-send) and Bypass never holds.
-        this.activeRoundAskLatchSilentMutationBlocked =
-          runAskedForApproval && !action.visibleText && permissionsMode !== "manual" && permissionsMode !== "bypass";
-        const commandResults = await this.executeWorkspaceCommandBatch(
-          action.commands,
-          controller.signal,
-          workspaceTrace,
-          args.onEvent,
-        );
-        commandResultsForContinuity.push(...commandResults);
-        // #5740: upgrade the record's outcome to what the batch actually
-        // reported (results align 1:1 with the commands). Gated on this round
-        // carrying mutating commands so a later read-only round can never
-        // relabel an earlier round's failure as applied.
-        if (
-          runUnderstoodRequest !== null &&
-          this.latestUnderstoodRequest === runUnderstoodRequest &&
-          action.commands.some(isMutatingWorkspaceCommand)
-        ) {
-          // A store read-back mismatch is a persistence failure: the record
-          // must never say "applied" while the same result tells Mari not to
-          // claim success (the diagnostics line is the surface users paste).
-          const anyMutatingFailed = commandResults.some(
-            (commandResult, index) =>
-              isMutatingWorkspaceCommand(action.commands[index]!) &&
-              (!commandResult.success || appliedMutationReadBackMismatched(commandResult)),
-          );
-          // #5756: a round that staged a sensitive change applied nothing for
-          // it - report "held" so diagnostics never corroborate a completion
-          // claim the verification guard would refuse.
-          const anyStaged = commandResults.some(isStagedSensitiveMutation);
-          runUnderstoodRequest = {
-            ...runUnderstoodRequest,
-            outcome: anyMutatingFailed ? "failed" : anyStaged ? "held" : "applied",
-          };
-          this.latestUnderstoodRequest = runUnderstoodRequest;
         }
 
         const repeatedFailure = commandResults

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -1205,10 +1205,17 @@ function rawJsonToolCalls(payload: Record<string, unknown>): unknown[] {
   return [];
 }
 
-function parseJsonCommandCallsFromPayload(payload: Record<string, unknown>): WorkspaceCommandCall[] {
+function parseJsonCommandCallsFromPayload(payload: Record<string, unknown>): {
+  calls: WorkspaceCommandCall[];
+  unrecognized: boolean;
+} {
   const calls: WorkspaceCommandCall[] = [];
+  let unrecognized = false;
   rawJsonToolCalls(payload).forEach((raw, index) => {
-    if (!isRecord(raw)) return;
+    if (!isRecord(raw)) {
+      unrecognized = true;
+      return;
+    }
     const requestedName = typeof raw.name === "string" ? raw.name.trim() : "";
     const directAction = isAppDataActionName(raw.action) ? raw.action.trim() : null;
     const nameAsAction = isAppDataActionName(requestedName) ? requestedName : null;
@@ -1218,12 +1225,18 @@ function parseJsonCommandCallsFromPayload(payload: Record<string, unknown>): Wor
         ? "app_data"
         : null;
     if (!workspaceName) {
-      // Reuse the provider parser for tool/parameters and native function wrappers.
-      calls.push(
-        ...parseTextualWorkspaceCommandCalls(
+      // Validate nested envelopes per entry too: one recognized call cannot hide a dropped sibling.
+      if (rawJsonToolCalls(raw).some((call) => call !== raw)) {
+        const nested = parseJsonCommandCallsFromPayload(raw);
+        calls.push(...nested.calls);
+        unrecognized ||= nested.unrecognized;
+      } else {
+        const recovered = parseTextualWorkspaceCommandCalls(
           JSON.stringify({ ...raw, ...(typeof raw.tool_name === "string" ? { name: raw.tool_name } : {}) }),
-        ),
-      );
+        );
+        calls.push(...recovered);
+        unrecognized ||= recovered.length === 0;
+      }
       return;
     }
 
@@ -1239,7 +1252,7 @@ function parseJsonCommandCallsFromPayload(payload: Record<string, unknown>): Wor
     const id = typeof raw.id === "string" && raw.id.trim() ? raw.id.trim() : newToolCallId(workspaceName, index);
     calls.push({ id, name: workspaceName, arguments: argumentsWithRecoveredAction });
   });
-  return calls;
+  return { calls, unrecognized };
 }
 
 function parseTextualWorkspaceCommandCalls(content: string): WorkspaceCommandCall[] {
@@ -1384,9 +1397,9 @@ function stripWorkspaceCommands(content: string): string {
 
 export function parseAssistantWorkspaceAction(content: string): AssistantWorkspaceAction {
   const { content: contentWithoutJson, matches } = removeJsonActionFrames(content);
-  const jsonCommands = matches.flatMap((match) => parseJsonCommandCallsFromPayload(match.payload));
-  const hasInvalidCommands =
-    jsonCommands.length !== matches.reduce((count, match) => count + rawJsonToolCalls(match.payload).length, 0);
+  const parsedFrames = matches.map((match) => ({ ...match, ...parseJsonCommandCallsFromPayload(match.payload) }));
+  const jsonCommands = parsedFrames.flatMap((frame) => frame.calls);
+  const hasInvalidCommands = parsedFrames.some((frame) => frame.unrecognized);
   const textualCommands = parseTextualWorkspaceCommandCalls(contentWithoutJson);
   // If JSON frames are present, treat all prose outside them as protocol leakage.
   // Textual calls have no visible-text field, so retain their surrounding prose.
@@ -1404,8 +1417,8 @@ export function parseAssistantWorkspaceAction(content: string): AssistantWorkspa
   // phrase: in a tolerated multi-frame response, a read-only frame's phrase
   // must not be attributed to another frame's mutations.
   const understoodRequest =
-    matches
-      .filter((match) => parseJsonCommandCallsFromPayload(match.payload).some(isMutatingWorkspaceCommand))
+    parsedFrames
+      .filter((frame) => frame.calls.some(isMutatingWorkspaceCommand))
       .map((match) =>
         typeof match.payload.understoodRequest === "string" ? match.payload.understoodRequest.trim() : "",
       )
@@ -2018,11 +2031,10 @@ export function workspaceTextClaimsMutationCompletion(text: string): boolean {
     new RegExp(`\\b(?:is|are|was|were|has been|have been)\\s+${adverbs}(?:${completedMutation})\\b`, "iu").test(
       normalized,
     ) ||
-    new RegExp(
-      `^(?:(?:the )?(?:edit|change|update)s?\\s+)?${adverbs}(?:${completedMutation})\\b[^?]*[.!]?$`,
-      "iu",
-    ).test(normalized) ||
-    /^done[.!]*$/iu.test(normalized)
+    new RegExp(`^(?:(?:the )?(?:edit|change|update)s?\\s+)${adverbs}(?:${completedMutation})\\b[^?]*[.!]?$`, "iu").test(
+      normalized,
+    ) ||
+    new RegExp(`^(?:${completedMutation}|done)[.!]*$`, "iu").test(normalized)
   );
 }
 

--- a/scripts/regressions/mari-completion-frames.regression.ts
+++ b/scripts/regressions/mari-completion-frames.regression.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChatMessage } from "../../packages/server/src/services/llm/base-provider.js";
+
+const storageDir = mkdtempSync(join(tmpdir(), "marinara-completion-frames-"));
+const previousStorageDir = process.env.FILE_STORAGE_DIR;
+process.env.FILE_STORAGE_DIR = storageDir;
+const { getDB, closeDB } = await import("../../packages/server/src/db/connection.js");
+try {
+  const db = await getDB();
+  const { ProfessorMariWorkspaceService } =
+    await import("../../packages/server/src/services/professor-mari/workspace-agent.service.js");
+  const { MariDbService } = await import("../../packages/server/src/services/mari-db/mari-db.service.js");
+  const { createChatsStorage } = await import("../../packages/server/src/services/storage/chats.storage.js");
+  const mariDb = new MariDbService(db);
+  const created = await mariDb.executeAction({
+    action: "character.create",
+    data: { name: "Frame regression", description: "Original" },
+    apply: true,
+  });
+  assert.equal(created.ok, true);
+  const characterId = String((created.summary?.preview?.[0] as { id?: string })?.id);
+  const chats = createChatsStorage(db);
+
+  for (const mode of ["auto", "manual", "plan"] as const) {
+    const chat = await chats.create({ name: `Mixed frame ${mode}`, mode: "conversation", characterIds: [] });
+    const calls: ChatMessage[][] = [];
+    const tokens: string[] = [];
+    const action = {
+      action: "character.update",
+      characterId,
+      patch: { description: `Updated in ${mode}` },
+      apply: true,
+    };
+    const service = new ProfessorMariWorkspaceService({ db } as never);
+    Object.assign(service, {
+      ensureMariCliShim: async () => {},
+      resolveConnection: async () => ({
+        id: "regression",
+        name: "Regression",
+        provider: "custom",
+        model: "test",
+        baseUrl: "http://127.0.0.1:1/v1",
+        apiKey: "",
+        maxContext: 8192,
+      }),
+      resolvePermissionsMode: async () => ({ mode, defaultMode: mode, source: "chat" }),
+      buildPromptMessages: async () => ({
+        messages: [{ role: "user", content: "Update the description." }],
+        manualApprovalArmed: false,
+      }),
+      baseChatOptions: () => ({ model: "test" }),
+      chatCompleteWorkspace: async (_provider: unknown, messages: ChatMessage[]) => {
+        calls.push(structuredClone(messages));
+        return {
+          content: JSON.stringify(
+            calls.length === 1
+              ? {
+                  say: "I've updated the description.",
+                  commands: [{ name: "app_data", arguments: action }],
+                  stop: false,
+                }
+              : { say: "The requested operation has been reviewed.", commands: [], stop: true },
+          ),
+          toolCalls: [],
+          finishReason: "stop",
+        };
+      },
+    });
+    await service.prompt({
+      chatId: chat.id,
+      text: "Update the description.",
+      onEvent: (event) => {
+        if (event.type === "token") tokens.push(String(event.data));
+      },
+    });
+    const current = await mariDb.executeAction({ action: "character.get", characterId });
+    assert.equal(current.ok, true);
+    if (mode === "auto") {
+      assert.match(
+        JSON.stringify(current),
+        /Updated in auto/u,
+        "a command sharing its frame with a completion claim must actually persist",
+      );
+      assert.match(tokens.join(""), /I've updated/u);
+      assert.equal(calls.length, 2);
+      assert.match(
+        JSON.stringify(calls[1]),
+        /Readback: store-verified/u,
+        "the next round receives the same frame's executed result",
+      );
+    } else {
+      assert.doesNotMatch(
+        JSON.stringify(current),
+        new RegExp(`Updated in ${mode}`, "u"),
+        `${mode} still prevents the edit`,
+      );
+    }
+  }
+  console.log("Mari mixed completion frames preserve edits and permission boundaries.");
+} finally {
+  await closeDB();
+  if (previousStorageDir === undefined) delete process.env.FILE_STORAGE_DIR;
+  else process.env.FILE_STORAGE_DIR = previousStorageDir;
+  rmSync(storageDir, { recursive: true, force: true });
+}

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -11242,6 +11242,23 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
           assert.deepEqual(recovered.commands[0]?.arguments, updateArgs);
         }
       }
+      const nestedCalls = [
+        { name: "app_data", arguments: updateArgs },
+        { name: "read", arguments: { path: "README.md" } },
+      ];
+      const nestedFrame = parseAssistantWorkspaceAction(
+        JSON.stringify({ commands: [{ tool_calls: nestedCalls }], stop: false }),
+      );
+      assert.equal(nestedFrame.protocolValid, true);
+      assert.equal(nestedFrame.commands.length, 2);
+      for (const commands of [
+        [{ tool_calls: nestedCalls }, { name: "unknown_tool" }],
+        [{ tool_calls: [...nestedCalls, { name: "unknown_tool" }] }],
+      ]) {
+        const invalid = parseAssistantWorkspaceAction(JSON.stringify({ commands, stop: false }));
+        assert.equal(invalid.protocolValid, false, "expanded nested commands cannot cancel out an unrecognized entry");
+        assert.deepEqual(invalid.commands, []);
+      }
       const malformed = parseAssistantWorkspaceAction(
         JSON.stringify({
           say: "Done!",
@@ -11257,7 +11274,6 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         "I’ve created the entry.",
         "I have now updated the card.",
         "I just created it.",
-        "Created the entry.",
         "Updated.",
         "Edit applied.",
         "Done!",
@@ -11270,6 +11286,9 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         "I verified the entry.",
         "Here are the updated instructions.",
         "I can create it.",
+        "Set its type to Constant",
+        "Added fields appear",
+        "Removed entries cannot be restored",
       ]) {
         assert.equal(workspaceTextClaimsMutationCompletion(text), false, text);
       }

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -11221,6 +11221,59 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.equal(fencedTrailingComma.commands[0]?.arguments.action, "lorebook.search");
       assert.equal(fencedTrailingComma.protocolValid, true);
 
+      const updateArgs = {
+        action: "lorebook.updateEntry",
+        entryId: "entry-1",
+        patch: { content: "Changed" },
+        apply: true,
+      };
+      for (const raw of [
+        { name: "app_data", parameters: updateArgs },
+        { tool: "app_data", arguments: updateArgs },
+        { tool_name: "app_data", parameters: updateArgs },
+        { type: "function", function: { name: "app_data", arguments: JSON.stringify(updateArgs) } },
+      ]) {
+        for (const commands of [[raw], raw]) {
+          const recovered = parseAssistantWorkspaceAction(
+            JSON.stringify({ say: "I’ve updated the entry.", commands, stop: false }),
+          );
+          assert.equal(recovered.protocolValid, true);
+          assert.equal(recovered.commands.length, 1);
+          assert.deepEqual(recovered.commands[0]?.arguments, updateArgs);
+        }
+      }
+      const malformed = parseAssistantWorkspaceAction(
+        JSON.stringify({
+          say: "Done!",
+          commands: [{ name: "app_data", arguments: updateArgs }, { name: "unknown_tool" }],
+          stop: true,
+        }),
+      );
+      assert.equal(malformed.protocolValid, false, "a dropped command must enter protocol repair");
+      assert.equal(malformed.stop, false, "an explicit stop cannot hide malformed commands");
+      assert.equal(malformed.commands.length, 0, "repair the whole frame before applying only part of it");
+      for (const claim of [
+        "I added the entry.",
+        "I’ve created the entry.",
+        "I have now updated the card.",
+        "I just created it.",
+        "Created the entry.",
+        "Updated.",
+        "Edit applied.",
+        "Done!",
+      ]) {
+        assert.equal(workspaceTextClaimsMutationCompletion(claim), true, claim);
+      }
+      for (const text of [
+        "I have not updated it.",
+        "Have I updated it?",
+        "I verified the entry.",
+        "Here are the updated instructions.",
+        "I can create it.",
+      ]) {
+        assert.equal(workspaceTextClaimsMutationCompletion(text), false, text);
+      }
+
       const unsupportedCompletion = parseAssistantWorkspaceAction(
         '{"say":"Done — I created it and verified it saved.","commands":[],"stop":true}',
       );


### PR DESCRIPTION
## Linked issue

Closes #5966
Closes #5967

## Why this change

Mari could claim a requested edit was saved without producing a review card. The unreleased claim audit also discarded real commands when their frame said the edit was complete before those commands had executed.

## What changed

- Execute a complete frame's commands before auditing its claim, and include the executed results in any repair conversation. Truncated frames still cannot execute. Existing permission floors and review handling remain in force.
- Reuse the provider's tolerant command parser for function wrappers and tool aliases; accept singleton command objects and `parameters`. An unrecognized command invalidates the whole frame for bounded protocol repair, preventing partial execution and silent drops.
- Correct the requested lorebook-edit example to `apply:true` and explain the flag in its schema. Explicit previews still save nothing.
- Recognize common completion wording, curly apostrophes, and bare completion phrases. Debug mode captures raw workspace replies; malformed frames produce a warning without logging their contents at the normal level.
- Add an Unreleased changelog entry and regression coverage.

## Validation

Automated evidence:

- `pnpm check` passed, including localization, formatting, lint/type checks, E2E types, and production builds.
- `pnpm regression:prompt` passed.
- The storage-backed mixed-frame regression fails against unchanged staging (the description remains `Original`) and passes with the fix. Auto mode persists the edit and returns store-verified evidence; Manual and Plan prevent it.
- Parser regressions fail before the fix and pass afterward, covering wrapper/alias/argument shapes, singleton commands, invalid mixed frames, and completion wording with negative controls.
- The wider Mari lane passed 24/25. `mari-guard-sibling-paths` fails its canonical store-link snapshot assertion on this macOS checkout; the exact failure also reproduces against unchanged staging. Hosted CI remains a merge gate.

Human verification tasks:

- [ ] Manually verify a requested lorebook edit produces its Keep/Restore card.
- [ ] Manually verify explicit previews and permission holds remain read-only.
- [ ] Manually verify a captured Kimi K3 or GLM 5.3 reply through its real provider. No live-provider result is claimed.
- [ ] Build and run the container.

## Risk and scope

The completion detector remains an English-language heuristic, and a state read cannot semantically prove every sentence in a claim. This fixes the demonstrated parser/ordering defects without changing mutation defaults or introducing another authorization gate. No user-facing docs, release metadata, dependencies, or mainline changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when Professor Mari edits frames and recovers from incomplete or malformed commands.
  - Ensured changes made alongside completion messages are correctly executed and verified.
  - Improved handling of preview versus saved changes and expanded recognition of mutation completion claims.
  - Added safer recovery when command formats cannot be interpreted, including clearer protocol repair behavior.

- **Tests**
  - Added regression coverage for mixed completion frames, permission modes, supported mutation command formats, and invalid command handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->