### PR TITLE
chore(ci): refresh the pnpm setup action

### DIFF
--- a/.github/actions/playwright-shard/action.yml
+++ b/.github/actions/playwright-shard/action.yml
@@ -25,7 +25,7 @@ runs:
   using: composite
   steps:
     - name: Set up pnpm
-      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
       with:
         run_install: false
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         with:
           run_install: false
 

--- a/.github/workflows/prealpha-platform-builds.yml
+++ b/.github/workflows/prealpha-platform-builds.yml
@@ -167,7 +167,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
 
@@ -257,7 +257,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         with:
           run_install: false
 

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         with:
           run_install: false
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/e2e/ux-feedback-sweep.e2e.ts
+++ b/e2e/ux-feedback-sweep.e2e.ts
@@ -278,12 +278,6 @@ test("UX sweep: Background library mobile toolbar, accent marker and settled mod
   await expect(card.locator("[data-background-default-toggle]")).toHaveAttribute("aria-pressed", "true");
   const useButton = card.getByRole("button", { name: /Use .* for this chat/ });
   await useButton.click();
-  const marker = card.locator("[data-background-selection-indicator]");
-  await expect(marker).toBeVisible();
-  const markerBox = (await marker.boundingBox())!;
-  const cardBox = (await card.boundingBox())!;
-  expect(markerBox.x + markerBox.width).toBeGreaterThan(cardBox.x + cardBox.width);
-  expect(markerBox.y).toBeLessThan(cardBox.y);
   await expect(library).toBeHidden();
   await expect(page.getByRole("button", { name: "Clear selection", exact: true })).toHaveAttribute(
     "class",
@@ -291,6 +285,13 @@ test("UX sweep: Background library mobile toolbar, accent marker and settled mod
   );
   await page.getByRole("button", { name: "Browse library", exact: true }).click();
   await expect(library).toHaveCSS("opacity", "1");
+  await expect(library.locator(".mari-modal-panel")).toHaveCSS("transform", "none");
+  const marker = card.locator("[data-background-selection-indicator]");
+  await expect(marker).toBeVisible();
+  const markerBox = (await marker.boundingBox())!;
+  const cardBox = (await card.boundingBox())!;
+  expect(markerBox.x + markerBox.width).toBeGreaterThan(cardBox.x + cardBox.width);
+  expect(markerBox.y).toBeLessThan(cardBox.y);
   await page.screenshot({ path: testInfo.outputPath("background-library.png") });
   if (testInfo.project.name === "mobile-webkit") {
     await expect(library.locator(".mari-modal-backdrop")).toHaveCSS("backdrop-filter", "none");


### PR DESCRIPTION
## Linked issue

Closes #6034
Supersedes #6012. Deferred npm updates are tracked in #6035.

## Why this change

Refresh the CI setup action while keeping Engine's reviewed pnpm version and workflow permissions stable. Include the shared Playwright action pin added since the original bot PR.

## What changed

- Pin all seven pnpm/action-setup uses to the verified v6.1.0 commit `ea17c68df8912ef543352723c149a84f56e3d413`.
- Preserve action inputs, runtime dependency versions, lockfile, permissions, and audit policy.
- Measure the existing background-library selection marker after reopening the settled dialog. The old browser test raced the automatic close after selection and could lose its card before reading its bounds; color/layout behavior and the expected geometry remain unchanged.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Manually verify the next release and pre-alpha workflow runs
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

`pnpm install`, `pnpm check`, and `git diff --check` passed locally. The production Docker image built and booted; `/api/health` returned `status: ok` and build commit `44da09795`. The temporary container was then removed. No manual browser walkthrough is claimed for this maintenance diff. The subsequent change only moves an existing browser assertion; it does not affect the application in that container.

Upstream's [signed v6.1.0 tag](https://github.com/pnpm/action-setup/releases/tag/v6.1.0) resolves to the pinned commit. The action adds support for pnpm 12; this change retains Engine's existing pnpm 10 pin. PR CI exercises the new action during installation, Node regressions, and browser shards. Release publication and pre-alpha packaging are not triggered by this PR and remain manual verification items.

The unchanged baseline npm audit reports five advisories, including unpatched adm-zip. Those block the five npm update PRs and are tracked separately in #6035; this CI maintenance change does not claim to fix them.

The first CI run also hit a 60-second timeout in the unchanged avatar-action test; that case passed twice locally in WebKit (10.9s and 9.4s). The other CI failure directly exposed the background-dialog measurement race corrected here. After the fix, that case passed locally in desktop Chromium, mobile Chromium, and mobile WebKit; E2E TypeScript validation and formatting checks also passed.

## Docs and release impact

Mechanical CI dependency refresh. No application version, UI, user-guide, or release behavior changes.

## UI evidence (if applicable)

No UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project’s pnpm setup tooling across automated validation, testing, build, security, and release workflows.

- **Tests**
  - Improved end-to-end coverage for the mobile background library workflow by validating library state, toolbar behavior, modal transitions, and selection indicators in a more reliable sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->