### PR TITLE
fix(game): explain the locked composer after a concluded session and offer New Session inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- After a Game Mode session is concluded, the composer now says so and offers a New Session button in place of the silently disabled input, so play can continue without hunting for the action in the Session panel (#6045).
 - Clicking "Manage package" from a feature agent's detail view now opens the agent's installed package rather than falling back to the first catalog entry (#6047).
 - Malformed Echo Chamber reactions no longer crash the chat. Native text selections pause automatic chat scrolling and take priority over touch shortcuts and composer focus handling (#6039).
 - Roleplay's notes command explicitly explains how characters can edit existing notes by supplying their full updated contents (#6039).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ## [Unreleased]
 
 - After a Game Mode session is concluded, the composer now says so and offers a New Session button in place of the silently disabled input, so play can continue without hunting for the action in the Session panel (#6045).
-- Added the `/send <message>` slash command to post a message as your persona without triggering generation (#6050).- The Termux and Linux launcher auto-update no longer aborts with "Cannot copy a socket file" when the previous server left its storage writer lease behind: the update snapshot skips the per-process lease directory and any socket or FIFO under the data directory (#6046).
+- Added the `/send <message>` slash command to post a message as your persona without triggering generation (#6050).
+- The Termux and Linux launcher auto-update no longer aborts with "Cannot copy a socket file" when the previous server left its storage writer lease behind: the update snapshot skips the per-process lease directory and any socket or FIFO under the data directory (#6046).
 - Clicking "Manage package" from a feature agent's detail view now opens the agent's installed package rather than falling back to the first catalog entry (#6047).
 - Malformed Echo Chamber reactions no longer crash the chat. Native text selections pause automatic chat scrolling and take priority over touch shortcuts and composer focus handling (#6039).
 - Roleplay's notes command explicitly explains how characters can edit existing notes by supplying their full updated contents (#6039).

--- a/packages/client/src/components/game/GameInput.tsx
+++ b/packages/client/src/components/game/GameInput.tsx
@@ -2,7 +2,18 @@
 // Game: Input Bar (send message, roll dice, attach files, emoji)
 // ──────────────────────────────────────────────
 import { useState, useRef, useEffect, useCallback, useMemo, type KeyboardEvent } from "react";
-import { Send, Dices, Paperclip, Smile, Users, MessageCircle, MessageSquare, Languages, Loader2 } from "lucide-react";
+import {
+  Send,
+  Dices,
+  Paperclip,
+  Smile,
+  Users,
+  MessageCircle,
+  MessageSquare,
+  Languages,
+  Loader2,
+  Play,
+} from "lucide-react";
 import { cn } from "../../lib/utils";
 import { EmojiPicker } from "../ui/EmojiPicker";
 import { SpeechToTextButton } from "../ui/SpeechToTextButton";
@@ -56,6 +67,14 @@ interface GameInputProps {
    * `force` keeps the normal styling — the GM won't be told this is an interrupt.
    */
   interruptMode?: "risky" | "force" | null;
+  /**
+   * The chat's session has been concluded, so drafting is locked until a new session
+   * starts. Swaps the placeholder for an explanation and, with `onStartNewSession`,
+   * renders the New Session action right in the composer (#6045).
+   */
+  sessionConcluded?: boolean;
+  onStartNewSession?: () => void;
+  startNewSessionPending?: boolean;
 }
 
 const QUICK_DICE = ["d20", "d6", "2d6", "d10", "d100", "d4", "d8", "d12"];
@@ -124,6 +143,9 @@ export function GameInput({
   onIllustrate,
   spatialCapabilityEnabled = false,
   interruptMode,
+  sessionConcluded = false,
+  onStartNewSession,
+  startNewSessionPending = false,
 }: GameInputProps) {
   const { t: localizeUi } = useUiTranslation();
   const { t } = useTranslation();
@@ -632,21 +654,35 @@ export function GameInput({
           }}
           onKeyDown={handleKeyDown}
           placeholder={
-            isStreaming
-              ? t("game.input.prepareNextMove")
-              : addressMode === "party"
-                ? t("game.input.sayToParty")
-                : addressMode === "gm"
-                  ? t("game.input.sayToGm")
-                  : pendingMoveLabel
-                    ? t("game.input.onArrival")
-                    : t("game.input.default")
+            sessionConcluded
+              ? t("game.input.sessionConcluded")
+              : isStreaming
+                ? t("game.input.prepareNextMove")
+                : addressMode === "party"
+                  ? t("game.input.sayToParty")
+                  : addressMode === "gm"
+                    ? t("game.input.sayToGm")
+                    : pendingMoveLabel
+                      ? t("game.input.onArrival")
+                      : t("game.input.default")
           }
           disabled={draftDisabled}
           rows={1}
           className="min-w-0 flex-1 resize-none bg-transparent px-2 py-1.5 text-sm leading-normal text-foreground outline-none placeholder:text-foreground/30 disabled:opacity-50"
           style={{ minHeight: 36, maxHeight: 120 }}
         />
+
+        {sessionConcluded && onStartNewSession && (
+          <button
+            type="button"
+            onClick={onStartNewSession}
+            disabled={startNewSessionPending}
+            className="flex h-8 shrink-0 items-center gap-1.5 rounded-xl bg-foreground/10 px-3 text-xs font-medium text-foreground/80 ring-1 ring-foreground/15 transition-colors hover:bg-foreground/15 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {startNewSessionPending ? <Loader2 size={14} className="animate-spin" /> : <Play size={14} />}
+            {t("game.input.startNewSession")}
+          </button>
+        )}
 
         {queuedDice && (
           <div className="flex items-center self-stretch rounded-lg border border-foreground/10 bg-foreground/10 px-2 text-xs text-foreground/70">

--- a/packages/client/src/components/game/GameInput.tsx
+++ b/packages/client/src/components/game/GameInput.tsx
@@ -677,10 +677,12 @@ export function GameInput({
             type="button"
             onClick={onStartNewSession}
             disabled={startNewSessionPending}
-            className="flex h-8 shrink-0 items-center gap-1.5 rounded-xl bg-foreground/10 px-3 text-xs font-medium text-foreground/80 ring-1 ring-foreground/15 transition-colors hover:bg-foreground/15 disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex h-8 shrink-0 items-center gap-1.5 rounded-xl bg-foreground/10 px-2 text-xs font-medium text-foreground/75 ring-1 ring-foreground/20 transition-colors hover:bg-foreground/15 disabled:cursor-not-allowed disabled:opacity-50 sm:px-3"
+            title={t("game.input.startNewSession")}
+            aria-label={t("game.input.startNewSession")}
           >
             {startNewSessionPending ? <Loader2 size={14} className="animate-spin" /> : <Play size={14} />}
-            {t("game.input.startNewSession")}
+            <span className="hidden sm:inline">{t("game.input.startNewSession")}</span>
           </button>
         )}
 

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -12541,6 +12541,9 @@ function GameSurfaceComponent({
                                 onIllustrate={handleManualSceneIllustration}
                                 spatialCapabilityEnabled={hierarchicalMapsActive}
                                 interruptMode={pendingInterruptMode}
+                                sessionConcluded={!sessionInteractive}
+                                onStartNewSession={handleStartNewSession}
+                                startNewSessionPending={startSessionLocked}
                               />
                             )
                           }
@@ -12635,6 +12638,9 @@ function GameSurfaceComponent({
                             onIllustrate={handleManualSceneIllustration}
                             spatialCapabilityEnabled={hierarchicalMapsActive}
                             interruptMode={pendingInterruptMode}
+                            sessionConcluded={!sessionInteractive}
+                            onStartNewSession={handleStartNewSession}
+                            startNewSessionPending={startSessionLocked}
                           />
                         )
                       }

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -504,6 +504,8 @@
   "game.input.sayToGm": "Say to GM...",
   "game.input.sayToParty": "Say to party...",
   "game.input.sendTurn": "Send game turn",
+  "game.input.sessionConcluded": "Session concluded. Start a new session to keep playing.",
+  "game.input.startNewSession": "New Session",
   "game.setup.translation.help": "Translate narration from the first response using Google Translate. Enter a language code, such as en or pl. You can change the provider in Chat Settings → Translation.",
   "game.storyboard.generatingKeyframes": "Generating keyframes...",
   "game.storyboard.keyframeAlt": "Storyboard keyframe {{index}}",


### PR DESCRIPTION
## Linked issue

Closes #6045

## Why this change

After ending a Game Mode session (the summary generates and lands in the session history), the composer goes dead: the textarea is disabled but still shows the ordinary "What do you do?" placeholder, and nothing on the surface says why or how to continue. Reloading or restarting the engine changes nothing because the concluded status is persisted on the chat, so it reads as a permanent lock, which is what #6045 reports.

This is working as designed on the server side: `gameSessionStatus: "concluded"` makes `GameSurface` pass `draftDisabled` / `disabled` to `GameInput`, and the intended way forward is the New Session action. The problem is that the only New Session control lives inside the Session panel's History tab (a small icon button), so a player who has never opened that panel has no path back into play.

## What changed

- `packages/client/src/components/game/GameInput.tsx`: new optional `sessionConcluded`, `onStartNewSession`, and `startNewSessionPending` props. When the session is concluded the placeholder reads "Session concluded. Start a new session to keep playing." and a New Session button renders in the composer next to the textarea (spinner while the start request is in flight). Below the `sm` breakpoint the button is icon-only (with title and aria-label) so the placeholder keeps its room on phones. Nothing changes for ready/active sessions.
- `packages/client/src/components/game/GameSurface.tsx`: both `GameInput` call sites pass `sessionConcluded={!sessionInteractive}`, `onStartNewSession={handleStartNewSession}` and `startNewSessionPending={startSessionLocked}`, so the composer button goes through the same handler as the Session panel (widget-preparation dialog when HUD widgets exist, in-flight guard, new-session chat creation).
- `packages/client/src/localization/locales/en.json`: two new `game.input.*` strings.
- `CHANGELOG.md`: Unreleased entry.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Before: on a Game Mode chat with `gameSessionStatus: "concluded"`, stepped through the narration to the composer; the textarea was disabled with the "What do you do?" placeholder and no New Session control anywhere in the composer.
- After (build from this branch on my production deploy): same chat, the composer shows the concluded placeholder and the New Session button, confirmed both from the rendered DOM (textarea placeholder text, button label) and visually.
- Active session control: the composer is unchanged on a chat whose status is `active`.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Before (staging build, concluded chat): disabled textarea with the ordinary "What do you do?" placeholder and no New Session control in the composer.

After (this branch on my deploy, same chat): placeholder "Session concluded. Start a new session to keep playing." with a New Session button rendered inline at the right of the textarea; the rest of the game surface (narration, choices, HUD) is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Game Mode now clearly announces when a session has concluded.
  - The composer displays a **New Session** button to start another session.
  - A loading indicator appears while a new session is starting.
  - Added localized messaging for the concluded-session state and **New Session** action.

- **Documentation**
  - Added an unreleased changelog entry describing the updated session conclusion experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->