### PR TITLE
fix(lorebook): keep location-budget drops out of later scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Location lorebook budgets now keep rejected constant entries out of later keyword and recursive scans, so prompt contents agree with skipped-entry diagnostics.
+
 - Restart Server now uses the launcher's console and waits for the old process to exit before replacing it, with bounded shutdown instead of detached or overlapping servers (#5934).
 - Malformed Game combat tags no longer trigger quadratic parsing delays in the browser (#5937).
 - Experience setup preserves explicit package configs without double nesting and accepts larger, bounded setup payloads (#5938).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,11 +99,11 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
-- Location lorebook budgets now keep rejected constant entries out of later keyword and recursive scans, so prompt contents agree with skipped-entry diagnostics.
 - Gemini reasoning replies now stream on Google's official API endpoint, including tool-using turns. Other endpoints retain the compatibility workaround that preserves proxy thought parts (#5904).
 - Professor Mari now executes a frame's edits before checking its completion claim, recovers common command formats, and repairs unrecognized commands instead of silently dropping them. Requested lorebook edits use the real save/review path; explicit previews remain read-only (#5966, #5967).
 
 - Command-only regenerations now save a swipe on the original turn instead of appending hidden rows. Game narration, storyboards, turn progress, and logs consistently skip hidden or empty turns; regenerating prose from a command anchor makes the new swipe visible (#5926, #5927).
+- Location lorebook budgets now keep rejected constant entries out of later keyword and recursive scans, so prompt contents agree with skipped-entry diagnostics (#5943).
 
 - Restart Server now uses the launcher's console and waits for the old process to exit before replacing it, with bounded shutdown instead of detached or overlapping servers (#5934).
 - Malformed Game combat tags no longer trigger quadratic parsing delays in the browser (#5937).

--- a/packages/server/src/services/lorebook/index.ts
+++ b/packages/server/src/services/lorebook/index.ts
@@ -1237,17 +1237,18 @@ export async function processLorebooks(
     relevantLorebooksById,
     options?.currentLocationTokenBudget,
   );
-  // Emptying the scan's INPUTS is not the same as skipping the scan: under an exact
-  // selection `allEntries` is the selection itself, and a constant entry activates
-  // here with no messages at all — so a picked constant the location budget had just
-  // dropped came straight back through this line while its skip record stayed on the
-  // response. The flag has to bind the call, not only its arguments.
-  const ordinaryActivatedEntries = forcedEntriesOnly ? [] : scanForActivatedEntries(messages, allEntries, scanOpts);
+  // A location-budget drop must stay out of every subsequent scan, including
+  // recursive activation. Constants otherwise re-enter even with no messages.
+  const locationBudgetSkippedIds = new Set(locationBudgetResult.skipped.map((entry) => entry.id));
+  const scannableEntries = allEntries.filter((entry) => !locationBudgetSkippedIds.has(entry.id));
+  const ordinaryActivatedEntries = forcedEntriesOnly
+    ? []
+    : scanForActivatedEntries(messages, scannableEntries, scanOpts);
   const initialActivatedEntries = mergeActivatedEntries(ordinaryActivatedEntries, locationBudgetResult.selected);
   const baseBudgetResult = anyRecursive
     ? resolveBudgetAndRecursivelyActivateLorebookEntriesWithDiagnostics(
         messages,
-        allEntries,
+        scannableEntries,
         scanOpts,
         maxRecursionDepth,
         relevantLorebooksById,

--- a/scripts/regressions/experience-lore-entries.regression.ts
+++ b/scripts/regressions/experience-lore-entries.regression.ts
@@ -281,6 +281,52 @@ try {
   } as Parameters<typeof connections.create>[0]);
   createdConnectionId = conn.id;
 
+  // #5943: the shared location budget binds ordinary and recursive scans too.
+  for (const recursiveScanning of [false, true]) {
+    const book = await createBook("Location budget", { tokenBudget: 4000, recursiveScanning });
+    const blocked = await lorebooks.createEntry({
+      lorebookId: book.id,
+      name: "Over budget",
+      constant: true,
+      content: loreContent("LOCATIONBLOCK", 1600),
+    } as Parameters<typeof lorebooks.createEntry>[0]);
+    const ambient = await lorebooks.createEntry({
+      lorebookId: book.id,
+      name: "Ambient",
+      constant: true,
+      content: "recursion-key",
+      preventRecursion: false,
+    } as Parameters<typeof lorebooks.createEntry>[0]);
+    const child = await lorebooks.createEntry({
+      lorebookId: book.id,
+      name: "Recursive child",
+      keys: ["recursion-key"],
+      content: "Child lore",
+    } as Parameters<typeof lorebooks.createEntry>[0]);
+    assert.ok(blocked && ambient && child);
+    const result = await processLorebooks(db, [], null, {
+      activeLorebookIds: [book.id],
+      forcedEntryIds: [blocked.id],
+      currentLocationTokenBudget: 100,
+    });
+    assert.equal(
+      result.activatedEntryIds.includes(blocked.id),
+      false,
+      "A dropped forced constant must not re-enter through a later scan",
+    );
+    assert.equal(result.activatedEntryIds.includes(ambient.id), true, "Unrelated ambient lore still activates");
+    assert.equal(
+      result.activatedEntryIds.includes(child.id),
+      recursiveScanning,
+      "Ordinary recursive activation remains available",
+    );
+    assert.equal(result.budgetSkippedEntries.filter((entry) => entry.id === blocked.id).length, 1);
+    assert.ok(
+      result.budgetSkippedEntries.every((entry) => !result.activatedEntryIds.includes(entry.id)),
+      "Skip diagnostics must describe entries actually omitted",
+    );
+  }
+
   // ── 1. Default-off: the unused path is the path that already shipped ──
   {
     const chat = await createExperienceChat("unused key");


### PR DESCRIPTION
## Linked issue

Closes #5943

## Why this change

A forced constant entry dropped by the location budget is reintroduced by the ordinary or recursive scan. Its debug record then says it was skipped even though the prompt includes it.

## What changed

Use the existing skipped-entry diagnostics to exclude location-budget drops from the ordinary and recursive scan inputs. Ambient and recursive lore still activates normally. Add a regression to the existing real-storage experience-lore suite and an Unreleased changelog entry.

## Validation

Automated: `pnpm check`, `pnpm regression:prompt`, and `node scripts/run-regressions.mjs --filter experience-lore-entries` passed. The new regression failed on unchanged staging because the rejected constant entry was present; it passes with both ordinary and recursive scans after the fix.

- [ ] `pnpm check`
- [ ] Prompt regression proving ordinary and recursive scans respect the same location-budget drop.
- [ ] Manually verify location lore diagnostics agree with the assembled prompt.

## Docs and release impact

Unreleased changelog entry; no new setting or version change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed location lorebook token-budget handling so entries rejected for exceeding the current-location budget remain excluded from keyword and recursive scans.
  - Prevented over-budget forced entries from being reactivated later in processing.
  - Improved consistency between skipped-entry diagnostics and the entries included in generated prompts.
  - Preserved existing behavior for eligible ambient entries and recursive child entries.
  - Ensured entries skipped due to budget limits are reported accurately and only once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->