### PR TITLE
fix(mari-db): resolve capability package tables registered after load

### DIFF
--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -865,6 +865,11 @@ const tableMetasByObject = new WeakMap<object, TableMeta>();
 const columnMetasByObject = new WeakMap<object, ColumnMeta>();
 const tableMetasByName = new Map<string, TableMeta>();
 
+/** Live lookup, so consumers that snapshot the schema at load still see package tables registered later. */
+export function getRegisteredFileTable(name: string): Table | undefined {
+  return tableMetasByName.get(name)?.table;
+}
+
 function tableNameOf(table: Table): string {
   return getFileTableConfig(table).name;
 }

--- a/packages/server/src/services/mari-db/mari-db.service.ts
+++ b/packages/server/src/services/mari-db/mari-db.service.ts
@@ -9,7 +9,12 @@ import { basename, join, resolve } from "node:path";
 import { eq } from "../../db/file-query.js";
 import type { DB } from "../../db/connection.js";
 import { flushDB } from "../../db/connection.js";
-import { CASCADE_DANGLING_EXEMPT_PREFIXES, CASCADES, FILE_BACKED_TABLES } from "../../db/file-backed-store.js";
+import {
+  CASCADE_DANGLING_EXEMPT_PREFIXES,
+  CASCADES,
+  FILE_BACKED_TABLES,
+  getRegisteredFileTable,
+} from "../../db/file-backed-store.js";
 import { getFileTableConfig, isFileTable, type AnyFileColumn, type AnyFileTable } from "../../db/file-schema.js";
 import * as schema from "../../db/schema/index.js";
 import { getFileStorageDir, getMonorepoRoot, isCustomToolScriptEnabled } from "../../config/runtime-config.js";
@@ -415,28 +420,30 @@ const JSON_COLUMNS: Record<string, readonly string[]> = {
   regex_scripts: ["trimStrings", "placement", "targetCharacterIds", "targetPromptPresetIds"],
 };
 
+function buildTableMeta(table: Parameters<typeof getFileTableConfig>[0]): TableMeta {
+  const config = getFileTableConfig(table);
+  const columns = config.columns.map((column) => ({
+    key: column.key,
+    dbName: column.name,
+    column,
+    primary: column.primary,
+    notNull: column.isNotNull,
+  }));
+  return {
+    name: config.name,
+    table,
+    columns,
+    byKey: new Map(columns.map((column) => [column.key, column])),
+    primaryKey: columns.find((column) => column.primary)?.key ?? null,
+  };
+}
+
 function buildTableMetas() {
   const metas = new Map<string, TableMeta>();
   for (const candidate of Object.values(schema)) {
     if (!isFileTable(candidate)) continue;
-    const table = candidate;
-    const config = getFileTableConfig(table);
-    const name = config.name;
-    if (!FILE_BACKED_TABLE_SET.has(name)) continue;
-    const columns = config.columns.map((column) => ({
-      key: column.key,
-      dbName: column.name,
-      column,
-      primary: column.primary,
-      notNull: column.isNotNull,
-    }));
-    metas.set(name, {
-      name,
-      table,
-      columns,
-      byKey: new Map(columns.map((column) => [column.key, column])),
-      primaryKey: columns.find((column) => column.primary)?.key ?? null,
-    });
+    const meta = buildTableMeta(candidate);
+    if (FILE_BACKED_TABLE_SET.has(meta.name)) metas.set(meta.name, meta);
   }
   return metas;
 }
@@ -715,8 +722,14 @@ function deepMerge(base: unknown, patch: unknown): unknown {
 }
 
 function getMeta(table: string): TableMeta {
-  const meta = TABLE_METAS.get(table);
-  if (!meta) throw new Error(`Unknown file-backed table: ${table}`);
+  let meta = TABLE_METAS.get(table);
+  if (!meta) {
+    // Capability packages register their tables after this module loads (registerTables).
+    const registered = getRegisteredFileTable(table);
+    if (!registered) throw new Error(`Unknown file-backed table: ${table}`);
+    meta = buildTableMeta(registered);
+    TABLE_METAS.set(table, meta);
+  }
   return meta;
 }
 

--- a/scripts/regressions/package-table-registration.regression.ts
+++ b/scripts/regressions/package-table-registration.regression.ts
@@ -30,6 +30,7 @@ const { fileTable, text } = await import("../../packages/server/src/db/file-sche
 const { eq } = await import("../../packages/server/src/db/file-query.js");
 const { createFileNativeDB, FILE_BACKED_TABLES } = await import("../../packages/server/src/db/file-backed-store.js");
 const { chats } = await import("../../packages/server/src/db/schema/index.js");
+const { getMariDbService } = await import("../../packages/server/src/services/mari-db/mari-db.service.js");
 
 /** Every path under `root`, so a rejected name cannot create anything unnoticed. */
 function treeSnapshot(root: string): string[] {
@@ -137,6 +138,11 @@ async function registersAndPersists() {
     db._fileStore.registerTables([packageNotes]);
     const afterReregister = await db.select().from(packageNotes);
     assert.equal(afterReregister.length, 1, "re-registration must not reset a live table");
+
+    // Mari's DB service snapshots table metadata at module load, before any
+    // package registers; it must still resolve a registered package table.
+    const listed = await getMariDbService(db).executeCli({ argv: ["db", "list", "package_demo_notes", "--json"] });
+    assert.match(JSON.stringify(listed), /note-1/, "Professor Mari can read a registered package table");
 
     await db._fileStore.flush();
     const shardDir = join(dir, "tables", "package_demo_notes");


### PR DESCRIPTION
Fixes #6113

- `file-backed-store.ts`: export `getRegisteredFileTable(name)` (live registry lookup).
- `mari-db.service.ts`: `getMeta` falls back to the live registry and caches the meta. Unregistered names still throw.
- Regression: `package-table-registration.regression.ts` lists a registered package table through Mari.

Verified: server `tsc --noEmit` clean; regression passes with fix, fails without it with the exact prod error.

Existing users: update Engine and restart; no data repair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Package-registered database tables are now recognized when accessed after startup.
  - The database listing command can now read and display data from tables registered by capability packages.
  - Unknown table requests continue to return an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->