### PR TITLE
fix(chat): guard Echo reactions and preserve native text selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- Malformed Echo Chamber reactions no longer crash the chat. Native text selections pause automatic chat scrolling and take priority over touch shortcuts and composer focus handling (#6039).
 - Roleplay's notes command explicitly explains how characters can edit existing notes by supplying their full updated contents (#6039).
 
 - Added an optional Visual Novel display for Roleplay: completed paragraphs appear above the existing composer with dialogue portraits and configured sprites. Open the attached history arrow for the full transcript and all message actions. Choose Classic or Visual Novel during setup or in Appearance → Roleplay, with separate portrait and sprite scales. Dice results and image attachments remain visible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- Roleplay's notes command explicitly explains how characters can edit existing notes by supplying their full updated contents (#6039).
+
 - Added an optional Visual Novel display for Roleplay: completed paragraphs appear above the existing composer with dialogue portraits and configured sprites. Open the attached history arrow for the full transcript and all message actions. Choose Classic or Visual Novel during setup or in Appearance → Roleplay, with separate portrait and sprite scales. Dice results and image attachments remain visible.
 
 - Roleplay Commands settings stay responsive while saving rapid changes. Documents now offers All/Narrator access, Soundtrack requires Music DJ to be added with agents enabled and follows the selected music source, and the Combat prerequisite names the Combat agent.

--- a/e2e/assigned-chat-sweep.e2e.ts
+++ b/e2e/assigned-chat-sweep.e2e.ts
@@ -398,6 +398,11 @@ for (const mode of ["roleplay", "conversation"] as const) {
     isMobile,
   }, info) => {
     const data = await fixture(request, mode);
+    const landingChat = await (
+      await request.post("/api/chats", {
+        data: { name: "Before opening selected history", mode, characterIds: [] },
+      })
+    ).json();
     try {
       for (let index = 0; index < 8; index++) {
         const response = await request.post(`/api/chats/${data.chat.id}/messages`, {
@@ -409,15 +414,38 @@ for (const mode of ["roleplay", "conversation"] as const) {
         });
         expect(response.ok()).toBeTruthy();
       }
-      await open(page, data.chat.id, {
+      await open(page, landingChat.id, {
         editMessageOnDoubleClick: true,
         intuitiveSwipeNavigation: true,
         streamingSpeed: 100,
       });
+      // An existing browser selection must delay, rather than consume, the
+      // incoming chat's one-time initial scroll to its latest message.
+      await page.evaluate(async (chatId) => {
+        const { useChatStore } = await import("/src/stores/chat.store.ts" as string);
+        const marker = document.createElement("span");
+        marker.id = "native-selection-fixture";
+        marker.style.position = "fixed";
+        marker.textContent = "Selection while opening chat";
+        document.body.append(marker);
+        const range = document.createRange();
+        range.selectNodeContents(marker);
+        document.getSelection()!.removeAllRanges();
+        document.getSelection()!.addRange(range);
+        useChatStore.getState().setActiveChatId(chatId);
+      }, data.chat.id);
       const transcript = page.locator("[data-chat-scroll]:visible").first();
       const composer = page.locator("textarea[data-chat-composer]:visible");
       const lastRow = transcript.locator("[data-message-id]").last();
       await expect(lastRow).toContainText("Selection history 7");
+      await expect.poll(() => transcript.evaluate((el) => el.scrollTop)).toBe(0);
+      await page.evaluate(() => {
+        document.getSelection()?.removeAllRanges();
+        document.getElementById("native-selection-fixture")?.remove();
+      });
+      await expect
+        .poll(() => transcript.evaluate((el) => el.scrollHeight - el.clientHeight - el.scrollTop))
+        .toBeLessThan(3);
       const row = transcript.locator(`[data-message-id="${await lastRow.getAttribute("data-message-id")}"]`);
       await page.evaluate(async (chatId) => {
         const { useChatStore } = await import("/src/stores/chat.store.ts" as string);
@@ -513,6 +541,7 @@ for (const mode of ["roleplay", "conversation"] as const) {
         .toBeLessThan(3);
     } finally {
       await data.cleanup();
+      await request.delete(`/api/chats/${landingChat.id}`);
     }
   });
 }

--- a/e2e/assigned-chat-sweep.e2e.ts
+++ b/e2e/assigned-chat-sweep.e2e.ts
@@ -390,3 +390,173 @@ test("Conversation Help explains the Reply action", async ({ page, request, isMo
     await data.cleanup();
   }
 });
+
+for (const mode of ["roleplay", "conversation"] as const) {
+  test(`${mode}: native text selection pauses automatic scrolling and touch shortcuts`, async ({
+    page,
+    request,
+    isMobile,
+  }, info) => {
+    const data = await fixture(request, mode);
+    try {
+      for (let index = 0; index < 8; index++) {
+        const response = await request.post(`/api/chats/${data.chat.id}/messages`, {
+          data: {
+            role: "assistant",
+            characterId: data.character.id,
+            content: `Selection history ${index}. ${"A quiet laboratory. ".repeat(12)}`,
+          },
+        });
+        expect(response.ok()).toBeTruthy();
+      }
+      await open(page, data.chat.id, {
+        editMessageOnDoubleClick: true,
+        intuitiveSwipeNavigation: true,
+        streamingSpeed: 100,
+      });
+      const transcript = page.locator("[data-chat-scroll]:visible").first();
+      const composer = page.locator("textarea[data-chat-composer]:visible");
+      const lastRow = transcript.locator("[data-message-id]").last();
+      await expect(lastRow).toContainText("Selection history 7");
+      const row = transcript.locator(`[data-message-id="${await lastRow.getAttribute("data-message-id")}"]`);
+      await page.evaluate(async (chatId) => {
+        const { useChatStore } = await import("/src/stores/chat.store.ts" as string);
+        useChatStore.getState().setStreaming(true, chatId);
+        useChatStore.getState().setStreamBuffer("A new turn begins.", chatId);
+      }, data.chat.id);
+      await expect(transcript.getByText("A new turn begins.", { exact: true })).toBeVisible();
+      await expect
+        .poll(() => transcript.evaluate((el) => el.scrollHeight - el.clientHeight - el.scrollTop))
+        .toBeLessThan(3);
+
+      for (const selectionTarget of ["message", "composer"] as const) {
+        if (selectionTarget === "message") {
+          await row.evaluate((el) => {
+            const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+            while (walker.nextNode()) {
+              const index = walker.currentNode.textContent?.indexOf("quiet laboratory") ?? -1;
+              if (index < 0) continue;
+              const range = document.createRange();
+              range.setStart(walker.currentNode, index);
+              range.setEnd(walker.currentNode, index + "quiet laboratory".length);
+              document.getSelection()!.removeAllRanges();
+              document.getSelection()!.addRange(range);
+              break;
+            }
+          });
+          await expect.poll(() => page.evaluate(() => document.getSelection()?.toString())).toBe("quiet laboratory");
+          if (isMobile) {
+            // Native selection handles are OS UI. These events exercise the app's
+            // competing handlers while a real browser Selection remains active.
+            await row.dispatchEvent("click", { clientX: 80, clientY: 250 });
+            await row.dispatchEvent("click", { clientX: 80, clientY: 250 });
+            await row.dispatchEvent("dblclick", { clientX: 80, clientY: 250 });
+            await expect(page.locator("[data-chat-message-editor]")).toHaveCount(0);
+            await expect.poll(() => page.evaluate(() => document.getSelection()?.toString())).toBe("quiet laboratory");
+          }
+        } else {
+          await composer.fill("Keep this selected draft text.");
+          await composer.evaluate((el: HTMLTextAreaElement) => el.setSelectionRange(5, 18));
+          const shell = composer.locator("..");
+          await shell.dispatchEvent("pointerdown", { pointerType: "touch", bubbles: true });
+          await expect
+            .poll(() =>
+              composer.evaluate((el: HTMLTextAreaElement) => el.value.slice(el.selectionStart, el.selectionEnd)),
+            )
+            .toBe("this selected");
+        }
+        const before = await transcript.evaluate((el) => el.scrollTop);
+        const nextText = `A new turn begins. ${selectionTarget} continuation. ${"More narrative arrives while text is selected. ".repeat(selectionTarget === "message" ? 8 : 16)}`;
+        await page.evaluate(
+          async ({ chatId, text }) => {
+            const { useChatStore } = await import("/src/stores/chat.store.ts" as string);
+            useChatStore.getState().setStreamBuffer(text, chatId);
+          },
+          { chatId: data.chat.id, text: nextText },
+        );
+        await expect(transcript.getByText(nextText, { exact: true })).toBeVisible();
+        // Allow both scheduled bottom-follow frames to run after the DOM paint.
+        await page.evaluate(
+          () => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))),
+        );
+        expect(Math.abs((await transcript.evaluate((el) => el.scrollTop)) - before)).toBeLessThan(3);
+        await info.attach(`${mode}-${selectionTarget}-selection-${info.project.name}.png`, {
+          body: await page.screenshot({ path: info.outputPath(`${mode}-${selectionTarget}-selection.png`) }),
+          contentType: "image/png",
+        });
+        await page.evaluate(() => {
+          document.getSelection()?.removeAllRanges();
+          const el = document.activeElement;
+          if (el instanceof HTMLTextAreaElement) el.setSelectionRange(el.value.length, el.value.length);
+        });
+        await transcript.evaluate((el) => {
+          el.scrollTop = el.scrollHeight;
+        });
+      }
+      await composer.blur();
+      await transcript.evaluate(
+        (el) =>
+          new Promise<void>((resolve) => {
+            el.scrollTop = el.scrollHeight;
+            // The scroll listener must observe the user's return before the next token.
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+      await page.evaluate(async (chatId) => {
+        const { useChatStore } = await import("/src/stores/chat.store.ts" as string);
+        useChatStore
+          .getState()
+          .setStreamBuffer(`Normal following resumes. ${"Continue the scene. ".repeat(80)}`, chatId);
+      }, data.chat.id);
+      await expect
+        .poll(() => transcript.evaluate((el) => el.scrollHeight - el.clientHeight - el.scrollTop))
+        .toBeLessThan(3);
+    } finally {
+      await data.cleanup();
+    }
+  });
+}
+
+test("Echo Chamber rejects malformed saved and live reactions without crashing the chat", async ({ page, request }) => {
+  const data = await fixture(request, "roleplay");
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  try {
+    expect(
+      (
+        await request.patch(`/api/chats/${data.chat.id}/metadata`, {
+          data: { enableAgents: true, activeAgentIds: ["echo-chamber"] },
+        })
+      ).ok(),
+    ).toBeTruthy();
+    await page.route(`**/api/agents/echo-messages/${data.chat.id}`, (route) =>
+      route.fulfill({
+        json: [
+          null,
+          { reaction: "No name" },
+          { characterName: 123, reaction: "Invalid name" },
+          { characterName: "Reader", reaction: { text: "Invalid reaction" } },
+          { characterName: "Reader", reaction: "Valid saved reaction", timestamp: 1 },
+        ],
+      }),
+    );
+    await open(page, data.chat.id, { echoChamberOpen: true });
+    const echo = page.locator('[data-roleplay-agent-window="echo"]');
+    await expect(echo.getByText("Valid saved reaction", { exact: true })).toBeVisible();
+    await page.evaluate(async () => {
+      const { useAgentStore } = await import("/src/stores/agent.store.ts" as string);
+      const store = useAgentStore.getState();
+      store.enqueueEchoMessages([
+        null,
+        { reaction: "Missing name" },
+        { characterName: "Reader", reaction: "Valid live reaction" },
+      ]);
+      store.revealNextEchoMessage();
+    });
+    await expect(echo.getByText("Valid live reaction", { exact: true })).toBeVisible();
+    await expect(page.locator("textarea[data-chat-composer]")).toBeVisible();
+    expect(errors).toEqual([]);
+  } finally {
+    await data.cleanup();
+  }
+});

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -21008,15 +21008,21 @@ test("mobile composers preserve history position and restore focus in Conversati
       while (!composerFocused && Date.now() < focusDeadline) {
         if (await showComposer.isVisible()) await activateControl(showComposer, testInfo);
         composerFocused = await textarea
-          .evaluate((element) => {
-            element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerType: "touch" }));
-            element.focus();
-            return document.activeElement === element;
-          })
+          .evaluate(
+            (element) => {
+              element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerType: "touch" }));
+              element.focus();
+              return document.activeElement === element;
+            },
+            undefined,
+            { timeout: 2_000 },
+          )
           .catch(() => false);
         if (!composerFocused) {
           await textarea.focus({ timeout: 2_000 }).catch(() => undefined);
-          composerFocused = await textarea.evaluate((element) => document.activeElement === element).catch(() => false);
+          composerFocused = await textarea
+            .evaluate((element) => document.activeElement === element, undefined, { timeout: 2_000 })
+            .catch(() => false);
         }
         if (!composerFocused) await page.waitForTimeout(250);
       }

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -33,6 +33,7 @@ import {
 } from "../../hooks/use-chats";
 
 import { getCurrentInputSnapshot, useChatStore } from "../../stores/chat.store";
