### PR TITLE
fix(client): open selected agent package from feature detail (#6047)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- Clicking "Manage package" from a feature agent's detail view now opens the agent's installed package rather than falling back to the first catalog entry (#6047).
 - Malformed Echo Chamber reactions no longer crash the chat. Native text selections pause automatic chat scrolling and take priority over touch shortcuts and composer focus handling (#6039).
 - Roleplay's notes command explicitly explains how characters can edit existing notes by supplying their full updated contents (#6039).
 

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -775,7 +775,7 @@ export function AppShell() {
         enabledForChat={selectedFeatureEnabledForChat}
         onEnabledForChatChange={setSelectedFeatureEnabledForChat}
         onClose={closeFeatureDetail}
-        onManagePackage={openAgentCatalog}
+        onManagePackage={() => openAgentCatalog(selectedFeaturePackage?.id)}
         capabilityProps={{
           debugMode,
           confirmAction: showConfirmDialog,


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #6047

## Why this change

In the Agents pane, clicking "Manage package" from a feature agent's detail view opened 8-Ball Pool instead of the agent being inspected. `AppShell` passed `openAgentCatalog` without arguments, causing the catalog to select its fallback first entry (`eightball`) instead of the active agent's package.

## What changed

- Updated `packages/client/src/components/layout/AppShell.tsx` to pass `() => openAgentCatalog(selectedFeaturePackage?.id)` to `FeatureAgentDetailHost`.
- Added an entry under `[Unreleased]` in `CHANGELOG.md`.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify in browser: open Agents pane -> open management detail for an installed feature agent (e.g. Illustrator or Noodle) -> click "Manage package" -> verify the catalog opens focused on that agent's package rather than defaulting to 8-Ball Pool.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed **Manage package** so it opens the selected feature agent’s installed package instead of the first package in the catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->