### PR TITLE
fix(launcher): skip the storage writer lease when snapshotting data for an update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- The Termux and Linux launcher auto-update no longer aborts with "Cannot copy a socket file" when the previous server left its storage writer lease behind: the update snapshot skips the per-process lease directory and any socket or FIFO under the data directory (#6046).
 - Clicking "Manage package" from a feature agent's detail view now opens the agent's installed package rather than falling back to the first catalog entry (#6047).
 - Malformed Echo Chamber reactions no longer crash the chat. Native text selections pause automatic chat scrolling and take priority over touch shortcuts and composer focus handling (#6039).
 - Roleplay's notes command explicitly explains how characters can edit existing notes by supplying their full updated contents (#6039).

--- a/scripts/protect-launcher-data.mjs
+++ b/scripts/protect-launcher-data.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
-import { chmod, cp, mkdir, open, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, cp, lstat, mkdir, open, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, resolve, sep } from "node:path";
 import { parseEnv } from "node:util";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -532,6 +532,12 @@ export async function snapshotLauncherData({
   const backupDir = resolve(backupRoot, backupName);
   const capabilityRuntimeLink = resolve(dataDir, "capability-packages", "node_modules");
   const downloadableDataDirs = ["models", "sidecar-runtime"].map((name) => resolve(dataDir, name));
+  // The storage writer lease is per-process runtime state (owner record plus the
+  // live.sock liveness socket, #5389). A snapshot taken while the previous server
+  // is still up, or after it died without releasing the lease, would try to copy
+  // that socket and fail with EINVAL, aborting the whole update (#6046). Nothing
+  // in the lease is user data, so leave the directory out entirely.
+  const writerLeaseDir = resolve(dataDir, "storage", ".writer-lease");
 
   await rm(incompleteDir, { recursive: true, force: true });
   try {
@@ -540,14 +546,25 @@ export async function snapshotLauncherData({
       recursive: true,
       preserveTimestamps: true,
       errorOnExist: true,
-      filter: (source) => {
+      filter: async (source) => {
         const sourcePath = resolve(source);
-        return (
-          sourcePath !== capabilityRuntimeLink &&
-          downloadableDataDirs.every(
+        if (sourcePath === capabilityRuntimeLink || sourcePath === writerLeaseDir) return false;
+        if (
+          !downloadableDataDirs.every(
             (downloadableDir) => sourcePath !== downloadableDir && !sourcePath.startsWith(`${downloadableDir}${sep}`),
           )
-        );
+        ) {
+          return false;
+        }
+        // Sockets and FIFOs cannot be copied (fs.cp rejects them with EINVAL) and
+        // carry no data worth restoring, wherever they live under the data dir.
+        try {
+          const entry = await lstat(sourcePath);
+          if (entry.isSocket() || entry.isFIFO()) return false;
+        } catch (error) {
+          if (error?.code !== "ENOENT") throw error;
+        }
+        return true;
       },
     });
     await writeFile(

--- a/scripts/regressions/launcher/update.regression.mjs
+++ b/scripts/regressions/launcher/update.regression.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -377,6 +378,23 @@ try {
   const galleryDir = join(defaultDataDir, "gallery");
   mkdirSync(galleryDir, { recursive: true });
   writeFileSync(join(galleryDir, "selfie.png"), "irreplaceable user data\n");
+  // #6046: a server that is still running (or died without releasing its lease)
+  // leaves the writer lease behind, including the live.sock liveness socket.
+  // fs.cp cannot copy a socket, so the snapshot used to abort and the launcher
+  // skipped the update. Unix sockets need a real listener; Windows has no
+  // filesystem socket entry, so only the directory exclusion is exercised there.
+  const storageDir = join(defaultDataDir, "storage");
+  const writerLeaseDir = join(storageDir, ".writer-lease");
+  mkdirSync(writerLeaseDir, { recursive: true });
+  writeFileSync(join(storageDir, "characters.json"), '{"sharded":true}\n');
+  writeFileSync(join(writerLeaseDir, "owner.json"), '{"pid":12,"hostId":null}\n');
+  const livenessSocket = process.platform === "win32" ? null : createServer();
+  if (livenessSocket) {
+    await new Promise((resolvePromise, rejectPromise) => {
+      livenessSocket.once("error", rejectPromise);
+      livenessSocket.listen(join(writerLeaseDir, "live.sock"), resolvePromise);
+    });
+  }
   symlinkSync(
     capabilityRuntimeDependencies,
     join(capabilityPackagesDir, "node_modules"),
@@ -413,6 +431,19 @@ try {
     "irreplaceable user data\n",
     "Launcher snapshots must keep user-created media",
   );
+  assert.equal(
+    readFileSync(join(snapshot.backupDir, "data", "storage", "characters.json"), "utf8"),
+    '{"sharded":true}\n',
+    "Launcher snapshots must keep sharded storage tables",
+  );
+  assert.equal(
+    existsSync(join(snapshot.backupDir, "data", "storage", ".writer-lease")),
+    false,
+    "Launcher snapshots must omit the per-process storage writer lease (#6046)",
+  );
+  if (livenessSocket) {
+    await new Promise((resolvePromise) => livenessSocket.close(resolvePromise));
+  }
 
   rmSync(defaultDataDir, { recursive: true, force: true });
   const restore = await restoreLauncherDataIfMissing({ root: fixtureRoot, backupRoot: fixtureBackupRoot, env: {} });


### PR DESCRIPTION
## Linked issue

Closes #6046

## Why this change

On Termux, the launcher's startup auto-update failed before it even reached git:

```
[ERROR] Could not protect launcher data: Cannot copy a socket file: cp returned EINVAL (cannot copy a socket file: .../.incomplete-update-.../data/storage/.writer-lease/live.sock)
[WARN] Could not create an update snapshot. Skipping auto-update to protect your data.
```

`snapshotLauncherData` (`scripts/protect-launcher-data.mjs`) copies the whole data directory with `fs.cp` before an update so the data can be restored if the update goes wrong. Since #5389 the storage writer lease keeps a Unix socket at `data/storage/.writer-lease/live.sock` for liveness checks. When the previous server is still running, or ended without releasing its lease (the reporter's diagnostics show 10 sessions that ended without a shutdown), that socket is still on disk when the launcher starts, `fs.cp` rejects it with `EINVAL`, the snapshot throws, and the launcher skips the update on every launch. The `.incomplete-update-*` directory named in the error is removed by the snapshot's own cleanup, which is why the reporter could not find it.

## What changed

- `scripts/protect-launcher-data.mjs`: the snapshot copy filter now excludes `data/storage/.writer-lease` (per-process runtime state, not user data) and, as a general backstop, any socket or FIFO under the data directory. Everything else the snapshot copied before is unchanged, and `restoreLauncherDataIfMissing` is unaffected because the backup no longer contains those entries.
- `scripts/regressions/launcher/update.regression.mjs`: the snapshot case now plants a writer-lease directory with an `owner.json` and, on non-Windows hosts, a real listening Unix socket at `live.sock`, and asserts the snapshot succeeds, omits the lease directory, and still preserves a sharded storage table next to it. Fails on the previous code with the exact `EINVAL` from the report on Linux, and on the lease-directory assertion everywhere.
- `CHANGELOG.md`: Unreleased entry.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `node scripts/regressions/launcher/update.regression.mjs` passes with the fix and fails against the previous `protect-launcher-data.mjs` on the new lease-directory assertion (`pnpm regression:launcher-update` is the CI lane that runs it).
- The socket branch of the regression is exercised on Linux CI; on Windows there is no filesystem socket entry, so only the directory exclusion runs there.
- This is launcher-only code (`start.sh` / `start-termux.sh` call the script); the Docker image never runs it, so there is nothing to observe on a container deploy.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable (launcher script).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Termux and Linux launcher auto-updates failing with “Cannot copy a socket file” when leftover server lease data is present.
  - Launcher data snapshots now safely skip temporary lease folders and socket or FIFO files while preserving user data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->