### PR TITLE
fix(ui): prevent Accent Pulse WebKit crashes and idle repaint bursts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Accent Pulse avoids a WebKit rendering crash and recurring color and shadow transition bursts on touchscreens. Appearance keeps covered Home effects paused while the accent preview continues (#5988).
 - Mobile message action icons remain available after closing action dialogs such as Peek Prompt (#5825).
 - Game-state tools now mark location/time changes as pending until the response is saved, then confirm storage on that message and swipe. Earlier turns stay unchanged, and refused or locked writes are reported. Failed and denied tool calls show a concise notification even when debug mode is off (#5898, #5901).
 - Package persistence now requires declared chat-read/chat-write permissions for chat and spatial snapshot access, including transactions. The package detail view distinguishes installed and catalog permissions and explains which permissions are API gates or trusted-code access declarations (#5899).

--- a/e2e/accent-pulse.e2e.ts
+++ b/e2e/accent-pulse.e2e.ts
@@ -40,7 +40,9 @@ for (const color of ["#a78bfa", "linear-gradient(90deg, #a78bfa, #ec4899, #22d3e
       const root = page.locator("html");
       await expect(root).toHaveAttribute("data-marinara-accent-animation");
       const firstAccent = await root.evaluate((element) => element.style.getPropertyValue("--primary"));
-      await expect.poll(() => root.evaluate((element) => element.style.getPropertyValue("--primary"))).not.toBe(firstAccent);
+      await expect
+        .poll(() => root.evaluate((element) => element.style.getPropertyValue("--primary")))
+        .not.toBe(firstAccent);
 
       // Sample real transition events while idle, rather than asserting a CSS rule's text.
       const rendering = await page.evaluate(async () => {

--- a/e2e/accent-pulse.e2e.ts
+++ b/e2e/accent-pulse.e2e.ts
@@ -1,0 +1,78 @@
+import { expect, test, type Page } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { seedUIState } from "./ui-state-fixture.js";
+
+const version = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version;
+
+async function runningHomeAnimations(page: Page) {
+  return page.locator('[data-component="HomeBrowserHub"]').evaluate((home) =>
+    home
+      .getAnimations({ subtree: true })
+      .filter((animation) => animation.playState === "running" && animation.effect?.getTiming().iterations === Infinity)
+      .map((animation) => (animation instanceof CSSAnimation ? animation.animationName : "other")),
+  );
+}
+
+for (const color of ["#a78bfa", "linear-gradient(90deg, #a78bfa, #ec4899, #22d3ee)"]) {
+  for (const theme of ["dark", "light"] as const) {
+    test(`mobile Accent Pulse keeps idle settings quiet (${color.startsWith("#") ? "solid" : "gradient"}, ${theme})`, async ({
+      page,
+    }, testInfo) => {
+      test.skip(!testInfo.project.name.includes("mobile"), "Touch-screen rendering budget.");
+      await seedUIState(page, {
+        hasCompletedOnboarding: true,
+        rightPanelOpen: false,
+        sidebarOpen: false,
+        appAccentColor: color,
+        appAccentPulseMode: true,
+        appAccentRgbMode: false,
+        theme,
+      });
+      await page.addInitScript((appVersion) => {
+        localStorage.setItem("marinara:whats-new:seen-version", appVersion);
+      }, version);
+      // Keep another browser project's synced Appearance choices out of this fixture.
+      await page.route("**/api/app-settings/ui", (route) => route.fulfill({ json: { value: null } }));
+      await page.goto("/");
+      await page.locator('[data-tour="panel-settings"]').tap();
+      await page.getByRole("tab", { name: "Appearance", exact: true }).tap();
+      await expect(page.getByLabel("Accent Pulse", { exact: true })).toBeChecked();
+      const root = page.locator("html");
+      await expect(root).toHaveAttribute("data-marinara-accent-animation");
+      const firstAccent = await root.evaluate((element) => element.style.getPropertyValue("--primary"));
+      await expect.poll(() => root.evaluate((element) => element.style.getPropertyValue("--primary"))).not.toBe(firstAccent);
+
+      // Sample real transition events while idle, rather than asserting a CSS rule's text.
+      const rendering = await page.evaluate(async () => {
+        const paintTransitions = new Set<string>();
+        const onTransition = (event: TransitionEvent) => {
+          if (/color|shadow|filter|background/i.test(event.propertyName)) paintTransitions.add(event.propertyName);
+        };
+        document.addEventListener("transitionrun", onTransition);
+        const before = document.documentElement.style.getPropertyValue("--primary");
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 2_500));
+          return {
+            paintTransitions: [...paintTransitions],
+            before,
+            after: document.documentElement.style.getPropertyValue("--primary"),
+          };
+        } finally {
+          document.removeEventListener("transitionrun", onTransition);
+        }
+      });
+      expect(rendering.after).not.toBe(rendering.before);
+      expect(rendering.paintTransitions).toEqual([]);
+      await expect.poll(() => runningHomeAnimations(page)).toEqual([]);
+      await testInfo.attach("idle-appearance.png", { body: await page.screenshot(), contentType: "image/png" });
+
+      // Returning to Home restores its visible ambient effects.
+      await page.locator('[data-tour="panel-settings"]').tap();
+      await expect.poll(async () => (await runningHomeAnimations(page)).length).toBeGreaterThan(0);
+      await page.emulateMedia({ reducedMotion: "reduce" });
+      await expect(root).not.toHaveAttribute("data-marinara-accent-animation");
+      await page.emulateMedia({ reducedMotion: "no-preference" });
+      await expect(root).toHaveAttribute("data-marinara-accent-animation");
+    });
+  }
+}

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -247,7 +247,7 @@ function escapeSvgAttribute(value: string) {
   return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-let cursorColorProbe: HTMLSpanElement | null = null;
+let colorProbe: HTMLSpanElement | null = null;
 let cursorCanvasContext: CanvasRenderingContext2D | null | undefined;
 
 function clampCursorColorByte(value: number) {
@@ -306,30 +306,32 @@ function normalizeCursorColorForSvg(color: string, fallback: string) {
   return normalizeCursorColorWithCanvas(clean) || clean;
 }
 
-function resolveCursorColor(color: string, fallback: string) {
+function resolveCssColor(color: string, fallback: string) {
   if (typeof document === "undefined") return fallback;
-  if (!cursorColorProbe) {
-    cursorColorProbe = document.createElement("span");
-    cursorColorProbe.setAttribute("aria-hidden", "true");
-    cursorColorProbe.style.position = "fixed";
-    cursorColorProbe.style.pointerEvents = "none";
-    cursorColorProbe.style.visibility = "hidden";
-    cursorColorProbe.style.width = "0";
-    cursorColorProbe.style.height = "0";
-    document.body.appendChild(cursorColorProbe);
-  } else if (!cursorColorProbe.isConnected) {
-    document.body.appendChild(cursorColorProbe);
+  if (!colorProbe) {
+    colorProbe = document.createElement("span");
+    colorProbe.setAttribute("aria-hidden", "true");
+    colorProbe.style.position = "fixed";
+    colorProbe.style.pointerEvents = "none";
+    colorProbe.style.visibility = "hidden";
+    colorProbe.style.width = "0";
+    colorProbe.style.height = "0";
+    colorProbe.style.transition = "none";
+    document.body.appendChild(colorProbe);
+  } else if (!colorProbe.isConnected) {
+    document.body.appendChild(colorProbe);
   }
 
-  cursorColorProbe.style.color = "";
-  cursorColorProbe.style.color = color;
-  if (!cursorColorProbe.style.color) return fallback;
+  colorProbe.style.color = "";
+  colorProbe.style.color = color;
+  if (!colorProbe.style.color) return fallback;
 
-  return normalizeCursorColorForSvg(getComputedStyle(cursorColorProbe).color, fallback);
+  return getComputedStyle(colorProbe).color || fallback;
 }
 
 function getAccentCursorColors(accent: string, theme: "dark" | "light") {
-  const fill = resolveCursorColor(accent, getDefaultAppAccentColor(theme));
+  const fallback = getDefaultAppAccentColor(theme);
+  const fill = normalizeCursorColorForSvg(resolveCssColor(accent, fallback), fallback);
   const stroke = theme === "light" ? "#1a1025" : "#050312";
 
   return { fill, stroke };
@@ -507,8 +509,6 @@ export function App() {
     () => getThemeAccentPulseConfig(activeCustomTheme?.css),
     [activeCustomTheme?.css],
   );
-  const pauseChromeEffectsForAppearance =
-    appearanceSettingsActive && !appAccentRgbMode && !appAccentPulseMode && !themeAccentPulseConfig.enabled;
   useLegacyThemeMigration();
   useSettingsSync();
   const showDownloadModal = useSidecarStore((s) => s.showDownloadModal);
@@ -651,12 +651,9 @@ export function App() {
 
   useEffect(() => {
     const root = document.documentElement;
+    // Keep the accent preview independent of Home's covered ambient effects.
     const syncEffectsPausedState = () => {
-      const paused = !(
-        document.visibilityState === "visible" &&
-        document.hasFocus() &&
-        !pauseChromeEffectsForAppearance
-      );
+      const paused = !(document.visibilityState === "visible" && document.hasFocus() && !appearanceSettingsActive);
       if (!paused) {
         delete root.dataset.marinaraEffectsPaused;
       } else {
@@ -680,7 +677,7 @@ export function App() {
       window.removeEventListener("pagehide", syncEffectsPausedState);
       delete root.dataset.marinaraEffectsPaused;
     };
-  }, [pauseChromeEffectsForAppearance]);
+  }, [appearanceSettingsActive]);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -776,10 +773,13 @@ export function App() {
     };
 
     const applyLiveAccent = () => {
-      const liveAccent =
+      const mixedAccent =
         animatedAccentIsGradient && animatedGradientStops.length > 1
           ? getGradientRgbAccent(animatedGradientStops)
           : getSolidRgbAccent(animatedSolidAccent);
+      // Resolve on the small probe before changing inherited tokens. Nested
+      // color-mix() values can abort WebKit while it resolves control backgrounds.
+      const liveAccent = resolveCssColor(mixedAccent, defaultAccent);
 
       const liveGradient = getSolidAccentGradient(liveAccent);
       if (appAccentRgbMode) {
@@ -827,10 +827,7 @@ export function App() {
 
       accentAnimationTimer = window.setTimeout(() => {
         accentAnimationTimer = null;
-        if (
-          !accentAnimationEnabled ||
-          !canRunAccentAnimation(reducedMotionQuery, pauseChromeEffectsForAppearance || reduceAmbientEffects)
-        ) {
+        if (!accentAnimationEnabled || !canRunAccentAnimation(reducedMotionQuery, reduceAmbientEffects)) {
           stopAccentAnimation();
           return;
         }
@@ -849,10 +846,7 @@ export function App() {
     };
 
     const syncAccentAnimationState = () => {
-      if (
-        accentAnimationEnabled &&
-        canRunAccentAnimation(reducedMotionQuery, pauseChromeEffectsForAppearance || reduceAmbientEffects)
-      ) {
+      if (accentAnimationEnabled && canRunAccentAnimation(reducedMotionQuery, reduceAmbientEffects)) {
         if (isTextEntryFocused()) {
           // Root accent ticks invalidate styles across the entire Roleplay
           // surface in Firefox. Freeze the current accent while the user is
@@ -871,9 +865,8 @@ export function App() {
     };
 
     if (accentAnimationEnabled) {
-      // Keep the custom cursor on the selected solid accent. Resolving a
-      // color-mix() cursor through getComputedStyle on every live accent tick
-      // causes a synchronous style flush that becomes noticeable in long sessions.
+      // Keep the custom cursor on the selected solid accent. Resolving it after
+      // live root-token writes forces a synchronous app-wide style flush.
       applyCursorAccent(solidAccent);
       setAccentModeDataset();
     } else {
@@ -918,7 +911,6 @@ export function App() {
     appAccentPulseMode,
     appAccentRgbMode,
     customCursorEnabled,
-    pauseChromeEffectsForAppearance,
     reduceAmbientEffects,
     theme,
     themeAccentPulseConfig.enabled,

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -1726,6 +1726,18 @@
     transform 180ms linear;
 }
 
+/* Touch accents should repaint at their tick cadence, not start color, border
+   and shadow transitions across every mounted control between ticks.
+   ponytail: root colors still update at 2 Hz; isolated accent layers are the
+   upgrade path if device profiles need a smaller rendering budget. */
+@media (pointer: coarse) {
+  html[data-marinara-accent-animation] *,
+  html[data-marinara-accent-animation] *::before,
+  html[data-marinara-accent-animation] *::after {
+    transition-property: opacity, transform, translate, scale, rotate !important;
+  }
+}
+
 /* ─────────────────────────────────────────────
    4c. SHARED EDITOR CHROME
    Used by character, persona, preset, lorebook, connection, and agent editors.


### PR DESCRIPTION
## Linked issue

Closes #5988. Owner: @SpicyMarinara.

## Why this change

Accent Pulse can crash WebKit's content process while opening Settings/Appearance with a solid accent. Three native crash reports from the local production/development repro abort in `WebCore::Style::Color::resolvedColor()` while applying a nested `color-mix()` background. The same production path with Pulse off survives. The transition-only mitigation still crashes; resolving the animated color before publishing root tokens fixes the repro.

Pulse also starts hundreds of paint-property transitions while idle, and enabling its Appearance preview resumes Home stars, logo and Professor effects behind the settings panel. This unnecessary rendering work is relevant to the reported iPhone heating.

The supplied iPhone history has one explicit settings refresh and two later page starts without recorded reload requests. It does not prove those restarts have the same native cause or establish a JavaScript memory leak. Its memory/session figures describe the Docker server, not the phone.

## What changed

- Reuse the existing browser color probe to resolve each live accent before changing inherited CSS tokens. Preserve color alpha/gamut and existing cursor normalization.
- On coarse-pointer screens, retain opacity/transform transitions while Pulse is active and stop repeatedly interpolating paint properties between its existing 500 ms ticks.
- Keep covered Home effects paused in Appearance independently of the working accent preview. Existing visibility, focus, typing and reduced-motion guards remain in use.
- Add the runnable mobile browser regression and an Unreleased changelog entry. No dependencies or new settings.

## Validation

Passed `pnpm check` (including localization, formatting, lint, E2E types and production builds).

Passed 25 selected browser cases across desktop Chromium, mobile Chromium and mobile WebKit (8 platform-specific skips):

```sh
pnpm smoke:ui e2e/accent-pulse.e2e.ts e2e/core-flows.e2e.ts e2e/client-runtime-diagnostics.e2e.ts --grep 'mobile Accent Pulse|gradient Accent Pulse|modal backdrops|home shell and primary|turning off the custom mouse pointer|support diagnostics persists|preload recovery is marked|Roleplay edit and older-message'
```

The new regression exercises real idle transition events, solid/gradient accents, dark/light themes, Home pause/resume and reduced-motion changes. It failed before the fix and passes afterward, including the native WebKit crash path.

Production measurements on isolated synthetic data, eight idle seconds in Appearance, gradient Pulse on:

| Measurement | Before | After |
| --- | ---: | ---: |
| WebKit transition events | 832 | 0 |
| Chromium transition events | 1,216 | 0 |
| Chromium main-thread task time | 0.877 s | 0.392 s |
| Chromium style recalculations | 489 | 33 |

Pulse still cycles at 2 Hz. These desktop-hosted browser measurements demonstrate a rendering reduction, not a physical-device temperature result. Five-minute production WebKit idle runs passed in both Appearance and Chat Settings with solid Pulse on: zero crashes, reloads or JavaScript errors; DOM counts stayed exactly 1,722 and 665 respectively; the accent continued cycling. The Chat Name section still expanded and the drawer closed normally afterward.

- [ ] Manually verify temperature and page stability during an extended session on the affected iPhone.
- [ ] Manually verify solid/gradient Pulse and touch interactions with the user's chosen theme.

## Docs and release impact

Added an Unreleased fix entry. No new UI copy, documentation changes or version bump.

## UI evidence (if applicable)

[Production before/after screenshots, measurements and native crash summary](https://gist.github.com/SpicyMarinara/e0c322015407ec34ecc5f130c240a409). Download the HTML to view its embedded screenshots. No real user data or full native crash reports are included.

The deliberate ceiling is that root accent tokens still update at 2 Hz. Coarse-pointer paint/dimension transitions settle immediately while Pulse is active; opacity and transform motion remain. Physical iPhone heat, battery drain and long-session stability still require on-device confirmation.
