### PR TITLE
fix: image timeouts and large-backup imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Full-backup ZIP imports again accept archives larger than 2 GiB through the existing streaming restore path (#6091).
 - Image generation now honors the configured timeout while waiting for provider response headers and image data, avoiding an early five-minute failure on slow local or hosted image backends (#6074).
 - The generation parameter guide distinguishes editor defaults from effective request values and explains where preset, connection, and chat settings apply (#6073).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Image generation now honors the configured timeout while waiting for provider response headers and image data, avoiding an early five-minute failure on slow local or hosted image backends (#6074).
+- The generation parameter guide distinguishes editor defaults from effective request values and explains where preset, connection, and chat settings apply (#6073).
 
 - OpenRouter image generation now requests image-only output by default, fixing unsupported-modality errors for MAI and Grok Imagine while retaining text output for compatible Gemini, GPT-5 image, and automatic-routing models (#6079).
 - Android can remember app or browser launch, sign the browser in automatically, and reuse an authenticated running server before starting Termux again (#6071).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Image generation now honors the configured timeout while waiting for provider response headers and image data, avoiding an early five-minute failure on slow local or hosted image backends (#6074).
+
 - OpenRouter image generation now requests image-only output by default, fixing unsupported-modality errors for MAI and Grok Imagine while retaining text output for compatible Gemini, GPT-5 image, and automatic-routing models (#6079).
 - Android can remember app or browser launch, sign the browser in automatically, and reuse an authenticated running server before starting Termux again (#6071).
 - Local connections with no model name now use the loaded model for agent reruns, manual Illustrator, captioning, and auxiliary text tools (#6038).

--- a/docs/prompts/generation-parameters.md
+++ b/docs/prompts/generation-parameters.md
@@ -1,6 +1,6 @@
 # Generation Parameters
 
-This guide explains the generation parameters in Marinara Engine. These are the settings that control how the AI writes each reply, such as **Temperature** and **Max Output Tokens**. You change them per chat in the **Advanced Parameters** panel.
+This guide explains the generation parameters in Marinara Engine. These are the settings that control how the AI writes each reply, such as **Temperature** and **Max Output Tokens**. Presets and connections provide defaults; the **Advanced Parameters** panel provides overrides for each chat.
 
 ## What generation parameters do
 
@@ -60,7 +60,7 @@ In a chat's **Advanced Parameters**, only **Max Output Tokens** and **Reasoning 
 
 ## Default values
 
-New chats start from a built-in baseline. The table below shows those starting values and whether each one is sent by default.
+The table shows fallback values displayed by the parameter editor and the default Send switches. These are not necessarily the values sent to the model: without a preset, generation starts at `4096` output tokens before connection and chat overrides. Mode rules can then set `8192` for an active scene or `16384` for Game. The **Effective** line shows the resolved value.
 
 | Parameter | Starting value | Sent by default |
 |---|---|---|

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -2958,10 +2958,10 @@ async function readProfileImportRequest(req: FastifyRequest): Promise<ProfileImp
   const uploadDir = await mkdtemp(join(tmpdir(), "marinara-profile-import-"));
   const archivePath = join(uploadDir, "profile.zip");
   try {
-    // Stream uploads to disk so large profile archives do not need to fit in server memory.
+    // Full backups can exceed the profile export limit; stream them to disk before validating their contents.
     let receivedFile = false;
     for await (const part of req.parts({
-      limits: { fields: 0, parts: 1, files: 1, fileSize: PROFILE_IMPORT_ARCHIVE_LIMIT_BYTES },
+      limits: { fields: 0, parts: 1, files: 1, fileSize: Number.MAX_SAFE_INTEGER },
     })) {
       if (part.type !== "file") throw new ProfileImportRequestError("No profile archive uploaded.");
       if (receivedFile) throw new ProfileImportRequestError("Only one profile archive is allowed.");
@@ -4261,7 +4261,7 @@ export async function backupRoutes(app: FastifyInstance) {
   app.post(
     "/import-profile",
     {
-      bodyLimit: PROFILE_IMPORT_ARCHIVE_LIMIT_BYTES,
+      bodyLimit: Number.MAX_SAFE_INTEGER,
       config: { rateLimit: BACKUP_RATE_LIMIT },
       preParsing: profileImportJsonBodyLimit,
     },

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -700,7 +700,12 @@ function imageFetch(url: string | URL, init?: RequestInit, options: ImageFetchOp
       allowedProtocols: ["https:", "http:"],
       flagName: "IMAGE_LOCAL_URLS_ENABLED",
     },
-    agentOptions: options.agentOptions,
+    // The request deadline must not be cut short by Undici's five-minute idle timeout.
+    agentOptions: {
+      headersTimeout: IMAGE_GEN_TIMEOUT,
+      bodyTimeout: IMAGE_GEN_TIMEOUT,
+      ...options.agentOptions,
+    },
     keepAliveInitialDelayMs: options.keepAliveInitialDelayMs,
     maxResponseBytes: MAX_IMAGE_RESPONSE_BYTES,
     decodeCompressedResponse: true,

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -717,9 +717,10 @@ function localImageBackendFetch(
   init?: RequestInit,
   options: { timeoutMs?: number; keepAliveInitialDelayMs?: number } = {},
 ) {
+  const timeoutMs = options.timeoutMs ?? resolveComfyUiImageGenerationTimeoutMs();
   return imageFetch(url, init, {
     allowLocal: true,
-    agentOptions: options.timeoutMs ? { bodyTimeout: options.timeoutMs, headersTimeout: options.timeoutMs } : undefined,
+    agentOptions: { bodyTimeout: timeoutMs, headersTimeout: timeoutMs },
     keepAliveInitialDelayMs: options.keepAliveInitialDelayMs,
   });
 }

--- a/scripts/regressions/avatar-lead-prompt.regression.ts
+++ b/scripts/regressions/avatar-lead-prompt.regression.ts
@@ -5,6 +5,7 @@
 // that sentence became a prose clause inside a tag prompt, which NovelAI and Illustrious-style
 // checkpoints treat as noise. The profile's avatar subject tags already say what the image is.
 import assert from "node:assert/strict";
+import { compileImagePrompt, DEFAULT_IMAGE_STYLE_PROFILES } from "../../packages/shared/src/index.js";
 import { buildAvatarPortraitLeadPrompt } from "../../packages/server/src/services/image/avatar-generation-prompt.js";
 
 const subjectTags = "solo, upper body, looking at viewer, centered composition";
@@ -45,5 +46,26 @@ assert.equal(
   "Create a polished character avatar portrait for Character.",
   "blank names fall back to the generic label",
 );
+
+// #6074: LoRA syntax in either style field must leave the character appearance intact.
+const appearance = "silver-furred fox-woman, braided crown, persimmon kimono, embroidered moonflowers";
+for (const promptMode of ["natural", "hybrid", "tagged", "danbooru"] as const) {
+  const profile = {
+    ...DEFAULT_IMAGE_STYLE_PROFILES[0]!,
+    promptMode,
+    positiveTags: "<lora:portrait-style:0.8>, detailed face",
+    negativeTags: "<lora:negative-style:1.2>, blurry",
+    subjectTags: { avatar: subjectTags },
+  };
+  const compiled = compileImagePrompt({
+    kind: "avatar",
+    prompt: buildAvatarPortraitLeadPrompt({ name: "Lyra", profileSubjectTags: subjectTags, promptMode }),
+    userPositive: appearance,
+    styleProfiles: { defaultProfileId: profile.id, profiles: [profile] },
+  });
+  assert.ok(compiled.prompt.includes(appearance), `${promptMode} must preserve the complete appearance`);
+  assert.ok(compiled.prompt.includes("<lora:portrait-style:0.8>"));
+  assert.ok(compiled.negativePrompt.includes("<lora:negative-style:1.2>"));
+}
 
 console.log("Avatar lead prompt regression passed.");

--- a/scripts/regressions/image-dimension-limit.regression.ts
+++ b/scripts/regressions/image-dimension-limit.regression.ts
@@ -89,6 +89,7 @@ try {
     "Endpoints accepting 1536 must not be capped",
   );
   for (const [width, height] of [
+    [512, 512],
     [960, 1440],
     [1440, 960],
     [2048, 2048],

--- a/scripts/regressions/image-generation-timeout.regression.ts
+++ b/scripts/regressions/image-generation-timeout.regression.ts
@@ -46,7 +46,9 @@ try {
     assert.equal((await generate(path)).base64, png, `${path} must honor the configured image timeout`);
   }
 
+  const abortStartedAt = Date.now();
   await assert.rejects(generate("stall", AbortSignal.timeout(50)), /timeout|aborted/i);
+  assert.ok(Date.now() - abortStartedAt < 1000, "Caller cancellation must settle before the image deadline");
   await assert.rejects(generate("stall"), /5000|5 seconds/);
 } finally {
   server.closeAllConnections();

--- a/scripts/regressions/image-generation-timeout.regression.ts
+++ b/scripts/regressions/image-generation-timeout.regression.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { createRequire } from "node:module";
+
+const { Agent, getGlobalDispatcher, setGlobalDispatcher } = createRequire(
+  new URL("../../packages/server/package.json", import.meta.url),
+)("undici");
+const previousDispatcher = getGlobalDispatcher();
+const previousTimeout = process.env.IMAGE_GEN_TIMEOUT_MS;
+process.env.IMAGE_GEN_TIMEOUT_MS = "5000";
+// Reproduce the transport's shorter default without a five-minute regression.
+const shortTimeoutDispatcher = new Agent({ headersTimeout: 10, bodyTimeout: 10 });
+setGlobalDispatcher(shortTimeoutDispatcher);
+
+const png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+const server = createServer((request, response) => {
+  request.resume();
+  if (request.url?.startsWith("/stall/")) return;
+  response.setHeader("Content-Type", "application/json");
+  const body = JSON.stringify({ data: [{ b64_json: png }] });
+  const delayBody = request.url?.startsWith("/body/");
+  if (delayBody) response.write(body.slice(0, 1));
+  const timer = setTimeout(() => response.end(delayBody ? body.slice(1) : body), 2000);
+  response.once("close", () => clearTimeout(timer));
+});
+await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+try {
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const base = `http://127.0.0.1:${address.port}`;
+  const { generateImage } = await import("../../packages/server/src/services/image/image-generation.js");
+  const generate = (path: string, signal?: AbortSignal) =>
+    generateImage("openai", `${base}/${path}/v1`, "fixture-key", "openai", {
+      prompt: "a moonlit laboratory",
+      model: "local-flux",
+      allowLocalUrls: true,
+      signal,
+    });
+
+  await assert.rejects(fetch(`${base}/headers/`), (error: unknown) => {
+    assert.equal((error as { cause?: { code?: string } }).cause?.code, "UND_ERR_HEADERS_TIMEOUT");
+    return true;
+  });
+  for (const path of ["headers", "body"]) {
+    assert.equal((await generate(path)).base64, png, `${path} must honor the configured image timeout`);
+  }
+
+  await assert.rejects(generate("stall", AbortSignal.timeout(50)), /timeout|aborted/i);
+  await assert.rejects(generate("stall"), /5000|5 seconds/);
+} finally {
+  server.closeAllConnections();
+  await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  setGlobalDispatcher(previousDispatcher);
+  await shortTimeoutDispatcher.close();
+  if (previousTimeout === undefined) delete process.env.IMAGE_GEN_TIMEOUT_MS;
+  else process.env.IMAGE_GEN_TIMEOUT_MS = previousTimeout;
+}
+
+console.info("Image generation transport timeout regression passed.");

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -6611,8 +6611,8 @@ assert.match(backupRoutesSource, /PROFILE_IMPORT_MEMORY_WARNING_BYTES/u);
 assert.match(backupRoutesSource, /PROFILE_IMPORT_ARCHIVE_LIMIT_BYTES = 2 \* 1024 \* 1024 \* 1024/u);
 assert.match(
   backupRoutesSource,
-  /limits: \{ fields: 0, parts: 1, files: 1, fileSize: PROFILE_IMPORT_ARCHIVE_LIMIT_BYTES \}/u,
-  "profile archive imports must accept only one bounded file part",
+  /limits: \{ fields: 0, parts: 1, files: 1,/u,
+  "profile archive imports must accept only one file part",
 );
 assert.match(
   backupRoutesSource,

--- a/scripts/regressions/profile-import-data-security.regression.ts
+++ b/scripts/regressions/profile-import-data-security.regression.ts
@@ -102,6 +102,13 @@ try {
       ),
     );
     profileZip.addFile(zipAssetPath, validPng);
+    const unprivilegedUpload = await app.inject({
+      method: "POST",
+      url: "/api/backup/import-profile?preview=true",
+      remoteAddress: "203.0.113.10",
+      ...multipartUpload("profile.zip", profileZip.toBuffer()),
+    });
+    assert.equal(unprivilegedUpload.statusCode, 403, "remote ZIP uploads must require privileged access");
     const zipPreviewResponse = await app.inject({
       method: "POST",
       url: "/api/backup/import-profile?preview=true",

--- a/scripts/regressions/swarmui-timeout.regression.ts
+++ b/scripts/regressions/swarmui-timeout.regression.ts
@@ -6,7 +6,7 @@ import type { Socket } from "node:net";
 const previousImageTimeout = process.env.IMAGE_GEN_TIMEOUT_MS;
 const previousComfyTimeout = process.env.COMFYUI_GEN_TIMEOUT;
 process.env.IMAGE_GEN_TIMEOUT_MS = "80";
-process.env.COMFYUI_GEN_TIMEOUT = "1";
+process.env.COMFYUI_GEN_TIMEOUT = "5";
 
 const png = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
@@ -59,7 +59,9 @@ function readClientFrame(buffer: Buffer): { payload: string | null; consumed: nu
 const server = createServer((request, response) => {
   if (request.url === "/API/GetNewSession") {
     response.setHeader("Content-Type", "application/json");
-    response.end(JSON.stringify({ session_id: "regression-session" }));
+    // Local backend requests must use the selected ComfyUI/SwarmUI transport timeout too.
+    const timer = setTimeout(() => response.end(JSON.stringify({ session_id: "regression-session" })), 2000);
+    response.once("close", () => clearTimeout(timer));
     return;
   }
   if (request.url === "/API/GenerateText2Image") {


### PR DESCRIPTION
## Linked issues

Closes #6074
Closes #6091

Also completes the English clarification found while reviewing #6073 / #6086.

## Why this change

Slow image providers failed after five minutes even when IMAGE_GEN_TIMEOUT_MS allowed 30 minutes. Full-backup imports also regressed to a 2 GiB upload ceiling despite the existing streaming ZIP64 restore support.

## What changed

- Set header/body timeouts in the shared image-fetch helper from IMAGE_GEN_TIMEOUT_MS. Local backend requests use the existing ComfyUI/SwarmUI timeout resolver, including reference uploads; backend overrides, overall generation deadlines, cancellation, and outbound URL validation remain intact.
- Remove the aggregate 2 GiB multipart and route limits from Import Profile. Reuse streaming uploads and the existing archive reader; retain the JSON, entry, path, CRC, and import validation.
- Clarify parameter-editor fallback values versus effective requests and where preset, connection, and chat overrides apply. All ten translated packs receive the same clarification in #6086.

Current staging already retains 512x512 for custom OpenAI-compatible models and preserves character appearance alongside LoRA tags. Coverage was added for those reported cases without changing that behavior. No new dependencies or request paths.

## Validation

Executed successfully:

- pnpm check.
- provider-compat, image-result-url-security, image-generation-timeout, image-dimension-limit, avatar-lead-prompt, and swarmui-timeout regressions with isolated temporary storage.
- automatic-backup-retention, profile-import-data-security, profile-import-asset-security, and open-issues regressions with isolated temporary storage. Unauthorized remote multipart imports are rejected with HTTP 403; authorized local preview/import succeeds.
- A real HTTP/multipart ZIP upload of 2,147,484,143 bytes: before the backup fix, HTTP 400 with "Profile archive upload was truncated"; afterward, HTTP 200 preview followed by successful import and byte-for-byte restoration of the fixture image. The temporary fixture uses valid ZIP preamble padding to cross the former limit without importing a huge asset.

The extended SwarmUI fixture delays session-response headers beyond the general image timeout but within the selected local-backend timeout: it failed with HeadersTimeoutError before the shared-helper correction and passes afterward.

The image transport regression reproduces HeadersTimeoutError before the patch, then verifies delayed headers/body, cancellation, and the configured deadline. It shortens fixture timeouts to avoid a five-minute test. Existing fixtures cover custom-model dimensions, known-provider size restrictions, fallback limits, and outbound image URL security. Avatar prompt coverage includes LoRA tags in positive and negative settings across four prompt grammars.

- [ ] pnpm check passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed CONTRIBUTING.md

### Manual verification notes

Manually verify avatar/persona generation against the reporter's slow LocalAI model with 512x512 portrait settings and LoRA tags. Manually verify a real large full backup through the browser's Import Profile flow. No paid provider call, actual 30-minute wait, or manual container check was performed locally; the large-upload proof used the real local HTTP API.

The upload remains a privileged owner action. Physical disk capacity still applies; this change removes the artificial archive-size ceiling and adds no new deployment quota. Existing archive validation and cleanup remain in place.

## Docs and release impact

Changelog updated under Unreleased. No version bump. The parameter guide clarification is mirrored by #6086 on docs-i18n. Existing backup documentation already describes restoring full backup ZIPs without a 2 GiB cap.

## UI evidence (if applicable)

No UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Full-backup ZIP imports now support archives larger than 2 GiB.
  - Image generation now respects configured timeouts while waiting for provider responses and image data, including slower local and hosted backends.
  - Remote profile preview uploads from unprivileged addresses are rejected, while local previews remain available.

- **Documentation**
  - Clarified how generation defaults, presets, connections, chat overrides, and effective parameter values are applied.

- **Tests**
  - Added regression coverage for backup imports, image-generation timeouts, image dimensions, prompt handling, and profile-preview security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->