### PR TITLE
docs: fix stale agent catalog count in agents-overview.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- Corrected the Agents overview page's catalog summary, which said 33 one-click packages (6 Writer, 9 Tracker, 18 Misc) while the linked per-agent reference and the README both say 36 (6 Writer, 11 Tracker, 19 Misc) (#6063).
+
 - Visual Novel paragraph navigation now loads older messages across history pages, shows matching translations alongside the source, and preserves source text when translated paragraph counts differ (#6044).
 
 - Roleplay's Visual Novel display now supports paragraph-by-paragraph progression with previous and next navigation controls, allowing users to step through all paragraphs of a turn and preceding messages without opening the full history view (#6044).

--- a/docs/agents/agents-overview.md
+++ b/docs/agents/agents-overview.md
@@ -8,7 +8,7 @@ Agents are small AI helpers that run automatically around your main chat reply. 
 
 Agents are turned on per chat, not per character. There is no agent toggle on a character card. Two chats with the same character can run completely different agents. You choose which agents run in each chat's settings.
 
-Fresh Marinara Engine installations start without optional agents. This keeps the base app and Termux installation smaller. The official v2.3.0+ catalog contains 33 one-click packages: 6 Writer Agents, 9 Tracker Agents, and 18 Misc Agents, including Long-Term Memory, Maps, Calls, Inventory Tracker, and all six Conversation games. Their source, manifests, downloadable artifacts, and repository-level catalog are public in [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents). For the complete per-agent guide, see [Downloadable Agents Reference](built-in-agents.md). To make your own, see [Creating Custom Agents](custom-agents.md).
+Fresh Marinara Engine installations start without optional agents. This keeps the base app and Termux installation smaller. The official v2.3.0+ catalog contains 36 one-click packages: 6 Writer Agents, 11 Tracker Agents, and 19 Misc Agents, including Long-Term Memory, Maps, Calls, Inventory Tracker, and all six Conversation games. Their source, manifests, downloadable artifacts, and repository-level catalog are public in [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents). For the complete per-agent guide, see [Downloadable Agents Reference](built-in-agents.md). To make your own, see [Creating Custom Agents](custom-agents.md).
 
 ## The three phases
 


### PR DESCRIPTION
## Why

`docs/agents/agents-overview.md` summarizes the official catalog as **33** one-click packages (6 Writer, 9 Tracker, 18 Misc). That disagrees with the detailed reference page it links to, `docs/agents/built-in-agents.md`, which says **36** official first-party packages, and with `README.md`'s feature list (also 36, with 19 Misc agents listed). A reader following the overview page's own link sees a different number one click later.

Found while cross-referencing Marinara's docs against notes from an external project evaluating this Engine as a frontend (dated against v2.4.4), then verified directly against the current `staging` docs.

Closes #6063.

## What changed

- `docs/agents/agents-overview.md`: 33 → 36 packages, 6 Writer / 9 → 11 Tracker / 18 → 19 Misc, matching `built-in-agents.md` and `README.md`.
- `CHANGELOG.md`: added an `[Unreleased]` entry.

## Note for reviewers

`built-in-agents.md`'s own body currently has 18 Misc `###` entries, not 19 — it appears to be missing a written section for **Slurp** (which README counts as the 19th Misc agent). This looks related to the recent "Removed the unfinished Slurp creator-feed material from the Noodle guides" changelog entry, i.e. Slurp may be deliberately left undocumented until it's finished. I left that alone and only fixed the summary-line disagreement, since writing a new agent section is a different scope than correcting a stale count — flagged for visibility in case it should stay open as its own follow-up.

## Test plan

- [ ] Confirm 36 / 6 / 11 / 19 matches the live `Pasta-Devs/Marinara-Agents` catalog counts, not just the two doc pages compared here.
- [ ] Skim `built-in-agents.md` to decide whether the missing Slurp section is intentional (unfinished feature) or should get its own follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)