+import { hasActiveTextSelection } from "../../lib/text-selection";
 import { useGenerate } from "../../hooks/use-generate";
 import { useGenerateGallerySelfie } from "../../hooks/use-gallery";
 import {
@@ -284,6 +285,7 @@ const shouldIgnoreIntuitiveSwipeTarget = (
   target: EventTarget | null,
   { allowEmptyMainComposer = false }: { allowEmptyMainComposer?: boolean } = {},
 ): boolean => {
+  if (hasActiveTextSelection()) return true;
   if (!(target instanceof Element)) return false;
   if (
     allowEmptyMainComposer &&
@@ -2509,6 +2511,7 @@ export const ChatArea = memo(function ChatArea() {
   const openedAtBottomChatIdRef = useRef<string | null>(null);
   const streamScrollFrameRef = useRef(0);
   const scrollToMessagesBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
+    if (hasActiveTextSelection()) return;
     const el = scrollRef.current;
     if (el) {
       el.scrollTo({ top: el.scrollHeight, behavior });

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -2570,19 +2570,26 @@ export const ChatArea = memo(function ChatArea() {
 
     let frame = 0;
     const scrollWhenSurfaceIsReady = () => {
+      if (frame) cancelAnimationFrame(frame);
+      if (hasActiveTextSelection()) return;
       if (!scrollRef.current && !messagesEndRef.current) {
         frame = requestAnimationFrame(scrollWhenSurfaceIsReady);
         return;
       }
 
+      document.removeEventListener("selectionchange", scrollWhenSurfaceIsReady);
       openedAtBottomChatIdRef.current = activeChatId;
       userScrolledAwayRef.current = false;
       isNearBottomRef.current = true;
       scheduleScrollToMessagesBottom("auto");
     };
 
+    document.addEventListener("selectionchange", scrollWhenSurfaceIsReady);
     scrollWhenSurfaceIsReady();
-    return () => cancelAnimationFrame(frame);
+    return () => {
+      cancelAnimationFrame(frame);
+      document.removeEventListener("selectionchange", scrollWhenSurfaceIsReady);
+    };
   }, [activeChatId, isFetchingNextPage, isLoading, loadedMessageCount, scheduleScrollToMessagesBottom]);
 
   useEffect(() => {

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -21,6 +21,7 @@ import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { updateCurrentInputSnapshot, useChatStore } from "../../stores/chat.store";
+import { hasActiveTextSelection } from "../../lib/text-selection";
 import { useAgentStore } from "../../stores/agent.store";
 import { useUIStore } from "../../stores/ui.store";
 import { useSidecarStore } from "../../stores/sidecar.store";
@@ -2041,6 +2042,7 @@ export const ChatInput = memo(function ChatInput({
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
         onPointerDown={(event) => {
+          if (hasActiveTextSelection()) return;
           const target = event.target as HTMLElement;
           if (target.closest("button, input, textarea, select, a, [role='button']")) return;
           event.preventDefault();

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -2127,6 +2127,10 @@ export const ChatMessage = memo(function ChatMessage({
 
   const handleMobileTap = useCallback(
     (e: React.MouseEvent) => {
+      if (matchMedia("(pointer: coarse)").matches && hasActiveTextSelection()) {
+        lastQuickTapRef.current = null;
+        return;
+      }
       // In multi-select mode, clicking toggles selection on any device
       if (multiSelectMode) {
         onToggleSelect?.({
@@ -2139,10 +2143,6 @@ export const ChatMessage = memo(function ChatMessage({
       }
       // Only toggle on touch devices
       if (!matchMedia("(pointer: coarse)").matches) return;
-      if (hasActiveTextSelection()) {
-        lastQuickTapRef.current = null;
-        return;
-      }
       // Don't toggle when tapping buttons, links, or the edit textarea
       const target = e.target as HTMLElement;
       if (target.closest("button, a, textarea")) return;

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -70,6 +70,7 @@ import { createMessageMacroResolver } from "../../lib/chat-macros";
 import { useApplyRegex } from "../../hooks/use-apply-regex";
 import { getDefaultChatTextColor, useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
+import { hasActiveTextSelection } from "../../lib/text-selection";
 import { parseChatMetadata } from "../../lib/chat-display";
 import { useTranslate } from "../../hooks/use-translate";
 import { api } from "../../lib/api-client";
@@ -2089,6 +2090,7 @@ export const ChatMessage = memo(function ChatMessage({
         return false;
       }
       if (isMessageQuickEditIgnoredTarget(target)) return false;
+      if (matchMedia("(pointer: coarse)").matches && hasActiveTextSelection()) return false;
       window.getSelection()?.removeAllRanges();
       setShowActions(false);
       startEditing();
@@ -2137,6 +2139,10 @@ export const ChatMessage = memo(function ChatMessage({
       }
       // Only toggle on touch devices
       if (!matchMedia("(pointer: coarse)").matches) return;
+      if (hasActiveTextSelection()) {
+        lastQuickTapRef.current = null;
+        return;
+      }
       // Don't toggle when tapping buttons, links, or the edit textarea
       const target = e.target as HTMLElement;
       if (target.closest("button, a, textarea")) return;

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -20,6 +20,7 @@ import {
 import { toast } from "sonner";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useChatStore } from "../../stores/chat.store";
+import { hasActiveTextSelection } from "../../lib/text-selection";
 import { useAgentStore } from "../../stores/agent.store";
 import { useUIStore } from "../../stores/ui.store";
 import { useSidecarStore } from "../../stores/sidecar.store";
@@ -2210,6 +2211,7 @@ export function ConversationInput({
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
         onPointerDown={(event) => {
+          if (hasActiveTextSelection()) return;
           const target = event.target as HTMLElement;
           if (target.closest("button, input, textarea, select, a, [role='button']")) return;
           event.preventDefault();

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -42,6 +42,7 @@ import { ConversationMessageLine } from "./ConversationMessageLine";
 import { MessageReactions } from "./MessageReactions";
 import { MessageThinkingModal } from "./MessageThinkingModal";
 import { useChatStore } from "../../stores/chat.store";
+import { hasActiveTextSelection } from "../../lib/text-selection";
 import { parseChatMetadata } from "../../lib/chat-display";
 import { resolveMessageReasoningDisplay } from "../../lib/message-reasoning";
 import {
@@ -748,7 +749,7 @@ export const ConversationMessage = memo(function ConversationMessage({
         });
         return;
       }
-      if (!matchMedia("(pointer: coarse)").matches) return;
+      if (!matchMedia("(pointer: coarse)").matches || hasActiveTextSelection()) return;
       setShowActions((v) => !v);
     },
     [isSelected, message.id, messageOrderIndex, multiSelectMode, onToggleSelect],

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -740,6 +740,7 @@ export const ConversationMessage = memo(function ConversationMessage({
     (e: React.MouseEvent) => {
       const target = e.target as HTMLElement;
       if (target.closest("button, a, textarea")) return;
+      if (matchMedia("(pointer: coarse)").matches && hasActiveTextSelection()) return;
       if (multiSelectMode) {
         onToggleSelect?.({
           messageId: message.id,
@@ -749,7 +750,7 @@ export const ConversationMessage = memo(function ConversationMessage({
         });
         return;
       }
-      if (!matchMedia("(pointer: coarse)").matches || hasActiveTextSelection()) return;
+      if (!matchMedia("(pointer: coarse)").matches) return;
       setShowActions((v) => !v);
     },
     [isSelected, message.id, messageOrderIndex, multiSelectMode, onToggleSelect],

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -34,6 +34,7 @@ import { PendingTypingDots } from "./PendingTypingDots";
 import { TranscriptWindowControls } from "./TranscriptWindowControls";
 import { PinnedImageOverlay } from "./PinnedImageOverlay";
 import { useChatStore } from "../../stores/chat.store";
+import { hasActiveTextSelection } from "../../lib/text-selection";
 import { useConversationGamesStore } from "../../stores/conversation-games.store";
 import { useUIStore } from "../../stores/ui.store";
 import { playConfiguredNotificationPing } from "../../lib/notification-sound";
@@ -576,6 +577,7 @@ export function ConversationView({
     keyboardOpen || composerFocused || hasLiveStream || hasDraftInput || isFetchingNextPage;
 
   const scrollToMessagesBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
+    if (hasActiveTextSelection()) return;
     const el = scrollRef.current;
     if (el) {
       el.scrollTo({ top: el.scrollHeight, behavior });

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -790,10 +790,17 @@ export function ConversationView({
       return;
     }
 
-    openedAtBottomChatIdRef.current = chatId;
-    userScrolledAwayRef.current = false;
-    isNearBottomRef.current = true;
-    scheduleScrollToMessagesBottom("auto");
+    const openAtBottom = () => {
+      if (hasActiveTextSelection()) return;
+      document.removeEventListener("selectionchange", openAtBottom);
+      openedAtBottomChatIdRef.current = chatId;
+      userScrolledAwayRef.current = false;
+      isNearBottomRef.current = true;
+      scheduleScrollToMessagesBottom("auto");
+    };
+    document.addEventListener("selectionchange", openAtBottom);
+    openAtBottom();
+    return () => document.removeEventListener("selectionchange", openAtBottom);
   }, [
     chatId,
     gotoRequest,

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -19,6 +19,7 @@ import { useAgentStore } from "../../stores/agent.store";
 import { useUIStore } from "../../stores/ui.store";
 import type { EchoChamberSide, EchoChamberSize } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
+import { hasActiveTextSelection } from "../../lib/text-selection";
 import { useChat } from "../../hooks/use-chats";
 import { useAgentConfigs } from "../../hooks/use-agents";
 import { useGenerate } from "../../hooks/use-generate";
@@ -312,6 +313,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
 
   // Auto-scroll when a new message becomes visible
   useEffect(() => {
+    if (hasActiveTextSelection()) return;
     if (scrollRef.current) {
       scrollRef.current.scrollTo({
         top: scrollRef.current.scrollHeight,

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -556,7 +556,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     let frame = window.requestAnimationFrame(() => {
       frame = window.requestAnimationFrame(() => {
         const scrollEl = scrollRef.current;
-        if (!scrollEl) return;
+        if (!scrollEl || hasActiveTextSelection()) return;
         scrollEl.scrollTo({ top: scrollEl.scrollHeight, behavior: "auto" });
       });
     });

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -3,6 +3,7 @@
 // ──────────────────────────────────────────────
 import { useCallback, useRef } from "react";
 import { audioManager } from "../lib/game-audio";
+import { normalizeEchoChamberMessages } from "../lib/echo-chamber-queue";
 import { characterDataSchema, normalizeAvatarCrop, type AvatarCrop } from "@marinara-engine/shared";
 import { useQueryClient, type InfiniteData, type QueryClient } from "@tanstack/react-query";
 import { toast, type ExternalToast } from "sonner";
@@ -2001,8 +2002,7 @@ export function useGenerate() {
                 // Push echo-chamber reactions to the dedicated echo store
                 if (result.agentType === "echo-chamber") {
                   const d = result.data as Record<string, unknown>;
-                  const reactions = (d.reactions as Array<{ characterName: string; reaction: string }>) ?? [];
-                  enqueueEchoMessages(reactions);
+                  enqueueEchoMessages(d.reactions);
                 }
 
                 // Push CYOA choices to the dedicated store
@@ -3686,8 +3686,7 @@ export function useGenerate() {
               if (result.success && result.data) {
                 if (result.agentType === "echo-chamber") {
                   const d = result.data as Record<string, unknown>;
-                  const reactions = (d.reactions as Array<{ characterName: string; reaction: string }>) ?? [];
-                  if (shouldApplyVisibleResult) enqueueEchoMessages(reactions);
+                  if (shouldApplyVisibleResult) enqueueEchoMessages(d.reactions);
                 }
                 // CYOA re-roll: push the freshly generated choices into the store
                 // so the buttons in CyoaChoices.tsx swap in immediately.
@@ -4084,9 +4083,9 @@ function formatAgentBubble(agentType: string, agentName: string, data: unknown):
     }
 
     case "echo-chamber": {
-      const reactions = (d.reactions as any[]) ?? [];
+      const reactions = normalizeEchoChamberMessages(d.reactions);
       if (!reactions.length) return null;
-      return reactions.map((r: any) => `💬 ${r.characterName}: ${r.reaction}`).join("\n");
+      return reactions.map((r) => `💬 ${r.characterName}: ${r.reaction}`).join("\n");
     }
 
     case "spotify": {

--- a/packages/client/src/hooks/use-visual-viewport-chat-bottom.ts
+++ b/packages/client/src/hooks/use-visual-viewport-chat-bottom.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState, type RefObject } from "react";
+import { hasActiveTextSelection } from "../lib/text-selection";
 
 export const CHAT_VISUAL_VIEWPORT_CHANGE_EVENT = "marinara:chat-visual-viewport-change";
 
@@ -135,7 +136,7 @@ export function useKeepLatestChatMessageVisible(
       pendingAnchor = null;
 
       const restore = () => {
-        if (!keyboardOpen) return;
+        if (!keyboardOpen || hasActiveTextSelection()) return;
         const scrollElement = scrollRef.current;
         if (!scrollElement) return;
         if (anchor.pinnedToBottom) {

--- a/packages/client/src/lib/echo-chamber-queue.ts
+++ b/packages/client/src/lib/echo-chamber-queue.ts
@@ -24,6 +24,29 @@ export type EchoChamberMessage = {
   timestamp: number;
 };
 
+/** Validate agent/API output before it reaches message rendering. */
+export function normalizeEchoChamberMessages(value: unknown, now = Date.now()): EchoChamberMessage[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((message, index) => {
+    if (
+      !message ||
+      typeof message.characterName !== "string" ||
+      !message.characterName.trim() ||
+      typeof message.reaction !== "string" ||
+      !message.reaction.trim()
+    )
+      return [];
+    return [
+      {
+        characterName: message.characterName,
+        reaction: message.reaction,
+        timestamp:
+          typeof message.timestamp === "number" && Number.isFinite(message.timestamp) ? message.timestamp : now + index,
+      },
+    ];
+  });
+}
+
 export type EchoChamberQueueState = {
   messages: EchoChamberMessage[];
   visibleCount: number;
@@ -37,19 +60,15 @@ export type EchoChamberQueueState = {
  */
 export function enqueueEchoChamberMessages(
   state: EchoChamberQueueState,
-  reactions: Array<{ characterName: string; reaction: string }>,
+  reactions: unknown,
   now = Date.now(),
 ): EchoChamberQueueState {
-  if (reactions.length === 0) return state;
+  const incoming = normalizeEchoChamberMessages(reactions, now);
+  if (incoming.length === 0) return state;
 
   const currentMessages = state.messages.slice(-ECHO_CHAMBER_MESSAGE_LIMIT);
   const visibleBefore = Math.min(Math.max(0, state.visibleCount), currentMessages.length);
   const baselineBefore = Math.min(Math.max(0, state.baseline), currentMessages.length);
-  const incoming = reactions.map((reaction, index) => ({
-    characterName: reaction.characterName,
-    reaction: reaction.reaction,
-    timestamp: now + index,
-  }));
   const uncapped = [...currentMessages, ...incoming];
   const droppedCount = Math.max(0, uncapped.length - ECHO_CHAMBER_MESSAGE_LIMIT);
 

--- a/packages/client/src/lib/text-selection.ts
+++ b/packages/client/src/lib/text-selection.ts
@@ -55,3 +55,18 @@ export function restoreTextSelectionAfterRender(snapshot: TextSelectionSnapshot)
     }
   };
 }
+
+/** Native selections belong to the browser, including selections inside editors. */
+export function hasActiveTextSelection(): boolean {
+  if (typeof document === "undefined") return false;
+  const active = document.activeElement;
+  if (
+    (active instanceof HTMLTextAreaElement || active instanceof HTMLInputElement) &&
+    active.selectionStart !== null &&
+    active.selectionEnd !== null &&
+    active.selectionStart !== active.selectionEnd
+  )
+    return true;
+  const selection = document.getSelection();
+  return !!selection && !selection.isCollapsed;
+}

--- a/packages/client/src/stores/agent.store.ts
+++ b/packages/client/src/stores/agent.store.ts
@@ -5,6 +5,7 @@ import { create } from "zustand";
 import {
   ECHO_CHAMBER_MESSAGE_LIMIT,
   enqueueEchoChamberMessages,
+  normalizeEchoChamberMessages,
   type EchoChamberMessage,
 } from "../lib/echo-chamber-queue";
 import type {
@@ -186,8 +187,8 @@ interface AgentState {
   dismissThoughtBubble: (index: number) => void;
   clearThoughtBubbles: () => void;
   addEchoMessage: (characterName: string, reaction: string) => void;
-  enqueueEchoMessages: (reactions: Array<{ characterName: string; reaction: string }>) => void;
-  setEchoMessages: (messages: Array<{ characterName: string; reaction: string; timestamp: number }>) => void;
+  enqueueEchoMessages: (reactions: unknown) => void;
+  setEchoMessages: (messages: unknown) => void;
   clearEchoMessages: () => void;
   setEchoVisibleCount: (count: number) => void;
   revealNextEchoMessage: () => void;
@@ -467,7 +468,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
 
   setEchoMessages: (messages) =>
     set((state) => {
-      const nextMessages = messages.slice(-ECHO_CHAMBER_MESSAGE_LIMIT);
+      const nextMessages = normalizeEchoChamberMessages(messages, 0).slice(-ECHO_CHAMBER_MESSAGE_LIMIT);
       return {
         echoMessages: nextMessages,
         echoVisibleCount: Math.min(state.echoVisibleCount, nextMessages.length),

--- a/packages/server/src/services/generation/roleplay-commands.ts
+++ b/packages/server/src/services/generation/roleplay-commands.ts
@@ -341,7 +341,7 @@ export function buildRoleplayCommandsReminder(args: {
     );
   if (args.privateAvailable && enabled("notes"))
     lines.push(
-      '- [notes: content="your current personal notes"] replaces your notes about motives, secrets, beliefs, lies and plans. Preserve relevant details and keep it short; these notes are available to you and narrator alone. [dismiss_notes] clears your notes when they\'re no longer needed or relevant.',
+      '- [notes: content="your current personal notes"] creates or edits your notes about motives, secrets, beliefs, lies and plans. To edit existing notes, send their full updated contents; this replaces your previous notes. Preserve relevant details and keep it short; these notes are available to you and narrator alone. [dismiss_notes] clears your notes when they\'re no longer needed or relevant.',
     );
   if (args.privateAvailable && enabled("memory"))
     lines.push(

--- a/packages/server/src/services/storage/agents.storage.ts
+++ b/packages/server/src/services/storage/agents.storage.ts
@@ -434,10 +434,15 @@ export function createAgentsStorage(db: DB) {
       for (const row of rows) {
         try {
           const data = JSON.parse(row.resultData);
-          const reactions = data?.reactions ?? [];
+          const reactions = Array.isArray(data?.reactions) ? data.reactions : [];
           const ts = new Date(row.createdAt).getTime();
           for (const r of reactions) {
-            if (r.characterName && r.reaction) {
+            if (
+              typeof r?.characterName === "string" &&
+              r.characterName.trim() &&
+              typeof r.reaction === "string" &&
+              r.reaction.trim()
+            ) {
               messages.push({ characterName: r.characterName, reaction: r.reaction, timestamp: ts });
             }
           }

--- a/scripts/regressions/assigned-chat-sweep.regression.ts
+++ b/scripts/regressions/assigned-chat-sweep.regression.ts
@@ -307,6 +307,41 @@ try {
     },
   ]);
   const agents = createAgentsStorage(db);
+  // Saved malformed Echo rows must not crash readers or drop valid siblings.
+  const echoChat = await chats.create({ name: "Echo validation", mode: "roleplay", characterIds: [] });
+  assert.ok(echoChat);
+  for (const reactions of [
+    {},
+    [
+      null,
+      { reaction: "Missing name" },
+      { characterName: 42, reaction: "Wrong name type" },
+      { characterName: "   ", reaction: "Blank name" },
+      { characterName: "Reader", reaction: {} },
+      { characterName: "Reader", reaction: " " },
+      { characterName: "Reader", reaction: "Valid saved reaction" },
+    ],
+  ]) {
+    await agents.saveRun({
+      agentConfigId: "echo-fixture",
+      chatId: echoChat.id,
+      messageId: null,
+      result: {
+        agentId: "echo-fixture",
+        agentType: "echo-chamber",
+        type: "echo_message",
+        data: { reactions },
+        tokensUsed: 0,
+        durationMs: 0,
+        success: true,
+        error: null,
+      },
+    });
+  }
+  assert.deepEqual(
+    (await agents.getEchoMessages(echoChat.id)).map(({ characterName, reaction }) => ({ characterName, reaction })),
+    [{ characterName: "Reader", reaction: "Valid saved reaction" }],
+  );
   const director = await agents.create({
     type: "director",
     name: "Narrative Director",

--- a/scripts/regressions/roleplay-commands.regression.ts
+++ b/scripts/regressions/roleplay-commands.regression.ts
@@ -283,6 +283,10 @@ for (const format of ["xml", "markdown", "none"] as const) {
   assert.doesNotMatch(reminder, /\[illustrate:/u, "an unavailable image agent must not be offered");
   assert.doesNotMatch(reminder, /YOUR|LIES|DECEPTIONS|Maximum \d|\n\s*\n\s*-/u);
   assert.match(reminder, /keep it short/iu);
+  assert.match(
+    reminder,
+    /To edit existing notes, send their full updated contents; this replaces your previous notes/u,
+  );
   assert.ok(
     reminder.includes(
       "only up to three reminders can exist at the same time; if you create more, the oldest one will be removed.",

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -467,8 +467,8 @@ assert.match(
   "active Roleplay tracker agents should expose their saved prompt templates",
 );
 assert.match(reducedAmbientEffectsHookSource, /manualPreference \|\| systemPreference/u);
-  assert.match(uiStoreSource, /version: UI_PERSISTENCE.version/u);
-  assert.ok(UI_PERSISTENCE.version >= 99, "the Roleplay persistence migration must remain applied");
+assert.match(uiStoreSource, /version: UI_PERSISTENCE.version/u);
+assert.ok(UI_PERSISTENCE.version >= 99, "the Roleplay persistence migration must remain applied");
 assert.match(globalStylesSource, /data-marinara-reduced-effects/u);
 const accentTransitionStyles =
   globalStylesSource.match(
@@ -1668,6 +1668,45 @@ assert.deepEqual(
   ],
   "tracker batch debug output should describe the real combined request",
 );
+
+// Agent output and persisted history are untrusted even when the API is typed.
+const malformedEchoReactions = [
+  null,
+  "not a reaction",
+  { reaction: "Missing name" },
+  { characterName: 42, reaction: "Wrong name type" },
+  { characterName: "   ", reaction: "Empty name" },
+  { characterName: "Watcher", reaction: { text: "Wrong reaction type" } },
+  { characterName: "Watcher", reaction: "  " },
+  { characterName: "Watcher", reaction: "A valid reaction" },
+];
+useAgentStore.getState().clearEchoMessages();
+useAgentStore.getState().enqueueEchoMessages(malformedEchoReactions);
+assert.deepEqual(
+  useAgentStore.getState().echoMessages.map(({ characterName, reaction }) => ({ characterName, reaction })),
+  [{ characterName: "Watcher", reaction: "A valid reaction" }],
+  "a malformed reaction must not enter the UI queue or hide valid siblings",
+);
+useAgentStore
+  .getState()
+  .setEchoMessages([
+    ...malformedEchoReactions,
+    { characterName: "Reader", reaction: "Valid saved reaction", timestamp: 12 },
+  ]);
+assert.equal(useAgentStore.getState().echoMessages.length, 2);
+assert.equal(useAgentStore.getState().echoMessages[0]?.timestamp, 7);
+assert.equal(useAgentStore.getState().echoMessages[1]?.timestamp, 12);
+for (const value of [null, {}, "malformed", 7]) {
+  useAgentStore.getState().enqueueEchoMessages(value);
+  assert.equal(useAgentStore.getState().echoMessages.length, 2);
+  useAgentStore.getState().setEchoMessages(value);
+  assert.equal(useAgentStore.getState().echoMessages.length, 0);
+  useAgentStore.getState().setEchoMessages([
+    { characterName: "A", reaction: "A" },
+    { characterName: "B", reaction: "B" },
+  ]);
+}
+useAgentStore.getState().clearEchoMessages();
 
 const queuedEchoBatch = enqueueEchoChamberMessages(
   {


### PR DESCRIPTION
## Linked issue

Closes #6039

## Why this change

A nameless Echo Chamber reaction could crash the entire chat at `characterName.length`. Native iPhone text selection could also lose its position to automatic scrolling or be mistaken for a message-editing gesture. The Roleplay notes prompt needed a clearer explanation of updating an existing note.

## What changed

- Validate Echo reactions at the existing client queue boundary, reuse that validation for activity bubbles, and reject malformed persisted entries individually so valid reactions still appear.
- Use the existing text-selection utility to pause automatic chat/keyboard scrolling while text is selected. Message touch shortcuts, multi-select handling, and composer-shell focus handling leave native selections alone. Opening a chat waits for an existing selection to clear before scrolling to the latest message; delayed Echo scrolling also checks at execution time.
- Explicitly tell characters to edit notes by sending their full updated contents, which replace the previous note. Existing note storage and character privacy rules are unchanged.
- Add focused browser, queue, storage, and prompt regressions plus changelog entries.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Completed locally: `pnpm check` (including localization, types, lint, and production build), `pnpm regression:prompt`, and the `roleplay-streaming`, `assigned-chat-sweep`, and `roleplay-commands` Node regressions. Nine focused Playwright cases pass across desktop Chromium, mobile Chromium, and iPhone-sized WebKit, including opening another chat during a selection. The existing mobile Chromium composer focus/history test also passes after bounding its missing-textarea retry waits (10 passed, 2 existing project skips). Five additional mobile keyboard, viewport-menu, and older-message-editing checks passed in the surrounding smoke run.

Before the fix, the browser regression reproduced a 260 px jump during selection and selection being replaced by message editing. The same checks now preserve the selection and scroll position; normal bottom-follow resumes after returning to the latest message. Missing names, non-string names/reactions, null entries, malformed containers, and valid siblings are covered for saved/live Echo data.

### Manual verification notes

Browser screenshots were inspected. Manually verify the physical iPhone selection handles and Copy/Cut menu in messages, composers, and message editors, including during streaming and keyboard opening. Desktop WebKit automation cannot reproduce the native iOS selection-handle UI. No physical iPhone was available here. Final-commit build validation, container build, CodeQL, CodeRabbit review, and the complete Node/browser regression matrix passed. One unchanged Game dice-history test timed out on the first WebKit attempt; both variants passed locally, and the affected CI shard passed on one retry (80 passed, 5 existing skips). The original failure and baseline comparison are recorded in the PR comments. Container boot was not tested locally.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

Changelog updated. No user-facing labels, translated documentation, dependencies, or release versions changed.

## UI evidence (if applicable)

[WebKit selection regression screenshots](https://gist.github.com/SpicyMarinara/96424bc5afa8e824c148058128e7a577). These show browser selection ranges, not physical iOS handles.

<details>
<summary>Roleplay message selection and Conversation draft selection during streaming</summary>

<img width="320" alt="Roleplay message selection stays in place during streaming" src="https://gist.githubusercontent.com/SpicyMarinara/96424bc5afa8e824c148058128e7a577/raw/f7835b420e64bc5cb2dc444c70f4eb5d0ea3b13e/roleplay-message-selection.png">
<img width="320" alt="Conversation draft selection remains active during streaming" src="https://gist.githubusercontent.com/SpicyMarinara/96424bc5afa8e824c148058128e7a577/raw/3bf57414bddfc1b94e5fb4b1d6170ba7a6448cc7/conversation-composer-selection.png">

</details>
