### PR TITLE
fix(game): preserve regenerated anchors and filter hidden turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Command-only regenerations now save a swipe on the original turn instead of appending hidden rows. Game narration, storyboards, turn progress, and logs consistently skip hidden or empty turns; regenerating prose from a command anchor makes the new swipe visible (#5926, #5927).
+
 - Restart Server now uses the launcher's console and waits for the old process to exit before replacing it, with bounded shutdown instead of detached or overlapping servers (#5934).
 - Malformed Game combat tags no longer trigger quadratic parsing delays in the browser (#5937).
 - Experience setup preserves explicit package configs without double nesting and accepts larger, bounded setup payloads (#5938).

--- a/e2e/game-verb-only-turn.e2e.ts
+++ b/e2e/game-verb-only-turn.e2e.ts
@@ -144,6 +144,14 @@ test("a hidden verb-only anchor does not blank the GM narration panel", async ({
     await expect(narrationPanel).toContainText(EARLIER_NARRATION, { timeout: 10_000 });
     await expect(narrationPanel).not.toContainText(HIDDEN_CONTEXT);
 
+    await page.getByRole("button", { name: "Logs", exact: true }).click();
+    const logs = page.getByRole("dialog").filter({ has: page.getByRole("heading", { name: "Session Logs" }) });
+    await expect(logs).toBeVisible();
+    await expect(logs).toContainText(GM_NARRATION);
+    await expect(logs).toContainText(EARLIER_NARRATION);
+    await expect(logs).not.toContainText(HIDDEN_CONTEXT);
+    await page.screenshot({ path: testInfo.outputPath("game-visible-logs.png") });
+
     // Both unreadable rows are still real rows on the server — the surface skipped them,
     // they were not dropped from the chat. Re-asserting the edited row's shape keeps the
     // fixture honest: it only exercises the predicate's content test while it stays the

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -66,7 +66,7 @@ import { getDefaultChatTextColor, useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { parseChatMetadata } from "../../lib/chat-display";
 import { parseMessageExtraRecord } from "../../lib/chat-message-extra";
-import { isMessageHiddenFromUser } from "../../lib/chat-message-visibility";
+import { isVisibleGameMessage } from "../../lib/chat-message-visibility";
 import { estimateGameSessionHistoryTokens } from "../../lib/game-session-history";
 import { createMessageMacroResolver, findCharacterByName } from "../../lib/chat-macros";
 import { animateTextHtml } from "./AnimatedText";
@@ -298,26 +298,6 @@ const SYNTHETIC_GAME_START_MESSAGE_RE = /^\s*\[start(?:\s+the)?\s+game\]\s*$/i;
 
 function isSyntheticGameStartMessage(message: Pick<NarrationMessage, "role" | "content">): boolean {
   return message.role === "user" && SYNTHETIC_GAME_START_MESSAGE_RE.test(message.content || "");
-}
-
-// A GM turn that leaves no prose behind — a command-only turn, or one that was
-// nothing but GM verb tags (#5798) — is still saved, as a hidden empty anchor its
-// writes can hang on. Roleplay and Conversation drop those rows while mapping the
-// transcript (`ChatRoleplaySurface`, `ConversationView`); the game surface reads a
-// single "latest GM turn" instead of mapping, so the same filter has to sit where
-// that row is picked or the anchor blanks the narration area. Same triple the
-// server uses to decide a message is worth previewing: visible content, not
-// hidden, not command-only.
-//
-// The commandOnly test is defensive redundancy, not a live filter: the server writes
-// that flag in exactly one place (`generate.routes.ts` empty-response branch) and
-// always sets hiddenFromUser in the same call, so no row the server produces today
-// reaches here on commandOnly alone. It stays for the day one of them is written
-// without the other, and because the server's own preview gate carries both.
-function isNarratableGmMessage(message: NarrationMessage): boolean {
-  if (isMessageHiddenFromUser(message)) return false;
-  if (parseMessageExtraRecord(message.extra).commandOnly === true) return false;
-  return !!message.content?.trim();
 }
 
 function hasExactCachedPrompt(message: Pick<Message, "extra"> | null): boolean {
@@ -1363,7 +1343,7 @@ export function GameNarration({
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i]!;
       if (msg.role !== "assistant" && msg.role !== "narrator") continue;
-      if (!isNarratableGmMessage(msg)) continue;
+      if (!isVisibleGameMessage(msg)) continue;
       return msg;
     }
     return null;
@@ -1453,7 +1433,7 @@ export function GameNarration({
         continue;
       }
       if (msg.role !== "assistant" && msg.role !== "narrator") continue;
-      if (!isNarratableGmMessage(msg)) continue;
+      if (!isVisibleGameMessage(msg)) continue;
       const segs = parseNarrationSegments(msg, speakerColors);
       for (let si = 0; si < segs.length; si++) {
         const seg = segs[si]!;
@@ -2501,6 +2481,7 @@ export function GameNarration({
     const entries: Array<{ messageId: string; segments: NarrationSegment[] }> = [];
     for (let i = 0; i < messages.length; i++) {
       const msg = messages[i]!;
+      if (!isVisibleGameMessage(msg)) continue;
 
       // Skip the party-chat message that's already rendered by the partyDialogue section
       // to avoid doubling it in the logs (the DB message + live partyDialogue state).

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -80,6 +80,7 @@ import { useConnections } from "../../hooks/use-connections";
 import { useAgentConfigs } from "../../hooks/use-agents";
 import { selectGameExperiencePackages, useInstalledCapabilityPackages } from "../../hooks/use-capability-packages";
 import { useGenerate } from "../../hooks/use-generate";
+import { isVisibleGameMessage } from "../../lib/chat-message-visibility";
 import { useBackdropDismiss } from "../../hooks/use-backdrop-dismiss";
 import { useGenerateSpatialMapDraft, useSpatialContext } from "../../hooks/use-spatial-context";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -3236,13 +3237,14 @@ function GameSurfaceComponent({
 
   const introPresentationStorageKey = `game-intro-presented:${activeChatId}`;
   const assistantTurnCount = useMemo(
-    () => messages.filter((m) => (m.role === "assistant" || m.role === "narrator") && !!m.content.trim()).length,
+    () => messages.filter((m) => (m.role === "assistant" || m.role === "narrator") && isVisibleGameMessage(m)).length,
     [messages],
   );
   const latestAssistantTurnForIntro = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i]!;
-      if (message.role === "assistant" || message.role === "narrator") return message;
+      if ((message.role === "assistant" || message.role === "narrator") && isVisibleGameMessage(message))
+        return message;
     }
     return null;
   }, [messages]);
@@ -3842,7 +3844,9 @@ function GameSurfaceComponent({
   // Process GM tags from the latest assistant message
   const latestAssistantMsg = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i]!.role === "assistant" || messages[i]!.role === "narrator") return messages[i];
+      const message = messages[i]!;
+      if ((message.role === "assistant" || message.role === "narrator") && isVisibleGameMessage(message))
+        return message;
     }
     return null;
   }, [messages]);
@@ -4060,6 +4064,7 @@ function GameSurfaceComponent({
   const combatLogEntries = useMemo(
     () =>
       messages
+        .filter(isVisibleGameMessage)
         .map((message) => ({
           id: message.id,
           role: message.role,

--- a/packages/client/src/lib/chat-message-visibility.ts
+++ b/packages/client/src/lib/chat-message-visibility.ts
@@ -18,3 +18,13 @@ export function isMessageHiddenFromUser(message: ChatMessageVisibilityInput): bo
   if (extra.diceRollResult && typeof extra.diceRollResult === "object") return false;
   return !hasVisibleUserMessagePayload(message.content, extra.attachments);
 }
+
+/** Game narration and logs share one rule for readable turns, including hidden command anchors. */
+export function isVisibleGameMessage(message: ChatMessageVisibilityInput): boolean {
+  return (
+    !isMessageHiddenFromUser(message) &&
+    parseMessageExtraRecord(message.extra).commandOnly !== true &&
+    typeof message.content === "string" &&
+    message.content.trim().length > 0
+  );
+}

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7610,12 +7610,15 @@ export async function generateRoutes(app: FastifyInstance) {
                 collectedGmVerbCalls.length,
                 input.chatId,
               );
-              const savedMsg = await chats.createMessage({
-                chatId: input.chatId,
-                role: "assistant",
-                characterId: targetCharId,
-                content: "",
-              });
+              if (input.regenerateMessageId) await chats.addSwipe(input.regenerateMessageId, "");
+              const savedMsg = input.regenerateMessageId
+                ? await chats.getMessage(input.regenerateMessageId)
+                : await chats.createMessage({
+                    chatId: input.chatId,
+                    role: "assistant",
+                    characterId: targetCharId,
+                    content: "",
+                  });
               const anchoredMsg = savedMsg?.id
                 ? await chats.updateMessageExtra(savedMsg.id, {
                     hiddenFromUser: true,
@@ -7643,7 +7646,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     chatId: input.chatId,
                     messageId: anchoredMsg.id,
                     swipeIndex: anchoredMsg.activeSwipeIndex ?? 0,
-                    regenerate: false,
+                    regenerate: Boolean(input.regenerateMessageId),
                     continuation: false,
                     directive: assistantSpatialDirective,
                   },

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -573,6 +573,7 @@ function freshSwipeMessageExtra(value: unknown): Record<string, unknown> {
     "reactions",
     "personaSnapshot",
   ]) {
+    if (current.commandOnly === true && (key === "hiddenFromAI" || key === "hiddenFromUser")) continue;
     if (Object.prototype.hasOwnProperty.call(current, key)) {
       next[key] = current[key];
     }

--- a/scripts/regressions/command-only-regenerate.regression.ts
+++ b/scripts/regressions/command-only-regenerate.regression.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "marinara-command-swipe-"));
+process.env.DATA_DIR = dir;
+process.env.FILE_STORAGE_DIR = join(dir, "storage");
+process.env.NODE_ENV = "test";
+process.env.MARINARA_LITE = "true";
+process.env.LOG_LEVEL = "silent";
+const requireServer = createRequire(new URL("../../packages/server/package.json", import.meta.url));
+const Fastify = requireServer("fastify") as typeof import("fastify").default;
+const { getDB, closeDB } = await import("../../packages/server/src/db/connection.js");
+const { generateRoutes } = await import("../../packages/server/src/routes/generate.routes.js");
+const { createChatsStorage } = await import("../../packages/server/src/services/storage/chats.storage.js");
+const { createConnectionsStorage } = await import("../../packages/server/src/services/storage/connections.storage.js");
+let content = '[react: emoji="😂"]';
+const provider = createServer(async (req, res) => {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(Buffer.from(chunk));
+  const body = JSON.parse(Buffer.concat(chunks).toString());
+  if (body.stream) {
+    res.writeHead(200, { "content-type": "text/event-stream" });
+    res.end(
+      `data: ${JSON.stringify({ choices: [{ index: 0, delta: { content }, finish_reason: null }] })}\n\ndata: ${JSON.stringify({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\ndata: [DONE]\n\n`,
+    );
+  } else {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify({ choices: [{ index: 0, message: { role: "assistant", content }, finish_reason: "stop" }] }),
+    );
+  }
+});
+const db = await getDB();
+const chats = createChatsStorage(db);
+const app = Fastify();
+app.decorate("db", db);
+await app.register(generateRoutes, { prefix: "/api/generate" });
+try {
+  await new Promise<void>((done) => provider.listen(0, "127.0.0.1", done));
+  const address = provider.address();
+  assert.ok(address && typeof address === "object");
+  const connection = await createConnectionsStorage(db).create({
+    name: "Local fixture",
+    provider: "custom",
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    model: "fixture",
+    apiKey: "fixture",
+  });
+  const chat = await chats.create({
+    name: "Command-only regenerate",
+    mode: "conversation",
+    characterIds: [],
+    connectionId: connection.id,
+    promptPresetId: null,
+  });
+  assert.ok(chat);
+  await chats.patchMetadata(chat.id, { enableAgents: false });
+  const generate = async (regenerateMessageId?: string) => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/generate/",
+      payload: { chatId: chat.id, regenerateMessageId },
+    });
+    assert.equal(response.statusCode, 200, response.body);
+    assert.ok(!response.body.includes('"type":"error"'), response.body);
+  };
+  await chats.createMessage({ chatId: chat.id, role: "user", content: "Begin." });
+  const original = await chats.createMessage({ chatId: chat.id, role: "assistant", content: "Original reply." });
+  assert.ok(original);
+  for (const expectedSwipe of [1, 2]) {
+    await generate(original.id);
+    const messages = await chats.listMessages(chat.id);
+    assert.equal(messages.length, 2, "A command-only regenerate must not append a new message");
+    const message = await chats.getMessage(original.id);
+    assert.equal(message?.activeSwipeIndex, expectedSwipe);
+    assert.equal(message?.content, "");
+    const extra = JSON.parse(message!.extra);
+    assert.equal(extra.commandOnly, true);
+    assert.equal(extra.hiddenFromUser, true);
+    const swipes = await chats.getSwipes(original.id);
+    assert.equal(swipes.length, expectedSwipe + 1);
+    assert.equal(JSON.parse(swipes[expectedSwipe].extra).commandOnly, true);
+  }
+  await chats.setActiveSwipe(original.id, 0);
+  assert.equal((await chats.getMessage(original.id))?.content, "Original reply.");
+  assert.notEqual(JSON.parse((await chats.getMessage(original.id))!.extra).hiddenFromUser, true);
+  await chats.setActiveSwipe(original.id, 2);
+  content = "A visible new reply.";
+  await generate(original.id);
+  const visible = await chats.getMessage(original.id);
+  assert.equal(visible?.content, content);
+  assert.notEqual(JSON.parse(visible!.extra).hiddenFromUser, true, "Anchor visibility must not hide a new prose swipe");
+  assert.notEqual(JSON.parse(visible!.extra).hiddenFromAI, true);
+  await chats.setActiveSwipe(original.id, 2);
+  assert.equal(JSON.parse((await chats.getMessage(original.id))!.extra).commandOnly, true);
+  const manuallyHidden = await chats.createMessage({ chatId: chat.id, role: "assistant", content: "Private note." });
+  assert.ok(manuallyHidden);
+  await chats.updateMessageExtra(manuallyHidden.id, { hiddenFromUser: true, hiddenFromAI: true });
+  await chats.addSwipe(manuallyHidden.id, "Another private note.");
+  const hiddenExtra = JSON.parse((await chats.getMessage(manuallyHidden.id))!.extra);
+  assert.equal(
+    hiddenExtra.hiddenFromUser,
+    true,
+    "Explicitly hidden ordinary messages keep their visibility on regeneration",
+  );
+  assert.equal(hiddenExtra.hiddenFromAI, true);
+} finally {
+  provider.closeAllConnections();
+  await new Promise<void>((done) => provider.close(() => done()));
+  await app.close();
+  await closeDB();
+  rmSync(dir, { recursive: true, force: true });
+}
+console.log("Command-only regeneration preserves message identity, swipe history, and visibility.");

--- a/scripts/regressions/spatial-only-message-visibility.regression.ts
+++ b/scripts/regressions/spatial-only-message-visibility.regression.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {
   hasVisibleUserMessagePayload,
   isMessageHiddenFromUser,
+  isVisibleGameMessage,
 } from "../../packages/client/src/lib/chat-message-visibility";
 
 assert.equal(hasVisibleUserMessagePayload("", []), false, "a spatial-only owner turn has no visible payload");
@@ -42,5 +43,13 @@ assert.equal(
   true,
   "an explicit hidden marker still takes precedence",
 );
+
+for (const role of ["assistant", "narrator", "user", "system"]) {
+  assert.equal(isVisibleGameMessage({ role, content: "Visible", extra: "{}" }), true);
+  assert.equal(isVisibleGameMessage({ role, content: "Visible", extra: { hiddenFromUser: true } }), false);
+  assert.equal(isVisibleGameMessage({ role, content: "Visible", extra: JSON.stringify({ commandOnly: true }) }), false);
+  assert.equal(isVisibleGameMessage({ role, content: "   ", extra: {} }), false);
+  assert.equal(isVisibleGameMessage({ role, content: "Visible", extra: "malformed" }), true);
+}
 
 console.log("Spatial-only message visibility regression checks passed.");


### PR DESCRIPTION
## Linked issue

Closes #5926
Closes #5927

## Why this change

A command-only regeneration appended an unrelated hidden message instead of adding a swipe to the requested turn. Game narration skipped hidden rows, while its latest-turn lookups and Logs modal still read them.

## What changed

- Reuse the existing swipe path for command-only regenerations in Conversation and Game, preserving message identity and each swipe's visibility. A later prose swipe becomes visible; explicitly hidden ordinary messages keep their existing visibility.
- Share the Game visibility predicate across narration, turn navigation, intro/progress/storyboard lookups, and both log views.
- Add a real local-provider generation/storage regression, visibility cases, and a browser assertion that hidden continuity notes stay out of session logs. Add an Unreleased changelog entry.

## Validation

Automated checks completed:
- `pnpm check` passed (one pre-existing React hook dependency warning).
- `node scripts/run-regressions.mjs --filter command-only-regenerate` passed; it fails on unchanged staging because the first regeneration appends a third message.
- `--filter spatial-only-message-visibility` and `--filter capability-gm-verb-runtime` passed.
- `pnpm smoke:ui e2e/game-verb-only-turn.e2e.ts --project=desktop-chromium` passed. Inspected the resulting session-log screenshot: two readable narration turns, no hidden continuity note.

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify a installed-package GM verb-only regeneration, navigate between its swipes, then regenerate prose. The storage/route regression uses Conversation commands to exercise the common save branch; package verb execution is covered separately by its existing runtime suite.
- Manually verify Game logs, intro restoration, storyboards and pre-combat return in an existing campaign on mobile and both themes. These checks are not claimed as completed.

## Docs and release impact

Only the Unreleased changelog changes; no release/version or user-guide changes.

## UI evidence (if applicable)

Automated desktop screenshot inspected locally (`game-visible-logs.png`). No visual styling or UI copy changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Command-only regenerations now save swipes on the original turn instead of creating hidden rows.
  * Game narration, storyboards, turn progress, combat logs, and session logs now skip hidden, command-only, and empty turns.
  * Regenerated prose from command-only turns now appears as a visible swipe.
  * Session Logs now correctly display readable narrations while excluding hidden continuity notes.

* **Tests**
  * Added coverage for command-only regeneration, swipe restoration, visibility handling, and session log behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->