### PR TITLE
feat(tracker): keep members of multi-character cards apart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
-- Character Tracker now keeps the members of a multi-character card apart. A scenario card that describes several people used to collapse into one tracked entry named after the card; each person now keeps their own name, state, and portrait across turns.
+- Character Tracker now keeps the members of a multi-character card apart. A scenario card that describes several people used to collapse into one tracked entry named after the card; each person now keeps their own name, state, and portrait across turns. Cards that mark their cast with `[CHARACTER: Name]` headers or repeated `Name:` fields are recognized up front, and a stale entry carrying the card's title is cleared (#6104).
 - Professor Mari's Home navigation field is ready to type into without an extra button click, with a shorter “Looking for…?” placeholder on mobile (#6099).
-
 - Automatic backups now check that the disk holding `backups/` has room for the next archive, including metadata and restore notes, before writing it. A run that would not fit is skipped with a clear message in Settings instead of filling the disk and retrying the full write every hour (#6087).
 - Deleting a character card now removes it from every Roleplay and Conversation chat it belonged to, as it already did for Game parties, and the Characters count in Chat Settings counts only cards that still exist (#6084).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+- Character Tracker now keeps the members of a multi-character card apart. A scenario card that describes several people used to collapse into one tracked entry named after the card; each person now keeps their own name, state, and portrait across turns.
 - Professor Mari's Home navigation field is ready to type into without an extra button click, with a shorter “Looking for…?” placeholder on mobile (#6099).
 
 - Automatic backups now check that the disk holding `backups/` has room for the next archive, including metadata and restore notes, before writing it. A run that would not fit is skipped with a clear message in Settings instead of filling the disk and retrying the full write every hour (#6087).

--- a/docs/agents/built-in-agents.md
+++ b/docs/agents/built-in-agents.md
@@ -110,6 +110,8 @@ Picks the best matching background image for the current scene from your uploade
 
 Tracks the characters present, plus their mood, actions, appearance, outfit, thoughts, and per-character stats such as HP. It can also create portrait images for new characters that have none.
 
+A single card that describes several people, such as a scenario card with a cast, is tracked as separate characters. Each member keeps their own name, mood, outfit, thoughts, and portrait instead of being folded into one entry named after the card.
+
 When a recurring character returns after leaving the scene, Character Tracker reuses their latest saved stats and custom fields for continuity. Characters backed by cards also receive their configured RPG pools and attributes as grounding, and always retain the card's avatar and crop. Automatically generated portraits remain limited to NPCs without a matching character card.
 
 - **Phase**: Post-Processing.

--- a/docs/agents/built-in-agents.md
+++ b/docs/agents/built-in-agents.md
@@ -110,7 +110,7 @@ Picks the best matching background image for the current scene from your uploade
 
 Tracks the characters present, plus their mood, actions, appearance, outfit, thoughts, and per-character stats such as HP. It can also create portrait images for new characters that have none.
 
-A single card that describes several people, such as a scenario card with a cast, is tracked as separate characters. Each member keeps their own name, mood, outfit, thoughts, and portrait instead of being folded into one entry named after the card.
+A single card that describes several people, such as a scenario card with a cast, is tracked as separate characters. Mark each person in the card text with a `[CHARACTER: Name]` header or a `Name:` field and Character Tracker picks them up from the first turn. Each member keeps their own name, mood, outfit, thoughts, and portrait instead of being folded into one entry named after the card.
 
 When a recurring character returns after leaving the scene, Character Tracker reuses their latest saved stats and custom fields for continuity. Characters backed by cards also receive their configured RPG pools and attributes as grounding, and always retain the card's avatar and crop. Automatically generated portraits remain limited to NPCs without a matching character card.
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -9815,8 +9815,10 @@ export async function generateRoutes(app: FastifyInstance) {
                   snapBeforeUpdate ??
                   trackerBaseGameStateSnapshot ??
                   (allowLatestGameStateFallback ? await gameStateStore.getLatest(input.chatId) : null);
-                const cardCharacterIds = applyTrackerCharacterCardIdentity(chars, charInfo);
                 const oldChars = parseJsonField<any[]>(previousCharacterSnapshot?.presentCharacters, []);
+                const cardCharacterIds = applyTrackerCharacterCardIdentity(chars, charInfo, {
+                  previousCharacters: [...oldChars, ...characterTrackerHistory],
+                });
                 preserveTrackerCharacterUiFields(chars, oldChars);
                 preserveTrackerCharacterUiFields(chars, characterTrackerHistory);
                 const characterLockState = previousCharacterSnapshot

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -6,7 +6,9 @@ import {
   applyTrackerFieldLocksToGameStatePatch,
   generationParametersSchema,
   normalizeInventoryTrackerRows,
+  extractCharacterCardCastMembers,
   normalizeTextForMatch,
+  type CharacterCardCastSource,
   normalizeSummaryTailMessages,
   normalizeWorldCustomFields,
   normalizeThinkingTagPairs,
@@ -1525,7 +1527,7 @@ export function collectLatestTrackerCharacterHistory(
   return history;
 }
 
-type TrackerCharacterCardIdentity = {
+type TrackerCharacterCardIdentity = CharacterCardCastSource & {
   id: string;
   name: string;
   avatarPath?: string | null;
@@ -1621,8 +1623,11 @@ export function parseTrackerCastCharacterId(value: unknown): { cardId: string; n
  * Some cards describe several people (a scenario card with a cast). The
  * tracker reports each of them with the card's id and their own name. Merging
  * those would erase everyone but the last one, so a card is treated as a
- * multi-character card when the batch carries two or more distinctly named
- * members for it, or when `previousCharacters` already holds a cast id for it.
+ * multi-character card when its own text lists a cast (see
+ * `extractCharacterCardCastMembers`), when the batch carries two or more
+ * distinctly named members for it, or when `previousCharacters` already holds
+ * a cast id for it. An entry that merely repeats the title of a card with a
+ * known cast is dropped: it is the old merged row, not a person.
  * Cast members keep their own name under a `<cardId>:cast:<name>` id, do not
  * inherit the card avatar, and are not reported in the returned card-id set,
  * so the NPC avatar path (library, stored, or generated portraits) applies.
@@ -1643,6 +1648,24 @@ export function applyTrackerCharacterCardIdentity(
   }
   for (const name of duplicateNames) cardsByName.delete(name);
   const canonicalCardNamesByKey = new Map([...cardsByName].map(([key, card]) => [key, card.name]));
+
+  // Cards whose text lists a cast are multi-character from the first turn on,
+  // and a bare member name (no id) links to its card through this map.
+  const declaredCastCardIds = new Set<string>();
+  const cardsByCastMember = new Map<string, TrackerCharacterCardIdentity>();
+  const ambiguousCastMembers = new Set<string>();
+  for (const card of cards) {
+    const members = extractCharacterCardCastMembers(card);
+    if (members.length === 0) continue;
+    declaredCastCardIds.add(card.id);
+    for (const member of members) {
+      const key = normalizeTextForMatch(member);
+      if (!key || cardsByName.has(key)) continue;
+      if (cardsByCastMember.has(key) && cardsByCastMember.get(key) !== card) ambiguousCastMembers.add(key);
+      else cardsByCastMember.set(key, card);
+    }
+  }
+  for (const key of ambiguousCastMembers) cardsByCastMember.delete(key);
 
   type ResolvedTrackerCharacter = {
     character: Record<string, unknown>;
@@ -1667,7 +1690,11 @@ export function applyTrackerCharacterCardIdentity(
       cardsById.get(trackerCharacterIdKey(character)) ??
       cardsByName.get(nameKey) ??
       (explicitCanonicalName ? cardsByName.get(normalizeTextForMatch(explicitCanonicalName)) : undefined);
-    if (!card) return { character, card: undefined, isCardName: false, castNameKey: "", viaCastId: false };
+    if (!card) {
+      const castCard = nameKey ? cardsByCastMember.get(nameKey) : undefined;
+      if (castCard) return { character, card: castCard, isCardName: false, castNameKey: nameKey, viaCastId: false };
+      return { character, card: undefined, isCardName: false, castNameKey: "", viaCastId: false };
+    }
 
     const cardNameKey = normalizeTextForMatch(card.name);
     const isCardName =
@@ -1679,7 +1706,7 @@ export function applyTrackerCharacterCardIdentity(
 
   // Multi-character cards: remembered from earlier snapshots, or evidenced by
   // this batch naming two or more distinct members of the same card.
-  const castCardIds = new Set<string>();
+  const castCardIds = new Set<string>(declaredCastCardIds);
   for (const previous of options.previousCharacters ?? []) {
     const parsed = parseTrackerCastCharacterId(previous.characterId);
     const card = parsed ? cardsById.get(parsed.cardId.toLowerCase()) : undefined;
@@ -1714,6 +1741,12 @@ export function applyTrackerCharacterCardIdentity(
   for (const { character, card, isCardName, castNameKey } of resolved) {
     if (!card) {
       canonicalCharacters.push(character);
+      continue;
+    }
+
+    if (declaredCastCardIds.has(card.id) && isCardName) {
+      // The card is a cast, so a row carrying the card's own title is the old
+      // merged entry (or the scenario itself), never one of the people on it.
       continue;
     }
 

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -1590,9 +1590,47 @@ export function canonicalizeGamePartySpeakerLabels(content: string, canonicalNam
   );
 }
 
+const TRACKER_CAST_ID_SEPARATOR = ":cast:";
+
+/**
+ * Character id for one member of a multi-character card: `<cardId>:cast:<normalized name>`.
+ * Cast ids stay stable across turns so locks, manual edits, NPC avatars, and
+ * continuity keep pointing at the same person even when the card itself is one row.
+ */
+export function buildTrackerCastCharacterId(cardId: string, name: unknown): string {
+  return `${cardId}${TRACKER_CAST_ID_SEPARATOR}${normalizeTextForMatch(name)}`;
+}
+
+export function parseTrackerCastCharacterId(value: unknown): { cardId: string; nameKey: string } | null {
+  if (typeof value !== "string") return null;
+  const index = value.indexOf(TRACKER_CAST_ID_SEPARATOR);
+  if (index <= 0) return null;
+  const cardId = value.slice(0, index).trim();
+  const nameKey = normalizeTextForMatch(value.slice(index + TRACKER_CAST_ID_SEPARATOR.length));
+  return cardId && nameKey ? { cardId, nameKey } : null;
+}
+
+/**
+ * Canonicalize tracked characters against the chat's character cards.
+ *
+ * A tracked entry that matches a card by id, exact name, or an explicit alias
+ * takes the card's id, name, and avatar, and duplicates collapse into one row.
+ * That keeps single-character cards stable when a model drifts between
+ * "Mari" and 'Marisol "Mari"'.
+ *
+ * Some cards describe several people (a scenario card with a cast). The
+ * tracker reports each of them with the card's id and their own name. Merging
+ * those would erase everyone but the last one, so a card is treated as a
+ * multi-character card when the batch carries two or more distinctly named
+ * members for it, or when `previousCharacters` already holds a cast id for it.
+ * Cast members keep their own name under a `<cardId>:cast:<name>` id, do not
+ * inherit the card avatar, and are not reported in the returned card-id set,
+ * so the NPC avatar path (library, stored, or generated portraits) applies.
+ */
 export function applyTrackerCharacterCardIdentity(
   characters: Array<Record<string, unknown>>,
   cards: TrackerCharacterCardIdentity[],
+  options: { previousCharacters?: ReadonlyArray<Record<string, unknown>> } = {},
 ): Set<string> {
   const cardsById = new Map(cards.map((card) => [card.id.trim().toLowerCase(), card]));
   const cardsByName = new Map<string, TrackerCharacterCardIdentity>();
@@ -1606,37 +1644,102 @@ export function applyTrackerCharacterCardIdentity(
   for (const name of duplicateNames) cardsByName.delete(name);
   const canonicalCardNamesByKey = new Map([...cardsByName].map(([key, card]) => [key, card.name]));
 
-  const matchedIds = new Set<string>();
-  const canonicalCharacters: Array<Record<string, unknown>> = [];
-  const canonicalIndexByCardId = new Map<string, number>();
-  for (const character of characters) {
+  type ResolvedTrackerCharacter = {
+    character: Record<string, unknown>;
+    card: TrackerCharacterCardIdentity | undefined;
+    /** The entry names the card itself (exact name, explicit alias, or no name at all). */
+    isCardName: boolean;
+    /** Normalized member name when the entry names someone other than the card. */
+    castNameKey: string;
+    viaCastId: boolean;
+  };
+
+  const resolved: ResolvedTrackerCharacter[] = characters.map((character) => {
+    const nameKey = trackerCharacterNameKey(character);
+    const castId = parseTrackerCastCharacterId(character.characterId);
+    const castCard = castId ? cardsById.get(castId.cardId.toLowerCase()) : undefined;
+    if (castId && castCard) {
+      return { character, card: castCard, isCardName: false, castNameKey: nameKey || castId.nameKey, viaCastId: true };
+    }
+
     const explicitCanonicalName = resolveExplicitCanonicalName(character.name, canonicalCardNamesByKey);
     const card =
       cardsById.get(trackerCharacterIdKey(character)) ??
-      cardsByName.get(trackerCharacterNameKey(character)) ??
+      cardsByName.get(nameKey) ??
       (explicitCanonicalName ? cardsByName.get(normalizeTextForMatch(explicitCanonicalName)) : undefined);
+    if (!card) return { character, card: undefined, isCardName: false, castNameKey: "", viaCastId: false };
+
+    const cardNameKey = normalizeTextForMatch(card.name);
+    const isCardName =
+      !nameKey ||
+      nameKey === cardNameKey ||
+      (!!explicitCanonicalName && normalizeTextForMatch(explicitCanonicalName) === cardNameKey);
+    return { character, card, isCardName, castNameKey: isCardName ? "" : nameKey, viaCastId: false };
+  });
+
+  // Multi-character cards: remembered from earlier snapshots, or evidenced by
+  // this batch naming two or more distinct members of the same card.
+  const castCardIds = new Set<string>();
+  for (const previous of options.previousCharacters ?? []) {
+    const parsed = parseTrackerCastCharacterId(previous.characterId);
+    const card = parsed ? cardsById.get(parsed.cardId.toLowerCase()) : undefined;
+    if (card) castCardIds.add(card.id);
+  }
+  const memberNamesByCard = new Map<string, Set<string>>();
+  for (const entry of resolved) {
+    if (!entry.card) continue;
+    if (entry.viaCastId) castCardIds.add(entry.card.id);
+    if (!entry.castNameKey) continue;
+    const members = memberNamesByCard.get(entry.card.id) ?? new Set<string>();
+    members.add(entry.castNameKey);
+    memberNamesByCard.set(entry.card.id, members);
+  }
+  for (const [cardId, members] of memberNamesByCard) {
+    if (members.size >= 2) castCardIds.add(cardId);
+  }
+
+  const matchedIds = new Set<string>();
+  const canonicalCharacters: Array<Record<string, unknown>> = [];
+  const canonicalIndexByKey = new Map<string, number>();
+  const pushOrMerge = (key: string, next: Record<string, unknown>) => {
+    const existingIndex = canonicalIndexByKey.get(key);
+    if (existingIndex === undefined) {
+      canonicalIndexByKey.set(key, canonicalCharacters.length);
+      canonicalCharacters.push(next);
+    } else {
+      canonicalCharacters[existingIndex] = { ...canonicalCharacters[existingIndex], ...next };
+    }
+  };
+
+  for (const { character, card, isCardName, castNameKey } of resolved) {
     if (!card) {
       canonicalCharacters.push(character);
       continue;
     }
 
-    const canonicalCharacter = {
+    if (castCardIds.has(card.id) && !isCardName && castNameKey) {
+      const castId = buildTrackerCastCharacterId(card.id, castNameKey);
+      const castCharacter: Record<string, unknown> = {
+        ...character,
+        characterId: castId,
+        name: typeof character.name === "string" ? character.name.trim() : castNameKey,
+      };
+      // A member never wears the card's portrait; NPC avatar enrichment finds their own.
+      if (card.avatarPath && castCharacter.avatarPath === card.avatarPath) {
+        castCharacter.avatarPath = null;
+        castCharacter.avatarCrop = null;
+      }
+      pushOrMerge(castId, castCharacter);
+      continue;
+    }
+
+    pushOrMerge(`card:${card.id}`, {
       ...character,
       characterId: card.id,
       name: card.name,
       avatarPath: card.avatarPath ?? null,
       avatarCrop: card.avatarCrop ?? null,
-    };
-    const existingIndex = canonicalIndexByCardId.get(card.id);
-    if (existingIndex === undefined) {
-      canonicalIndexByCardId.set(card.id, canonicalCharacters.length);
-      canonicalCharacters.push(canonicalCharacter);
-    } else {
-      canonicalCharacters[existingIndex] = {
-        ...canonicalCharacters[existingIndex],
-        ...canonicalCharacter,
-      };
-    }
+    });
     matchedIds.add(card.id);
   }
   characters.splice(0, characters.length, ...canonicalCharacters);

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -3066,7 +3066,12 @@ async function applyRetryResultEffects(args: {
             previousCharacters = [];
           }
         }
-        applyTrackerCharacterCardIdentity(presentCharacters, agentContext.characters);
+        applyTrackerCharacterCardIdentity(presentCharacters, agentContext.characters, {
+          previousCharacters: [
+            ...previousCharacters,
+            ...((agentContext.characterTrackerHistory ?? []) as unknown as Array<Record<string, unknown>>),
+          ],
+        });
         preserveTrackerCharacterUiFields(presentCharacters, previousCharacters);
         preserveTrackerCharacterUiFields(
           presentCharacters,

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -33,6 +33,7 @@ import {
   publicAgentOutput,
   getDefaultAgentPrompt,
   flattenAgentConditionalMacros,
+  extractCharacterCardCastMembers,
   normalizeRpgStatPools,
   resolveMacros,
   extractLeadingThinkingBlocks,
@@ -2861,6 +2862,12 @@ function buildLoreBlock(context: AgentContext, sources: CustomAgentContextSource
     parts.push(`<characters>`);
     for (const char of context.characters) {
       parts.push(`<character id="${char.id}" name="${char.name}">`);
+      const castMembers = extractCharacterCardCastMembers(char);
+      if (castMembers.length > 0) {
+        parts.push(
+          `This card describes several people: ${castMembers.join(", ")}. Treat each as a separate character; the card name itself is not a character.`,
+        );
+      }
       pushLoreField(parts, "Description", char.description, CHARACTER_LORE_DESCRIPTION_LIMIT);
       pushLoreField(parts, "Personality", char.personality, CHARACTER_LORE_FIELD_LIMIT);
       pushLoreField(parts, "Backstory", char.backstory, CHARACTER_LORE_FIELD_LIMIT);
@@ -3070,7 +3077,7 @@ function buildAgentExtras(
   if (agentTypes.includes("character-tracker") && context.characters.length > 0) {
     parts.push(`<character_tracker_cards>`);
     parts.push(
-      "A character card may describe several people (for example a scenario card with a cast). Track each of them as a separate entry: set characterId to that card's id and name to the person's own name. Never fold several people into one entry named after the card. When an earlier state lists a member under an id ending in `:cast:<name>`, reuse that id.",
+      "A character card may describe several people (for example a scenario card with a cast). Track each of them as a separate entry: set characterId to that card's id and name to the person's own name. Never fold several people into one entry named after the card. If the current state or history lists an entry named after such a card, replace it with one entry per person who is actually present. When an earlier state lists a member under an id ending in `:cast:<name>`, reuse that id.",
     );
     parts.push(`</character_tracker_cards>`);
   }

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -3067,6 +3067,14 @@ function buildAgentExtras(
     if (characterPromptBlock) parts.push(characterPromptBlock);
   }
 
+  if (agentTypes.includes("character-tracker") && context.characters.length > 0) {
+    parts.push(`<character_tracker_cards>`);
+    parts.push(
+      "A character card may describe several people (for example a scenario card with a cast). Track each of them as a separate entry: set characterId to that card's id and name to the person's own name. Never fold several people into one entry named after the card. When an earlier state lists a member under an id ending in `:cast:<name>`, reuse that id.",
+    );
+    parts.push(`</character_tracker_cards>`);
+  }
+
   if (agentTypes.includes("character-tracker") && context.characterTrackerHistory?.length) {
     parts.push(`<character_tracker_history>`);
     parts.push(

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -148,6 +148,7 @@ export * from "./utils/thinking-tags.js";
 export * from "./utils/rpg-stats.js";
 export * from "./utils/lorebook-folder-tree.js";
 export * from "./utils/text-matching.js";
+export * from "./utils/character-cast.js";
 export * from "./utils/speaker-segments.js";
 export * from "./utils/sprite-labels.js";
 export * from "./utils/managed-generation-parameters.js";

--- a/packages/shared/src/utils/character-cast.ts
+++ b/packages/shared/src/utils/character-cast.ts
@@ -1,0 +1,69 @@
+import { normalizeTextForMatch } from "./text-matching.js";
+
+/** Character card text fields that may describe several people on one card. */
+export type CharacterCardCastSource = {
+  name?: unknown;
+  description?: unknown;
+  personality?: unknown;
+  scenario?: unknown;
+  backstory?: unknown;
+  appearance?: unknown;
+};
+
+const MAX_CAST_MEMBERS = 12;
+const MAX_MEMBER_NAME_LENGTH = 60;
+
+/** `[CHARACTER: Ana]`, `[Character - Julia]`, `[CHAR: Mira]` block headers. */
+const BRACKET_HEADER_RE = /\[\s*(?:character|char)\s*(?:[:\-–—]\s*)([^\]\r\n]{1,60})\]/giu;
+/** `Name: Ana`, `Full Name: Julia`, `**Name:** Mira` at the start of a line. */
+const NAME_FIELD_RE = /^[\s*_\-•>]*(?:full\s+name|name)\s*[*_]*\s*[:：]\s*[*_]*\s*([^\r\n]{1,120})$/gimu;
+
+function cleanMemberName(raw: string): string {
+  return raw
+    .replace(/[*_`"“”'‘’]/gu, "")
+    .replace(/\s*\((?:[^()]*)\)\s*$/u, "")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function looksLikePersonName(value: string): boolean {
+  if (!value || value.length > MAX_MEMBER_NAME_LENGTH) return false;
+  if (/[.!?;]/u.test(value)) return false;
+  return value.split(" ").length <= 5;
+}
+
+function collectFromPattern(text: string, pattern: RegExp, into: Map<string, string>): void {
+  pattern.lastIndex = 0;
+  for (const match of text.matchAll(pattern)) {
+    const name = cleanMemberName(match[1] ?? "");
+    if (!looksLikePersonName(name)) continue;
+    const key = normalizeTextForMatch(name);
+    if (key && !into.has(key)) into.set(key, name);
+  }
+}
+
+/**
+ * Detect the people described by one character card.
+ *
+ * Cards that bundle a cast (a scenario card with a mother and a daughter, a
+ * party of adventurers) usually mark each person with a `[CHARACTER: Name]`
+ * header or repeated `Name:` fields. Returns the distinct member names when at
+ * least two are found and an empty list otherwise, so a normal single-person
+ * card is never treated as a cast. The card's own name is never a member.
+ */
+export function extractCharacterCardCastMembers(card: CharacterCardCastSource): string[] {
+  const fields = [card.description, card.personality, card.scenario, card.backstory, card.appearance];
+  const text = fields.filter((value): value is string => typeof value === "string" && value.length > 0).join("\n");
+  if (!text) return [];
+
+  const cardNameKey = normalizeTextForMatch(card.name);
+  const members = new Map<string, string>();
+  collectFromPattern(text, BRACKET_HEADER_RE, members);
+  if (members.size < 2) {
+    members.clear();
+    collectFromPattern(text, NAME_FIELD_RE, members);
+  }
+  if (cardNameKey) members.delete(cardNameKey);
+  if (members.size < 2) return [];
+  return [...members.values()].slice(0, MAX_CAST_MEMBERS);
+}

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import {
+  extractCharacterCardCastMembers,
   ANIME_GAME_PROMPT_TEMPLATE_ID,
   ANIME_GAME_SYSTEM_PROMPT,
   ANIME_GAME_VIDEO_PROMPT_TEMPLATE_ID,
@@ -10941,6 +10942,38 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       const soloMatches = applyTrackerCharacterCardIdentity(soloAlias, [castCard]);
       assert.equal(soloMatches.has("resort-card"), true);
       assert.equal(soloAlias[0]?.name, "Vacation Resort");
+
+      // A card whose text lists its cast is multi-character from the first turn:
+      // the old merged row named after the card is dropped, and bare member names link to the card.
+      const declaredCastCard = {
+        ...castCard,
+        description:
+          "[PREMISE]\nA trip.\n\n[CHARACTER: Ana]\nFull Name: Ana\nAge: 20\n\n[CHARACTER: Julia]\nFull Name: Julia\nAge: 41",
+      };
+      assert.deepEqual(extractCharacterCardCastMembers(declaredCastCard), ["Ana", "Julia"]);
+      assert.deepEqual(
+        extractCharacterCardCastMembers({ name: "Mira", description: "[CHARACTER: Mira]\nA lone knight." }),
+        [],
+      );
+      assert.deepEqual(
+        extractCharacterCardCastMembers({
+          name: "Party",
+          description: "Name: Rook\nRole: scout\n\nName: Vale\nRole: mage",
+        }),
+        ["Rook", "Vale"],
+      );
+      const declaredBatch: Array<Record<string, unknown>> = [
+        {
+          characterId: "resort-card",
+          name: "Vacation Resort",
+          mood: "Excited",
+          avatarPath: "/api/avatars/file/resort.png",
+        },
+        { name: "Julia", mood: "Sleeping" },
+      ];
+      const declaredMatches = applyTrackerCharacterCardIdentity(declaredBatch, [declaredCastCard]);
+      assert.equal(declaredMatches.has("resort-card"), false);
+      assert.deepEqual(declaredBatch, [{ characterId: "resort-card:cast:julia", name: "Julia", mood: "Sleeping" }]);
 
       assert.equal(
         canonicalizeGamePartySpeakerLabels(

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -10906,6 +10906,42 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       applyTrackerCharacterCardIdentity(unrelatedLongName, [{ id: "party-card", name: "Mari" }]);
       assert.deepEqual(unrelatedLongName, [{ name: "Mari Calder" }]);
 
+      // Multi-character cards: two distinctly named members of one card stay separate.
+      const castCard = { id: "resort-card", name: "Vacation Resort", avatarPath: "/api/avatars/file/resort.png" };
+      const castBatch: Array<Record<string, unknown>> = [
+        { characterId: "resort-card", name: "Ana", mood: "Playful", avatarPath: "/api/avatars/file/resort.png" },
+        { characterId: "resort-card", name: "Julia", mood: "Sleeping" },
+      ];
+      const castMatches = applyTrackerCharacterCardIdentity(castBatch, [castCard]);
+      assert.equal(castMatches.has("resort-card"), false);
+      assert.deepEqual(castBatch, [
+        { characterId: "resort-card:cast:ana", name: "Ana", mood: "Playful", avatarPath: null, avatarCrop: null },
+        { characterId: "resort-card:cast:julia", name: "Julia", mood: "Sleeping" },
+      ]);
+
+      // A lone member on a later turn keeps the cast identity when earlier state remembers the cast.
+      const loneMember: Array<Record<string, unknown>> = [{ characterId: "resort-card", name: "Ana", mood: "Bored" }];
+      applyTrackerCharacterCardIdentity(loneMember, [castCard], {
+        previousCharacters: [{ characterId: "resort-card:cast:julia", name: "Julia" }],
+      });
+      assert.deepEqual(loneMember, [{ characterId: "resort-card:cast:ana", name: "Ana", mood: "Bored" }]);
+
+      // A model echoing a cast id resolves to the same member, and duplicates merge.
+      const echoedCast: Array<Record<string, unknown>> = [
+        { characterId: "resort-card:cast:ana", name: "Ana", mood: "Smug" },
+        { characterId: "resort-card", name: "ana", outfit: "hoodie" },
+      ];
+      applyTrackerCharacterCardIdentity(echoedCast, [castCard]);
+      assert.deepEqual(echoedCast, [
+        { characterId: "resort-card:cast:ana", name: "ana", mood: "Smug", outfit: "hoodie" },
+      ]);
+
+      // Without cast evidence a single differently named entry still canonicalizes to the card.
+      const soloAlias: Array<Record<string, unknown>> = [{ characterId: "resort-card", name: "Ana" }];
+      const soloMatches = applyTrackerCharacterCardIdentity(soloAlias, [castCard]);
+      assert.equal(soloMatches.has("resort-card"), true);
+      assert.equal(soloAlias[0]?.name, "Vacation Resort");
+
       assert.equal(
         canonicalizeGamePartySpeakerLabels(
           '[Marisol "Mari"] [main] [happy]: "Ready."\n\nMarisol "Mari" crosses the room.',


### PR DESCRIPTION
## Linked issue

Closes #6104.

## Why this change

When one character card describes several people, Character Tracker can collapse its separate outputs into one entry named after the card. Preserve each reported cast member’s identity and portrait while retaining manually added characters and legacy state until a replacement is available.

## What changed

- Recognize declared cast names and reuse prior multi-character identities in generation and tracker retries.
- Keep cast members separate from the shared card portrait; preserve single-character card behavior.
- Preserve manual IDs and legacy rows; use bounded parsing for authored name fields.
- Keep package-owned prompt instructions outside Engine. Document the final host behavior and add regressions.

## Validation

`pnpm install --frozen-lockfile`, `pnpm check`, and `git diff --check` pass on `031f0995c1672278fb5c55f9f49ce8dc6e3bbeb7`, which merges staging `5fa59f030159539831ec2aae0242015bd7361b64`. This merge adds only the existing native-dice browser-test timeout and changelog entry. All three `pnpm regression:prompt` lanes passed on `c65196b9f32a3bbe4da3d17c34405929788d4ecd`; the tracker and prompt source is unchanged. The regression first reproduced the manual-ID failure on the contributor’s original head. Documentation translations are included in #6138.

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Manually verify a multi-character card, a returning cast member, a manually added matching name, and a single-character card in the tracker UI. Verify each character’s avatar and custom stats.

## Docs and release impact

Updated the Character Tracker guide and Unreleased changelog. No version change. All ten translated guides are covered by #6138.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-character cards are now tracked as separate characters, preserving each member’s name, mood, outfit, thoughts, and portrait.
  * Cast members can receive portraits through the same available sources as other characters.
  * Character tracking better preserves cast identities across updates and removes outdated card-title entries when individual members are identified.
  * Single-character cards continue using their card identity and portrait.

* **Documentation**
  * Added guidance for defining and managing multi-character cards and their individual portraits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->