### PR TITLE
fix(backup): leave the storage writer lease out of full backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- Download Backup and automatic backups no longer include the storage writer lease, so a data folder restored by hand from the archive starts without the "Another Marinara Engine process may be using" error (#6083).
+
 - Updated ZIP handling to adm-zip 0.6.1 to block extraction through destination symlinks and removed the temporary dependency-audit exception (#6075).
 
 - Conversation prompts no longer lose character or persona details when ordinary prose between macros mentions identity fields such as description or personality (#6066).

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -14,7 +14,7 @@ import { StringDecoder } from "string_decoder";
 import { randomBytes, randomUUID } from "crypto";
 import { createInflateRaw, inflateRawSync } from "zlib";
 import AdmZip from "adm-zip";
-import { FILE_BACKED_TABLES } from "../db/file-backed-store.js";
+import { FILE_BACKED_TABLES, STORAGE_WRITER_LEASE_FILENAME } from "../db/file-backed-store.js";
 import { migrateLegacyNoodleAccountRow } from "../db/noodle-platform-migration.js";
 import { migrateLegacyNoodlePostAccessRow } from "../db/noodle-access-migration.js";
 import { getFileTableConfig, isFileTable, type AnyFileTable } from "../db/file-schema.js";
@@ -2991,6 +2991,11 @@ async function readProfileImportRequest(req: FastifyRequest): Promise<ProfileImp
   }
 }
 
+/** Test seam for proving which files under a data directory a full backup collects. */
+export async function collectBackupDirectorySourcesForRegression(sourceDir: string, entryRoot: string) {
+  return (await collectDirectoryZipSources(sourceDir, entryRoot)).map((source) => source.entryName);
+}
+
 /** Production-reader seam for proving that a full backup remains loadable by profile import. */
 export async function readStoredBackupImportForRegression(filePath: string, safePath: string) {
   const zip = await readProfileZipArchive(filePath);
@@ -3063,6 +3068,8 @@ async function collectDirectoryZipSources(
     for (const entry of entries) {
       const fullPath = join(current, entry.name);
       if (entry.isDirectory()) {
+        // The writer lease is per-process runtime state; a restored copy blocks startup on another host (#6083).
+        if (current === sourceDir && entry.name === STORAGE_WRITER_LEASE_FILENAME) continue;
         stack.push(fullPath);
         continue;
       }

--- a/scripts/regressions/automatic-backup-retention.regression.ts
+++ b/scripts/regressions/automatic-backup-retention.regression.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   buildBackupRestoreNotes,
+  collectBackupDirectorySourcesForRegression,
   inspectStoredBackupArchiveForRegression,
   isPermittedLargeStoredBackupEntry,
   limitAutomaticBackupOmissionHistory,
@@ -342,6 +343,25 @@ try {
   );
 } finally {
   await rm(zipFixtureRoot, { recursive: true, force: true });
+}
+
+const storageFixtureRoot = await mkdtemp(join(tmpdir(), "marinara-backup-lease-regression-"));
+try {
+  await mkdir(join(storageFixtureRoot, ".writer-lease"));
+  await mkdir(join(storageFixtureRoot, "tables", ".writer-lease"), { recursive: true });
+  await writeFile(join(storageFixtureRoot, ".writer-lease", "owner.json"), "{}", "utf8");
+  await writeFile(join(storageFixtureRoot, "tables", ".writer-lease", "keep.json"), "{}", "utf8");
+  await writeFile(join(storageFixtureRoot, "tables", "settings.json"), "{}", "utf8");
+  assert.deepEqual(
+    (await collectBackupDirectorySourcesForRegression(storageFixtureRoot, "marinara-automatic-backup/storage")).sort(),
+    [
+      "marinara-automatic-backup/storage/tables/.writer-lease/keep.json",
+      "marinara-automatic-backup/storage/tables/settings.json",
+    ],
+    "full backups must leave out the top-level storage writer lease and nothing else",
+  );
+} finally {
+  await rm(storageFixtureRoot, { recursive: true, force: true });
 }
 
 const timestampedName = automaticBackupArchiveFilename(new Date("2026-07-27T20:00:00.000Z"));


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #6083

## Why this change

- Download Backup and the automatic backup archive `storage/.writer-lease/owner.json`, the per-process writer lease record. It is runtime state, not user data.
- Restoring the archive by hand (the manual path `RESTORE.txt` describes) carries the stale lease into the new data folder. On another machine the lease reclaim logic has no same-host proof, so startup stops with "Another Marinara Engine process (PID …, host …) may be using …" until the user deletes the directory.
- The inclusion was never a decision: `storage` has been a backup directory since 1.4.0 and the lease was added under it in August (#5389) without the backup being revisited. Nothing reads the lease from an archive, and the launcher's update snapshot already leaves the directory out for the same reason (#6056).

## What changed

- `collectDirectoryZipSources` skips the top-level `.writer-lease` directory of each backup source directory (only `storage` has one). One line plus a one-line comment; nothing else about the walk changes.
- New test seam `collectBackupDirectorySourcesForRegression` and a case in `automatic-backup-retention.regression.ts` proving the top-level lease is left out while a same-named directory deeper in the tree is still collected.
- CHANGELOG entry under `[Unreleased]`.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check`: passed (exit code 0).
- `node scripts/run-regressions.mjs --filter automatic-backup-retention`: passed, including the new case.
- Isolated server built from this branch (`DATA_DIR`, `TEMP`, `MARINARA_ENV_FILE` pointing to a scratch folder, port 9123): with `storage/.writer-lease/owner.json` present on disk, `POST /api/backup/download/start` → `/status` → `/file` produced a backup with 192 entries and no `writer-lease` entry. Before this change the same flow on 2.4.5 included `<root>/storage/.writer-lease/owner.json` (verified on a real Download Backup while writing the issue).
- Import Profile is unaffected: it merges tables from the profile manifest and never copies raw `storage/` files, so the lease entry was only reaching manual restores.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable: no UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Downloaded and automatic backups no longer include the storage writer lease.
  - Manually restored data folders now start without the “Another Marinara Engine process may be using” error.
  - Table-level lease and settings files remain included in backups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->