### PR TITLE
fix(mobile): preserve message actions after dialog dismissal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Mobile message action icons remain available after closing action dialogs such as Peek Prompt (#5825).
 - Game-state tools now mark location/time changes as pending until the response is saved, then confirm storage on that message and swipe. Earlier turns stay unchanged, and refused or locked writes are reported. Failed and denied tool calls show a concise notification even when debug mode is off (#5898, #5901).
 - Package persistence now requires declared chat-read/chat-write permissions for chat and spatial snapshot access, including transactions. The package detail view distinguishes installed and catalog permissions and explains which permissions are API gates or trusted-code access declarations (#5899).
 - Game turns now keep every dice roll on its swipe, show dice and skill-check cards in sequence, and retain roll history in Logs and stacked history, including when displaying translated narration. Text-only connections can request ordinary dice and explicit success pools; the GM receives the real results in one follow-up request before finishing outcome narration (#5956, #5959, #5960, #5961).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2079,79 +2079,131 @@ test("mobile Roleplay context and edit controls keep their chrome and space", as
   }
 });
 
-test("mobile Roleplay Peek prompt keeps its tapped action visible and labels prompt totals clearly", async ({
-  page,
-}, testInfo) => {
-  test.skip(!testInfo.project.name.includes("mobile"), "The sticky action state is mobile-only.");
+for (const layout of ["Roleplay", "Classic Conversation", "Bubble Conversation"] as const) {
+  for (const theme of ["dark", "light"] as const) {
+    test(`mobile ${layout} Peek prompt keeps its tapped action visible and labels prompt totals clearly (${theme})`, async ({
+      page,
+    }, testInfo) => {
+      test.skip(!testInfo.project.name.includes("mobile"), "The sticky action state is mobile-only.");
 
-  let chatId: string | null = null;
-  try {
-    const chatResponse = await page.request.post("/api/chats", {
-      data: { name: "Mobile Roleplay Peek Prompt Smoke", mode: "roleplay", characterIds: [] },
+      let chatId: string | null = null;
+      let characterId: string | null = null;
+      try {
+        const characterResponse = await page.request.post("/api/characters", {
+          data: { data: { name: "Action fixture" } },
+        });
+        expect(characterResponse.ok(), await characterResponse.text()).toBeTruthy();
+        characterId = ((await characterResponse.json()) as { id: string }).id;
+        const chatResponse = await page.request.post("/api/chats", {
+          data: {
+            name: "Mobile message action proof",
+            mode: layout === "Roleplay" ? "roleplay" : "conversation",
+            characterIds: [characterId],
+          },
+        });
+        expect(chatResponse.ok(), await chatResponse.text()).toBeTruthy();
+        const chat = (await chatResponse.json()) as { id: string };
+        chatId = chat.id;
+        const otherResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
+          data: { role: "user", content: "A different message." },
+        });
+        expect(otherResponse.ok(), await otherResponse.text()).toBeTruthy();
+        const otherMessage = (await otherResponse.json()) as { id: string };
+        const messageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
+          data: {
+            role: "assistant",
+            characterId,
+            content: "A mobile prompt action remains within reach.",
+            extra: {
+              cachedPrompt: [
+                { role: "system", content: "Stay in character." },
+                { role: "user", content: "Continue the scene." },
+              ],
+            },
+          },
+        });
+        expect(messageResponse.ok(), await messageResponse.text()).toBeTruthy();
+        const message = (await messageResponse.json()) as { id: string };
+
+        await prepareFreshClient(page);
+        await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
+        await page.goto("/");
+        await page.evaluate(
+          async ({ layout, theme }) => {
+            const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
+              useUIStore: {
+                getState: () => {
+                  setChatChromeTextColor: (value: string) => void;
+                  setTheme: (value: "dark" | "light") => void;
+                  setConversationMessageStyle: (value: "classic" | "bubble") => void;
+                };
+              };
+            };
+            const ui = useUIStore.getState();
+            ui.setTheme(theme);
+            ui.setConversationMessageStyle(layout === "Bubble Conversation" ? "bubble" : "classic");
+            ui.setChatChromeTextColor(theme === "dark" ? "#14b8a6" : "#17645c");
+          },
+          { layout, theme },
+        );
+
+        const messageRow = page.locator(`[data-message-id="${message.id}"]`);
+        await messageRow.scrollIntoViewIfNeeded();
+        await messageRow.dispatchEvent("click");
+        const peekPrompt = messageRow.getByRole("button", { name: "Peek prompt", exact: true });
+        const copy = messageRow.getByRole("button", { name: "Copy", exact: true });
+        await expect(peekPrompt).toBeVisible();
+        await expect(copy).toBeVisible();
+        const actionColor = await readCssVariableColor(page, "--marinara-chat-message-action-text");
+        await expect(peekPrompt).toHaveCSS("color", actionColor);
+
+        await peekPrompt.tap();
+        await expect(page.getByRole("heading", { name: "Assembled Prompt" })).toBeVisible();
+        await expect(page.getByText(/^2 sections · ~\d+ tokens$/u)).toBeVisible();
+        await expect(page.getByText(/&middot;/u)).toHaveCount(0);
+        await expect(peekPrompt).toBeAttached();
+        await expect(peekPrompt).toHaveCSS("color", actionColor);
+        await expect(copy).toHaveCSS("color", actionColor);
+
+        await testInfo.attach(`mobile-roleplay-peek-prompt-${testInfo.project.name}.png`, {
+          body: await page.screenshot({ fullPage: true }),
+          contentType: "image/png",
+        });
+        await page.getByRole("button", { name: "Close assembled prompt", exact: true }).tap();
+        await expect(page.getByRole("heading", { name: "Assembled Prompt" })).toHaveCount(0);
+        await expect(messageRow.locator(".mari-message-actions")).toHaveCSS("opacity", "1");
+        await expect(peekPrompt.locator("svg")).toBeVisible();
+        await expect(peekPrompt).toHaveCSS("color", actionColor);
+        // A touch action must not create an animated transform layer underneath
+        // the dialog: iOS can leave that SVG layer unpainted after dismissal.
+        await expect(peekPrompt).not.toHaveCSS("transition-property", "all");
+        await peekPrompt.tap();
+        await expect(page.getByRole("heading", { name: "Assembled Prompt" })).toBeVisible();
+        await page.getByRole("button", { name: "Close assembled prompt", exact: true }).tap();
+        await expect(page.getByRole("heading", { name: "Assembled Prompt" })).toHaveCount(0);
+        await expect(messageRow.locator(".mari-message-actions")).toHaveCSS("opacity", "1");
+
+        await messageRow.getByRole("button", { name: "Delete", exact: true }).tap();
+        const deleteDialog = page.getByRole("dialog", { name: "Delete message", exact: true });
+        await expect(deleteDialog).toBeVisible();
+        await deleteDialog.getByRole("button", { name: "Cancel", exact: true }).tap();
+        await expect(deleteDialog).toBeHidden();
+        await expect(messageRow.locator(".mari-message-actions")).toHaveCSS("opacity", "1");
+        await expect(peekPrompt.locator("svg")).toBeVisible();
+        await page.screenshot({ path: testInfo.outputPath("message-actions-after-dialogs.png") });
+
+        await page
+          .locator(`[data-message-id="${otherMessage.id}"]`)
+          .getByText("A different message.", { exact: true })
+          .tap();
+        await expect(messageRow.locator(".mari-message-actions")).toHaveCSS("opacity", "0");
+      } finally {
+        if (chatId) await bestEffortDelete(page.request, `/api/chats/${chatId}?force=true`);
+        if (characterId) await bestEffortDelete(page.request, `/api/characters/${characterId}`);
+      }
     });
-    expect(chatResponse.ok(), await chatResponse.text()).toBeTruthy();
-    const chat = (await chatResponse.json()) as { id: string };
-    chatId = chat.id;
-    const messageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
-      data: {
-        role: "assistant",
-        content: "A mobile prompt action remains within reach.",
-        extra: {
-          cachedPrompt: [
-            { role: "system", content: "Stay in character." },
-            { role: "user", content: "Continue the scene." },
-          ],
-        },
-      },
-    });
-    expect(messageResponse.ok(), await messageResponse.text()).toBeTruthy();
-    const message = (await messageResponse.json()) as { id: string };
-
-    await prepareFreshClient(page);
-    await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
-    await page.goto("/");
-    await page.evaluate(async () => {
-      const { useUIStore } = (await import("/src/stores/ui.store.ts" as string)) as {
-        useUIStore: { getState: () => { setChatChromeTextColor: (value: string) => void } };
-      };
-      useUIStore.getState().setChatChromeTextColor("#14b8a6");
-    });
-
-    const messageRow = page.locator(`[data-message-id="${message.id}"]`);
-    await messageRow.scrollIntoViewIfNeeded();
-    await messageRow.dispatchEvent("click");
-    const peekPrompt = messageRow.getByRole("button", { name: "Peek prompt", exact: true });
-    const copy = messageRow.getByRole("button", { name: "Copy", exact: true });
-    await expect(peekPrompt).toBeVisible();
-    await expect(copy).toBeVisible();
-    const actionColor = await readCssVariableColor(page, "--marinara-chat-message-action-text");
-    await expect(peekPrompt).toHaveCSS("color", actionColor);
-
-    await peekPrompt.tap();
-    await expect(page.getByRole("heading", { name: "Assembled Prompt" })).toBeVisible();
-    await expect(page.getByText(/^2 sections · ~\d+ tokens$/u)).toBeVisible();
-    await expect(page.getByText(/&middot;/u)).toHaveCount(0);
-    await expect(peekPrompt).toBeAttached();
-    await expect(peekPrompt).toHaveCSS("color", actionColor);
-    await expect(copy).toHaveCSS("color", actionColor);
-
-    await testInfo.attach(`mobile-roleplay-peek-prompt-${testInfo.project.name}.png`, {
-      body: await page.screenshot({ fullPage: true }),
-      contentType: "image/png",
-    });
-    await page.getByRole("button", { name: "Close assembled prompt", exact: true }).tap();
-    await expect(page.getByRole("heading", { name: "Assembled Prompt" })).toHaveCount(0);
-    await expect(peekPrompt.locator("svg")).toBeVisible();
-    await expect(peekPrompt).toHaveCSS("color", actionColor);
-    // A touch action must not create an animated transform layer underneath
-    // the dialog: iOS can leave that SVG layer unpainted after dismissal.
-    await expect(peekPrompt).not.toHaveCSS("transition-property", "all");
-    await peekPrompt.tap();
-    await expect(page.getByRole("heading", { name: "Assembled Prompt" })).toBeVisible();
-  } finally {
-    if (chatId) await bestEffortDelete(page.request, `/api/chats/${chatId}?force=true`);
   }
