### PR TITLE
fix(chat): keep the aspect ratio of EXIF-rotated image attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ## [Unreleased]
 
 - Roleplay's Visual Novel display portrait now honors configured character and persona Avatar Crops (#6044).
+- Image attachments in Roleplay and Conversation no longer come out squashed when the photo carries an EXIF rotation (most phone photos): the attachment compressor now reads the orientation tag before choosing the decode size, so the browser's rotated bitmap is resized with matching width and height (#6053).
 - After a Game Mode session is concluded, the composer now says so and offers a New Session button in place of the silently disabled input, so play can continue without hunting for the action in the Session panel (#6045).
 - Added the `/send <message>` slash command to post a message as your persona without triggering generation (#6050).
 - The Termux and Linux launcher auto-update no longer aborts with "Cannot copy a socket file" when the previous server left its storage writer lease behind: the update snapshot skips the per-process lease directory and any socket or FIFO under the data directory (#6046).

--- a/packages/client/src/lib/chat-attachment-images.ts
+++ b/packages/client/src/lib/chat-attachment-images.ts
@@ -27,9 +27,58 @@ function uint24Le(bytes: Uint8Array, offset: number): number {
   return bytes[offset]! | (bytes[offset + 1]! << 8) | (bytes[offset + 2]! << 16);
 }
 
+/** EXIF orientations 5-8 rotate the displayed image by 90 degrees, swapping its width and height. */
+const TRANSPOSING_EXIF_ORIENTATIONS = new Set([5, 6, 7, 8]);
+
+/**
+ * Read the `Orientation` tag from an APP1 Exif segment. `segmentOffset` points at the segment
+ * length field; returns null when the segment is not Exif or the tag is absent or malformed.
+ */
+function readExifOrientation(bytes: Uint8Array, segmentOffset: number, segmentLength: number): number | null {
+  const segmentEnd = segmentOffset + segmentLength;
+  const exifHeader = segmentOffset + 2;
+  if (
+    exifHeader + 6 > segmentEnd ||
+    bytes[exifHeader] !== 0x45 ||
+    bytes[exifHeader + 1] !== 0x78 ||
+    bytes[exifHeader + 2] !== 0x69 ||
+    bytes[exifHeader + 3] !== 0x66 ||
+    bytes[exifHeader + 4] !== 0x00 ||
+    bytes[exifHeader + 5] !== 0x00
+  ) {
+    return null;
+  }
+  const tiff = exifHeader + 6;
+  if (tiff + 8 > segmentEnd) return null;
+  const littleEndian = bytes[tiff] === 0x49 && bytes[tiff + 1] === 0x49;
+  if (!littleEndian && !(bytes[tiff] === 0x4d && bytes[tiff + 1] === 0x4d)) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (view.getUint16(tiff + 2, littleEndian) !== 0x002a) return null;
+  const ifdOffset = view.getUint32(tiff + 4, littleEndian);
+  const ifd = tiff + ifdOffset;
+  if (ifdOffset < 8 || ifd + 2 > segmentEnd) return null;
+  const entryCount = view.getUint16(ifd, littleEndian);
+  for (let index = 0; index < entryCount; index += 1) {
+    const entry = ifd + 2 + index * 12;
+    if (entry + 12 > segmentEnd) return null;
+    if (view.getUint16(entry, littleEndian) !== 0x0112) continue;
+    if (view.getUint16(entry + 2, littleEndian) !== 3 || view.getUint32(entry + 4, littleEndian) !== 1) return null;
+    const orientation = view.getUint16(entry + 8, littleEndian);
+    return orientation >= 1 && orientation <= 8 ? orientation : null;
+  }
+  return null;
+}
+
+/**
+ * Read the encoded JPEG frame size as the browser will decode it: `createImageBitmap` applies the
+ * EXIF orientation, so a transposing orientation swaps the width and height stored in the frame
+ * header. Feeding the raw header size into `resizeWidth`/`resizeHeight` would otherwise squash a
+ * rotated phone photo into the opposite aspect ratio.
+ */
 function readJpegDimensions(bytes: Uint8Array): ImageDimensions | null {
   if (bytes[0] !== 0xff || bytes[1] !== 0xd8) return null;
   const startOfFrameMarkers = new Set([0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf]);
+  let orientation: number | null = null;
   let offset = 2;
   while (offset + 8 < bytes.length) {
     if (bytes[offset] !== 0xff) {
@@ -42,15 +91,22 @@ function readJpegDimensions(bytes: Uint8Array): ImageDimensions | null {
     if (marker === 0xd9 || marker === 0xda || offset + 2 > bytes.length) break;
     const segmentLength = uint16Be(bytes, offset);
     if (segmentLength < 2 || offset + segmentLength > bytes.length) break;
+    if (marker === 0xe1 && orientation === null) {
+      orientation = readExifOrientation(bytes, offset, segmentLength);
+    }
     if (startOfFrameMarkers.has(marker) && segmentLength >= 7) {
-      return { height: uint16Be(bytes, offset + 3), width: uint16Be(bytes, offset + 5) };
+      const height = uint16Be(bytes, offset + 3);
+      const width = uint16Be(bytes, offset + 5);
+      return orientation !== null && TRANSPOSING_EXIF_ORIENTATIONS.has(orientation)
+        ? { width: height, height: width }
+        : { width, height };
     }
     offset += segmentLength;
   }
   return null;
 }
 
-function readEncodedImageDimensions(bytes: Uint8Array): ImageDimensions | null {
+export function readEncodedImageDimensions(bytes: Uint8Array): ImageDimensions | null {
   if (bytes.length >= 24 && bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) {
     const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
     return { width: view.getUint32(16), height: view.getUint32(20) };
@@ -181,12 +237,13 @@ export async function prepareImageAttachment(blob: Blob, displayName = "image"):
       (decodeSize.width !== encodedDimensions.width || decodeSize.height !== encodedDimensions.height);
     if (shouldResizeWhileDecoding && decodeSize) {
       bitmap = await createImageBitmap(blob, {
+        imageOrientation: "from-image",
         resizeWidth: decodeSize.width,
         resizeHeight: decodeSize.height,
         resizeQuality: "high",
       });
     } else {
-      bitmap = await createImageBitmap(blob);
+      bitmap = await createImageBitmap(blob, { imageOrientation: "from-image" });
     }
     assertSafeImageDimensions(bitmap);
     const shouldCompress =

--- a/scripts/regressions/chat-attachment-exif-orientation.regression.ts
+++ b/scripts/regressions/chat-attachment-exif-orientation.regression.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { readEncodedImageDimensions } from "../../packages/client/src/lib/chat-attachment-images.js";
+
+type Endian = "II" | "MM";
+
+function exifApp1(orientation: number, endian: Endian): number[] {
+  const le = endian === "II";
+  const u16 = (value: number) => (le ? [value & 0xff, value >> 8] : [value >> 8, value & 0xff]);
+  const u32 = (value: number) =>
+    le
+      ? [value & 0xff, (value >> 8) & 0xff, (value >> 16) & 0xff, value >>> 24]
+      : [value >>> 24, (value >> 16) & 0xff, (value >> 8) & 0xff, value & 0xff];
+  const tiff = [
+    ...(le ? [0x49, 0x49] : [0x4d, 0x4d]),
+    ...u16(0x002a),
+    ...u32(8),
+    ...u16(1),
+    ...u16(0x0112),
+    ...u16(3),
+    ...u32(1),
+    ...u16(orientation),
+    ...u16(0),
+    ...u32(0),
+  ];
+  const payload = [0x45, 0x78, 0x69, 0x66, 0x00, 0x00, ...tiff];
+  const length = payload.length + 2;
+  return [0xff, 0xe1, length >> 8, length & 0xff, ...payload];
+}
+
+function sof0(width: number, height: number): number[] {
+  // Baseline frame header: length 17, precision 8, height, width, 3 components.
+  return [
+    0xff,
+    0xc0,
+    0x00,
+    0x11,
+    0x08,
+    height >> 8,
+    height & 0xff,
+    width >> 8,
+    width & 0xff,
+    0x03,
+    0x01,
+    0x22,
+    0x00,
+    0x02,
+    0x11,
+    0x01,
+    0x03,
+    0x11,
+    0x01,
+  ];
+}
+
+function jpeg(segments: number[][]): Uint8Array {
+  return new Uint8Array([0xff, 0xd8, ...segments.flat(), 0xff, 0xda, 0x00, 0x02, 0xff, 0xd9]);
+}
+
+const landscapeFrame = sof0(3000, 2000);
+
+assert.deepEqual(
+  readEncodedImageDimensions(jpeg([landscapeFrame])),
+  { width: 3000, height: 2000 },
+  "a JPEG without Exif keeps its frame size",
+);
+
+for (const endian of ["II", "MM"] as const) {
+  assert.deepEqual(
+    readEncodedImageDimensions(jpeg([exifApp1(1, endian), landscapeFrame])),
+    { width: 3000, height: 2000 },
+    `orientation 1 (${endian}) keeps the frame size`,
+  );
+  assert.deepEqual(
+    readEncodedImageDimensions(jpeg([exifApp1(3, endian), landscapeFrame])),
+    { width: 3000, height: 2000 },
+    `orientation 3 (${endian}) is a 180-degree turn and keeps the frame size`,
+  );
+  for (const orientation of [5, 6, 7, 8]) {
+    assert.deepEqual(
+      readEncodedImageDimensions(jpeg([exifApp1(orientation, endian), landscapeFrame])),
+      { width: 2000, height: 3000 },
+      `orientation ${orientation} (${endian}) swaps width and height, matching the decoded bitmap`,
+    );
+  }
+}
+
+// A non-Exif APP1 (e.g. XMP) before the Exif segment is ignored rather than misread.
+const xmpApp1 = [0xff, 0xe1, 0x00, 0x08, 0x68, 0x74, 0x74, 0x70, 0x3a, 0x2f];
+assert.deepEqual(
+  readEncodedImageDimensions(jpeg([xmpApp1, exifApp1(6, "II"), landscapeFrame])),
+  { width: 2000, height: 3000 },
+  "an XMP APP1 ahead of the Exif segment does not hide the orientation",
+);
+
+// A truncated Exif segment never throws and falls back to the frame size.
+const truncated = exifApp1(6, "II").slice(0, 16);
+truncated[2] = 0x00;
+truncated[3] = truncated.length - 2;
+assert.deepEqual(
+  readEncodedImageDimensions(jpeg([truncated, landscapeFrame])),
+  { width: 3000, height: 2000 },
+  "a truncated Exif segment is ignored",
+);
+
+// Other formats are untouched.
+const png = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x06,
+  0x40, 0x00, 0x00, 0x01, 0x90, 0x08, 0x02, 0x00, 0x00, 0x00,
+]);
+assert.deepEqual(readEncodedImageDimensions(png), { width: 1600, height: 400 }, "PNG header parsing is unchanged");
+
+console.log("chat-attachment-exif-orientation regression passed");


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #6053

## Why this change

- Attaching a photo in Roleplay or Conversation produced a horizontally squashed image, both in the preview and in the payload sent to the model. The attachment compressor reads the frame size from the JPEG header to pick a decode-time resize, but `createImageBitmap` applies the EXIF orientation before it resizes. A phone photo stored as 3000x2000 with orientation 6 decodes as a 2000x3000 portrait and was then forced into a 1536x1024 bitmap, so the compressed JPEG itself carried the wrong aspect ratio. Every later `object-fit` was already correct; the pixels were wrong.
- Reproduced on the production deploy: decoding such a file plainly yields 2000x3000, while the pipeline's `resizeWidth: 1536, resizeHeight: 1024` call yields the portrait content squashed into a landscape bitmap.

## What changed

- The JPEG header walk in `chat-attachment-images.ts` now also reads the Exif `Orientation` tag (APP1, both byte orders, bounds-checked) and swaps the frame width and height for the transposing orientations 5 to 8, so the resize hint matches the bitmap the browser will produce.
- Both `createImageBitmap` calls pin `imageOrientation: "from-image"`, so the behaviour does not depend on a browser default. This is belt and braces; the dimension swap is the fix.
- Known limitation: only JPEG carries the orientation tag that browsers honour here. PNG has no orientation metadata and browsers do not auto-rotate WebP from its EXIF chunk, so those formats are unchanged.
- New regression `scripts/regressions/chat-attachment-exif-orientation.regression.ts` covers orientations 1, 3, 5 to 8 in both byte orders, a non-Exif APP1 ahead of the Exif segment, a truncated Exif segment, and the untouched PNG path.
- CHANGELOG entry.

Game Mode is not affected: its composer stores the raw file without running the compressor.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm --filter @marinara-engine/client lint` green (one pre-existing unrelated warning); `node scripts/run-regressions.mjs --filter chat-attachment-exif-orientation` passes.
- `pnpm check` green locally.
- Verified on the production deploy with a 3000x2000 JPEG carrying EXIF orientation 6 (displays as 2000x3000 portrait). Before: decoding the file plainly gives 2000x3000, while the pipeline's `resizeWidth: 1536, resizeHeight: 1024` call produced the portrait content squashed into a landscape bitmap. After deploying this branch: attaching the same file produces a 1024x1536 JPEG payload, portrait preserved.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Payload dimensions on the production deploy for the same EXIF orientation 6 photo:

| | prepared attachment |
|---|---|
| before | 1536x1024 (squashed landscape) |
| after | 1024x1536 (portrait, correct) |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image attachments in Roleplay and Conversation being squashed when photos include EXIF rotation metadata.
  * Attachments now preserve the correct width and height during compression, including photos taken on most phones.

* **Tests**
  * Added regression coverage for rotated JPEGs, EXIF formats, truncated metadata, and PNG dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->