### PR TITLE
Fix Conversation swipe alignment and Termux restart leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,8 +111,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
-- Conversation swipe controls align with the message text and avoid an extra empty row when hidden (#6009).
-- Termux storage uses the existing writer liveness check to recover a stopped server's lease without rebooting when PID ownership cannot be established, while keeping active writers protected (#6010).
+- Conversation swipe controls align with the start of the message row. Hidden mobile actions and disabled swipe controls no longer leave unused space below messages (#6009).
+- New Termux storage leases can recover after a stopped server without rebooting, even when Android cannot establish PID ownership. Active writers remain protected (#6010).
 
 - Narrative Director push actions add only the selected natural/random nudge, without an extra planning-model direction or stale cached direction on regeneration. Secret Plot runs only while enabled (#6008).
 - Roleplay DMs now mark new, reused, and linked Conversation threads unread, including after reload (#6000).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Conversation swipe controls align with the message text and avoid an extra empty row when hidden (#6009).
+- Termux storage uses the existing writer liveness check to recover a stopped server's lease without rebooting when PID ownership cannot be established, while keeping active writers protected (#6010).
+
 - Narrative Director push actions add only the selected natural/random nudge, without an extra planning-model direction or stale cached direction on regeneration. Secret Plot runs only while enabled (#6008).
 - Roleplay DMs now mark new, reused, and linked Conversation threads unread, including after reload (#6000).
 - Roleplay streaming now applies the same display regexes and scope settings as completed messages, preserving incomplete fragments until a regex matches (#5994).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2464,11 +2464,15 @@ test("Conversation message actions follow their messages on desktop and mobile",
           const firstButton = actionElement?.querySelector<HTMLElement>("button");
           if (!contentElement || !actionElement || !firstButton) return null;
           const contentBox = contentElement.getBoundingClientRect();
+          const swipeBox = element.querySelector<HTMLElement>(":scope > .mari-message-swipes")?.getBoundingClientRect();
           const actionBox = actionElement.getBoundingClientRect();
           const buttonBox = firstButton.getBoundingClientRect();
           return {
             position: getComputedStyle(actionElement).position,
-            verticalGap: actionBox.top - contentBox.bottom,
+            // Swipes now form their own footer row. Check the actual gaps
+            // around it, without counting its touch targets as empty space.
+            swipeGap: swipeBox ? swipeBox.top - contentBox.bottom : 0,
+            verticalGap: actionBox.top - (swipeBox?.bottom ?? contentBox.bottom),
             leftOffset: Math.abs(buttonBox.left - contentBox.left),
             actionBottom: actionBox.bottom,
             rowBottom: element.getBoundingClientRect().bottom,
@@ -2476,6 +2480,8 @@ test("Conversation message actions follow their messages on desktop and mobile",
         });
         expect(metrics).not.toBeNull();
         expect(metrics!.position).toBe("static");
+        expect(metrics!.swipeGap).toBeGreaterThanOrEqual(0);
+        expect(metrics!.swipeGap).toBeLessThanOrEqual(5);
         expect(metrics!.verticalGap).toBeGreaterThanOrEqual(0);
         expect(metrics!.verticalGap).toBeLessThanOrEqual(5);
         expect(metrics!.leftOffset).toBeLessThanOrEqual(6);

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -5898,6 +5898,15 @@ test("Conversation swipe controls match Roleplay sizing and chat-chrome colors",
           const row = page.locator(`[data-message-id="${messageId}"]`);
           const control = row.locator(".mari-message-swipes");
           await expect(control).toBeVisible();
+          if (layout !== "roleplay") {
+            const start = await row.evaluate(
+              (element) =>
+                element.getBoundingClientRect().left + Number.parseFloat(getComputedStyle(element).paddingLeft),
+            );
+            expect
+              .soft(Math.abs((await control.boundingBox())!.x - start), `${layout} swipes align with the message row`)
+              .toBeLessThan(1);
+          }
           const input = control.getByRole("textbox");
           await expect(input).toHaveValue("1");
           // Compare the settled theme color, not WebKit's retained Oklab
@@ -6005,6 +6014,10 @@ for (const mode of ["conversation", "roleplay"] as const) {
       const row = page.locator(`[data-message-id="${message.id}"]`);
       const actions = row.locator(".mari-message-actions");
       await expect(row).toBeVisible();
+      if (mobile && mode === "conversation") {
+        await expect(actions).toBeHidden();
+        expect(await actions.evaluate((element) => element.getBoundingClientRect().height)).toBe(0);
+      }
       await expect(row.locator(".mari-message-swipes")).toBeVisible();
       await expect(row.getByRole("button", { name: "Previous swipe", exact: true })).toBeDisabled();
       await expect(row.getByRole("textbox", { name: "Jump to swipe, 1 through 1", exact: true })).toHaveValue("1");

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -30,6 +30,7 @@ import { GenerationReplayDetailsModal, hasGenerationReplayDetails } from "./Gene
 import {
   HiddenFromAIConversationButton,
   ConversationMessageLightbox,
+  ConversationMessageSwipes,
   type MessageData,
   type MessageRenderContext,
 } from "./ConversationMessageShared";
@@ -1138,6 +1139,8 @@ export const ConversationMessage = memo(function ConversationMessage({
         >
           {isBubbleStyle ? <ConversationMessageBubble ctx={ctx} /> : <ConversationMessageLine ctx={ctx} />}
         </div>
+
+        <ConversationMessageSwipes ctx={ctx} />
 
         {(!hideActions || (hasReasoning && !isUser)) && (
           <ConversationMessageActions

--- a/packages/client/src/components/chat/ConversationMessageActions.tsx
+++ b/packages/client/src/components/chat/ConversationMessageActions.tsx
@@ -98,7 +98,7 @@ export function ConversationMessageActions({
         "mari-message-actions flex w-full min-w-0 flex-wrap items-center justify-between gap-1 px-1 transition-all md:justify-start md:gap-x-2",
         visible
           ? "visible pointer-events-auto opacity-100"
-          : "invisible pointer-events-none opacity-0 group-hover:visible group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:visible group-focus-within:pointer-events-auto group-focus-within:opacity-100",
+          : "invisible pointer-events-none opacity-0 max-md:hidden max-md:group-hover:flex max-md:group-focus-within:flex group-hover:visible group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:visible group-focus-within:pointer-events-auto group-focus-within:opacity-100",
         thinkingOnly && "max-sm:[&>*:not(.mari-message-thinking-action)]:hidden",
       )}
       data-component="ConversationMessage.Actions"

--- a/packages/client/src/components/chat/ConversationMessageBubble.tsx
+++ b/packages/client/src/components/chat/ConversationMessageBubble.tsx
@@ -16,7 +16,6 @@ import {
   ConversationMessageEditForm,
   ConversationMessageAttachments,
   ConversationMessageTranslation,
-  ConversationMessageSwipes,
   ConversationMessageName,
   diceRollReplacesMessageContent,
   nameColorStyle,
@@ -59,17 +58,11 @@ export function ConversationMessageBubble({ ctx }: { ctx: MessageRenderContext }
     isHiddenCollapsed,
     hiddenFromAIHeader,
     onExpandHidden,
-    hideActions,
     hideTimestamp,
     showActions,
     forceShowActions,
     showMessageNumbers,
     messageIndex,
-    hasSwipes,
-    swipeCount,
-    onSetActiveSwipe,
-    canRegenerate,
-    onRegenerate,
     onImageOpen,
     onRemoveAttachment,
     translatedText,
@@ -344,20 +337,6 @@ export function ConversationMessageBubble({ ctx }: { ctx: MessageRenderContext }
           )}
         </div>
       </div>
-
-      {/* Swipe controls — separate row so avatar never drifts */}
-      {!hideActions && (hasSwipes || (canRegenerate && onRegenerate)) && (
-        <div className={cn("mt-1", isUser ? "flex justify-end" : "pl-12")}>
-          <ConversationMessageSwipes
-            isUser={isUser}
-            messageId={message.id}
-            activeSwipeIndex={message.activeSwipeIndex}
-            swipeCount={swipeCount}
-            onSetActiveSwipe={(idx) => onSetActiveSwipe?.(message.id, idx)}
-            onCreateNextSwipe={canRegenerate && onRegenerate ? () => onRegenerate(message.id) : undefined}
-          />
-        </div>
-      )}
     </>
   );
 }

--- a/packages/client/src/components/chat/ConversationMessageGrouped.tsx
+++ b/packages/client/src/components/chat/ConversationMessageGrouped.tsx
@@ -60,9 +60,6 @@ export function ConversationMessageGrouped({
     hideTimestamp,
     showMessageNumbers,
     messageIndex,
-    hasSwipes,
-    swipeCount,
-    onSetActiveSwipe,
     renderedContent,
     onImageOpen,
     onRemoveAttachment,
@@ -119,9 +116,7 @@ export function ConversationMessageGrouped({
   };
   const hasTranslationContent = Boolean(translatedText || isTranslating);
   const hasAttachmentContent = (extra.attachments?.length ?? 0) > 0 && !IMAGE_URL_RE.test(renderedContent.trim());
-  const hasSwipeContent = !hideActions && (hasSwipes || Boolean(canRegenerate && onRegenerate));
-  const hasTrailingContent =
-    isStreaming || (!isHiddenCollapsed && (hasTranslationContent || hasAttachmentContent || hasSwipeContent));
+  const hasTrailingContent = isStreaming || (!isHiddenCollapsed && (hasTranslationContent || hasAttachmentContent));
 
   return (
     <div
@@ -397,11 +392,11 @@ export function ConversationMessageGrouped({
         })
       )}
 
-      {/* Trailing content (cursor, translation, attachments, swipes): kept in a
+      {/* Trailing content (cursor, translation, attachments): kept in a
           [data-card-css] wrapper so themes retain the reach they had when the
           attribute lived on the block root — but only rendered when it has
           content, so container-styling themes can't paint an empty box. The
-          action row stays OUTSIDE the wrapper because it is app chrome, like
+          control rows stay OUTSIDE the wrapper because they are app chrome, like
           the reaction chip rows. */}
       {hasTrailingContent && (
         <div {...cardCssProps}>
@@ -430,23 +425,12 @@ export function ConversationMessageGrouped({
                   onRemove={onRemoveAttachment}
                 />
               </div>
-
-              {!hideActions && (hasSwipes || (canRegenerate && onRegenerate)) && (
-                <div className="ml-14 mt-1.5">
-                  <ConversationMessageSwipes
-                    isUser={false}
-                    messageId={message.id}
-                    activeSwipeIndex={message.activeSwipeIndex}
-                    swipeCount={swipeCount}
-                    onSetActiveSwipe={(idx) => onSetActiveSwipe?.(message.id, idx)}
-                    onCreateNextSwipe={canRegenerate && onRegenerate ? () => onRegenerate(message.id) : undefined}
-                  />
-                </div>
-              )}
             </>
           )}
         </div>
       )}
+
+      <ConversationMessageSwipes ctx={ctx} />
 
       {/* Action bar */}
       {(!hideActions || hasReasoning) && (

--- a/packages/client/src/components/chat/ConversationMessageLine.tsx
+++ b/packages/client/src/components/chat/ConversationMessageLine.tsx
@@ -15,7 +15,6 @@ import {
   ConversationMessageEditForm,
   ConversationMessageAttachments,
   ConversationMessageTranslation,
-  ConversationMessageSwipes,
   ConversationMessageName,
   diceRollReplacesMessageContent,
   formatTimestamp,
@@ -53,17 +52,11 @@ export function ConversationMessageLine({ ctx }: { ctx: MessageRenderContext }) 
     isHiddenCollapsed,
     hiddenFromAIHeader,
     onExpandHidden,
-    hideActions,
     hideTimestamp,
     showActions,
     forceShowActions,
     showMessageNumbers,
     messageIndex,
-    hasSwipes,
-    swipeCount,
-    onSetActiveSwipe,
-    canRegenerate,
-    onRegenerate,
     onImageOpen,
     onRemoveAttachment,
     translatedText,
@@ -262,19 +255,6 @@ export function ConversationMessageLine({ ctx }: { ctx: MessageRenderContext }) 
               onImageOpen={onImageOpen}
               onRemove={onRemoveAttachment}
             />
-
-            {!hideActions && (hasSwipes || (canRegenerate && onRegenerate)) && (
-              <div className="mt-1.5">
-                <ConversationMessageSwipes
-                  isUser={isUser}
-                  messageId={message.id}
-                  activeSwipeIndex={message.activeSwipeIndex}
-                  swipeCount={swipeCount}
-                  onSetActiveSwipe={(idx) => onSetActiveSwipe?.(message.id, idx)}
-                  onCreateNextSwipe={canRegenerate && onRegenerate ? () => onRegenerate(message.id) : undefined}
-                />
-              </div>
-            )}
           </>
         )}
       </div>

--- a/packages/client/src/components/chat/ConversationMessageShared.tsx
+++ b/packages/client/src/components/chat/ConversationMessageShared.tsx
@@ -642,33 +642,28 @@ export function ConversationMessageTranslation({
 }
 
 /** Compact swipe control — consistent style for all Conversation layouts. */
-export function ConversationMessageSwipes({
-  isUser,
-  messageId,
-  activeSwipeIndex,
-  swipeCount,
-  onSetActiveSwipe,
-  onCreateNextSwipe,
-  className,
-}: {
-  isUser: boolean;
-  messageId: string;
-  activeSwipeIndex: number;
-  swipeCount: number;
-  onSetActiveSwipe: (index: number) => void;
-  onCreateNextSwipe?: () => void;
-  className?: string;
-}) {
+export function ConversationMessageSwipes({ ctx }: { ctx: MessageRenderContext }) {
   const alwaysShow = useUIStore((state) => state.alwaysDisplayConversationSwipeMenu);
+  const {
+    message,
+    isUser,
+    hideActions,
+    isHiddenCollapsed,
+    hasSwipes,
+    swipeCount,
+    onSetActiveSwipe,
+    canRegenerate,
+    onRegenerate,
+  } = ctx;
+  if (hideActions || isHiddenCollapsed || (!hasSwipes && !(canRegenerate && onRegenerate))) return null;
   return (
     <SwipeJumpControl
       alwaysShow={alwaysShow && !isUser}
-      messageId={messageId}
-      activeSwipeIndex={activeSwipeIndex}
+      messageId={message.id}
+      activeSwipeIndex={message.activeSwipeIndex}
       swipeCount={swipeCount}
-      onSetActiveSwipe={onSetActiveSwipe}
-      onCreateNextSwipe={onCreateNextSwipe}
-      className={className}
+      onSetActiveSwipe={(idx) => onSetActiveSwipe?.(message.id, idx)}
+      onCreateNextSwipe={canRegenerate && onRegenerate ? () => onRegenerate(message.id) : undefined}
     />
   );
 }

--- a/packages/client/src/components/chat/ConversationMessageShared.tsx
+++ b/packages/client/src/components/chat/ConversationMessageShared.tsx
@@ -664,6 +664,7 @@ export function ConversationMessageSwipes({ ctx }: { ctx: MessageRenderContext }
       swipeCount={swipeCount}
       onSetActiveSwipe={(idx) => onSetActiveSwipe?.(message.id, idx)}
       onCreateNextSwipe={canRegenerate && onRegenerate ? () => onRegenerate(message.id) : undefined}
+      className={ctx.isBubbleStyle && isUser ? "justify-end" : undefined}
     />
   );
 }

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -1518,19 +1518,6 @@ const CURRENT_CLOCK_TICKS_PER_SECOND = (() => {
   }
 })();
 
-const CURRENT_CONTAINER_WRITER_SCOPE_ID = (() => {
-  if (process.platform !== "linux" || process.env.MARINARA_DOCKER !== "true") return null;
-  try {
-    const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
-    if (bootId) {
-      return createHash("sha256").update(`marinara-writer-lease-boot\n${bootId}`).digest("hex");
-    }
-  } catch {
-    return null;
-  }
-  return null;
-})();
-
 function writerLeaseBelongsToCurrentHost(record: StorageWriterLeaseRecord) {
   if (record.version === 2 || record.version === 4) {
     return Boolean(CURRENT_HOST_ID && record.hostId === CURRENT_HOST_ID);
@@ -1552,9 +1539,11 @@ async function startWriterLeaseLiveness(
   if (process.platform === "win32" || !scopeId) return null;
 
   const socketPath = writerLeaseLivenessPath(path);
-  // sockaddr_un is shortest on macOS (103 usable bytes). Stay below every
-  // supported POSIX limit instead of letting a platform silently truncate it.
-  if (Buffer.byteLength(socketPath) > 100) return null;
+  // Unix socket paths allow 107 bytes on Linux/Android, 103 on macOS.
+  // The default Termux install needs 101; reject oversized paths before
+  // Node can silently truncate them.
+  const maxPathBytes = process.platform === "linux" || process.platform === "android" ? 107 : 103;
+  if (Buffer.byteLength(socketPath) > maxPathBytes) return null;
 
   // Container PID namespaces can reuse the same internal PID after a recreation.
   // A socket on the shared data mount remains reachable while its writer lives,
@@ -1578,7 +1567,7 @@ async function startWriterLeaseLiveness(
     rmSync(socketPath, { force: true });
     logger.debug(
       { err: error, path: socketPath },
-      "[file-storage] Writer lease socket is unavailable; a stale container lease may require manual recovery.",
+      "[file-storage] Writer lease socket is unavailable; a stale writer lease may require manual recovery.",
     );
     return null;
   }
@@ -2343,8 +2332,18 @@ class FileTableStore {
 
   private async acquireWriterLease() {
     const path = writerLeasePath(this.rootDir);
-    const writerScopeId = this.testHooks?.writerLeaseScopeId ?? CURRENT_CONTAINER_WRITER_SCOPE_ID;
     const writerBootId = this.testHooks?.writerLeaseBootId ?? CURRENT_BOOT_ID;
+    // Container PID reuse and Android's restricted process visibility can
+    // make PID ownership uncertain. Reuse the kernel-owned socket proof,
+    // scoped to this boot; Termux enables it only for its app-private HOME.
+    const useLiveness =
+      (process.platform === "linux" && process.env.MARINARA_DOCKER === "true") ||
+      isTermuxPrivateHomeStorage(this.rootDir);
+    const writerScopeId =
+      this.testHooks?.writerLeaseScopeId ??
+      (useLiveness && writerBootId
+        ? createHash("sha256").update(`marinara-writer-lease-boot\n${writerBootId}`).digest("hex")
+        : null);
     const writerPidNamespace = this.testHooks?.writerLeasePidNamespace ?? CURRENT_PID_NAMESPACE;
     for (let attempt = 0; attempt < 10; attempt++) {
       const token = randomUUID();

--- a/scripts/regressions/storage-writer-lock.regression.ts
+++ b/scripts/regressions/storage-writer-lock.regression.ts
@@ -132,7 +132,10 @@ try {
     const containerLeaseHooks = { writerLeaseScopeId: "writer-lock-container-host" };
     const db = await createFileNativeDB(containerLeaseHooks);
     const leaseTemplate = readJson<LeaseRecord>(ownerPath(dir));
-    const socketPathIsSupported = process.platform !== "win32" && Buffer.byteLength(livenessPath(dir)) <= 100;
+    const socketPathIsSupported =
+      process.platform !== "win32" &&
+      Buffer.byteLength(livenessPath(dir)) <=
+        (process.platform === "linux" || process.platform === "android" ? 107 : 103);
     assert.equal(
       leaseTemplate.version,
       leaseTemplate.bootId ? 4 : socketPathIsSupported ? 3 : 2,
@@ -297,7 +300,11 @@ try {
       const afterReboot = await createFileNativeDB({ writerLeaseBootId: "writer-lock-current-boot" });
       assert.notEqual(readJson<LeaseRecord>(ownerPath(dir)).token, "stale-reused-pid-token");
       await afterReboot._fileStore.close();
+    }
 
+    // macOS has no process-start-time proof; exercise PID reuse only where
+    // the runtime implements it, using a valid v4 boot identity on each host.
+    if (leaseTemplate.hostId && leaseTemplate.bootId) {
       mkdirSync(leasePath(dir));
       writeFileSync(
         ownerPath(dir),
@@ -531,9 +538,13 @@ try {
       // "shareable" here so the HOME rule is what this proves).
       const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
       const previousHome = process.env.HOME;
-      const termuxHome = mkdtempSync(join(tmpdir(), "marinara-termux-home-"));
+      // Keep the real socket path at the 101 bytes used by the reported
+      // default Termux install, even on macOS with its longer temp directory.
+      const termuxHome = mkdtempSync("/tmp/me-termux-");
       tempDirs.push(termuxHome);
-      const termuxStorage = join(termuxHome, "Marinara-Engine", "packages", "server", "data", "storage");
+      const termuxStorage = join(termuxHome, "s".repeat(101 - Buffer.byteLength(livenessPath(termuxHome)) - 1));
+      assert.equal(Buffer.byteLength(livenessPath(termuxStorage)), 101);
+      const termuxHooks = { writerLeaseBootId: "termux-current-boot" };
       process.env.FILE_STORAGE_DIR = termuxStorage;
       mkdirSync(leasePath(termuxStorage), { recursive: true });
       writeFileSync(
@@ -550,10 +561,77 @@ try {
       try {
         Object.defineProperty(process, "platform", { ...platformDescriptor, value: "android" });
         process.env.HOME = termuxHome;
-        termuxDb = await createFileNativeDB();
+        termuxDb = await createFileNativeDB(termuxHooks);
         assert.notEqual(readJson<LeaseRecord>(ownerPath(termuxStorage)).token, "stale-termux-token");
+        const termuxLease = readJson<LeaseRecord>(ownerPath(termuxStorage));
+        assert.ok(termuxLease.scopeId, "Termux private-home leases enable the existing liveness proof");
+        assert.equal(existsSync(livenessPath(termuxStorage)), true, "the default Termux path fits a real socket");
+        await assert.rejects(
+          createFileNativeDB(termuxHooks),
+          StorageWriterLeaseError,
+          "a live Termux writer stays locked",
+        );
+        assert.equal(readJson<LeaseRecord>(ownerPath(termuxStorage)).token, termuxLease.token);
         await termuxDb._fileStore.close();
         termuxDb = undefined;
+        assert.equal(existsSync(leasePath(termuxStorage)), false, "clean Termux shutdown releases the lease");
+
+        // A real force-killed socket owner leaves ECONNREFUSED. Name our live
+        // PID with a fresh timestamp so neither PID proof can reclaim it.
+        mkdirSync(leasePath(termuxStorage));
+        await leaveStaleSocket(livenessPath(termuxStorage));
+        const crashedLease = { ...termuxLease, hostId: null, pid: process.pid, acquiredAt: new Date().toISOString() };
+        writeFileSync(ownerPath(termuxStorage), JSON.stringify({ ...crashedLease, scopeId: "another-boot" }));
+        await assert.rejects(
+          createFileNativeDB(termuxHooks),
+          StorageWriterLeaseError,
+          "a foreign socket scope stays locked",
+        );
+        writeFileSync(ownerPath(termuxStorage), JSON.stringify(crashedLease));
+        termuxDb = await createFileNativeDB(termuxHooks);
+        assert.notEqual(readJson<LeaseRecord>(ownerPath(termuxStorage)).token, crashedLease.token);
+        await termuxDb._fileStore.close();
+        termuxDb = undefined;
+
+        mkdirSync(leasePath(termuxStorage));
+        writeFileSync(ownerPath(termuxStorage), JSON.stringify(crashedLease));
+        await assert.rejects(
+          createFileNativeDB(termuxHooks),
+          StorageWriterLeaseError,
+          "a missing socket is not proof of exit",
+        );
+        writeFileSync(ownerPath(termuxStorage), JSON.stringify({ ...crashedLease, scopeId: undefined }));
+        await assert.rejects(
+          createFileNativeDB(termuxHooks),
+          StorageWriterLeaseError,
+          "an uncertain legacy owner without a socket stays locked",
+        );
+        rmSync(leasePath(termuxStorage), { recursive: true });
+
+        termuxDb = await createFileNativeDB({ writerLeaseBootId: "" });
+        assert.equal(
+          readJson<LeaseRecord>(ownerPath(termuxStorage)).scopeId,
+          undefined,
+          "no boot identity means no socket scope",
+        );
+        await termuxDb._fileStore.close();
+        termuxDb = undefined;
+
+        if (platformDescriptor.value === "linux" || platformDescriptor.value === "android") {
+          for (const pathBytes of [107, 108]) {
+            const storage = join(termuxHome, "s".repeat(pathBytes - Buffer.byteLength(livenessPath(termuxHome)) - 1));
+            process.env.FILE_STORAGE_DIR = storage;
+            termuxDb = await createFileNativeDB(termuxHooks);
+            assert.equal(
+              existsSync(livenessPath(storage)),
+              pathBytes === 107,
+              "Linux socket paths respect the kernel byte limit",
+            );
+            assert.equal(Boolean(readJson<LeaseRecord>(ownerPath(storage)).scopeId), pathBytes === 107);
+            await termuxDb._fileStore.close();
+            termuxDb = undefined;
+          }
+        }
 
         const outsideHome = useTempStorage("termux-outside-home");
         mkdirSync(leasePath(outsideHome));
@@ -571,6 +649,13 @@ try {
         symlinkSync(outsideHome, linkedOutsideHome, "dir");
         process.env.FILE_STORAGE_DIR = linkedOutsideHome;
         await assert.rejects(createFileNativeDB({ writerLeaseStorageIsMachineLocal: false }), StorageWriterLeaseError);
+        rmSync(leasePath(outsideHome), { recursive: true });
+        termuxDb = await createFileNativeDB(termuxHooks);
+        assert.equal(
+          readJson<LeaseRecord>(ownerPath(outsideHome)).scopeId,
+          undefined,
+          "a symlink outside Termux HOME does not enable its liveness scope",
+        );
       } finally {
         if (termuxDb) await termuxDb._fileStore.close();
         Object.defineProperty(process, "platform", platformDescriptor);


### PR DESCRIPTION
## Linked issues

Closes #6009
Closes #6010

## Why this change

Conversation swipe controls inherited the avatar-column indentation, placing them 51–60 px away from the start of the message row on mobile. Hidden actions also reserved a full row of space.

Termux did not enable Engine's existing writer-liveness socket, and its normal 101-byte socket path exceeded the old 100-byte cutoff. If Android cannot prove that a PID no longer belongs to the old writer, startup then requires manual recovery or a reboot. This is consistent with #6010; the rare failure on the reporter's physical phone was not reproduced.

## What changed

- Reuse the Conversation swipe component at the start of classic, bubble and grouped message rows. Remove duplicated wrappers and collapse unrevealed mobile actions. Keep swipe sizes, preferences, keyboard access and right-aligned user-bubble controls.
- Enable the existing boot-scoped liveness socket for Termux app-private home storage. Honor native path limits (107 bytes on Linux/Android, 103 on macOS). A refused connection to the same-boot socket proves the writer stopped even when PID ownership is uncertain.
- Extend existing browser and storage regressions. Keep PID-reuse proof restricted to platforms that implement it in the existing writer-lock fixture.

## Validation

Completed locally:

- `pnpm install` and `pnpm check` (includes localization, formatting, lint, TypeScript and production builds).
- `node scripts/run-regressions.mjs --filter storage`: 3/3 on macOS and 3/3 in Linux Docker, with isolated data.
- `node scripts/run-regressions.mjs --filter shutdown`: 3/3, including production server SIGINT and duplicate-signal shutdown.
- Targeted Playwright matrix: 18/18 across desktop Chromium, mobile Chromium and mobile WebKit. Covers classic/bubble/grouped layouts, light/dark themes, 320 px widths, navigation, saved swipe preferences, mobile actions and keyboard reply access. The final alignment check passed again on all three browsers after preserving user-bubble alignment.
- Production Docker image built; health returned `ok`, a second writer was rejected, and four production browser captures passed.
- New assertions failed before the fixes: swipe offset and reserved mobile action height; missing Termux liveness scope.

### Storage claim boundary

| Path or proof | Result |
| --- | --- |
| New Termux private-home lease, normal 101-byte socket path | Real listener created; clean close releases lease |
| Same boot, force-killed socket owner, PID that still appears alive | Reclaimed through socket refusal |
| Live writer, missing socket, foreign scope, uncertain legacy owner | Startup refused |
| Legacy Termux lease with definitely exited PID | Existing recovery preserved |
| Symlink to storage outside app-private home; unavailable boot identity | No new Termux socket scope |
| Linux 107-byte and 108-byte paths | 107 works; 108 safely falls back without a socket |

The tests simulate Android platform/home/boot identity on POSIX hosts and use real sockets/process termination. Legacy or unsupported leases still require the existing PID/boot proof or manual recovery. This PR does not establish why the reporter's original PID could not be verified.

### Manual verification to complete

- [ ] Manually verify swipe positioning and action reveal in Android WebView, in light and dark themes.
- [ ] Manually verify Ctrl-C and Restart Server on a physical Termux device; confirm a second live server remains blocked.
- [ ] Read and follow `CONTRIBUTING.md` and independently verify the relevant test plan.

## Docs and release impact

Both fixes are recorded under CHANGELOG Unreleased. Reviewed README, android/README, CONTRIBUTING, CONFIGURATION, TROUBLESHOOTING and FAQ together; existing launch/restart instructions remain applicable. No user-facing docs, dependency, schema or version changes.

## UI evidence

[Before/after screenshots and light-theme captures](https://gist.github.com/SpicyMarinara/b0c69a0337ff5d04c079f74b2c867b01), using a synthetic chat only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Conversation swipe controls now align with the start of message rows without leaving unused space below messages.
  - On smaller screens, message action controls remain hidden unless hovered or focused.
  - Termux storage leases can recover after a stopped server without requiring a device reboot, while active writers remain protected.
- **Tests**
  - Expanded coverage for conversation layouts and storage writer-lock recovery across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->