### PR TITLE
fix: open Professor Mari Home navigation input immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- Professor Mari's Home navigation field is ready to type into without an extra button click, with a shorter “Looking for…?” placeholder on mobile (#6099).
+
 - Automatic backups now check that the disk holding `backups/` has room for the next archive, including metadata and restore notes, before writing it. A run that would not fit is skipped with a clear message in Settings instead of filling the disk and retrying the full write every hour (#6087).
 - Deleting a character card now removes it from every Roleplay and Conversation chat it belonged to, as it already did for Game parties, and the Characters count in Chat Settings counts only cards that still exist (#6084).
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -11802,6 +11802,18 @@ test("Professor Mari visibly arrives on Home and navigates without AI", async ({
 
   const assistant = page.locator('aside[aria-label="Professor Mari assistant"]');
   await expect(assistant).toBeVisible({ timeout: 6_000 });
+  const navigationInput = assistant.getByRole("textbox");
+  await expect(navigationInput).toBeVisible();
+  await expect(navigationInput).toHaveAttribute(
+    "placeholder",
+    testInfo.project.name.includes("mobile") ? "Looking for…?" : "What are you looking for?",
+  );
+  await expect(navigationInput).not.toBeFocused();
+  await expect(assistant.getByRole("button", { name: "Help Me Navigate", exact: true })).toHaveCount(0);
+  await navigationInput.fill("unfinished destination");
+  await navigationInput.press("Escape");
+  await expect(navigationInput).toBeVisible();
+  await expect(navigationInput).toHaveValue("");
   await expect(
     assistant.getByText("Hey, having trouble finding something? Looking for a Chats tab? Let me help!", {
       exact: true,
@@ -11835,7 +11847,6 @@ test("Professor Mari visibly arrives on Home and navigates without AI", async ({
   }
   await recallButton.click();
   await expect(assistant).toBeVisible();
-  const navigationInput = assistant.getByPlaceholder("What are you looking for?");
   await expect(navigationInput).toBeFocused();
   await navigationInput.fill("quantum spaghetti cupboard");
   await navigationInput.press("Enter");
@@ -11863,6 +11874,7 @@ test("Professor Mari visibly arrives on Home and navigates without AI", async ({
   await page.getByRole("tab", { name: "Home", exact: true }).click();
   await expect(page.getByRole("heading", { name: "What shall we cook tonight?" })).toBeVisible();
   await expect(assistant).toBeVisible({ timeout: 1_000 });
+  await expect(navigationInput).toBeVisible();
 
   const chatResponse = await page.request.post("/api/chats", {
     data: {
@@ -11921,8 +11933,7 @@ test("Professor Mari opens a named character directly in its editor", async ({ p
         })),
       )
       .toEqual({ paused: undefined, reduced: "true" });
-    await assistant.getByRole("button", { name: "Help Me Navigate", exact: true }).click();
-    const navigationInput = assistant.getByPlaceholder("What are you looking for?");
+    const navigationInput = assistant.getByRole("textbox");
     await navigationInput.fill(resourceName);
     await navigationInput.press("Enter");
     await expect(assistant.getByText("Here, found it!", { exact: true })).toBeVisible();

--- a/packages/client/src/components/chat/HomeBrowserHub.tsx
+++ b/packages/client/src/components/chat/HomeBrowserHub.tsx
@@ -877,8 +877,11 @@ function FloatingProfessorMari({
   const [phase, setPhase] = useState<"arriving" | "idle" | "map" | "shrug">(
     professorMariNavigatorRuntime.hasAppeared ? "idle" : "arriving",
   );
-  const [mode, setMode] = useState<"prompt" | "input" | "success" | "failure">("prompt");
+  const [mode, setMode] = useState<"input" | "success" | "failure">("input");
   const [query, setQuery] = useState("");
+  const [mobile, setMobile] = useState(
+    () => typeof window !== "undefined" && window.matchMedia("(max-width: 639px)").matches,
+  );
   const inputRef = useRef<HTMLInputElement | null>(null);
   const appearanceTimerRef = useRef<number | null>(null);
   const arrivalCompleteTimerRef = useRef<number | null>(null);
@@ -927,7 +930,7 @@ function FloatingProfessorMari({
   const returnToIdle = useCallback(() => {
     clearTimers();
     pendingNavigationTargetRef.current = null;
-    setMode("prompt");
+    setMode("input");
     setPhase("idle");
     setQuery("");
   }, [clearTimers]);
@@ -943,7 +946,7 @@ function FloatingProfessorMari({
       setDragLayout(null);
       setDragging(false);
       setMinimized(false);
-      setMode("prompt");
+      setMode("input");
       setPhase("idle");
       setQuery("");
       setVisible(pageActive);
@@ -958,6 +961,14 @@ function FloatingProfessorMari({
       focusFrameRef.current = null;
       inputRef.current?.focus();
     });
+  }, []);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 639px)");
+    const syncMobile = () => setMobile(mediaQuery.matches);
+    syncMobile();
+    mediaQuery.addEventListener("change", syncMobile);
+    return () => mediaQuery.removeEventListener("change", syncMobile);
   }, []);
 
   useEffect(() => {
@@ -1332,13 +1343,6 @@ function FloatingProfessorMari({
     setMinimized(true);
     setVisible(false);
   };
-  const openInput = () => {
-    clearTimers();
-    pendingNavigationTargetRef.current = null;
-    setMode("input");
-    setPhase("idle");
-    queueInputFocus();
-  };
   const returnToSearch = () => {
     clearTimers();
     pendingNavigationTargetRef.current = null;
@@ -1493,15 +1497,7 @@ function FloatingProfessorMari({
                 ? t("home.assistant.notFound")
                 : t("home.assistant.prompt")}
         </p>
-        {!dragging && mode === "prompt" ? (
-          <button
-            type="button"
-            onClick={openInput}
-            className="mari-chrome-control mari-chrome-control--compact mari-chrome-control--selected mari-accent-animated mt-2 h-8 px-3 text-[0.6875rem] font-extrabold"
-          >
-            {t("home.assistant.navigate")}
-          </button>
-        ) : !dragging && mode === "input" ? (
+        {!dragging && mode === "input" ? (
           <form onSubmit={submitNavigation} className="relative mt-2">
             <input
               ref={inputRef}
@@ -1510,7 +1506,8 @@ function FloatingProfessorMari({
               onKeyDown={(event) => {
                 if (event.key === "Escape") returnToIdle();
               }}
-              placeholder={t("home.assistant.searchPlaceholder")}
+              aria-label={t("home.assistant.searchPlaceholder")}
+              placeholder={t(mobile ? "home.assistant.searchPlaceholderMobile" : "home.assistant.searchPlaceholder")}
               className="mari-chrome-field h-9 w-full rounded-lg pl-3 pr-9 text-xs"
             />
             <button

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -602,6 +602,7 @@
   "home.assistant.prompt": "Hey, having trouble finding something? Looking for a Chats tab? Let me help!",
   "home.assistant.searchAction": "Find this in Marinara",
   "home.assistant.searchPlaceholder": "What are you looking for?",
+  "home.assistant.searchPlaceholderMobile": "Looking for…?",
   "home.browser.achievements": "Achievements",
   "home.browser.address": "marinara/home",
   "home.browser.addressLabel": "Current Marinara address: {{address}}",


### PR DESCRIPTION
## Linked issue

Closes #6099

## Why this change

Professor Mari navigation makes users click “Help Me Navigate” before entering a destination. Opening the existing form immediately removes that repeated step; a shorter mobile placeholder fits the small field.

## What changed

- Start and reset navigation in the existing input state.
- Show “Looking for…?” in the mobile field while preserving desktop wording.
- Preserve minimize/restore, successful navigation, and error recovery.

## Validation

- `pnpm check` passed (localization, formatting, lint/type checks, production build).
- Focused `pnpm smoke:ui` coverage passed: 3 desktop Chromium checks and 4 mobile Chromium/WebKit checks.
- The updated initial-input assertion failed on the previous implementation in desktop and mobile Chromium, then passed with the fix.
- Browser checks cover initial availability and placeholder, no initial autofocus, Escape, minimize/restore, unknown destinations and Back to search, navigation, return to Home, named characters, and desktop dragging/reset.
- Light/dark browser screenshots inspected. Physical-device keyboard behavior remains a manual check; no physical-device claim.

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify the Home input is immediately available on desktop and a physical phone, including mobile keyboard behavior.
- Manually verify navigation, an unknown destination, minimize/restore, and return to Home.

## Docs and release impact

Updated CHANGELOG.md and canonical English UI copy. No version or user-guide changes.

## UI evidence (if applicable)

[Before/after desktop and mobile screenshots](https://gist.github.com/SpicyMarinara/37390edce7f1c0a67590255ecb0176e4), using isolated synthetic test data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Professor Mari’s navigation input is immediately available for typing.
  - The input now uses a shorter “Looking for…?” placeholder on mobile devices.
  - Pressing Escape clears unfinished navigation text while keeping the input visible.
- **Bug Fixes**
  - Improved navigation input accessibility with a descriptive label.
  - Removed the extra step of selecting a button before entering a destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->