### PR TITLE
fix(backup): check free space before writing the automatic backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- Automatic backups now check that the disk holding `backups/` has room for the next archive before writing it. A run that would not fit is skipped with a clear message in Settings instead of filling the disk and retrying the full write every hour (#6087).
+
 - Updated ZIP handling to adm-zip 0.6.1 to block extraction through destination symlinks and removed the temporary dependency-audit exception (#6075).
 
 - Conversation prompts no longer lose character or persona details when ordinary prose between macros mentions identity fields such as description or personality (#6066).

--- a/docs/data/backup-and-restore.md
+++ b/docs/data/backup-and-restore.md
@@ -49,6 +49,10 @@ restorable, streamed archive format as **Download Backup**, including uploaded m
 one exists. Keep a separate copy outside Marinara's data folder if you need protection from a lost disk, erased app
 storage, or a device reset.
 
+Each run needs free space for one more full archive on the disk that holds `backups/`, because the previous archive
+is kept until the new one is complete. If there is not enough room, Marinara skips that run and shows the reason next
+to the Automatic Backups control; it tries again on the next check once space is freed.
+
 ## Export Profile
 
 **Export Profile** creates a smaller file with your account data. Media is included, so avatars, images, and your custom notification sound come along too.

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -3208,7 +3208,11 @@ async function writeAutomaticBackup(app: FastifyInstance, retentionCount: number
         // A run that cannot fit would fail with ENOSPC and be retried in full every hour; refuse it up front (#6087).
         const freeBytes = await statfs(backupsRoot)
           .then((fsStat) => Number(fsStat.bavail) * Number(fsStat.bsize))
-          .catch(() => null);
+          .catch((error) => {
+            const logError = error instanceof Error ? error : new Error(String(error));
+            logger.warn(logError, "[backup] Could not read free disk space; writing the automatic backup unchecked");
+            return null;
+          });
         const error = freeBytes === null ? null : automaticBackupFreeSpaceError(freeBytes, archiveBytes);
         if (error) throw new Error(error);
       },

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -6,7 +6,21 @@ import { Transform } from "node:stream";
 import { extname, join, relative } from "path";
 import { createReadStream, createWriteStream, existsSync, readdirSync, statSync } from "fs";
 import type { Dirent, WriteStream } from "fs";
-import { chmod, cp, mkdir, copyFile, readFile, readdir, writeFile, stat, mkdtemp, rm, open, rename } from "fs/promises";
+import {
+  chmod,
+  cp,
+  mkdir,
+  copyFile,
+  readFile,
+  readdir,
+  writeFile,
+  stat,
+  statfs,
+  mkdtemp,
+  rm,
+  open,
+  rename,
+} from "fs/promises";
 import type { FileHandle } from "fs/promises";
 import { tmpdir } from "os";
 import { pipeline } from "stream/promises";
@@ -61,6 +75,7 @@ import {
   AUTOMATIC_BACKUP_FILENAME,
   automaticBackupArchiveFilename,
   automaticBackupExists,
+  automaticBackupFreeSpaceError,
   normalizeAutomaticBackupRetentionCount,
   parseAutomaticBackupRetentionCount,
   pruneAutomaticBackupFiles,
@@ -3102,6 +3117,7 @@ async function writeFullBackupArchive(
   outputPath: string,
   backupName: string,
   workingDir: string,
+  beforeWrite?: (archiveBytes: number) => Promise<void>,
 ) {
   const dataDir = getDataDir();
   const omittedEntries = new Set<string>();
@@ -3148,6 +3164,8 @@ async function writeFullBackupArchive(
     entryName: `${backupName}/RESTORE.txt`,
     buildData: () => Buffer.from(buildBackupRestoreNotes([...omittedEntries]), "utf8"),
   });
+  // Stored entries make the file sizes the archive size, apart from headers.
+  await beforeWrite?.(sources.reduce((total, source) => total + ("filePath" in source ? source.size : 0), 0));
   await writeStoredZipArchive(outputPath, sources, {
     skipFailedFileEntries: true,
     entryLimitBytes: Number.MAX_SAFE_INTEGER,
@@ -3174,7 +3192,20 @@ async function writeAutomaticBackup(app: FastifyInstance, retentionCount: number
     } else {
       await rm(legacyPreviousPath, { force: true });
     }
-    const { omittedEntries } = await writeFullBackupArchive(app, pendingPath, "marinara-automatic-backup", workingDir);
+    const { omittedEntries } = await writeFullBackupArchive(
+      app,
+      pendingPath,
+      "marinara-automatic-backup",
+      workingDir,
+      async (archiveBytes) => {
+        // A run that cannot fit would fail with ENOSPC and be retried in full every hour; refuse it up front (#6087).
+        const freeBytes = await statfs(backupsRoot)
+          .then((fsStat) => Number(fsStat.bavail) * Number(fsStat.bsize))
+          .catch(() => null);
+        const error = freeBytes === null ? null : automaticBackupFreeSpaceError(freeBytes, archiveBytes);
+        if (error) throw new Error(error);
+      },
+    );
     const hadPreviousBackup = existsSync(finalPath);
     try {
       if (hadPreviousBackup) {

--- a/packages/server/src/services/backup/automatic-backup-retention.ts
+++ b/packages/server/src/services/backup/automatic-backup-retention.ts
@@ -5,6 +5,7 @@ export const AUTOMATIC_BACKUP_FILENAME = "marinara-automatic-backup.zip";
 export const AUTOMATIC_BACKUP_RETENTION_MIN = 1;
 export const AUTOMATIC_BACKUP_RETENTION_MAX = 9_999;
 export const DEFAULT_AUTOMATIC_BACKUP_RETENTION_COUNT = 1;
+export const AUTOMATIC_BACKUP_FREE_SPACE_HEADROOM_BYTES = 256 * 1024 * 1024;
 
 export type AutomaticBackupFile = {
   filename: string;
@@ -26,6 +27,18 @@ export function normalizeAutomaticBackupRetentionCount(value: unknown): number {
     return DEFAULT_AUTOMATIC_BACKUP_RETENTION_COUNT;
   }
   return Math.min(AUTOMATIC_BACKUP_RETENTION_MAX, Math.max(AUTOMATIC_BACKUP_RETENTION_MIN, Math.trunc(value)));
+}
+
+function formatBackupBytes(bytes: number): string {
+  const gib = bytes / 1024 ** 3;
+  return gib >= 1 ? `${gib.toFixed(1)} GiB` : `${Math.ceil(bytes / 1024 ** 2)} MiB`;
+}
+
+/** Settings-panel message when the backups disk cannot hold the next archive, or null when it can. */
+export function automaticBackupFreeSpaceError(freeBytes: number, archiveBytes: number): string | null {
+  const requiredBytes = archiveBytes + AUTOMATIC_BACKUP_FREE_SPACE_HEADROOM_BYTES;
+  if (freeBytes >= requiredBytes) return null;
+  return `Not enough free space for the automatic backup: ${formatBackupBytes(freeBytes)} free, about ${formatBackupBytes(requiredBytes)} needed.`;
 }
 
 export function automaticBackupArchiveFilename(date: Date, uniqueSuffix = ""): string {

--- a/scripts/regressions/automatic-backup-free-space.regression.ts
+++ b/scripts/regressions/automatic-backup-free-space.regression.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import AdmZip from "adm-zip";
+import fs from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Fastify from "../../packages/server/node_modules/fastify/fastify.js";
+
+const root = await fs.mkdtemp(join(tmpdir(), "marinara-backup-space-"));
+const oldDataDir = process.env.DATA_DIR;
+const oldStorageDir = process.env.FILE_STORAGE_DIR;
+process.env.DATA_DIR = root;
+process.env.FILE_STORAGE_DIR = join(root, "storage");
+const originalStatfs = fs.statfs;
+let freeBytes = 0;
+let spaceChecks = 0;
+Object.assign(fs, {
+  statfs: async (path: string) => {
+    assert.equal(path, join(root, "backups"));
+    spaceChecks++;
+    const actual = await originalStatfs(path);
+    return { ...actual, bsize: 1, bavail: freeBytes };
+  },
+});
+syncBuiltinESMExports();
+const app = Fastify();
+let closeDb: (() => Promise<void>) | undefined;
+try {
+  const { getDB, closeDB } = await import("../../packages/server/src/db/connection.js");
+  closeDb = closeDB;
+  app.decorate("db", await getDB());
+  const { backupRoutes } = await import("../../packages/server/src/routes/backup.routes.js");
+  const backups = join(root, "backups");
+  await fs.mkdir(backups, { recursive: true });
+  const previousPath = join(backups, "marinara-automatic-backup.zip");
+  const previous = new AdmZip();
+  previous.addFile("RESTORE.txt", Buffer.from("Previous backup"));
+  const previousBytes = previous.toBuffer();
+  await fs.writeFile(previousPath, previousBytes);
+  await app.register(backupRoutes, { prefix: "/api/backup" });
+  await app.ready();
+  const settings = async () => (await app.inject({ method: "GET", url: "/api/backup/automatic" })).json();
+  const enable = async (enabled: boolean) => {
+    const response = await app.inject({
+      method: "PUT",
+      url: "/api/backup/automatic",
+      payload: { enabled, frequency: "daily", retentionCount: 1 },
+    });
+    assert.equal(response.statusCode, 200, response.body);
+  };
+  const waitFor = async (predicate: (value: any) => boolean) => {
+    for (let attempt = 0; attempt < 100; attempt++) {
+      const value = await settings();
+      if (predicate(value)) return value;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    assert.fail("Automatic backup did not settle");
+  };
+  await enable(true);
+  const refused = await waitFor((value) => typeof value.lastError === "string");
+  assert.match(refused.lastError, /Not enough free space/u);
+  assert.equal(refused.lastBackupAt, null);
+  assert.equal(refused.backupExists, true);
+  assert.equal(spaceChecks, 1);
+  assert.deepEqual(await fs.readFile(previousPath), previousBytes);
+  assert.deepEqual(
+    await fs.readdir(backups),
+    ["marinara-automatic-backup.zip"],
+    "no partial archive or rotation after refusal",
+  );
+
+  await enable(false);
+  freeBytes = 1024 ** 4;
+  await enable(true);
+  const saved = await waitFor((value) => !!value.lastBackupAt);
+  assert.equal(saved.lastError, null);
+  assert.equal(saved.backupExists, true);
+  assert.equal(spaceChecks, 2);
+  const archives = await fs.readdir(backups);
+  assert.equal(archives.length, 1);
+  const bytes = await fs.readFile(join(backups, archives[0]!));
+  assert.equal(bytes.readUInt32LE(0), 0x04034b50, "available space permits a real ZIP write");
+  assert.notDeepEqual(bytes, previousBytes);
+  assert.ok(new AdmZip(bytes).getEntries().some((entry) => entry.entryName.endsWith("/RESTORE.txt")));
+  console.info(
+    "Automatic backup refuses insufficient space, preserves the previous archive, and succeeds after space is freed.",
+  );
+} finally {
+  await app.close();
+  await closeDb?.();
+  Object.assign(fs, { statfs: originalStatfs });
+  syncBuiltinESMExports();
+  if (oldDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = oldDataDir;
+  if (oldStorageDir === undefined) delete process.env.FILE_STORAGE_DIR;
+  else process.env.FILE_STORAGE_DIR = oldStorageDir;
+  await fs.rm(root, { recursive: true, force: true });
+}

--- a/scripts/regressions/automatic-backup-retention.regression.ts
+++ b/scripts/regressions/automatic-backup-retention.regression.ts
@@ -20,7 +20,9 @@ import {
 } from "../../packages/server/src/services/import/profile-import-assets.js";
 import {
   AUTOMATIC_BACKUP_FILENAME,
+  AUTOMATIC_BACKUP_FREE_SPACE_HEADROOM_BYTES,
   automaticBackupArchiveFilename,
+  automaticBackupFreeSpaceError,
   isAutomaticBackupFilename,
   listAutomaticBackupFiles,
   normalizeAutomaticBackupRetentionCount,
@@ -44,6 +46,19 @@ assert.equal(
 );
 assert.deepEqual(limitAutomaticBackupOmissionHistory(["kept", 42, "also-kept"]), ["kept", "also-kept"]);
 assert.equal(limitAutomaticBackupOmissionHistory(["x".repeat(256 * 1024 + 1)]).length, 0);
+const archiveBytes = 5 * 1024 ** 3;
+assert.equal(
+  automaticBackupFreeSpaceError(archiveBytes + AUTOMATIC_BACKUP_FREE_SPACE_HEADROOM_BYTES, archiveBytes),
+  null,
+);
+assert.equal(
+  automaticBackupFreeSpaceError(archiveBytes + AUTOMATIC_BACKUP_FREE_SPACE_HEADROOM_BYTES - 1, archiveBytes),
+  "Not enough free space for the automatic backup: 5.2 GiB free, about 5.3 GiB needed.",
+);
+assert.equal(
+  automaticBackupFreeSpaceError(0, 100 * 1024 ** 2),
+  "Not enough free space for the automatic backup: 0 MiB free, about 356 MiB needed.",
+);
 
 const backupRouteSource = await readFile(
   new URL("../../packages/server/src/routes/backup.routes.ts", import.meta.url),
@@ -56,6 +71,11 @@ assert.match(
 assert.match(
   backupRouteSource,
   /withAutomaticBackupLifecycleLock\(\(\) =>\s*pruneAutomaticBackupFiles\(backupsRoot, next\.retentionCount\)/u,
+);
+assert.match(
+  backupRouteSource,
+  /statfs\(backupsRoot\)[\s\S]*?automaticBackupFreeSpaceError\(/u,
+  "the automatic backup must check the backups disk before writing its archive",
 );
 assert.equal(
   isPermittedLargeStoredBackupEntry(


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #6087

## Why this change

- The automatic backup writes a full copy of the data folder into `backups/`, on the same disk as the live `storage/` tables, without checking that the space exists. The previous archive is kept until the new one is complete, so peak usage is two full archives plus the retained history.
- When the write fails with ENOSPC the failure is recorded but `lastBackupAt` is not advanced, so the backup stays due and the hourly timer retries the whole write, filling the disk again every hour while any other write on that disk can fail.
- No user report yet; found while reviewing the backup code. The change is preventive and deliberately small.

## What changed

- `automaticBackupFreeSpaceError(freeBytes, archiveBytes)` in `automatic-backup-retention.ts`: pure decision plus the message shown in Settings, with a fixed 256 MiB headroom on top of the archive size.
- `writeFullBackupArchive` takes an optional `beforeWrite(archiveBytes)` hook, called after every source is collected and before the output file is opened. The archive is stored, not compressed, so the sum of the collected file sizes is the archive size apart from headers. Download Backup does not pass the hook and is unchanged.
- `writeAutomaticBackup` passes the hook: `fs.promises.statfs` on `backups/`, compare, throw the message if it does not fit. The existing catch stores it as `lastError`, which the Automatic Backups control already displays. If `statfs` itself fails, the check is skipped and the backup proceeds as today, so the guard can never block a backup on its own.
- Retention, rotation order, the 9999 limit and the UI are untouched.
- Regression: three pure cases for the message (fits exactly, one byte short, empty disk) and a source assertion that the automatic backup consults `statfs` before writing.
- Docs: one paragraph in `docs/data/backup-and-restore.md`; CHANGELOG entry under `[Unreleased]`.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check`: passed (exit code 0).
- `node scripts/run-regressions.mjs --filter automatic-backup-retention`: passed, including the new cases.
- `fs.promises.statfs` checked on Windows 10 against the data drive: it reports the same free space as the OS (253.5 GiB), so the guard works on Windows as well as Linux/Termux.
- Isolated server built from this branch (`DATA_DIR`, `TEMP`, `MARINARA_ENV_FILE` pointing to a scratch folder, port 9123): enabling Automatic Backups (daily, keep 2) produced `marinara-automatic-backup.zip` (29.2 MiB) within a second, with `lastBackupAt` set and `lastError: null`, so the happy path is unchanged when space is plentiful.
- The refusal path is covered by the pure regression cases; I did not fill a real disk to trigger ENOSPC.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable: no UI change. The message reuses the existing `lastError` slot next to the Automatic Backups control.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic backups now check available disk space before creating an archive.
  * Runs that would exceed available space are skipped with a clear message in Settings and retried during the next check after space is freed.
  * The previous archive is retained until the new one finishes, requiring space for an additional full archive.

* **Documentation**
  * Updated backup and restore guidance with automatic backup disk-space requirements.

* **Tests**
  * Added coverage for insufficient-space handling and backup validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Maintainer sweep validation

Added `automatic-backup-free-space.regression.ts` and ran it against an isolated real Fastify backup route: zero available space reports the error without changing the previous archive or leaving a partial ZIP; available space then permits a complete, readable ZIP and normal retention. The check mocks the free-space query rather than filling the host disk. Translated documentation is covered by #6097.
