### PR TITLE
fix(game): stop satellite connections inheriting chat-wide generation parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Roleplay's Visual Novel display portrait now honors configured character and persona Avatar Crops (#6044).
 - Image attachments in Roleplay and Conversation no longer come out squashed when the photo carries an EXIF rotation (most phone photos): the attachment compressor now reads the orientation tag before choosing the decode size, so the browser's rotated bitmap is resized with matching width and height (#6053).
+- Game Mode satellite calls that run on their own connection (Scene Analysis, the illustrator prompt rewriter, and the storyboard planner) no longer inherit the chat-wide generation parameters of the main roleplay connection, so an OpenRouter provider-routing object or other provider-specific custom parameter set for the main connection no longer breaks Scene Analysis on a different provider (#6049).
 - After a Game Mode session is concluded, the composer now says so and offers a New Session button in place of the silently disabled input, so play can continue without hunting for the action in the Session panel (#6045).
 - Added the `/send <message>` slash command to post a message as your persona without triggering generation (#6050).
 - The Termux and Linux launcher auto-update no longer aborts with "Cannot copy a socket file" when the previous server left its storage writer lease behind: the update snapshot skips the per-process lease directory and any socket or FIFO under the data directory (#6046).

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -3096,8 +3096,11 @@ function mergeEnabledParameters(
  * connection. A dedicated satellite connection (Scene Analysis, illustrator prompt, storyboard
  * planner) must run on its own defaults only: provider-specific `customParameters` such as an
  * OpenRouter `provider` routing object otherwise leak into a provider that rejects them.
- * Without a dedicated connection the satellite falls back to the chat connection and inherits
- * the chat parameters exactly as before.
+ *
+ * The chat parameters are inherited only when the resolved connection is the chat's own
+ * connection. A chat on the random pool has no single id to compare against, so it inherits
+ * whenever no dedicated connection was requested. A fallback to some other connection (for
+ * example the default agent connection) never inherits, even when nothing was requested.
  */
 export function inheritsChatGenerationParameters(args: {
   requestedConnectionId: string | null | undefined;
@@ -3105,8 +3108,9 @@ export function inheritsChatGenerationParameters(args: {
   chatConnectionId: string | null | undefined;
 }): boolean {
   const requested = args.requestedConnectionId || null;
-  if (!requested) return true;
-  return requested === args.chatConnectionId || args.resolvedConnectionId === args.chatConnectionId;
+  if (args.resolvedConnectionId === args.chatConnectionId) return true;
+  if (requested) return requested === args.chatConnectionId;
+  return args.chatConnectionId === "random";
 }
 
 export function resolveStoredGameGenerationParameters(

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -1036,7 +1036,13 @@ async function summarizeIllustrationFromNarration(args: {
       sceneConnId,
       args.chat.connectionId,
     );
-    const parameters = resolveStoredGameGenerationParameters(args.meta, defaultGenerationParameters);
+    const parameters = resolveStoredGameGenerationParameters(args.meta, defaultGenerationParameters, {
+      includeChatParameters: inheritsChatGenerationParameters({
+        requestedConnectionId: sceneConnId,
+        resolvedConnectionId: conn.id,
+        chatConnectionId: args.chat.connectionId,
+      }),
+    });
     const provider = await createGameMainProvider(args.connections, conn, baseUrl);
     const messages = await buildIllustrationNarrationSummaryMessages({
       promptOverridesStorage: args.promptOverridesStorage,
@@ -1361,7 +1367,16 @@ async function createDynamicGameImagePromptGenerator(args: {
       return undefined;
     }
     const { conn, baseUrl, defaultGenerationParameters } = resolvedConnection;
-    const parameters = resolveStoredGameGenerationParameters(args.meta, defaultGenerationParameters);
+    const parameters = resolveStoredGameGenerationParameters(args.meta, defaultGenerationParameters, {
+      includeChatParameters: inheritsChatGenerationParameters({
+        requestedConnectionId:
+          readTrimmedString(args.meta.illustratorPromptConnectionId) ||
+          readTrimmedString(args.meta.gameSceneConnectionId) ||
+          readTrimmedString(args.setupConfig?.sceneConnectionId),
+        resolvedConnectionId: conn.id,
+        chatConnectionId: args.chat.connectionId,
+      }),
+    });
     const provider = await createGameMainProvider(args.connections, conn, baseUrl);
 
     return async (request) => {
@@ -3048,7 +3063,7 @@ function parseStoredGenerationParameters(raw: unknown): StoredGenerationParamete
   return result.success ? result.data : null;
 }
 
-function mergeStoredGenerationParameters(...sources: Array<unknown>): StoredGenerationParameters | null {
+export function mergeStoredGenerationParameters(...sources: Array<unknown>): StoredGenerationParameters | null {
   const merged: StoredGenerationParameters = {};
   for (const source of sources) {
     const parsed = parseStoredGenerationParameters(source);
@@ -3076,12 +3091,36 @@ function mergeEnabledParameters(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
-function resolveStoredGameGenerationParameters(
+/**
+ * Chat-wide generation parameters (`meta.chatParameters`) are edited against the chat's own
+ * connection. A dedicated satellite connection (Scene Analysis, illustrator prompt, storyboard
+ * planner) must run on its own defaults only: provider-specific `customParameters` such as an
+ * OpenRouter `provider` routing object otherwise leak into a provider that rejects them.
+ * Without a dedicated connection the satellite falls back to the chat connection and inherits
+ * the chat parameters exactly as before.
+ */
+export function inheritsChatGenerationParameters(args: {
+  requestedConnectionId: string | null | undefined;
+  resolvedConnectionId: string;
+  chatConnectionId: string | null | undefined;
+}): boolean {
+  const requested = args.requestedConnectionId || null;
+  if (!requested) return true;
+  return requested === args.chatConnectionId || args.resolvedConnectionId === args.chatConnectionId;
+}
+
+export function resolveStoredGameGenerationParameters(
   meta: Record<string, unknown> | null | undefined,
   connectionDefaults: StoredGenerationParameters | null | undefined,
+  options: { includeChatParameters?: boolean } = {},
 ) {
+  const { includeChatParameters = true } = options;
   const setupConfig = (meta?.gameSetupConfig as Record<string, unknown> | null | undefined) ?? null;
-  return mergeStoredGenerationParameters(connectionDefaults, setupConfig?.generationParameters, meta?.chatParameters);
+  return mergeStoredGenerationParameters(
+    connectionDefaults,
+    setupConfig?.generationParameters,
+    includeChatParameters ? meta?.chatParameters : undefined,
+  );
 }
 
 function resolveGameModelAccessPolicy(args: {
@@ -11602,12 +11641,19 @@ export async function gameRoutes(app: FastifyInstance) {
 
     const meta = parseMeta(chat.metadata);
     const sceneConnId = (meta.gameSceneConnectionId as string) || null;
+    const requestedSceneConnId = input.connectionId ?? sceneConnId;
     const { conn, baseUrl, defaultGenerationParameters } = await resolveConnection(
       connections,
-      input.connectionId ?? sceneConnId,
+      requestedSceneConnId,
       chat.connectionId,
     );
-    const gameGenerationParameters = resolveStoredGameGenerationParameters(meta, defaultGenerationParameters);
+    const gameGenerationParameters = resolveStoredGameGenerationParameters(meta, defaultGenerationParameters, {
+      includeChatParameters: inheritsChatGenerationParameters({
+        requestedConnectionId: requestedSceneConnId,
+        resolvedConnectionId: conn.id,
+        chatConnectionId: chat.connectionId,
+      }),
+    });
     const enableGen = !!meta.enableSpriteGeneration;
     const enableAutoGen = enableGen && meta.gameImageAutoGenerationEnabled !== false;
     const storyboardBackgroundVisualEnabled = meta.gameStoryboardViewerDisplayMode === "background";
@@ -12293,10 +12339,18 @@ export async function gameRoutes(app: FastifyInstance) {
         sceneConnId,
         chat.connectionId,
       );
+      const includeChatParameters = inheritsChatGenerationParameters({
+        requestedConnectionId: sceneConnId,
+        resolvedConnectionId: conn.id,
+        chatConnectionId: chat.connectionId,
+      });
       const parameters =
         ownerMode === "game"
-          ? resolveStoredGameGenerationParameters(meta, defaultGenerationParameters)
-          : mergeStoredGenerationParameters(defaultGenerationParameters, meta.chatParameters);
+          ? resolveStoredGameGenerationParameters(meta, defaultGenerationParameters, { includeChatParameters })
+          : mergeStoredGenerationParameters(
+              defaultGenerationParameters,
+              includeChatParameters ? meta.chatParameters : undefined,
+            );
       const provider = await createGameMainProvider(connections, conn, baseUrl);
 
       const setupCfg = ownerMode === "game" ? ((meta.gameSetupConfig as Record<string, unknown> | null) ?? null) : null;

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -1278,7 +1278,8 @@ export async function resolveDynamicGameImagePromptConnection(args: {
 }) {
   const explicitConnectionId = readTrimmedString(args.meta.illustratorPromptConnectionId);
   if (explicitConnectionId) {
-    return resolveConnection(args.connections, explicitConnectionId, null);
+    const resolved = await resolveConnection(args.connections, explicitConnectionId, null);
+    return { ...resolved, requestedConnectionId: explicitConnectionId };
   }
 
   let lastError: unknown;
@@ -1293,7 +1294,10 @@ export async function resolveDynamicGameImagePromptConnection(args: {
   );
   for (const candidateId of candidateIds) {
     try {
-      return await resolveConnection(args.connections, candidateId, null);
+      const resolved = await resolveConnection(args.connections, candidateId, null);
+      // Report the candidate that actually resolved: a stale scene id that matches the chat
+      // connection but no longer exists must not make the fallback look like the chat connection.
+      return { ...resolved, requestedConnectionId: candidateId };
     } catch (err) {
       lastError = err;
     }
@@ -1301,7 +1305,8 @@ export async function resolveDynamicGameImagePromptConnection(args: {
 
   const defaultAgentConnection = await args.connections.getDefaultForAgents();
   if (defaultAgentConnection) {
-    return resolveConnection(args.connections, defaultAgentConnection.id, null);
+    const resolved = await resolveConnection(args.connections, defaultAgentConnection.id, null);
+    return { ...resolved, requestedConnectionId: defaultAgentConnection.id };
   }
 
   throw lastError instanceof Error ? lastError : new Error("No text connection configured for dynamic image prompts");
@@ -1366,13 +1371,10 @@ async function createDynamicGameImagePromptGenerator(args: {
       );
       return undefined;
     }
-    const { conn, baseUrl, defaultGenerationParameters } = resolvedConnection;
+    const { conn, baseUrl, defaultGenerationParameters, requestedConnectionId } = resolvedConnection;
     const parameters = resolveStoredGameGenerationParameters(args.meta, defaultGenerationParameters, {
       includeChatParameters: inheritsChatGenerationParameters({
-        requestedConnectionId:
-          readTrimmedString(args.meta.illustratorPromptConnectionId) ||
-          readTrimmedString(args.meta.gameSceneConnectionId) ||
-          readTrimmedString(args.setupConfig?.sceneConnectionId),
+        requestedConnectionId,
         resolvedConnectionId: conn.id,
         chatConnectionId: args.chat.connectionId,
       }),

--- a/scripts/regressions/game-satellite-connection-parameters.regression.ts
+++ b/scripts/regressions/game-satellite-connection-parameters.regression.ts
@@ -40,60 +40,34 @@ const explicitlyIncluded = resolveStoredGameGenerationParameters(meta, sceneDefa
 });
 assert.deepEqual(explicitlyIncluded, inherited, "includeChatParameters: true matches the default behavior");
 
-// Guard: only a genuinely separate satellite connection opts out of the chat parameters.
+// Guard: only the chat's own connection inherits the chat parameters.
+const guard = (requestedConnectionId: string | null, resolvedConnectionId: string, chatConnectionId: string | null) =>
+  inheritsChatGenerationParameters({ requestedConnectionId, resolvedConnectionId, chatConnectionId });
+assert.equal(guard(null, "main", "main"), true, "no dedicated connection => the chat connection => inherit");
+assert.equal(guard("", "main", "main"), true, "blank dedicated connection id behaves like none");
+assert.equal(guard("main", "main", "main"), true, "dedicated connection that IS the chat connection => inherit");
+assert.equal(guard("scene", "scene", "main"), false, "dedicated scene connection => do not inherit");
 assert.equal(
-  inheritsChatGenerationParameters({
-    requestedConnectionId: null,
-    resolvedConnectionId: "main",
-    chatConnectionId: "main",
-  }),
-  true,
-  "no dedicated connection => the chat connection => inherit",
-);
-assert.equal(
-  inheritsChatGenerationParameters({
-    requestedConnectionId: "",
-    resolvedConnectionId: "main",
-    chatConnectionId: "main",
-  }),
-  true,
-  "blank dedicated connection id behaves like none",
-);
-assert.equal(
-  inheritsChatGenerationParameters({
-    requestedConnectionId: "main",
-    resolvedConnectionId: "main",
-    chatConnectionId: "main",
-  }),
-  true,
-  "dedicated connection that IS the chat connection => inherit",
-);
-assert.equal(
-  inheritsChatGenerationParameters({
-    requestedConnectionId: "scene",
-    resolvedConnectionId: "scene",
-    chatConnectionId: "main",
-  }),
-  false,
-  "dedicated scene connection => do not inherit",
-);
-assert.equal(
-  inheritsChatGenerationParameters({
-    requestedConnectionId: "scene",
-    resolvedConnectionId: "scene",
-    chatConnectionId: null,
-  }),
+  guard("scene", "scene", null),
   false,
   "dedicated scene connection with no chat connection => do not inherit",
 );
 assert.equal(
-  inheritsChatGenerationParameters({
-    requestedConnectionId: "random",
-    resolvedConnectionId: "main",
-    chatConnectionId: "main",
-  }),
-  true,
-  "random pool that lands on the chat connection => inherit",
+  guard(null, "agents-default", null),
+  false,
+  "fallback to the default agent connection with no chat connection => do not inherit",
+);
+assert.equal(
+  guard(null, "agents-default", "main"),
+  false,
+  "fallback to the default agent connection instead of the chat connection => do not inherit",
+);
+assert.equal(guard(null, "pool-member", "random"), true, "chat on the random pool, nothing requested => inherit");
+assert.equal(guard("random", "pool-member", "random"), true, "requesting the chat's own random pool => inherit");
+assert.equal(
+  guard("random", "pool-member", "main"),
+  false,
+  "dedicated random pool beside a fixed chat connection => do not inherit",
 );
 
 console.log("game-satellite-connection-parameters regression passed");

--- a/scripts/regressions/game-satellite-connection-parameters.regression.ts
+++ b/scripts/regressions/game-satellite-connection-parameters.regression.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import {
+  inheritsChatGenerationParameters,
+  resolveStoredGameGenerationParameters,
+} from "../../packages/server/src/routes/game.routes.js";
+
+// Chat-wide parameters carry a main-connection-only OpenRouter routing object.
+const meta = {
+  chatParameters: {
+    temperature: 0.9,
+    customParameters: { provider: { only: ["vertex"] } },
+  },
+  gameSetupConfig: {
+    generationParameters: { topP: 0.5 },
+  },
+};
+const sceneDefaults = { temperature: 0.2, customParameters: { top_k: 40 } };
+
+const inherited = resolveStoredGameGenerationParameters(meta, sceneDefaults);
+assert.equal(inherited?.temperature, 0.9, "default path still layers the chat parameters last");
+assert.equal(inherited?.topP, 0.5, "setup-config parameters still merge on the default path");
+assert.deepEqual(
+  inherited?.customParameters,
+  { top_k: 40, provider: { only: ["vertex"] } },
+  "default path still merges chat customParameters",
+);
+
+const scoped = resolveStoredGameGenerationParameters(meta, sceneDefaults, { includeChatParameters: false });
+assert.equal(scoped?.temperature, 0.2, "a dedicated satellite connection keeps its own defaults");
+assert.equal(scoped?.topP, 0.5, "setup-config parameters still merge for a satellite connection");
+assert.deepEqual(scoped?.customParameters, { top_k: 40 }, "main-connection customParameters do not leak");
+assert.equal(
+  "provider" in (scoped?.customParameters ?? {}),
+  false,
+  "the OpenRouter provider routing object stays with the main connection",
+);
+
+const explicitlyIncluded = resolveStoredGameGenerationParameters(meta, sceneDefaults, {
+  includeChatParameters: true,
+});
+assert.deepEqual(explicitlyIncluded, inherited, "includeChatParameters: true matches the default behavior");
+
+// Guard: only a genuinely separate satellite connection opts out of the chat parameters.
+assert.equal(
+  inheritsChatGenerationParameters({
+    requestedConnectionId: null,
+    resolvedConnectionId: "main",
+    chatConnectionId: "main",
+  }),
+  true,
+  "no dedicated connection => the chat connection => inherit",
+);
+assert.equal(
+  inheritsChatGenerationParameters({
+    requestedConnectionId: "",
+    resolvedConnectionId: "main",
+    chatConnectionId: "main",
+  }),
+  true,
+  "blank dedicated connection id behaves like none",
+);
+assert.equal(
+  inheritsChatGenerationParameters({
+    requestedConnectionId: "main",
+    resolvedConnectionId: "main",
+    chatConnectionId: "main",
+  }),
+  true,
+  "dedicated connection that IS the chat connection => inherit",
+);
+assert.equal(
+  inheritsChatGenerationParameters({
+    requestedConnectionId: "scene",
+    resolvedConnectionId: "scene",
+    chatConnectionId: "main",
+  }),
+  false,
+  "dedicated scene connection => do not inherit",
+);
+assert.equal(
+  inheritsChatGenerationParameters({
+    requestedConnectionId: "scene",
+    resolvedConnectionId: "scene",
+    chatConnectionId: null,
+  }),
+  false,
+  "dedicated scene connection with no chat connection => do not inherit",
+);
+assert.equal(
+  inheritsChatGenerationParameters({
+    requestedConnectionId: "random",
+    resolvedConnectionId: "main",
+    chatConnectionId: "main",
+  }),
+  true,
+  "random pool that lands on the chat connection => inherit",
+);
+
+console.log("game-satellite-connection-parameters regression passed");


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #6049

## Why this change

- Scene Analysis (and its siblings) already resolve their own connection through `gameSceneConnectionId`, but the generation parameters for that call were still built by merging `meta.chatParameters`, the chat-wide bag the user edits against the **main** roleplay connection. Its `customParameters` (for example an OpenRouter `provider` routing object, or Vertex-only fields) therefore travelled to a different provider, which rejected the request with the OpenRouter 404 / Gemini 400 described in the issue.
- Roleplay's auxiliary paths (chat summary, image captioning) already use only the resolved connection's own defaults. Game Mode's satellites now follow the same rule.

## What changed

- `resolveStoredGameGenerationParameters` takes an `includeChatParameters` option (default `true`, so every untouched call site is unchanged).
- New `inheritsChatGenerationParameters` guard: chat parameters are inherited only when the resolved connection is the chat's own connection (a chat on the random pool inherits whenever no dedicated connection was requested). A dedicated satellite connection, or a fallback such as the default agent connection, uses its own defaults plus the game setup parameters.
- Applied at the four satellite call sites: `/scene-wrap` (Scene Analysis), the illustration narration summarizer, the dynamic illustrator prompt rewriter, and the storyboard planner (both its game and roleplay branches).
- Regression `scripts/regressions/game-satellite-connection-parameters.regression.ts` pins the merge behaviour and the guard.
- CHANGELOG entry.

Behaviour note: a satellite running on its own connection no longer picks up sampler tweaks (temperature, reasoning effort, etc.) set for the main chat either. That is the intended scoping, matching how Roleplay's summarizer and captioning already behave.

Out of scope: the game endpoints that accept a one-off `connectionId` in the request body (conclusion, progression, recruit cards, party turn, the lorebook keeper queued after a conclusion) still inherit the chat parameters. Those run the main roleplay flow through another connection for one call rather than acting as a separate agent, so today's behaviour is kept there.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` green locally; `pnpm --filter @marinara-engine/server lint` green; `node scripts/run-regressions.mjs --filter game-satellite-connection-parameters` and `--filter prompt.regression` pass.
- Manually verify on the production deploy: main connection with a custom `provider` parameter + Scene Analysis on a different provider; play a turn and confirm `/scene-wrap` succeeds.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A (server-side only).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Game Mode satellite calls so Scene Analysis, illustration prompt rewriting, storyboard planning, and scene summaries use the selected connection’s generation settings.
  * Prevented provider-specific chat settings from interfering with satellite connections when different AI providers are used.
  * Corrected connection resolution for dynamic image prompts and unavailable scene connections.

* **Tests**
  * Added regression coverage for generation-parameter handling across main, dedicated, and random-pool connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->