-});
+}
 
 test("mobile Conversation editing exposes the final line before text changes", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("mobile"), "The mobile message-editor scroll buffer is mobile-only.");

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2192,11 +2192,10 @@ for (const layout of ["Roleplay", "Classic Conversation", "Bubble Conversation"]
         await expect(peekPrompt.locator("svg")).toBeVisible();
         await page.screenshot({ path: testInfo.outputPath("message-actions-after-dialogs.png") });
 
-        await page
-          .locator(`[data-message-id="${otherMessage.id}"]`)
-          .getByText("A different message.", { exact: true })
-          .tap();
+        const otherMessageRow = page.locator(`[data-message-id="${otherMessage.id}"]`);
+        await otherMessageRow.getByText("A different message.", { exact: true }).tap();
         await expect(messageRow.locator(".mari-message-actions")).toHaveCSS("opacity", "0");
+        await expect(otherMessageRow.locator(".mari-message-actions")).toHaveCSS("opacity", "1");
       } finally {
         if (chatId) await bestEffortDelete(page.request, `/api/chats/${chatId}?force=true`);
         if (characterId) await bestEffortDelete(page.request, `/api/characters/${characterId}`);

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -2101,6 +2101,11 @@ export const ChatMessage = memo(function ChatMessage({
   useEffect(() => {
     if (!showActions) return;
     const handleTouch = (e: TouchEvent) => {
+      if (
+        e.target instanceof Element &&
+        e.target.closest('[role="dialog"], [role="alertdialog"], [role="menu"], [data-chat-floating-panel]')
+      )
+        return;
       if (msgRef.current && !msgRef.current.contains(e.target as Node)) {
         setShowActions(false);
       }

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -765,6 +765,11 @@ export const ConversationMessage = memo(function ConversationMessage({
   useEffect(() => {
     if (!showActions) return;
     const handleTouch = (e: TouchEvent) => {
+      if (
+        e.target instanceof Element &&
+        e.target.closest('[role="dialog"], [role="alertdialog"], [role="menu"], [data-chat-floating-panel]')
+      )
+        return;
       if (msgRef.current && !msgRef.current.contains(e.target as Node)) setShowActions(false);
     };
     document.addEventListener("touchstart", handleTouch);

--- a/packages/client/src/components/chat/PeekPromptModal.tsx
+++ b/packages/client/src/components/chat/PeekPromptModal.tsx
@@ -548,6 +548,7 @@ export function PeekPromptModal({ data, onClose }: PeekPromptModalProps) {
 
   return (
     <div
+      data-chat-floating-panel
       className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 max-md:pt-[env(safe-area-inset-top)]"
       onClick={onClose}
     >


### PR DESCRIPTION
## Linked issue

Closes #5825, reopened for the disappearing-action recurrence. The separate literal `&middot;` issue was already fixed by #5826 and remains covered by the prompt-label assertions in this PR.

## Why this change

On mobile, tapping Close or Cancel in a message action dialog also reached the message's outside-touch handler. It cleared the selected action row underneath the dialog, so the icons disappeared after dismissal until the user selected the message again. The old regression asserted SVG visibility, which does not detect an ancestor with opacity zero.

## What changed

Both message components now ignore outside touches originating inside a dialog, menu or chat floating panel. Peek Prompt uses the existing floating-panel marker on its overlay. Tapping another message still dismisses the previous action row. The product fix adds eleven lines across the existing components.

Expanded the existing browser regression to check the action row's actual opacity after repeated Peek Prompt dismissal and Delete / Cancel in Roleplay, Classic Conversation and Bubble Conversation. It also verifies normal outside-touch dismissal and retains the earlier icon-color and prompt-label checks.

## Validation

- Passed `pnpm check` (localization, formatting, lint, TypeScript and production build).
- Reproduced the disappearing action row on mobile Chromium and mobile WebKit before the fix: the strengthened original regression received opacity `0` after closing Peek Prompt. The same checks pass after the fix.
- Passed all 12 focused mobile cases: both engines, three layouts, light and dark themes.
- The targeted `pnpm smoke:ui` run passed 14 cases across desktop Chromium and both mobile engines. One existing mobile WebKit swipe-preference persistence check timed out after reload in that concurrent run; it passed when rerun in isolation with the same code. The action-row, dialog and shell checks passed.

- [ ] Manually verify repeated Peek Prompt open/close on the affected physical mobile device.
- [ ] Manually verify another action dialog can be closed without reselecting the message.

## Docs and release impact

Added the user-facing Unreleased changelog entry. No user-facing documentation or localization changes are needed for this interaction fix.

## UI evidence (if applicable)

[Before/after screenshots](https://gist.github.com/SpicyMarinara/a5d585513210b00a97e2bafadff9ef41) are embedded in a downloadable HTML artifact. Inspected mobile WebKit captures show the missing row before the fix and retained icons after repeated dismissals. These are synthetic browser fixtures, not physical-device screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Mobile message action icons now remain available when interacting with or closing dialogs, menus, and other floating panels.
  - Tapping within these overlays no longer unintentionally dismisses the message action row.
  - Message actions remain consistent when switching between messages, including after canceling a delete confirmation.
  - Improved consistency across Roleplay, Classic Conversation, and Bubble Conversation layouts in both light and dark themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

