### PR TITLE
fix(gemini): stream reasoning on official Google endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Gemini reasoning replies now stream on Google's official API endpoint, including tool-using turns. Other endpoints retain the compatibility workaround that preserves proxy thought parts (#5904).
+
 - Restart Server now uses the launcher's console and waits for the old process to exit before replacing it, with bounded shutdown instead of detached or overlapping servers (#5934).
 - Malformed Game combat tags no longer trigger quadratic parsing delays in the browser (#5937).
 - Experience setup preserves explicit package configs without double nesting and accepts larger, bounded setup payloads (#5938).

--- a/packages/server/src/services/llm/providers/google.provider.ts
+++ b/packages/server/src/services/llm/providers/google.provider.ts
@@ -1016,7 +1016,7 @@ export class GoogleProvider extends BaseLLMProvider {
       return;
     }
 
-    // ── SSE streaming path (no thinking) ──
+    // ── SSE streaming path ──
     const reader = response.body?.getReader();
     if (!reader) throw new Error("No response body");
 
@@ -1108,6 +1108,7 @@ export class GoogleProvider extends BaseLLMProvider {
       }
     } finally {
       if (options.signal) options.signal.removeEventListener("abort", onAbort);
+      await reader.cancel().catch(() => {});
     }
 
     if (!responseText) {

--- a/packages/server/src/services/llm/providers/google.provider.ts
+++ b/packages/server/src/services/llm/providers/google.provider.ts
@@ -101,6 +101,14 @@ const GOOGLE_CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platf
 const serviceAccountTokenCache = new Map<string, { accessToken: string; expiresAtMs: number }>();
 const LINKAPI_CONSOLE_HOSTS = new Set(["linkapi.ai", "www.linkapi.ai", "home.linkapi.ai"]);
 
+function supportsGoogleThinkingStreaming(baseUrl: string): boolean {
+  try {
+    return new URL(baseUrl).hostname === "generativelanguage.googleapis.com";
+  } catch {
+    return false;
+  }
+}
+
 function normalizeGoogleBaseUrl(baseUrl: string): string {
   const trimmed = baseUrl.replace(/\/+$/, "");
   try {
@@ -604,10 +612,10 @@ export class GoogleProvider extends BaseLLMProvider {
     // Stream the tools round whenever the caller wired a token sink and did not opt out.
     // The gate is deliberately narrower than the base `options.stream ?? !!options.onToken`
     // formula: a caller that sets `stream: true` without a sink (the agent tool loop) keeps
-    // the buffered path it uses today. Thinking turns also stay buffered, for the reason
-    // chat() documents below — proxies like linkapi.ai strip thought parts from SSE streams
-    // but return them in non-streaming responses.
-    const useStream = !!options.onToken && options.stream !== false && !thinkingConfig;
+    // the buffered path it uses today. Only the official endpoint streams thinking;
+    // unrecognized proxies retain the workaround for stripped thought parts.
+    const useStream =
+      !!options.onToken && options.stream !== false && (!thinkingConfig || supportsGoogleThinkingStreaming(base));
     const endpoint = useStream ? "streamGenerateContent" : "generateContent";
     const url =
       this.providerKind === "google_vertex"
@@ -870,10 +878,9 @@ export class GoogleProvider extends BaseLLMProvider {
         ? normalizeGoogleGenerativeLanguageBaseUrl(this.baseUrl)
         : normalizeGoogleBaseUrl(this.baseUrl);
 
-    // When thinking is enabled, force non-streaming (generateContent) because
-    // proxies like linkapi.ai strip thought parts from SSE streams but return
-    // them in non-streaming responses. Text is still yielded so SSE works.
-    const useStreaming = options.stream && !thinkingConfig;
+    // Proxies can strip thought parts from SSE; keep their buffered workaround.
+    // Google's official endpoint carries those parts in its stream.
+    const useStreaming = options.stream && (!thinkingConfig || supportsGoogleThinkingStreaming(base));
     const endpoint = useStreaming ? "streamGenerateContent" : "generateContent";
     const url =
       this.providerKind === "google_vertex"
@@ -977,7 +984,7 @@ export class GoogleProvider extends BaseLLMProvider {
       throw llmHttpErrorFromResponse(`${label} error ${response.status}: ${sanitizeApiError(errorText)}`, response);
     }
 
-    // ── Non-streaming path (also used when thinking is enabled) ──
+    // ── Non-streaming path (also used for proxy thinking turns) ──
     if (!useStreaming) {
       const json = JSON.parse(await readDecodedText()) as GeminiResponsePayload;
       const candidate = json.candidates?.[0];

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -2951,6 +2951,95 @@ try {
   const sseFrames = (frames: Array<Record<string, unknown>>) =>
     frames.map((frame) => `data: ${JSON.stringify(frame)}\n`).join("\n");
 
+  // #5904: the official endpoint streams reasoning in both generation paths.
+  // Keep the tail withheld until the token sink runs, so buffering cannot pass.
+  const originalGoogleFetch = globalThis.fetch;
+  try {
+    for (const withTools of [false, true]) {
+      let streamController: ReadableStreamDefaultController<Uint8Array>;
+      const encoder = new TextEncoder();
+      const thoughts: string[] = [];
+      const tokens: string[] = [];
+      let savedParts: unknown[] | undefined;
+      globalThis.fetch = async (input) => {
+        assert.match(
+          String(input),
+          /^https:\/\/generativelanguage\.googleapis\.com\/v1beta\/models\/gemini-2\.5-flash:streamGenerateContent\?alt=sse$/u,
+        );
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              streamController = controller;
+              controller.enqueue(
+                encoder.encode(
+                  sseFrames([
+                    { candidates: [{ content: { parts: [{ text: "Thinking", thought: true }] } }] },
+                    { candidates: [{ content: { parts: [{ text: "Answer" }] } }] },
+                  ]),
+                ),
+              );
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      };
+      const google = new GoogleProvider("https://generativelanguage.googleapis.com", "test");
+      const result = await google.chatComplete([{ role: "user", content: "reason" }], {
+        model: "gemini-2.5-flash",
+        stream: true,
+        reasoningEffort: "high",
+        signal: AbortSignal.timeout(3000),
+        onResponseParts: (parts) => {
+          savedParts = parts;
+        },
+        ...(withTools ? { tools: [rollDiceTool] } : {}),
+        onThinking: (chunk) => {
+          thoughts.push(chunk);
+        },
+        onToken: (chunk) => {
+          tokens.push(chunk);
+          streamController.enqueue(
+            encoder.encode(
+              sseFrames([
+                {
+                  candidates: [
+                    {
+                      content: {
+                        parts: [
+                          { thoughtSignature: "thought-signature" },
+                          ...(withTools
+                            ? [
+                                {
+                                  functionCall: { name: "roll_dice", args: { notation: "1d20" } },
+                                  thoughtSignature: "call-signature",
+                                },
+                              ]
+                            : []),
+                        ],
+                      },
+                      finishReason: "STOP",
+                    },
+                  ],
+                },
+              ]),
+            ),
+          );
+          streamController.close();
+        },
+      });
+      assert.deepEqual(thoughts, ["Thinking"]);
+      assert.deepEqual(tokens, ["Answer"]);
+      assert.equal(result.content, "Answer");
+      assert.match(JSON.stringify(result.providerMetadata?.geminiParts ?? savedParts), /thought-signature/u);
+      if (withTools) {
+        assert.equal(result.toolCalls[0]?.function.name, "roll_dice");
+        assert.match(JSON.stringify(result.providerMetadata?.geminiParts), /call-signature/u);
+      }
+    }
+  } finally {
+    globalThis.fetch = originalGoogleFetch;
+  }
+
   // Explicit debug logs the final serialized provider body, but not auth headers.
   const priorWarn = logger.warn;
   const priorLevel = logger.level;
@@ -3244,9 +3333,7 @@ try {
       functionCall: { id, name: "roll_dice", args: { notation: "1d20" } },
       thoughtSignature: `signature-${id}`,
     }));
-    geminiStreamFrames = [
-      { candidates: [{ content: { parts: identifiedParts }, finishReason: "STOP" }] },
-    ];
+    geminiStreamFrames = [{ candidates: [{ content: { parts: identifiedParts }, finishReason: "STOP" }] }];
     const identifiedResult = await gemini.chatComplete([{ role: "user", content: "roll twice" }], {
       model: "gemini-2.0-flash",
       tools: [rollDiceTool],
@@ -3265,11 +3352,13 @@ try {
             tool_calls: identifiedResult.toolCalls,
             ...(replayMetadata ? { providerMetadata: identifiedResult.providerMetadata } : {}),
           },
-          ...identifiedResult.toolCalls.map((call, index): ChatMessage => ({
-            role: "tool",
-            tool_call_id: call.id,
-            content: JSON.stringify({ total: 17 + index }),
-          })),
+          ...identifiedResult.toolCalls.map(
+            (call, index): ChatMessage => ({
+              role: "tool",
+              tool_call_id: call.id,
+              content: JSON.stringify({ total: 17 + index }),
+            }),
+          ),
         ],
         { model: "gemini-2.0-flash", tools: [rollDiceTool], onToken: () => {} },
       );

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -3036,6 +3036,30 @@ try {
         assert.match(JSON.stringify(result.providerMetadata?.geminiParts), /call-signature/u);
       }
     }
+    let cancelled = false;
+    globalThis.fetch = async () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode(
+                sseFrames([{ candidates: [{ content: { parts: [{ text: "First chunk" }] } }] }]),
+              ),
+            );
+          },
+          cancel() {
+            cancelled = true;
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    const iterator = new GoogleProvider("https://generativelanguage.googleapis.com", "test").chat(
+      [{ role: "user", content: "reason" }],
+      { model: "gemini-2.5-flash", reasoningEffort: "high", stream: true, signal: AbortSignal.timeout(3000) },
+    );
+    assert.equal((await iterator.next()).value, "First chunk");
+    await iterator.return(undefined);
+    assert.equal(cancelled, true, "Stopping a thinking stream must release its still-open response body");
   } finally {
     globalThis.fetch = originalGoogleFetch;
   }


### PR DESCRIPTION
## Linked issue

Closes #5904

## Why this change

Gemini reasoning replies buffered the entire turn on Google's own API because a workaround for proxies that strip thought parts applied to every endpoint. Users waited with an empty reply even though the native API supports streaming thought summaries.

## What changed

Both the ordinary and tool-calling paths use the same hostname check: thinking can stream on `generativelanguage.googleapis.com`, while other endpoints retain their existing buffered compatibility path. Explicit non-streaming requests and tool calls without a token sink retain their existing behavior. No new setting or dependency.

## Validation

- `pnpm check` passed, including the production build.
- Provider compatibility regressions passed. The new case failed against the original buffered endpoint and passes after the fix.
- Both native generation paths are exercised with a withheld stream tail: text must reach its callback before the rest of the response can arrive. Thought summaries and signatures survive, including a tool-call signature. Existing proxy-buffering and no-token-sink controls also pass.
- [ ] Manually verify a reasoning reply streams on a real Google API connection, with and without tools.
- [ ] Manually verify an existing proxy connection retains its thought summaries.
- [ ] Build and run the container.

The provider tests use controlled responses, not a paid live-provider call. Google's [official Gemini 2.5 example](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/getting-started/intro_gemini_2_5_flash.ipynb) demonstrates streaming with `include_thoughts` enabled.

## Docs and release impact

Unreleased changelog entry included. No user-facing documentation or release-version changes. Vertex and unrecognized proxies keep their existing compatibility behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Gemini reasoning responses now stream correctly through Google’s official API, including tool-using conversations.
  - Compatibility is preserved for proxy endpoints that require buffered reasoning responses.

- **Tests**
  - Added regression coverage for streamed reasoning, tool calls, token callbacks, provider metadata, and request cleanup.

- **Documentation**
  - Updated the changelog with the Gemini streaming fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->