### PR TITLE
feat(chat): add /send command for persona messages without generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- Added the `/send <message>` slash command to post a message as your persona without triggering generation (#6050).
 - Clicking "Manage package" from a feature agent's detail view now opens the agent's installed package rather than falling back to the first catalog entry (#6047).
 - Malformed Echo Chamber reactions no longer crash the chat. Native text selections pause automatic chat scrolling and take priority over touch shortcuts and composer focus handling (#6039).
 - Roleplay's notes command explicitly explains how characters can edit existing notes by supplying their full updated contents (#6039).

--- a/docs/chats/guided-and-impersonate.md
+++ b/docs/chats/guided-and-impersonate.md
@@ -124,7 +124,7 @@ You choose which actions show from settings.
 
 The three actions are:
 
-- **Post only**: add your typed message to the chat without triggering an AI reply.
+- **Post only**: add your typed message to the chat without triggering an AI reply. You can also run this with the `/send <message>` slash command.
 - **Guide reply**: send your typed text as a `/guided` direction instead of a normal message.
 - **Impersonate**: generate a reply as your persona, using your typed text as the direction. This action is hidden in Conversation chats, because Impersonate does not work there.
 

--- a/docs/chats/slash-commands.md
+++ b/docs/chats/slash-commands.md
@@ -27,6 +27,7 @@ These commands help you manage the chat and its messages. They work in **Convers
 | Command | Also works as | What it does |
 |---|---|---|
 | `/help` | | Lists every slash command. |
+| `/send` | | Posts a message as your persona without triggering generation. |
 | `/continue` | `/cont` | Adds more text to the last AI reply, without sending a new message. The **Add a new line before /continue text** option in **Settings → General → Responses** controls whether that text starts after a blank line or directly at the cutoff. |
 | `/goto` | `/jump`, `/scroll` | Scrolls the chat to a message by its number. |
 | `/hide` | | Hides one or more messages from the AI on future turns. |

--- a/packages/client/src/lib/slash-commands.ts
+++ b/packages/client/src/lib/slash-commands.ts
@@ -677,6 +677,18 @@ const COMMANDS: SlashCommand[] = [
     },
   },
   {
+    name: "send",
+    description: "Post a message as your persona without triggering generation",
+    usage: "/send <message>",
+    local: true,
+    async execute(args, ctx) {
+      const content = stripSingleWrappingQuotePair(args);
+      if (!content) return { handled: true, feedback: "Usage: /send <message>" };
+      await ctx.createMessage({ role: "user", content, characterId: null });
+      return { handled: true };
+    },
+  },
+  {
     name: "guided",
     aliases: ["narrator", "narrate", "nar"],
     description: "Steer the narrative — the AI will narrate events in the direction you describe",

--- a/scripts/regressions/conversation-game-slash.regression.ts
+++ b/scripts/regressions/conversation-game-slash.regression.ts
@@ -69,4 +69,37 @@ assert.equal(
   "Uninstalled games must not contribute slash commands",
 );
 
+const sendCommand = matchSlashCommand('/send "A persona beat"', { mode: "roleplay" });
+assert.ok(sendCommand, "/send must match slash command parsing");
+assert.equal(sendCommand?.command.name, "send");
+let createdRole: string | null = null;
+let createdContent: string | null = null;
+let createdCharacterId: string | null | undefined = "sentinel";
+let generateCalls = 0;
+const result = await sendCommand?.command.execute(sendCommand.args, {
+  chatId: "test-chat",
+  mode: "roleplay",
+  createMessage: async (data: { role: string; content: string; characterId?: string | null }) => {
+    createdRole = data.role;
+    createdContent = data.content;
+    createdCharacterId = data.characterId;
+  },
+  generate: async () => {
+    generateCalls += 1;
+  },
+} as never);
+assert.deepEqual(result, { handled: true });
+assert.equal(createdRole, "user");
+assert.equal(createdContent, "A persona beat");
+assert.equal(createdCharacterId, null);
+assert.equal(generateCalls, 0);
+
+const emptySendResult = await sendCommand?.command.execute("   ", {
+  chatId: "test-chat",
+  mode: "roleplay",
+  createMessage: async () => {},
+  generate: async () => {},
+} as never);
+assert.deepEqual(emptySendResult, { handled: true, feedback: "Usage: /send <message>" });
+
 console.info("Dynamic conversation game slash regressions passed.");


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #6050

## Why this change

Users need a way to insert intentional persona story beats or prompt setups into the chat history without immediately triggering an LLM generation. This allows subsequent commands like `/guided <direction>` or `/as <character>` to generate in response to the newly placed persona message while maintaining natural message order.

## What changed

- Added `/send <message>` slash command in `packages/client/src/lib/slash-commands.ts` (`local: true`), stripping single wrapping quotes when supplied and invoking `ctx.createMessage({ role: "user", content, characterId: null })` without calling `ctx.generate()`.
- Added documentation for `/send` in `docs/chats/slash-commands.md` and referenced it under Quick Replies' Post Only action in `docs/chats/guided-and-impersonate.md`.
- Added unreleased entry in `CHANGELOG.md` referencing issue `#6050`.
- Added regression tests in `scripts/regressions/conversation-game-slash.regression.ts` validating `/send` matching, empty usage handling, user-role message creation, and verifying zero LLM generation calls.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify typing `/send Hello world` in a Roleplay and Conversation chat creates a persona user message without triggering generation.
- Manually verify typing `/send` without arguments returns the usage hint.
- Manually verify follow-up with `/guided` steers the subsequent reply referencing the sent persona message.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `/send <message>` slash command.
  - Posts messages as the active persona without triggering an AI-generated response.
  - Supports messages wrapped in a single pair of quotes.
  - Shows usage guidance when no message is provided.

- **Documentation**
  - Added `/send` to the chat and message command reference.
  - Documented it as an alternative to the “Post only” quick reply action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->