### PR TITLE
fix(roleplay): clarify private notes and honor Chroma in command editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- Roleplay notes and memory editors now follow Chroma colors. Personal notes are prompted to stay brief and track private state and plans for future turns instead of recapping scenes (#6069).
+
 - Visual Novel paragraph navigation now loads older messages across history pages, shows matching translations alongside the source, and preserves source text when translated paragraph counts differ (#6044).
 
 - Roleplay's Visual Novel display now supports paragraph-by-paragraph progression with previous and next navigation controls, allowing users to step through all paragraphs of a turn and preceding messages without opening the full history view (#6044).

--- a/e2e/roleplay-commands.e2e.ts
+++ b/e2e/roleplay-commands.e2e.ts
@@ -429,6 +429,40 @@ test("Roleplay commands default off, scope private notes, and follow swipes and 
     await note.getByRole("button", { name: "Alice used notes command!", exact: true }).click();
     await note.getByRole("button", { name: "Edit", exact: true }).click();
     const editor = page.locator('[data-component="ExpandedTextarea"]');
+    const checkEditorColors = async (command: string) => {
+      for (const theme of ["dark", "light"] as const) {
+        await page.evaluate(async (theme) => {
+          const { useUIStore } = await import("/src/stores/ui.store.ts" as string);
+          useUIStore.getState().setTheme(theme);
+          useUIStore.getState().setAppAccentColor("#3b9fe8");
+          useUIStore.getState().setChatChromeTextColor(theme === "dark" ? "#d4d4d4" : "#242424");
+        }, theme);
+        await expect(page.locator("html")).toHaveAttribute("data-theme", theme);
+        const colors = await editor.evaluate((element) => {
+          const probe = element.ownerDocument.createElement("span");
+          element.append(probe);
+          probe.style.color = "var(--marinara-chat-chrome-panel-muted)";
+          const text = getComputedStyle(probe).color;
+          probe.style.color = "var(--marinara-chat-chrome-button-text)";
+          const icon = getComputedStyle(probe).color;
+          probe.remove();
+          return { text, icon };
+        });
+        await testInfo.attach(`${command}-editor-${theme}`, {
+          body: await page.screenshot({
+            animations: "disabled",
+            path: testInfo.outputPath(`${command}-editor-${theme}.png`),
+          }),
+          contentType: "image/png",
+        });
+        await expect(editor.getByText(/^\d+ characters$/u)).toHaveCSS("color", colors.text);
+        await expect(editor.getByRole("button", { name: "Cancel", exact: true }).first()).toHaveCSS(
+          "color",
+          colors.icon,
+        );
+      }
+    };
+    await checkEditorColors("notes");
     await editor.locator("textarea").fill("EDITED_BATCH_SECRET");
     const editUrl = `**/api/chats/${chat.id}/messages/*/extra?swipeIndex=*`;
     await page.route(editUrl, (route) => route.fulfill({ status: 500, json: { error: "Synthetic save failure" } }), {
@@ -442,6 +476,27 @@ test("Roleplay commands default off, scope private notes, and follow swipes and 
     expect(await preview(narrator)).toContain("EDITED_BATCH_SECRET");
     expect(await preview(bob)).not.toContain("EDITED_BATCH_SECRET");
     await expect(note).toContainText('[notes: content="BATCH_SECRET"]');
+    const memory = page.locator('[data-roleplay-command="memory"]').last();
+    await memory.getByRole("button", { name: "Alice used memory command!", exact: true }).click();
+    await memory.getByRole("button", { name: "Edit", exact: true }).click();
+    await checkEditorColors("memory");
+    await editor.locator("textarea").fill("EDITED_REMINDER: retrieve the key tomorrow");
+    await editor.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(editor).toBeHidden();
+    await memory.getByRole("button", { name: "Edit", exact: true }).click();
+    await editor.locator("textarea").fill("CANCELED_REMINDER");
+    await editor.getByRole("button", { name: "Cancel", exact: true }).first().click();
+    await expect(editor).toBeHidden();
+    output = "She considers her next move.";
+    await generate(alice);
+    const editedPrompt = contentOf(requests.at(-1));
+    expect(editedPrompt).toContain("Do not recap scenes or repeat chat history; use [memory] for reminders.");
+    expect(editedPrompt).toContain("1–3 short bullets, under 80 words total");
+    expect(editedPrompt).toContain("EDITED_BATCH_SECRET");
+    expect(editedPrompt).toContain("EDITED_REMINDER: retrieve the key tomorrow");
+    expect(editedPrompt).not.toMatch(/ALICE_REMINDER|CANCELED_REMINDER|\[notes: content="BATCH_SECRET"\]/u);
+    expect(await preview(narrator)).toContain("EDITED_REMINDER: retrieve the key tomorrow");
+    expect(await preview(bob)).not.toContain("EDITED_REMINDER");
     await testInfo.attach(`roleplay-command-edit-${testInfo.project.name}.png`, {
       body: await page.screenshot({ animations: "disabled", path: testInfo.outputPath("roleplay-command-edit.png") }),
       contentType: "image/png",

--- a/e2e/roleplay-commands.e2e.ts
+++ b/e2e/roleplay-commands.e2e.ts
@@ -490,7 +490,7 @@ test("Roleplay commands default off, scope private notes, and follow swipes and 
     output = "She considers her next move.";
     await generate(alice);
     const editedPrompt = contentOf(requests.at(-1));
-    expect(editedPrompt).toContain("Do not recap scenes or repeat chat history; use [memory] for reminders.");
+    expect(editedPrompt).toContain("Do not recap scenes or repeat chat history.");
     expect(editedPrompt).toContain("1–3 short bullets, under 80 words total");
     expect(editedPrompt).toContain("EDITED_BATCH_SECRET");
     expect(editedPrompt).toContain("EDITED_REMINDER: retrieve the key tomorrow");

--- a/packages/client/src/components/ui/ExpandedTextarea.tsx
+++ b/packages/client/src/components/ui/ExpandedTextarea.tsx
@@ -94,7 +94,7 @@ export function ExpandedTextarea({
           >
             <h2 className={isChatSurface ? NEUTRAL_PANEL_TITLE : "text-sm font-semibold"}>{title}</h2>
             <div className="flex items-center gap-2">
-              <span className="text-[0.625rem] text-[var(--muted-foreground)]">
+              <span className="text-[0.625rem] text-[var(--marinara-chat-chrome-panel-muted)]">
                 {value.length} {localizeUi("ui.noodle.noodlehome.characters")}
               </span>
               <button
@@ -105,7 +105,7 @@ export function ExpandedTextarea({
                   "flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs transition-colors",
                   isChatSurface
                     ? "border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-[var(--marinara-chat-chrome-button-text)] hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]"
-                    : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                    : "text-[var(--marinara-chat-chrome-button-text)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]",
                 )}
               >
                 <Minimize2 size="0.875rem" />

--- a/packages/server/src/services/generation/roleplay-commands.ts
+++ b/packages/server/src/services/generation/roleplay-commands.ts
@@ -341,7 +341,7 @@ export function buildRoleplayCommandsReminder(args: {
     );
   if (args.privateAvailable && enabled("notes"))
     lines.push(
-      '- [notes: content="your current personal notes"] creates or edits your notes about motives, secrets, beliefs, lies and plans. To edit existing notes, send their full updated contents; this replaces your previous notes. Preserve relevant details and keep it short; these notes are available to you and narrator alone. [dismiss_notes] clears your notes when they\'re no longer needed or relevant.',
+      '- [notes: content="brief private state and plans"] keeps private state that should guide future turns: unspoken thoughts, changed attitudes, secrets, and pending plans. Do not recap scenes or repeat chat history; use [memory] for reminders. To edit existing notes, send their full updated contents; this replaces your previous notes. Keep only still-relevant details in 1–3 short bullets, under 80 words total. Notes are available to you and the narrator alone. [dismiss_notes] clears them when no longer needed.',
     );
   if (args.privateAvailable && enabled("memory"))
     lines.push(

--- a/packages/server/src/services/generation/roleplay-commands.ts
+++ b/packages/server/src/services/generation/roleplay-commands.ts
@@ -341,7 +341,7 @@ export function buildRoleplayCommandsReminder(args: {
     );
   if (args.privateAvailable && enabled("notes"))
     lines.push(
-      '- [notes: content="brief private state and plans"] keeps private state that should guide future turns: unspoken thoughts, changed attitudes, secrets, and pending plans. Do not recap scenes or repeat chat history; use [memory] for reminders. To edit existing notes, send their full updated contents; this replaces your previous notes. Keep only still-relevant details in 1–3 short bullets, under 80 words total. Notes are available to you and the narrator alone. [dismiss_notes] clears them when no longer needed.',
+      '- [notes: content="brief private state and plans"] keeps private state that should guide future turns: unspoken thoughts, changed attitudes, secrets, and pending plans. Do not recap scenes or repeat chat history. To edit existing notes, send their full updated contents; this replaces your previous notes. Keep only still-relevant details in 1–3 short bullets, under 80 words total. Notes are available to you and the narrator alone. [dismiss_notes] clears them when no longer needed.',
     );
   if (args.privateAvailable && enabled("memory"))
     lines.push(


### PR DESCRIPTION
## Linked issue

Closes #6069

## Why this change

Roleplay's notes and memory text editors retain lavender controls under custom Chroma colors, and the notes prompt permits lengthy scene recaps. Users need the editor to respect their theme and notes to preserve concise private state and plans for future turns.

## What changed

- Expanded text editor character counts follow Chroma muted text; collapse controls and their hover states follow Chroma accent colors.
- The notes prompt reserves notes for private state and plans that guide future turns, excludes scene recaps, and asks for 1–3 short bullets under 80 words. It stands on its own without referring to separately toggled commands. Existing replacement and dismissal behavior is preserved.
- Extend the existing Roleplay browser regression to verify both editors across light/dark themes, saved notes and memory edits in the next provider request, canceled edits, and private audience boundaries.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify notes and memory character counts and collapse controls follow Chroma in light/dark mode and on mobile.
- Manually verify saved edits appear in the next generation prompt and canceled edits do not persist.
- Passed locally: `pnpm check`, `pnpm regression:prompt`, and `node scripts/run-regressions.mjs --filter scripts/regressions/roleplay-commands.regression.ts`.
- Passed locally: `pnpm smoke:ui e2e/roleplay-commands.e2e.ts e2e/chat-sweep.e2e.ts --grep 'default off, scope private notes|Notification position' --workers=1` (6/6 across desktop Chromium, Android-sized Chromium, and iPhone-sized WebKit).
- Repeated after the final prompt correction: `pnpm check`, prompt/command regressions, and `pnpm smoke:ui e2e/roleplay-commands.e2e.ts --grep 'default off, scope private notes' --workers=1` (3/3).
- The initial full local browser run was stopped in favor of the complete CI shards. Its notification-position failure passed on the isolated rerun across all three browsers. No full local-suite pass is claimed.
- Built the Docker image and started an isolated container; `/api/health` reported `status: ok`, and the app page returned HTTP 200. Removed the temporary container afterward. CI also builds the latest prompt-only correction.
- The browser regression reproduced the original color bug before the fix: the count stayed `rgb(212, 173, 252)` instead of the selected Chroma text.
- The existing save path required no product-code change. Browser coverage exercises failed saves/retry, cancellation, saved text in the next actual generation request to a synthetic provider, narrator access, and unrelated-character exclusion.
- Manually verify note-writing quality with a preferred live model and on a physical phone; deterministic browser fixtures cannot establish live-model compliance or real-device behavior.

Prompt proof covers current and legacy command extras, disabled commands, per-character privacy, swipes, branches, and saved edits. The 80-word target is a prompt instruction; existing saved/user-edited notes are not truncated.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

Includes an Unreleased changelog entry. No version bump or user-facing documentation changes.

## UI evidence (if applicable)

[Full synthetic screenshot set](https://gist.github.com/SpicyMarinara/b01c3884af2f227b2fa6abbed95619b7), including dark and light iPhone-sized WebKit. Screenshots were inspected after the final fix.

| Before | After |
| --- | --- |
| ![Before: lavender count and collapse control](https://gist.githubusercontent.com/SpicyMarinara/b01c3884af2f227b2fa6abbed95619b7/raw/71d939e43d32ac190ae9c393542a7ee91b9604ff/before-desktop.png) | ![After: Chroma text and accent controls](https://gist.githubusercontent.com/SpicyMarinara/b01c3884af2f227b2fa6abbed95619b7/raw/6b46624528882dd1e5ab54eb27b7a3f9f70e6373/after-desktop.png) |
