### PR TITLE
fix(roleplay): apply avatar crop to Visual Novel portrait (#6044)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- Roleplay's Visual Novel display portrait now honors configured character and persona Avatar Crops (#6044).
 - Clicking "Manage package" from a feature agent's detail view now opens the agent's installed package rather than falling back to the first catalog entry (#6047).
 - Malformed Echo Chamber reactions no longer crash the chat. Native text selections pause automatic chat scrolling and take priority over touch shortcuts and composer focus handling (#6039).
 - Roleplay's notes command explicitly explains how characters can edit existing notes by supplying their full updated contents (#6039).

--- a/e2e/roleplay-vn.e2e.ts
+++ b/e2e/roleplay-vn.e2e.ts
@@ -494,3 +494,36 @@ test("VN history opens at the newest message and scene art respects size, activi
     for (const id of extras) await request.delete(`/api/characters/${id}`);
   }
 });
+
+test("Roleplay VN portrait honors avatar crop and allows history expansion", async ({ page, request }) => {
+  const data = await fixture(request, true);
+  try {
+    const crop = { srcX: 0.2, srcY: 0.1, srcWidth: 0.5, srcHeight: 0.5 };
+    const charRes = await request.get(`/api/characters/${data.character.id}`);
+    expect(charRes.ok()).toBeTruthy();
+    const charJson = await charRes.json();
+    const rawData = JSON.parse(charJson.data);
+    rawData.extensions = { ...(rawData.extensions ?? {}), avatarCrop: crop };
+    expect((await request.patch(`/api/characters/${data.character.id}`, { data: { data: rawData } })).ok()).toBeTruthy();
+
+    await open(page, data.chat.id);
+    const vn = page.locator("[data-roleplay-vn]");
+    const avatarImg = vn.getByRole("img", { name: "Mari", exact: true });
+    await expect(avatarImg).toBeVisible();
+    await expect(avatarImg).toHaveCSS("position", "absolute");
+    await expect(avatarImg).toHaveCSS("width", "200%");
+    await expect(avatarImg).toHaveCSS("height", "200%");
+    await expect(avatarImg).toHaveCSS("top", "-20%");
+    await expect(avatarImg).toHaveCSS("left", "-40%");
+
+    const expandBtn = vn.getByRole("button", { name: "Show chat history" });
+    await expect(expandBtn).toBeVisible();
+    await expandBtn.click();
+    const history = page.locator("[data-chat-scroll]");
+    await expect(history).toBeVisible();
+    await expect(history.locator(`[data-message-id="${data.message.id}"]`).first()).toBeVisible();
+  } finally {
+    await data.cleanup();
+  }
+});
+

--- a/e2e/roleplay-vn.e2e.ts
+++ b/e2e/roleplay-vn.e2e.ts
@@ -504,17 +504,23 @@ test("Roleplay VN portrait honors avatar crop and allows history expansion", asy
     const charJson = await charRes.json();
     const rawData = JSON.parse(charJson.data);
     rawData.extensions = { ...(rawData.extensions ?? {}), avatarCrop: crop };
-    expect((await request.patch(`/api/characters/${data.character.id}`, { data: { data: rawData } })).ok()).toBeTruthy();
+    expect(
+      (await request.patch(`/api/characters/${data.character.id}`, { data: { data: rawData } })).ok(),
+    ).toBeTruthy();
 
     await open(page, data.chat.id);
     const vn = page.locator("[data-roleplay-vn]");
     const avatarImg = vn.getByRole("img", { name: "Mari", exact: true });
     await expect(avatarImg).toBeVisible();
     await expect(avatarImg).toHaveCSS("position", "absolute");
-    await expect(avatarImg).toHaveCSS("width", "200%");
-    await expect(avatarImg).toHaveCSS("height", "200%");
-    await expect(avatarImg).toHaveCSS("top", "-20%");
-    await expect(avatarImg).toHaveCSS("left", "-40%");
+    expect(
+      await avatarImg.evaluate((element) => ({
+        width: element.style.width,
+        height: element.style.height,
+        top: element.style.top,
+        left: element.style.left,
+      })),
+    ).toEqual({ width: "200%", height: "200%", top: "-20%", left: "-40%" });
 
     const expandBtn = vn.getByRole("button", { name: "Show chat history" });
     await expect(expandBtn).toBeVisible();
@@ -526,4 +532,3 @@ test("Roleplay VN portrait honors avatar crop and allows history expansion", asy
     await data.cleanup();
   }
 });
-

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -3127,6 +3127,8 @@ export const ChatMessage = memo(function ChatMessage({
       </div>
     );
 
+  const vnAvatarCropStyle = expressionAvatarUrl ? {} : avatarCropStyle;
+
   if (visualNovel) {
     return (
       <>
@@ -3143,7 +3145,7 @@ export const ChatMessage = memo(function ChatMessage({
                 src={displayAvatarUrl}
                 alt={displayName}
                 className="h-full w-full object-cover"
-                style={panelAvatarCropStyle}
+                style={vnAvatarCropStyle}
               />
             ) : (
               <div


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #6044

## Why this change

In Roleplay's Visual Novel presentation mode, character and persona avatars with custom Avatar Crops were ignoring the configured crop and rendering uncropped/stretched. This occurred because the VN portrait container was applying `panelAvatarCropStyle`, which bypasses source-rectangle crops intended for wide rectangular panels.

## What changed

- Updated `ChatMessage.tsx` (Visual Novel branch) to use `vnAvatarCropStyle` (`expressionAvatarUrl ? {} : avatarCropStyle`), correctly applying `getAvatarCropStyle` directly to the square Visual Novel avatar portrait.
- Added E2E regression test in `e2e/roleplay-vn.e2e.ts` verifying that avatar crops are preserved and applied to the VN portrait, and that the chat history popout remains expandable.
- Updated `CHANGELOG.md` under `[Unreleased]`.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify that custom cropped avatars render correctly in Roleplay Visual Novel mode.
- Manually verify that expanding chat history displays previous messages.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Visual Novel mode portraits now correctly honor configured character and persona avatar crops.
  - Cropped portraits display with the intended positioning and sizing, including when expression avatars are shown.
  - Expanded chat history in Visual Novel mode continues to display seeded messages correctly.

- **Tests**
  - Added coverage to verify avatar crop rendering and chat history expansion in Visual Novel mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->